### PR TITLE
feat: provision to setup opening entries for salary paid till date and tax deducted till date

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1069,13 +1069,13 @@ class SalarySlip(TransactionBase):
 			)
 			exempted_amount = flt(exempted_amount[0][0]) if exempted_amount else 0
 
-		opening_taxable_earning = self.get_opening_taxable_earnings_or_paid_tax(
+		opening_taxable_earning = self.get_opening_for(
 			"taxable_earnings_till_date", start_date, end_date
 		)
 
 		return (taxable_earnings + opening_taxable_earning) - exempted_amount
 
-	def get_opening_taxable_earnings_or_paid_tax(self, field_to_select, start_date, end_date):
+	def get_opening_for(self, field_to_select, start_date, end_date):
 		return (
 			frappe.db.get_value(
 				"Salary Structure Assignment",
@@ -1117,9 +1117,7 @@ class SalarySlip(TransactionBase):
 			)[0][0]
 		)
 
-		tax_deducted_till_date = self.get_opening_taxable_earnings_or_paid_tax(
-			"tax_deducted_till_date", start_date, end_date
-		)
+		tax_deducted_till_date = self.get_opening_for("tax_deducted_till_date", start_date, end_date)
 
 		return total_tax_paid + tax_deducted_till_date
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1069,7 +1069,7 @@ class SalarySlip(TransactionBase):
 			)
 			exempted_amount = flt(exempted_amount[0][0]) if exempted_amount else 0
 
-		opening_taxable_earning = self.get_opening_taxable_earnings(
+		opening_taxable_earning = self.get_opening_taxable_earnings_or_paid_tax(
 			"salary_paid_till_date", start_date, end_date
 		)
 
@@ -1082,6 +1082,7 @@ class SalarySlip(TransactionBase):
 				"employee": self.employee,
 				"salary_structure": self.salary_structure,
 				"from_date": ["between", start_date, end_date],
+				"docstatus": 1,
 			},
 			field_to_select,
 		)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1081,7 +1081,7 @@ class SalarySlip(TransactionBase):
 			{
 				"employee": self.employee,
 				"salary_structure": self.salary_structure,
-				"from_date": ["between", start_date, end_date],
+				"from_date": ["between", [start_date, end_date]],
 				"docstatus": 1,
 			},
 			field_to_select,

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -18,6 +18,7 @@ from frappe.utils import (
 	get_last_day,
 	getdate,
 	nowdate,
+	rounded,
 )
 from frappe.utils.make_random import get_random
 
@@ -1076,6 +1077,103 @@ class TestSalarySlip(FrappeTestCase):
 		activity_type.costing_rate = 20
 		activity_type.wage_rate = 25
 		activity_type.save()
