### PR TITLE
fix: set Expense Claim Payable Account in Expense Claim

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -471,7 +471,7 @@ def get_advances(employee, advance_id=None):
 def get_expense_claim(
 	employee_name, company, employee_advance_name, posting_date, paid_amount, claimed_amount
 ):
-	default_payable_account = frappe.get_cached_value("Company", company, "default_payable_account")
+	default_payable_account = frappe.get_cached_value("Company", company, "default_expense_claim_payable_account")
 	default_cost_center = frappe.get_cached_value("Company", company, "cost_center")
 
 	expense_claim = frappe.new_doc("Expense Claim")

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -471,7 +471,9 @@ def get_advances(employee, advance_id=None):
 def get_expense_claim(
 	employee_name, company, employee_advance_name, posting_date, paid_amount, claimed_amount
 ):
-	default_payable_account = frappe.get_cached_value("Company", company, "default_expense_claim_payable_account")
+	default_payable_account = frappe.get_cached_value(
+		"Company", company, "default_expense_claim_payable_account"
+	)
 	default_cost_center = frappe.get_cached_value("Company", company, "cost_center")
 
 	expense_claim = frappe.new_doc("Expense Claim")


### PR DESCRIPTION
When making an Expense Claim from Employee Advance, field Payable Account is still taken from the Company - Default Payable Account, while if you make a new Expense Claim field Payable Account is filled from Company - Default Expense Claim Payable Account.