### PR TITLE
refactor: remove client side code for current datetime

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -2,9 +2,7 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Employee Checkin', {
-	setup: (frm) => {
-		if(!frm.doc.time) {
-			frm.set_value("time", frappe.datetime.now_datetime());
-		}
-	}
+	// setup: (frm) => {
+
+	// }
 });


### PR DESCRIPTION
This doesn't change anything.  Just removes client-side code. DocField option already sets this. 


https://github.com/frappe/hrms/blob/57c3dbd16c6f158b8964154033947301c0b662f7/hrms/hr/doctype/employee_checkin/employee_checkin.json#L57-L65