+
+	def test_salary_slip_generation_against_opening_entries_in_ssa(self):
+		import math
+
+		from hrms.payroll.doctype.payroll_period.payroll_period import get_period_factor
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+		from hrms.payroll.report.income_tax_computation.income_tax_computation import (
+			IncomeTaxComputationReport,
+		)
+
+		payroll_period = create_payroll_period(
+			name="_Test Payroll Period for Tax",
+			company="_Test Company",
+			start_date="2022-04-01",
+			end_date="2023-03-31",
+		)
+
+		emp = make_employee(
+			"test_employee_ss_with_opening_balance@salary.com",
+			company="_Test Company",
+			**{"date_of_joining": "2021-12-01"},
+		)
+		employee_doc = frappe.get_doc("Employee", emp)
+
+		create_tax_slab(payroll_period, allow_tax_exemption=True)
+
+		salary_structure_name = "Test Salary Structure for Opening Balance"
+		if not frappe.db.exists("Salary Structure", salary_structure_name):
+			salary_structure_doc = make_salary_structure(
+				salary_structure_name,
+				"Monthly",
+				company="_Test Company",
+				employee=emp,
+				from_date="2022-04-01",
+				payroll_period=payroll_period,
+				test_tax=True,
+			)
+
+		# validate no salary slip exists for the employee
+		self.assertTrue(
+			frappe.db.count(
+				"Salary Slip",
+				{
+					"employee": emp,
+					"salary_structure": salary_structure_doc.name,
+					"docstatus": 1,
+					"start_date": [">=", "2022-04-01"],
+				},
+			)
+			== 0
+		)
+
+		remaining_sub_periods = get_period_factor(
+			emp,
+			get_first_day("2022-10-01"),
+			get_last_day("2022-10-01"),
+			"Monthly",
+			payroll_period,
+			depends_on_payment_days=0,
+		)[1]
+
+		prev_period = math.ceil(remaining_sub_periods)
+
+		# Set annual and monthly tax amount and earnings
+		# col, data = IncomeTaxComputationReport(
+		# 	{
+		# 		"company": "_Test Company",
+		# 		"payroll_period": payroll_period.name,
+		# 		"employee": employee_doc.name
+		# 	}
+		# ).run()
+
+		annual_tax = 93036  # 89220 #data[0].get('applicable_tax')
+		monthly_tax_amount = 7732.40  # 7435 #annual_tax/12
+		annual_earnings = 933600  # data[0].get('ctc')
+		monthly_earnings = 77800  # annual_earnings/12
+
+		# Get Salary Structure Assignment
+		ssa = frappe.get_value(
+			"Salary Structure Assignment",
+			{"employee": emp, "salary_structure": salary_structure_doc.name},
+			"name",
+		)
+		ssa_doc = frappe.get_doc("Salary Structure Assignment", ssa)
+
+		# Set opening balance for earning and tax deduction in Salary Structure Assignment
+		ssa_doc.taxable_earnings_till_date = monthly_earnings * prev_period
+		ssa_doc.tax_deducted_till_date = monthly_tax_amount * prev_period
+		ssa_doc.save()
+
+		# Create Salary Slip
+		salary_slip = make_salary_slip(
+			salary_structure_doc.name, employee=employee_doc.name, posting_date=getdate("2022-10-01")
+		)
+		for deduction in salary_slip.deductions:
+			if deduction.salary_component == "TDS":
+				self.assertEqual(deduction.amount, rounded(monthly_tax_amount))
 
 
 def get_no_of_days():

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1087,12 +1087,25 @@ class TestSalarySlip(FrappeTestCase):
 			IncomeTaxComputationReport,
 		)
 
-		payroll_period = create_payroll_period(
-			name="_Test Payroll Period for Tax",
-			company="_Test Company",
-			start_date="2022-04-01",
-			end_date="2023-03-31",
+		payroll_period = frappe.db.get_value(
+			"Payroll Period",
+			{
+				"company": "_Test Company",
+				"start_date": ["<=", "2023-03-31"],
+				"end_date": [">=", "2022-04-01"],
+			},
+			"name",
 		)
+
+		if not payroll_period:
+			payroll_period = create_payroll_period(
+				name="_Test Payroll Period for Tax",
+				company="_Test Company",
+				start_date="2022-04-01",
+				end_date="2023-03-31",
+			)
+		else:
+			payroll_period = frappe.get_cached_doc("Payroll Period", payroll_period)
 
 		emp = make_employee(
 			"test_employee_ss_with_opening_balance@salary.com",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -51,15 +51,16 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		});
 	},
 
