### PR TITLE
fix: Change Department fieldtype to Link in Leave Balance Report

### DIFF
--- a/hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -22,9 +22,9 @@ def execute(filters=None):
 
 def get_columns(leave_types):
 	columns = [
-		_("Employee") + ":Link.Employee:150",
+		_("Employee") + ":Link/Employee:150",
 		_("Employee Name") + "::200",
-		_("Department") + "::150",
+		_("Department") + ":Link/Department:150",
 	]
 
 	for leave_type in leave_types:


### PR DESCRIPTION
Version:

ERPNext: v14.1.2
Frappe Framework: v14.7.0
Payments: 0.0.1
HRMS: 0.0.1
___
Reference PR: https://github.com/frappe/erpnext/pull/32252
___

**Before:**
- When add column from the report then does not show link fields like employee and department.

**After:**
- After set the link field option, when add columns from the report then link fields will appear.

`_("Employee") + ":Link.Employee:150",` ---> `_("Employee") + ":Link/Employee:150",`
`_("Department") + "::150",` ---> `_("Department") + ":Link/Department:150",`


Thank You!