### PR TITLE
fix: move auto attendance for all shifts to hourly long queue

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -178,6 +178,8 @@ scheduler_events = {
 	],
 	"hourly": [
 		"hrms.hr.doctype.daily_work_summary_group.daily_work_summary_group.trigger_emails",
+	],
+	"hourly_long": [
 		"hrms.hr.doctype.shift_type.shift_type.process_auto_attendance_for_all_shifts",
 	],
 	"daily": [


### PR DESCRIPTION
process auto attendance for all shifts via hourly long queue since it goes through a lot of data and doctypes before generating anything conclusive