+	refresh: function(frm) {
+		if(frm.doc.__onload && frm.doc.__onload.unhide_earnings_and_taxation_section){
+			frm.unhide_earnings_and_taxation_section = frm.doc.__onload.unhide_earnings_and_taxation_section;
+			frm.trigger("set_earnings_and_taxation_section_visibility");
+		}
+	},
+
 	employee: function(frm) {
 		if (frm.doc.employee) {
-			frappe.call({
-				method: "set_payroll_cost_centers",
-				doc: frm.doc,
-				callback: function(data) {
-					refresh_field("payroll_cost_centers");
-				}
-			});
+			frm.trigger("set_employee_dependent_properties");
 		}
 		else {
 			frm.set_value("payroll_cost_centers", []);
@@ -72,5 +73,32 @@ frappe.ui.form.on('Salary Structure Assignment', {
 				frm.set_value("payroll_payable_account", r.default_payroll_payable_account);
 			});
 		}
-	}
+	},
+
+	set_employee_dependent_properties: function(frm) {
+		frappe.call({
+			method: "set_employee_dependent_properties",
+			doc: frm.doc,
+			callback: function(data) {
+				frm.unhide_earnings_and_taxation_section = data.message.unhide_earnings_and_taxation_section;
+				frm.trigger("set_earnings_and_taxation_section_visibility");
+				refresh_field("payroll_cost_centers");
+			}
+		});
+	},
+
+	set_earnings_and_taxation_section_visibility: function(frm) {
+		if(frm.unhide_earnings_and_taxation_section){
+			frm.set_df_property('earnings_and_taxation_section', 'hidden', 0);
+		}
+		else{
+			frm.set_df_property('earnings_and_taxation_section', 'hidden', 1);
+		}
+	},
+
+	from_date: function(frm) {
+		if (frm.doc.from_date) {
+			frm.trigger("set_employee_dependent_properties" );
+		}
+	},
 });

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -52,15 +52,16 @@ frappe.ui.form.on('Salary Structure Assignment', {
 	},
 
 	refresh: function(frm) {
-		if(frm.doc.__onload && frm.doc.__onload.unhide_earnings_and_taxation_section){
-			frm.unhide_earnings_and_taxation_section = frm.doc.__onload.unhide_earnings_and_taxation_section;
+		if(frm.doc.__onload){
+			frm.unhide_earnings_and_taxation_section = !frm.doc.__onload.earning_and_deduction_entries_exists;
 			frm.trigger("set_earnings_and_taxation_section_visibility");
 		}
 	},
 
 	employee: function(frm) {
 		if (frm.doc.employee) {
-			frm.trigger("set_employee_dependent_properties");
+			frm.trigger("set_payroll_cost_centers");
+			frm.trigger("valiadte_joining_date_and_salary_slips");
 		}
 		else {
 			frm.set_value("payroll_cost_centers", []);
@@ -75,14 +76,26 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		}
 	},
 
-	set_employee_dependent_properties: function(frm) {
+	set_payroll_cost_centers: function(frm) {
+		if (frm.doc.payroll_cost_centers.length < 1) {
+			frappe.call({
+				method: "set_payroll_cost_centers",
+				doc: frm.doc,
+				callback: function(data) {
+					refresh_field("payroll_cost_centers");
+				}
+			})
+		}
+	},
+
+	valiadte_joining_date_and_salary_slips: function(frm) {
 		frappe.call({
-			method: "set_employee_dependent_properties",
+			method: "earning_and_deduction_entries_exists",
 			doc: frm.doc,
 			callback: function(data) {
-				frm.unhide_earnings_and_taxation_section = data.message.unhide_earnings_and_taxation_section;
+				let earning_and_deduction_entries_exists = data.message;
+				frm.unhide_earnings_and_taxation_section = ! earning_and_deduction_entries_exists;
 				frm.trigger("set_earnings_and_taxation_section_visibility");
-				refresh_field("payroll_cost_centers");
 			}
 		});
 	},
@@ -98,7 +111,7 @@ frappe.ui.form.on('Salary Structure Assignment', {
 
 	from_date: function(frm) {
 		if (frm.doc.from_date) {
-			frm.trigger("set_employee_dependent_properties" );
+			frm.trigger("valiadte_joining_date_and_salary_slips" );
 		}
 	},
 });

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -25,7 +25,7 @@
   "variable",
   "amended_from",
   "earnings_and_taxation_section",
-  "salary_paid_till_date",
+  "taxable_earnings_till_date",
   "column_break_20",
   "tax_deducted_till_date",
   "section_break_17",
@@ -178,13 +178,6 @@
   },
   {
    "allow_on_submit": 1,
-   "fieldname": "salary_paid_till_date",
-   "fieldtype": "Currency",
-   "label": "Salary Paid Till Date",
-   "options": "currency"
-  },
-  {
-   "allow_on_submit": 1,
    "fieldname": "tax_deducted_till_date",
    "fieldtype": "Currency",
    "label": "Tax Deducted Till Date",
@@ -195,16 +188,23 @@
    "fieldtype": "Column Break"
   },
   {
-   "collapsible_depends_on": "eval:doc.salary_paid_till_date && doc.tax_deducted_till_date",
+   "collapsible_depends_on": "eval:doc.taxable_earnings_till_date && doc.tax_deducted_till_date",
    "fieldname": "earnings_and_taxation_section",
    "fieldtype": "Section Break",
    "hidden": 1,
    "label": "Earnings and Taxation "
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "taxable_earnings_till_date",
+   "fieldtype": "Currency",
+   "label": "Taxable Earnings Till Date",
+   "options": "currency"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-23 12:33:45.955520",
+ "modified": "2022-11-24 11:43:57.942233",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -24,6 +24,10 @@
   "column_break_9",
   "variable",
   "amended_from",
+  "earnings_and_taxation_section",
+  "salary_paid_till_date",
+  "column_break_20",
+  "tax_deducted_till_date",
   "section_break_17",
   "payroll_cost_centers"
  ],
@@ -171,11 +175,36 @@
    "label": "Grade",
    "options": "Employee Grade",
    "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "salary_paid_till_date",
+   "fieldtype": "Currency",
+   "label": "Salary Paid Till Date",
+   "options": "currency"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "tax_deducted_till_date",
+   "fieldtype": "Currency",
+   "label": "Tax Deducted Till Date",
+   "options": "currency"
+  },
+  {
+   "fieldname": "column_break_20",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible_depends_on": "eval:doc.salary_paid_till_date && doc.tax_deducted_till_date",
+   "fieldname": "earnings_and_taxation_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Earnings and Taxation "
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-06 12:18:36.972336",
+ "modified": "2022-11-23 12:33:45.955520",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -31,7 +31,7 @@ class SalaryStructureAssignment(Document):
 					_(
 						"""
 						Not found any salary slip record(s) for the employee {0}. <br><br>
-						Please specify opening balances for <b>Taxable Earnings Till Date</b> and total <b>Tax Deducted Till Date</b>,
+						Please specify opening balances for <b>Taxable Earnings Till Date</b> and <b>Tax Deducted Till Date</b> (if any),
 						under <b>Earnings and Taxation</b> sections, for the correct tax calculation in future salary slips.
 						"""
 					).format(self.employee),
@@ -131,7 +131,7 @@ class SalaryStructureAssignment(Document):
 
 	@frappe.whitelist()
 	def set_earnings_and_taxation_section(self):
-		if self.has_joined_in_same_month() or self.has_salary_slip():
+		if not self.has_joined_in_same_month() or self.has_salary_slip():
 			return {
 				"unhide_earnings_and_taxation_section": 0,
 			}

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -26,11 +26,18 @@ class SalaryStructureAssignment(Document):
 		self.set_payroll_payable_account()
 
 		if self.set_earnings_and_taxation_section().get("unhide_earnings_and_taxation_section"):
-			frappe.msgprint(
-				_(
-					"Please mension opening entries for taxable earnings till date and total tax deducted till date"
+			if not self.taxable_earnings_till_date and not self.tax_deducted_till_date:
+				frappe.msgprint(
+					_(
+						"""
+						Not found any salary slip record(s) for the employee {0}. <br><br>
+						Please specify opening balances for <b>Taxable Earnings Till Date</b> and total <b>Tax Deducted Till Date</b>,
+						under <b>Earnings and Taxation</b> sections, for the correct tax calculation in future salary slips.
+						"""
+					).format(self.employee),
+					indicator="orange",
+					title=_("Warning"),
 				)
-			)
 
 		if not self.get("payroll_cost_centers"):
 			self.set_payroll_cost_centers()

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -24,6 +24,14 @@ class SalaryStructureAssignment(Document):
 		self.validate_dates()
 		self.validate_income_tax_slab()
 		self.set_payroll_payable_account()
+
+		if self.set_earnings_and_taxation_section().get("unhide_earnings_and_taxation_section"):
+			frappe.msgprint(
+				_(
+					"Please mension opening entries for taxable earnings till date and total tax deducted till date"
+				)
+			)
+
 		if not self.get("payroll_cost_centers"):
 			self.set_payroll_cost_centers()
 


### PR DESCRIPTION
### Scenario: 
<img width="664" alt="Screenshot 2022-11-23 at 6 08 19 PM" src="https://user-images.githubusercontent.com/3784093/203548892-224026c3-7ed4-45cb-969c-486a7207e076.png">

There is no salary slip record in Frappe HRMS for the period of July to November. Now from November user wants to maintain salary slips in Frappe HRMS. But in Frappe HRMS, there is no provision to set up the salary paid to date and tax deducted it.  

### Solution

Provision to set up opening balances for Salary paid to date and tax deducted to date.

<img width="1318" alt="Screenshot 2022-11-23 at 6 04 22 PM" src="https://user-images.githubusercontent.com/3784093/203548209-e415266d-b1c7-432c-9a8d-da83ab3b773d.png">

Warning message
<img width="652" alt="Screenshot 2022-11-28 at 1 36 47 PM" src="https://user-images.githubusercontent.com/3784093/204225738-63439de6-3bad-4250-ab5d-d387c6197e50.png">

