### PR TITLE
feat: auto leave allocation

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -191,8 +191,14 @@ scheduler_events = {
 		"hrms.hr.utils.generate_leave_encashment",
 		"hrms.hr.utils.allocate_earned_leaves",
 	],
-	"weekly": ["hrms.controllers.employee_reminders.send_reminders_in_advance_weekly"],
-	"monthly": ["hrms.controllers.employee_reminders.send_reminders_in_advance_monthly"],
+	"weekly": [
+		"hrms.controllers.employee_reminders.send_reminders_in_advance_weekly",
+		"hrms.hr.doctype.auto_leave_allocation.auto_leave_allocation.process_weekly_auto_leave_allocation",
+	],
+	"monthly": [
+		"hrms.controllers.employee_reminders.send_reminders_in_advance_monthly",
+		"hrms.hr.doctype.auto_leave_allocation.auto_leave_allocation.process_monthly_auto_leave_allocation",
+	],
 }
 
 advance_payment_doctypes = ["Gratuity", "Employee Advance"]

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
@@ -9,14 +9,20 @@ frappe.ui.form.on('Auto Leave Allocation', {
 		frm.trigger("render_filters_table");
 		if (frm.doc.docstatus === 1 && frm.doc.start_date <= frappe.datetime.get_today()) {
 			frm.add_custom_button(__("Allocate"), function () {
-				frm.call('run_allocation').then(r => {
-					if (r.message) {
-						frappe.show_alert({
-							message: __('Executed allocation. Check error log for any issue(s).'),
-							indicator: 'green'
-						}, 5);
-					}
-				});
+				frappe.confirm(__('Are you sure you want to proceed? This might cause duplicate entries.'),
+					() => {
+						// action to perform if Yes is selected
+						frm.call('run_allocation').then(r => {
+							if (r.message) {
+								frappe.show_alert({
+									message: __('Executed allocation. Check error log for any issue(s).'),
+									indicator: 'green'
+								}, 5);
+							}
+						});
+					}, () => {
+						// action to perform if No is selected
+					})
 			});
 		}
 	},

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Auto Leave Allocation', {
+	setup: function(frm) {
+		frappe.model.with_doctype("Employee");
+	},
+	refresh: function(frm) {
+		frm.trigger("render_filters_table");
+		if (frm.doc.docstatus === 1) {
+			frm.add_custom_button(__("Allocate"), function () {
+				frm.call('run_allocation')
+			});
+		}
+	},
+	render_filters_table: function (frm) {
+		let wrapper = $(frm.get_field("filters_json").wrapper).empty();
+		let table = $(`<table class="table table-bordered" style="cursor:pointer; margin:0px;">
+			<thead>
+				<tr>
+					<th>${__("Filter")}</th>
+					<th>${__("Condition")}</th>
+					<th>${__("Value")}</th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>`).appendTo(wrapper);
+		$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+
+		let filters = JSON.parse(frm.doc.filters_json || "[]");
+		var filters_set = false;
+
+		let fields = [
+			{
+				fieldtype: "HTML",
+				fieldname: "filter_area",
+			},
+		];
+
+		if (filters.length > 0) {
+			filters.forEach((filter) => {
+				const filter_row = $(`<tr>
+						<td>${filter[1]}</td>
+						<td>${filter[2] || ""}</td>
+						<td>${filter[3]}</td>
+					</tr>`);
+
+				table.find("tbody").append(filter_row);
+				filters_set = true;
+			});
+		}
+
+
+		if (!filters_set) {
+			const filter_row = $(`<tr><td colspan="3" class="text-muted text-center">
+				${__("Click to Set Filters")}</td></tr>`);
+			table.find("tbody").append(filter_row);
+		}
+
+		table.on("click", () => {
+			frm.doc.docstatus === 1 && frappe.throw(__("Cannot edit filters for submitted document."));
+
+			let dialog = new frappe.ui.Dialog({
+				title: __("Set Filters"),
+				fields: fields,
+				primary_action: function () {
+					let values = this.get_values();
+					if (values) {
+						this.hide();
+						let filters = frm.filter_group.get_filters();
+						frm.set_value("filters_json", JSON.stringify(filters));
+						frm.trigger("render_filters_table");
+					}
+				},
+				primary_action_label: "Set",
+			});
+			frappe.dashboards.filters_dialog = dialog;
+
+			frm.filter_group = new frappe.ui.FilterGroup({
+				parent: dialog.get_field("filter_area").$wrapper,
+				doctype: "Employee",
+				on_change: () => { },
+			});
+
+			frm.filter_group.add_filters_to_filter_group(filters);
+			dialog.show();
+			dialog.set_values(filters);
+		});
+	},
+});

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.js
@@ -7,9 +7,16 @@ frappe.ui.form.on('Auto Leave Allocation', {
 	},
 	refresh: function(frm) {
 		frm.trigger("render_filters_table");
-		if (frm.doc.docstatus === 1) {
+		if (frm.doc.docstatus === 1 && frm.doc.start_date <= frappe.datetime.get_today()) {
 			frm.add_custom_button(__("Allocate"), function () {
-				frm.call('run_allocation')
+				frm.call('run_allocation').then(r => {
+					if (r.message) {
+						frappe.show_alert({
+							message: __('Executed allocation. Check error log for any issue(s).'),
+							indicator: 'green'
+						}, 5);
+					}
+				});
 			});
 		}
 	},

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.json
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.json
@@ -1,0 +1,146 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2022-12-02 13:14:12.734478",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "frequency",
+  "amended_from",
+  "column_break_4",
+  "start_date",
+  "end_date",
+  "section_break_6",
+  "leave_type",
+  "new_allocation",
+  "carry_forward",
+  "column_break_8",
+  "filters_json"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Series",
+   "options": "HR-ALA-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Start Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "frequency",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Frequency",
+   "options": "Monthly\nWeekly",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "End Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_6",
+   "fieldtype": "Section Break",
+   "label": "Allocation"
+  },
+  {
+   "fieldname": "column_break_8",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "leave_type",
+   "fieldtype": "Link",
+   "label": "Leave Type",
+   "options": "Leave Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "new_allocation",
+   "fieldtype": "Float",
+   "label": "New Allocation",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Auto Leave Allocation",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "carry_forward",
+   "fieldtype": "Check",
+   "label": "Add unused leaves from previous allocations"
+  },
+  {
+   "fieldname": "filters_json",
+   "fieldtype": "Code",
+   "label": "Condition",
+   "options": "JSON"
+  }
+ ],
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2022-12-02 15:42:35.099849",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Auto Leave Allocation",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -62,6 +62,7 @@ class AutoLeaveAllocation(Document):
 		to_date = min(to_date, getdate(self.end_date))
 		conditions = json.loads(self.filters_json) or []
 		conditions.append(["Employee", "status", "=", "Active"])
