### PR TITLE
fix: use `add_docshare` instead of `add` for doc sharing

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -571,7 +571,9 @@ def get_previous_claimed_amount(employee, payroll_period, non_pro_rata=False, co
 def share_doc_with_approver(doc, user):
 	# if approver does not have permissions, share
 	if not frappe.has_permission(doc=doc, ptype="submit", user=user):
-		frappe.share.add(doc.doctype, doc.name, user, submit=1, flags={"ignore_share_permission": True})
+		frappe.share.add_docshare(
+			doc.doctype, doc.name, user, submit=1, flags={"ignore_share_permission": True}
+		)
 
 		frappe.msgprint(
 			_("Shared with the user {0} with {1} access").format(user, frappe.bold("submit"), alert=True)


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/18416 `frappe.share.add` doesn't accept flags anymore. Use `frappe.share.add_docshare` instead

<img width="916" alt="image" src="https://user-images.githubusercontent.com/24353136/198816510-1d235ee5-a550-41cb-b7be-ff6c93acc3e0.png">
