### PR TITLE
fix(UX): sort holidays by date

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,6 @@
 
 # sort and cleanup imports
 4872c156974291f0c4c88f26033fef0b900ca995
+
+# old black formatting commit (from erpnext)
+76c895a6c659356151433715a1efe9337e348c11

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -517,7 +517,9 @@ def get_holidays_for_employee(
 	if only_non_weekly:
 		filters["weekly_off"] = False
 
-	holidays = frappe.get_all("Holiday", fields=["description", "holiday_date"], filters=filters)
+	holidays = frappe.get_all(
+		"Holiday", fields=["description", "holiday_date"], filters=filters, order_by="holiday_date"
+	)
 
 	return holidays
 


### PR DESCRIPTION
Holiday reminders don't sort holidays, ascending sort makes sense by default 🤓 

Example:
<img width="547" alt="Screenshot 2022-08-01 at 11 58 04 AM" src="https://user-images.githubusercontent.com/9079960/182085789-31e7c28b-8761-4945-81bb-1e98105ef298.png">