+		conditions.append(["Employee", "date_of_joining", "<=", from_date])
 		employees = frappe.db.get_all("Employee", filters=conditions, pluck="name")
 		for emp in employees:
 			try:

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -21,8 +21,7 @@ class AutoLeaveAllocation(Document):
 			self.filters_json = "[]"
 
 	def on_submit(self):
-		# self.run_allocation()
-		return
+		self.run_allocation()
 
 	def validate_dates(self):
 		if self.start_date >= self.end_date:
@@ -83,7 +82,7 @@ class AutoLeaveAllocation(Document):
 		self.start_date = getdate(self.start_date)
 		self.end_date = getdate(self.end_date)
 		if self.start_date > getdate():
-			return
+			return False
 
 		to_date = min(getdate(), self.end_date)
 		from_date = self.start_date

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import add_to_date, get_last_day, get_last_day_of_week, getdate
+
+
+class OverlapError(frappe.ValidationError):
+	pass
+
+
+class AutoLeaveAllocation(Document):
+	def validate(self):
+		self.validate_dates()
+		self.validate_overlap()
+		if not self.filters_json:
+			self.filters_json = "[]"
+
+	def on_submit(self):
+		# self.run_allocation()
+		return
+
+	def validate_dates(self):
+		if self.start_date >= self.end_date:
+			frappe.throw(_("End date should be greater than start date."))
+
+	def validate_overlap(self):
+		db_ala = frappe.qb.DocType("Auto Leave Allocation")
+		query = (
+			frappe.qb.from_(db_ala)
+			.select(db_ala.name)
+			.where(db_ala.docstatus != 2)
+			.where(db_ala.leave_type == self.leave_type)
+			.where(
+				((db_ala.start_date >= self.start_date) & (db_ala.start_date <= self.end_date))
+				| ((db_ala.end_date >= self.start_date) & (db_ala.end_date <= self.end_date))
+				| ((db_ala.start_date <= self.start_date) & (db_ala.end_date >= self.end_date))
+			)
+		)
+		if self.name:
+			query = query.where(db_ala.name != self.name)
+
+		overlapping_entries = query.run(pluck=True)
+		if overlapping_entries:
+			frappe.throw(
+				_("The following entries overlaps with this document: {}").format(
+					", ".join(overlapping_entries)
+				),
+				OverlapError,
+			)
+
+	def allocate_leave(self, from_date):
+		to_date = (
+			get_last_day(from_date) if self.frequency == "Monthly" else get_last_day_of_week(from_date)
+		)
+		conditions = json.loads(self.filters_json) or []
+		conditions.append(["Employee", "status", "=", "Active"])
+		employees = frappe.db.get_all("Employee", filters=conditions, pluck="name")
+		for emp in employees:
+			try:
+				frappe.get_doc(
+					{
+						"doctype": "Leave Allocation",
+						"employee": emp,
+						"leave_type": self.leave_type,
+						"from_date": from_date,
+						"to_date": to_date,
+						"new_leaves_allocated": self.new_allocation,
+						"carry_forward": self.carry_forward,
+					}
+				).submit()
+			except Exception as e:
+				frappe.log_error(title=f"Could not auto allocate leave for {emp}", message=str(e))
+				continue
+
+	@frappe.whitelist()
+	def run_allocation(self):
+		self.start_date = getdate(self.start_date)
+		self.end_date = getdate(self.end_date)
+		if self.start_date > getdate():
+			return
+
+		to_date = min(getdate(), self.end_date)
+		from_date = self.start_date
+		last_day = get_last_day if self.frequency == "Monthly" else get_last_day_of_week
+
+		while from_date <= to_date:
+			self.allocate_leave(from_date=from_date)
+			from_date = last_day(from_date)
+			from_date = add_to_date(from_date, days=1)
+
+		return True
+
+
+def process_auto_leave_allocation(frequency):
+	today = getdate()
+	db_ala = frappe.qb.DocType("Auto Leave Allocation")
+	active_ala = (
+		frappe.qb.from_(db_ala)
+		.select(db_ala.name)
+		.where(db_ala.docstatus == 1)
+		.where(db_ala.frequency == frequency)
+		.where(db_ala.start_date <= today)
+		.where(db_ala.end_date >= today)
+		.run(pluck=True)
+	)
+	frappe.log_error(str(active_ala))
+	for ala in active_ala:
+		frappe.get_doc("Auto Leave Allocation", ala).allocate_leave(today)
+
+
+def process_weekly_auto_leave_allocation():
+	process_auto_leave_allocation("Weekly")
+
+
+def process_monthly_auto_leave_allocation():
+	process_auto_leave_allocation("Monthly")

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -79,13 +79,12 @@ class AutoLeaveAllocation(Document):
 
 	@frappe.whitelist()
 	def run_allocation(self):
