### PR TITLE
Fix bugs monthly attendance sheet

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -492,13 +492,14 @@ def get_attendance_status_for_detailed_view(
 
 def get_holiday_status(day: int, holidays: List) -> str:
 	status = None
-	for holiday in holidays:
-		if day == holiday.get("day_of_month"):
-			if holiday.get("weekly_off"):
-				status = "Weekly Off"
-			else:
-				status = "Holiday"
-			break
+	if holidays:
+		for holiday in holidays:
+			if day == holiday.get("day_of_month"):
+				if holiday.get("weekly_off"):
+					status = "Weekly Off"
+				else:
+					status = "Holiday"
+				break
 	return status
 
 

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -572,7 +572,7 @@ def get_attendance_years() -> str:
 	if year_list:
 		year_list.sort(key=lambda d: d.year, reverse=True)
 	else:
-		year_list = [getdate().year]
+		year_list = [frappe._dict({"year": getdate().year})]
 
 	return "\n".join(cstr(entry.year) for entry in year_list)
 


### PR DESCRIPTION
fix: year_list when doesn't exist attendance records
This bug happens when we open the Report Monthly Attendance Sheet and doesn't exist Attendance records.
Fix AttributeError: 'int' object has no attribute 'year'
![error1](https://user-images.githubusercontent.com/101831262/204272347-e1cb8d1f-5941-48e8-b951-142b86c50b8b.png)
![error2](https://user-images.githubusercontent.com/101831262/204272528-54a3554e-c3fb-4669-8bfe-ac199840b5d4.png)


fix: get_holiday_status when holidays are None
This bug happens when we try to call the get_holiday_status method
with 'holidays' parameter equal None.
'holidays' is None because the company doesn't have a Default Holiday List defined and the employees don't have a Holiday List defined either.

Bug: TypeError: 'NoneType' object is not iterable
![error4](https://user-images.githubusercontent.com/101831262/204272938-a8011b8d-2e19-444a-b2a4-f67f4fd53b00.png)
