### PR TITLE
fix: Do not allow to update hidden and read_only fields in Employee Promotion

### DIFF
--- a/hrms/hr/employee_property_update.js
+++ b/hrms/hr/employee_property_update.js
@@ -58,7 +58,12 @@ frappe.ui.form.on(cur_frm.doctype, {
 				const field_label_map = {};
 				frappe.get_meta("Employee").fields.forEach(d => {
 					field_label_map[d.fieldname] = __(d.label) + ` (${d.fieldname})`;
-					if (!in_list(exclude_field_types, d.fieldtype) && !in_list(exclude_fields, d.fieldname) && !d.hidden && !d.read_only) {
+					if (
+						!in_list(exclude_field_types, d.fieldtype) 
+						&& !in_list(exclude_fields, d.fieldname) 
+						&& !d.hidden 
+						&& !d.read_only
+					) {
 						allowed_fields.push({
 							label: field_label_map[d.fieldname],
 							value: d.fieldname,

--- a/hrms/hr/employee_property_update.js
+++ b/hrms/hr/employee_property_update.js
@@ -59,9 +59,9 @@ frappe.ui.form.on(cur_frm.doctype, {
 				frappe.get_meta("Employee").fields.forEach(d => {
 					field_label_map[d.fieldname] = __(d.label) + ` (${d.fieldname})`;
 					if (
-						!in_list(exclude_field_types, d.fieldtype) 
-						&& !in_list(exclude_fields, d.fieldname) 
-						&& !d.hidden 
+						!in_list(exclude_field_types, d.fieldtype)
+						&& !in_list(exclude_fields, d.fieldname)
+						&& !d.hidden
 						&& !d.read_only
 					) {
 						allowed_fields.push({

--- a/hrms/hr/employee_property_update.js
+++ b/hrms/hr/employee_property_update.js
@@ -58,7 +58,7 @@ frappe.ui.form.on(cur_frm.doctype, {
 				const field_label_map = {};
 				frappe.get_meta("Employee").fields.forEach(d => {
 					field_label_map[d.fieldname] = __(d.label) + ` (${d.fieldname})`;
-					if (!in_list(exclude_field_types, d.fieldtype) && !in_list(exclude_fields, d.fieldname)) {
+					if (!in_list(exclude_field_types, d.fieldtype) && !in_list(exclude_fields, d.fieldname) && !d.hidden && !d.read_only) {
 						allowed_fields.push({
 							label: field_label_map[d.fieldname],
 							value: d.fieldname,


### PR DESCRIPTION
Currently the system allows to update `Hidden` and `Read Only` fields of `Employee` master using `Employee Promotion`. 