-		self.start_date = getdate(self.start_date)
-		self.end_date = getdate(self.end_date)
-		if self.start_date > getdate():
+		from_date = getdate(self.start_date)
+		to_date = getdate(self.end_date)
+		if from_date > getdate():
 			return False
 
-		to_date = min(getdate(), self.end_date)
-		from_date = self.start_date
+		to_date = min(getdate(), to_date)
 		last_day = get_last_day if self.frequency == "Monthly" else get_last_day_of_week
 
 		while from_date <= to_date:

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -71,6 +71,7 @@ class AutoLeaveAllocation(Document):
 						"to_date": to_date,
 						"new_leaves_allocated": self.new_allocation,
 						"carry_forward": self.carry_forward,
+						"auto_leave_allocation": self.name,
 					}
 				).submit()
 			except Exception as e:

--- a/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/auto_leave_allocation.py
@@ -6,7 +6,9 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_to_date, get_last_day, get_last_day_of_week, getdate
+from frappe.utils import add_to_date, flt, formatdate, get_last_day, get_last_day_of_week, getdate
+
+from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import create_leave_ledger_entry
 
 
 class OverlapError(frappe.ValidationError):
@@ -34,6 +36,7 @@ class AutoLeaveAllocation(Document):
 			.select(db_ala.name)
 			.where(db_ala.docstatus != 2)
 			.where(db_ala.leave_type == self.leave_type)
