### PR TITLE
refactor(payroll_entry): get_employee_list

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -22,7 +22,11 @@ from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_
 )
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
-from hrms.payroll.doctype.payroll_entry.payroll_entry import get_end_date, get_start_end_dates
+from hrms.payroll.doctype.payroll_entry.payroll_entry import (
+	PayrollEntry,
+	get_end_date,
+	get_start_end_dates,
+)
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	create_account,
 	make_deduction_salary_component,
@@ -398,7 +402,7 @@ class TestPayrollEntry(FrappeTestCase):
 def get_payroll_entry(**args):
 	args = frappe._dict(args)
 
-	payroll_entry = frappe.new_doc("Payroll Entry")
+	payroll_entry: PayrollEntry = frappe.new_doc("Payroll Entry")
 	payroll_entry.company = args.company or erpnext.get_default_company()
 	payroll_entry.start_date = args.start_date or "2016-11-01"
 	payroll_entry.end_date = args.end_date or "2016-11-30"


### PR DESCRIPTION
Came across this problematic section that was choking the switch to
mariadb client. Spent more time than required figuring this block out,
so re-wrote for better debugability.

Salvaged from https://github.com/frappe/erpnext/pull/31454/commits/45364beb1f11cff32bba7583bdfe52b4718f4c7c via https://github.com/frappe/erpnext/pull/31454