### PR TITLE
fix: Expense claim status not updating on reconciling using payment reco tool

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -139,7 +139,7 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 		"on_cancel": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
-		"on_update_after_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim"
+		"on_update_after_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 	},
 	"Journal Entry": {
 		"validate": "hrms.hr.doctype.expense_claim.expense_claim.validate_expense_claim_in_jv",

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -139,6 +139,7 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 		"on_cancel": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
+		"on_update_after_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim"
 	},
 	"Journal Entry": {
 		"validate": "hrms.hr.doctype.expense_claim.expense_claim.validate_expense_claim_in_jv",
@@ -146,6 +147,7 @@ doc_events = {
 			"hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 			"hrms.hr.doctype.full_and_final_statement.full_and_final_statement.update_full_and_final_statement_status",
 		],
+		"on_update_after_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 		"on_cancel": [
 			"hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 			"hrms.payroll.doctype.salary_slip.salary_slip.unlink_ref_doc_from_salary_slip",


### PR DESCRIPTION
<img width="1319" alt="Screenshot 2022-10-13 at 5 17 13 PM" src="https://user-images.githubusercontent.com/42651287/195588205-a15aa983-0082-49b0-a7c2-d8554c89f32a.png">

The total reimbursed amount gets to a value more than the actual amount, this happens in a very specific scenario when payment is done through a single journal entry for multiple employees, and the reconciliation is done using the Payment Reconciliation tool one employee at a time, the reimbursed amount was updated every time for all Expense Claims even if one employee record were reconciled

The issue was not happening currently because the trigger post submit (when the allocation was done using reconcilition tool) was itself broken, fixed that by adding hook methods