+			.where(db_ala.filters_json == self.filters_json)
 			.where(
 				((db_ala.start_date >= self.start_date) & (db_ala.start_date <= self.end_date))
 				| ((db_ala.end_date >= self.start_date) & (db_ala.end_date <= self.end_date))
@@ -56,11 +59,19 @@ class AutoLeaveAllocation(Document):
 		to_date = (
 			get_last_day(from_date) if self.frequency == "Monthly" else get_last_day_of_week(from_date)
 		)
+		to_date = min(to_date, getdate(self.end_date))
 		conditions = json.loads(self.filters_json) or []
 		conditions.append(["Employee", "status", "=", "Active"])
 		employees = frappe.db.get_all("Employee", filters=conditions, pluck="name")
 		for emp in employees:
 			try:
+				# get_overlapping_entries only considers super-sets of the leave allocation it plans to create.
+				overlapping_entries = get_overlapping_entries(emp, self.leave_type, from_date, to_date)
+				if overlapping_entries:
+					update_overlapping_leave_allocation(
+						overlapping_entries[0][0], self.leave_type, self.new_allocation, from_date, to_date
+					)
+					continue
 				frappe.get_doc(
 					{
 						"doctype": "Leave Allocation",
@@ -73,8 +84,10 @@ class AutoLeaveAllocation(Document):
 						"auto_leave_allocation": self.name,
 					}
 				).submit()
-			except Exception as e:
-				frappe.log_error(title=f"Could not auto allocate leave for {emp}", message=str(e))
+			except Exception:
+				frappe.log_error(
+					title=f"Could not auto allocate leave for {emp}", message=str(frappe.get_traceback())
+				)
 				continue
 
 	@frappe.whitelist()
@@ -118,3 +131,47 @@ def process_weekly_auto_leave_allocation():
 
 def process_monthly_auto_leave_allocation():
 	process_auto_leave_allocation("Monthly")
+
+
+def update_overlapping_leave_allocation(allocation, leave_type, earned_leaves, from_date, to_date):
+	leave_type = frappe.get_cached_doc("Leave Type", leave_type)
+	allocation = frappe.get_doc("Leave Allocation", allocation)
+	new_allocation = flt(allocation.total_leaves_allocated) + flt(earned_leaves)
+
+	if new_allocation > leave_type.max_leaves_allowed and leave_type.max_leaves_allowed > 0:
+		new_allocation = leave_type.max_leaves_allowed
+
+	if new_allocation != allocation.total_leaves_allocated:
+		allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
+		args = dict(
+			leaves=earned_leaves,
+			from_date=from_date,
+			to_date=to_date,
+			is_carry_forward=0,
+		)
+		create_leave_ledger_entry(allocation, args)
+
+		if leave_type.based_on_date_of_joining:
+			text = _("allocated {0} leave(s) via scheduler on {1} based on the date of joining").format(
+				frappe.bold(earned_leaves), frappe.bold(formatdate(from_date))
+			)
+		else:
+			text = _("allocated {0} leave(s) via scheduler on {1}").format(
+				frappe.bold(earned_leaves), frappe.bold(formatdate(from_date))
+			)
+
+		allocation.add_comment(comment_type="Info", text=text)
+
+
+def get_overlapping_entries(employee, leave_type, from_date, to_date):
+	Allocation = frappe.qb.DocType("Leave Allocation")
+	return (
+		frappe.qb.from_(Allocation)
+		.select(Allocation.name)
+		.where(
+			(Allocation.employee == employee)
+			& (Allocation.leave_type == leave_type)
+			& (Allocation.docstatus == 1)
+			& ((Allocation.from_date <= from_date) & (Allocation.to_date >= to_date))
+		)
+	).run()

--- a/hrms/hr/doctype/auto_leave_allocation/test_auto_leave_allocation.py
+++ b/hrms/hr/doctype/auto_leave_allocation/test_auto_leave_allocation.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from hrms.hr.doctype.auto_leave_allocation.auto_leave_allocation import OverlapError
+
+test_records = frappe.get_test_records("Auto Leave Allocation")
+test_dependencies = ["Employee", "Leave Type"]
+
+
+class TestAutoLeaveAllocation(FrappeTestCase):
+	def setUp(self):
+		for dt in ["Auto Leave Allocation", "Leave Allocation"]:
+			frappe.db.delete(dt)
+
+		frappe.db.set_value("Leave Type", "Casual Leave", "max_leaves_allowed", 0)
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.db.rollback()
+		frappe.set_user("Administrator")
+
+	def test_leave_allocation(self):
+		ala_doc = frappe.copy_doc(test_records[1])
+		ala_doc.submit()
+
+		alloc_count = frappe.db.get_all(
+			"Leave Allocation",
+			filters={
+				"from_date": ["between", [ala_doc.start_date, ala_doc.end_date]],
+				"leave_type": ala_doc.leave_type,
+			},
+			fields=["count(name) as count"],
+			group_by="employee",
+		)
+
+		for alloc in alloc_count:
+			self.assertEqual(alloc["count"], 14)
+
+	def test_overlap_error(self):
+		frappe.copy_doc(test_records[0]).insert()
+		ala_doc = frappe.copy_doc(test_records[0])
+
+		ala_doc.start_date = "2022-11-25"
+		ala_doc.end_date = "2022-12-05"
+		self.assertRaises(OverlapError, ala_doc.save)
+
+		ala_doc.start_date = "2022-12-05"
+		ala_doc.end_date = "2022-12-15"
+		self.assertRaises(OverlapError, ala_doc.save)
+
+		ala_doc.start_date = "2022-12-25"
+		ala_doc.end_date = "2023-01-15"
+		self.assertRaises(OverlapError, ala_doc.save)
+
+		ala_doc.start_date = "2023-01-05"
+		ala_doc.end_date = "2023-01-15"
+		ala_doc.save()
+
+	def test_start_end_dates(self):
+		ala_doc = frappe.copy_doc(test_records[0])
+
+		ala_doc.start_date = "2022-11-25"
+		ala_doc.end_date = "2021-12-05"
+		self.assertRaises(frappe.ValidationError, ala_doc.save)

--- a/hrms/hr/doctype/auto_leave_allocation/test_records.json
+++ b/hrms/hr/doctype/auto_leave_allocation/test_records.json
@@ -1,0 +1,24 @@
+[
+    {
+        "docstatus": 0,
+        "naming_series": "HR-ALA-.YYYY.-",
+        "start_date": "2022-12-01",
+        "end_date": "2022-12-31",
+        "frequency": "Monthly",
+        "leave_type": "Casual Leave",
+        "new_allocation": 1,
+        "carry_forward": 0,
+        "doctype": "Auto Leave Allocation"
+    },
+    {
+        "docstatus": 0,
+        "naming_series": "HR-ALA-.YYYY.-",
+        "start_date": "2022-09-01",
+        "end_date": "2022-11-30",
+        "frequency": "Weekly",
+        "leave_type": "Casual Leave",
+        "new_allocation": 1,
+        "carry_forward": 0,
+        "doctype": "Auto Leave Allocation"
+    }
+]

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -27,6 +27,7 @@
   "leave_period",
   "leave_policy",
   "leave_policy_assignment",
+  "auto_leave_allocation",
   "carry_forwarded_leaves_count",
   "expired",
   "amended_from",
@@ -230,6 +231,14 @@
    "options": "Company",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "auto_leave_allocation",
+   "fieldtype": "Link",
+   "label": "Auto Leave Allocation",
+   "no_copy": 1,
+   "options": "Auto Leave Allocation",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-ok",
@@ -237,7 +246,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-04-07 09:50:33.145825",
+ "modified": "2022-12-02 19:24:08.180094",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52111700/205317258-26e1a938-c345-4a45-8ebf-6e059f246d19.png)

Auto Leave Allocation helps users automatically allocate leaves to employees on monthly or weekly basis. Unlike earned leaves, which are allocated at the end of the month, these are allocated in the beginning itself.