### PR TITLE
fix: mark attendance issue with joining and relieving date, and fix future attendance marking

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -350,10 +350,12 @@ def get_unmarked_days(employee, month, exclude_holidays=0):
 	start_day = 1
 	end_day = calendar.monthrange(today.year, month_map[month])[1] + 1
 
-	if joining_date and joining_date.month == month_map[month]:
+	if joining_date and joining_date.year == today.year and joining_date.month == month_map[month]:
 		start_day = joining_date.day
 
-	if relieving_date and relieving_date.month == month_map[month]:
+	if (
+		relieving_date and relieving_date.year == today.year and relieving_date.month == month_map[month]
+	):
 		end_day = relieving_date.day + 1
 
 	dates_of_month = [

--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -13,6 +13,8 @@ frappe.listview_settings['Attendance'] = {
 	onload: function(list_view) {
 		let me = this;
 		const months = moment.months();
+		const curMonth = moment().format("MMMM");
+		months.splice(months.indexOf(curMonth) + 1);
 		list_view.page.add_inner_button(__("Mark Attendance"), function() {
 			let dialog = new frappe.ui.Dialog({
 				title: __("Mark Attendance"),


### PR DESCRIPTION
### Steps to reproduce:

#### Issue 1

https://github.com/frappe/hrms/issues/72

#### Issue 2

1. Go to /app/attendance.
2. Click the `mark attendance` button.

You'll find that even months in the future are present, which shouldn't be the case. 

--

Now users won't face the mark attendance issue related to joining and relieving date (fixes #72), and they won't be able to see future months in the mark attendance months list.