### PR TITLE
fix: add Employee ID with Employee Name in Attendance Tool

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -98,7 +98,7 @@ erpnext.MarkedEmployee = class MarkedEmployee {
 				<label class="marked-employee-label"><span class="%(icon)s"></span>\
 				%(employee)s</label>\
 				</div>', {
-					employee: m.employee_name,
+					employee: m.employee +' : '+ m.employee_name,
 					icon: attendance_icon,
 					color_class: color_class
 				})).appendTo(row);
@@ -261,7 +261,7 @@ erpnext.EmployeeSelector = class EmployeeSelector {
 				<div class="checkbox">\
 				<label><input type="checkbox" class="employee-check" employee="%(employee)s"/>\
 				%(employee)s</label>\
-				</div></div>', {employee: m.employee_name})).appendTo(row);
+				</div></div>', {employee: m.employee +' : '+ m.employee_name})).appendTo(row);
 		});
 
 		mark_employee_toolbar.appendTo($(this.wrapper));


### PR DESCRIPTION
With large number of employees, it is difficult to identify with just their name.

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/188409194-c8ba59b1-5c9f-4ef4-b7ef-bf7e3c39e794.png">
