### PR TITLE
fix: ignore gl entry linking at the time of Payroll Entry cancellation

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -90,6 +90,8 @@ class PayrollEntry(Document):
 			)
 
 	def on_cancel(self):
+		self.ignore_linked_doctypes = "GL Entry"
+
 		frappe.delete_doc(
 			"Salary Slip",
 			frappe.db.sql_list(


### PR DESCRIPTION
![fbAHvyj](https://user-images.githubusercontent.com/3784093/212307832-618b2740-fd59-43b3-8800-431b13ca1aff.png)
