### PR TITLE
fix: remove hard-coded roles for populating leave balance reports

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -111,34 +111,30 @@ def get_data(filters: Filters) -> List:
 				employee.leave_approver
 			)
 
-			if (
-				(leave_approvers and len(leave_approvers) and user in leave_approvers)
-				or (user in ["Administrator", employee.user_id])
-				or ("HR Manager" in frappe.get_roles(user))
-			):
-				if len(active_employees) > 1:
-					row = frappe._dict()
-				row.employee = employee.name
-				row.employee_name = employee.employee_name
+			if len(active_employees) > 1:
+				row = frappe._dict()
 
-				leaves_taken = (
-					get_leaves_for_period(employee.name, leave_type, filters.from_date, filters.to_date) * -1
-				)
+			row.employee = employee.name
+			row.employee_name = employee.employee_name
 
-				new_allocation, expired_leaves, carry_forwarded_leaves = get_allocated_and_expired_leaves(
-					filters.from_date, filters.to_date, employee.name, leave_type
-				)
-				opening = get_opening_balance(employee.name, leave_type, filters, carry_forwarded_leaves)
+			leaves_taken = (
+				get_leaves_for_period(employee.name, leave_type, filters.from_date, filters.to_date) * -1
+			)
 
-				row.leaves_allocated = new_allocation
-				row.leaves_expired = expired_leaves
-				row.opening_balance = opening
-				row.leaves_taken = leaves_taken
+			new_allocation, expired_leaves, carry_forwarded_leaves = get_allocated_and_expired_leaves(
+				filters.from_date, filters.to_date, employee.name, leave_type
+			)
+			opening = get_opening_balance(employee.name, leave_type, filters, carry_forwarded_leaves)
 
-				# not be shown on the basis of days left it create in user mind for carry_forward leave
-				row.closing_balance = new_allocation + opening - (row.leaves_expired + leaves_taken)
-				row.indent = 1
-				data.append(row)
+			row.leaves_allocated = new_allocation
+			row.leaves_expired = expired_leaves
+			row.opening_balance = opening
+			row.leaves_taken = leaves_taken
+
+			# not be shown on the basis of days left it create in user mind for carry_forward leave
+			row.closing_balance = new_allocation + opening - (row.leaves_expired + leaves_taken)
+			row.indent = 1
+			data.append(row)
 
 	return data
 

--- a/hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -65,21 +65,16 @@ def get_data(filters, leave_types):
 		if employee.leave_approver:
 			leave_approvers.append(employee.leave_approver)
 
-		if (
-			(len(leave_approvers) and user in leave_approvers)
-			or (user in ["Administrator", employee.user_id])
-			or ("HR Manager" in frappe.get_roles(user))
-		):
-			row = [employee.name, employee.employee_name, employee.department]
-			available_leave = get_leave_details(employee.name, filters.date)
-			for leave_type in leave_types:
-				remaining = 0
-				if leave_type in available_leave["leave_allocation"]:
-					# opening balance
-					remaining = available_leave["leave_allocation"][leave_type]["remaining_leaves"]
+		row = [employee.name, employee.employee_name, employee.department]
+		available_leave = get_leave_details(employee.name, filters.date)
+		for leave_type in leave_types:
+			remaining = 0
+			if leave_type in available_leave["leave_allocation"]:
+				# opening balance
+				remaining = available_leave["leave_allocation"][leave_type]["remaining_leaves"]
 
-				row += [remaining]
+			row += [remaining]
 
-			data.append(row)
+		data.append(row)
 
 	return data


### PR DESCRIPTION
## Before:

An employee with the "HR User" role is not able to see the leave balances of employees who report to them even if they have permission. 

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/24353136/210710338-49622fb6-6b37-42c7-9fb1-656f3a7116f8.png">

This is because the visibility for records in leave balance reports is hard-coded to HR Manager, Administrator, and leave approvers

## After:

Remove hard-coded roles for populating leave balance reports and respect permissions set up in the system

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/24353136/210710194-bac52cf3-5cd3-450a-bd1d-adb648b6551e.png">
