### PR TITLE
fix: run regional setups on app installation

### DIFF
--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -13,13 +13,11 @@ def make_company_fixtures(doc, method=None):
 	if not frappe.flags.country_change:
 		return
 
-	run_regional_setup(doc.name, doc.country)
+	run_regional_setup(doc.country)
 	make_salary_components(doc.country)
 
 
-def run_regional_setup(company, country):
-	company = company or frappe.db.get_value("Global Defaults", None, "default_company")
-
+def run_regional_setup(country):
 	try:
 		module_name = f"hrms.regional.{frappe.scrub(country)}.setup.setup"
 		frappe.get_attr(module_name)()
@@ -38,8 +36,11 @@ def make_salary_components(country):
 	docs = []
 
 	file_name = "salary_components.json"
-	file_path = frappe.get_app_path("hrms", "payroll", "data", file_name)
-	docs.extend(json.loads(read_data_file(file_path)))
+
+	# default components already added
+	if not frappe.db.exists("Salary Component", "Basic"):
+		file_path = frappe.get_app_path("hrms", "payroll", "data", file_name)
+		docs.extend(json.loads(read_data_file(file_path)))
 
 	file_path = frappe.get_app_path("hrms", "regional", frappe.scrub(country), "data", file_name)
 	docs.extend(json.loads(read_data_file(file_path)))

--- a/hrms/patches/post_install/create_country_fixtures.py
+++ b/hrms/patches/post_install/create_country_fixtures.py
@@ -1,0 +1,9 @@
+import frappe
+
+from hrms.overrides.company import make_salary_components, run_regional_setup
+
+
+def execute():
+	for country in frappe.get_all("Company", pluck="country", distinct=True):
+		run_regional_setup(country)
+		make_salary_components(country)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -15,7 +15,6 @@ def after_install():
 	update_hr_defaults()
 	add_non_standard_user_types()
 	set_single_defaults()
-	frappe.db.commit()
 	run_post_install_patches()
 	click.secho("Thank you for installing Frappe HR!", fg="green")
 
@@ -630,6 +629,8 @@ def get_post_install_patches():
 		"erpnext.patches.v13_0.update_expense_claim_status_for_paid_advances",
 		"erpnext.patches.v14_0.delete_employee_transfer_property_doctype",
 		"erpnext.patches.v13_0.set_payroll_entry_status",
+		# HRMS
+		"create_country_fixtures",
 	)
 
 


### PR DESCRIPTION
Currently, regional setups run on the `on_update` method for company. Run these setups post installation too in case of existing companies 