### PR TITLE
fix: job opening not set in application web form

### DIFF
--- a/hrms/hr/doctype/job_opening/templates/job_opening_row.html
+++ b/hrms/hr/doctype/job_opening/templates/job_opening_row.html
@@ -7,11 +7,11 @@
 	<div>
 		{%- if doc.job_application_route -%}
 		<a class='btn btn-primary'
-		href='/{{doc.job_application_route}}?new=1&job_title={{ doc.name }}'>
+		href='/{{doc.job_application_route}}/new?job_title={{ doc.name }}'>
 		{{ _("Apply Now") }}</a>
 		{% else %}
 		<a class='btn btn-primary'
-		href='/job_application?new=1&job_title={{ doc.name }}'>
+		href='/job_application/new?job_title={{ doc.name }}'>
 		{{ _("Apply Now") }}</a>
 		{% endif %}
 	</div>

--- a/hrms/templates/generators/job_opening.html
+++ b/hrms/templates/generators/job_opening.html
@@ -21,11 +21,11 @@
 <p style='margin-top: 30px'>
 	{%- if job_application_route -%}
 	<a class='btn btn-primary'
-	href='/{{job_application_route}}?new=1&job_title={{ doc.name }}'>
+	href='/{{job_application_route}}/new?job_title={{ doc.name }}'>
 	{{ _("Apply Now") }}</a>
 	{% else %}
 	<a class='btn btn-primary'
-	href='/job_application?new=1&job_title={{ doc.name }}'>
+	href='/job_application/new?job_title={{ doc.name }}'>
 	{{ _("Apply Now") }}</a>
 	{% endif %}
 </p>


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/41

## Problem:

After the web form routing changes for new forms in https://github.com/frappe/frappe/pull/17232, the Job Application web form no longer populates query param for opening.

![application-before](https://user-images.githubusercontent.com/24353136/187147787-24f0c0fe-3e56-4056-9af2-f4b0b3975824.gif)


## Fix:

Change the links to work with the new routing

![application-after](https://user-images.githubusercontent.com/24353136/187147504-de67676d-5502-4c07-94b3-60907de3cb16.gif)

