### PR TITLE
fix: Filter Employee doesn't work correctly in Report Monthly Attendance Sheet

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -176,9 +176,7 @@ def get_total_days_in_month(filters: Filters) -> int:
 
 
 def get_data(filters: Filters, attendance_map: Dict) -> List[Dict]:
-	employee_details, group_by_param_values = get_employee_related_details(
-		filters.group_by, filters.company
-	)
+	employee_details, group_by_param_values = get_employee_related_details(filters)
 	holiday_map = get_holiday_map(filters)
 	data = []
 
@@ -243,7 +241,7 @@ def get_attendance_map(filters: Filters) -> Dict:
 	return attendance_map
 
 
-def get_employee_related_details(group_by: str, company: str) -> Tuple[Dict, List]:
+def get_employee_related_details(filters: Filters) -> Tuple[Dict, List]:
 	"""Returns
 	1. nested dict for employee details
 	2. list of values for the group by filter
@@ -261,9 +259,13 @@ def get_employee_related_details(group_by: str, company: str) -> Tuple[Dict, Lis
 			Employee.company,
 			Employee.holiday_list,
 		)
-		.where(Employee.company == company)
+		.where(Employee.company == filters.company)
 	)
 
+	if filters.employee:
+		query = query.where(Employee.name == filters.employee)
+
+	group_by = filters.group_by
 	if group_by:
 		group_by = group_by.lower()
 		query = query.orderby(group_by)


### PR DESCRIPTION
Report Monthly Attendance Sheet
Filter Employee doesn't work properly when Summarized View is Checked.


![image](https://user-images.githubusercontent.com/101831262/204574381-224dc684-e9d9-4d9d-9f2b-2c6d0e2cd59d.png)
![image](https://user-images.githubusercontent.com/101831262/204574564-837d9f1a-3cf6-49e8-8935-744f5813c1b4.png)
![image](https://user-images.githubusercontent.com/101831262/204574716-4b7665d5-1de5-4ec2-bae2-bc6600ee81e0.png)
