### PR TITLE
fix(test): set repayment schedule type in loan tests

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -253,6 +253,7 @@ class TestPayrollEntry(FrappeTestCase):
 				loan_account="Loan Account - _TC",
 				interest_income_account="Interest Income Account - _TC",
 				penalty_income_account="Penalty Income Account - _TC",
+				repayment_schedule_type="Monthly as per repayment start date",
 			)
 
 		loan = create_loan(

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -614,6 +614,7 @@ class TestSalarySlip(FrappeTestCase):
 			loan_account="Loan Account - _TC",
 			interest_income_account="Interest Income Account - _TC",
 			penalty_income_account="Penalty Income Account - _TC",
+			repayment_schedule_type="Monthly as per repayment start date",
 		)
 
 		payroll_period = create_payroll_period(name="_Test Payroll Period 1", company="_Test Company")


### PR DESCRIPTION
After https://github.com/frappe/erpnext/pull/32424 loan tests for payroll started failing because `repayment_schedule_type` was not set in Loan Type. 

<img width="944" alt="image" src="https://user-images.githubusercontent.com/24353136/199410794-88979136-be63-4226-b15f-304dc1b8420c.png">

Set repayment schedule type in loan tests to fix this.