### PR TITLE
fix: Validation for total amount reimbursed

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -341,6 +341,10 @@ class ExpenseClaim(AccountsController):
 
 def update_reimbursed_amount(doc, amount):
 	doc.total_amount_reimbursed += amount
+	
+	if doc.total_amount_reimbursed > doc.total_sanctioned_amount:
+		frappe.throw(_("Total Reimbursed Amount cannot be greater than Total Sanctioned Amount"))
+
 	frappe.db.set_value(
 		"Expense Claim", doc.name, "total_amount_reimbursed", doc.total_amount_reimbursed
 	)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -342,7 +342,7 @@ class ExpenseClaim(AccountsController):
 def update_reimbursed_amount(doc, amount):
 	doc.total_amount_reimbursed += amount
 	
-	if doc.total_amount_reimbursed > doc.total_sanctioned_amount:
+	if flt(doc.total_amount_reimbursed) > flt(doc.total_sanctioned_amount):
 		frappe.throw(_("Total Reimbursed Amount cannot be greater than Total Sanctioned Amount"))
 
 	frappe.db.set_value(


### PR DESCRIPTION
<img width="1319" alt="Screenshot 2022-10-13 at 5 17 13 PM" src="https://user-images.githubusercontent.com/42651287/195588205-a15aa983-0082-49b0-a7c2-d8554c89f32a.png">

For reasons unknown yet the total reimbursed amount is getting updated more as the total sanctioned amount, adding a validation to avoid this