### PR TITLE
fix(Timesheet): only show create salary slip button to users who have perm

### DIFF
--- a/hrms/public/js/timesheet.js
+++ b/hrms/public/js/timesheet.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Timesheet", {
 	refresh(frm) {
-		if (frm.doc.docstatus == 1) {
+		if (frm.doc.docstatus === 1 && frappe.model.can_create("Salary Slip")) {
 			if (!frm.doc.salary_slip && frm.doc.employee) {
 				frm.add_custom_button(__("Create Salary Slip"), function() {
 					frm.trigger("make_salary_slip");


### PR DESCRIPTION
The "Create Salary Slip" button in Timesheet is visible to everyone, irrespective of their permission. Only show the button to users who have permission to create.