### PR TITLE
fix: remove customizations on app uninstallation and throw error if installation fails

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -77,7 +77,7 @@ jinja = {
 # ------------
 
 # before_install = "hrms.install.before_install"
-after_install = "hrms.setup.after_install"
+after_install = "hrms.install.after_install"
 after_migrate = "hrms.setup.update_select_perm_after_install"
 
 # Uninstallation

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -78,12 +78,12 @@ jinja = {
 
 # before_install = "hrms.install.before_install"
 after_install = "hrms.setup.after_install"
-after_migrate = ["hrms.setup.update_select_perm_after_install"]
+after_migrate = "hrms.setup.update_select_perm_after_install"
 
 # Uninstallation
 # ------------
 
-# before_uninstall = "hrms.uninstall.before_uninstall"
+before_uninstall = "hrms.uninstall.before_uninstall"
 # after_uninstall = "hrms.uninstall.after_uninstall"
 
 # Desk Notifications

--- a/hrms/install.py
+++ b/hrms/install.py
@@ -1,0 +1,21 @@
+import click
+
+from hrms.setup import after_install as setup
+
+
+def after_install():
+	try:
+		print("Setting up Frappe HR...")
+		setup()
+
+		click.secho("Thank you for installing Frappe HR!", fg="green")
+
+	except Exception as e:
+		BUG_REPORT_URL = "https://github.com/frappe/hrms/issues/new"
+		click.secho(
+			"Installation for Frappe HR app failed due to an error."
+			" Please try re-installing the app or"
+			f" report the issue on {BUG_REPORT_URL} if not resolved.",
+			fg="bright_red",
+		)
+		raise e

--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -17,6 +17,28 @@ def make_company_fixtures(doc, method=None):
 	make_salary_components(doc.country)
 
 
+def delete_company_fixtures():
+	countries = frappe.get_all(
+		"Company",
+		distinct="True",
+		pluck="country",
+	)
+
+	for country in countries:
+		try:
+			module_name = f"hrms.regional.{frappe.scrub(country)}.setup.uninstall"
+			frappe.get_attr(module_name)()
+		except ImportError:
+			pass
+		except Exception:
+			frappe.log_error("Unable to delete country fixtures for HRMS")
+			frappe.throw(
+				_("Failed to delete defaults for country {0}. Please contact support.").format(
+					frappe.bold(country)
+				)
+			)
+
+
 def run_regional_setup(country):
 	try:
 		module_name = f"hrms.regional.{frappe.scrub(country)}.setup.setup"

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -5,11 +5,18 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
+from hrms.setup import delete_custom_fields
+
 
 def setup():
 	make_custom_fields()
 	add_custom_roles_for_reports()
 	create_gratuity_rule_for_india()
+
+
+def uninstall():
+	custom_fields = get_custom_fields()
+	delete_custom_fields(custom_fields)
 
 
 def make_custom_fields(update=True):

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -21,7 +21,6 @@ def after_install():
 	update_erpnext_access()
 	frappe.db.commit()
 	run_post_install_patches()
-	click.secho("Thank you for installing Frappe HR!", fg="green")
 
 
 def before_uninstall():

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -8,6 +8,7 @@ from frappe.desk.page.setup_wizard.setup_wizard import make_records
 from frappe.installer import update_site_config
 
 from hrms.subscription_utils import update_erpnext_access
+from hrms.overrides.company import delete_company_fixtures
 
 
 def after_install():
@@ -25,6 +26,7 @@ def after_install():
 
 def before_uninstall():
 	delete_custom_fields(get_custom_fields())
+	delete_company_fixtures()
 
 
 def get_custom_fields():

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -23,6 +23,10 @@ def after_install():
 	click.secho("Thank you for installing Frappe HR!", fg="green")
 
 
+def before_uninstall():
+	delete_custom_fields(get_custom_fields())
+
+
 def get_custom_fields():
 	"""HR specific custom fields that need to be added to the masters in ERPNext"""
 	return {
@@ -657,3 +661,16 @@ def run_post_install_patches():
 				frappe.get_attr(f"hrms.patches.post_install.{patch_name}.execute")()
 	finally:
 		frappe.flags.in_patch = False
+
+
+def delete_custom_fields(custom_fields):
+	for doctype, fields in custom_fields.items():
+		frappe.db.delete(
+			"Custom Field",
+			{
+				"fieldname": ("in", [field["fieldname"] for field in fields]),
+				"dt": doctype,
+			},
+		)
+
+		frappe.clear_cache(doctype=doctype)

--- a/hrms/uninstall.py
+++ b/hrms/uninstall.py
@@ -1,0 +1,21 @@
+import click
+
+from hrms.setup import before_uninstall as remove_custom_fields
+
+
+def before_uninstall():
+	try:
+		print("Removing customizations created by the Frappe HR app...")
+		remove_custom_fields()
+
+	except Exception as e:
+		BUG_REPORT_URL = "https://github.com/frappe/hrms/issues/new"
+		click.secho(
+			"Removing Customizations for Frappe HR failed due to an error."
+			" Please try again or"
+			f" report the issue on {BUG_REPORT_URL} if not resolved.",
+			fg="bright_red",
+		)
+		raise e
+
+	click.secho("Frappe HR app customizations have been removed successfully...", fg="green")


### PR DESCRIPTION
Remove custom fields and regional company fixtures on app uninstall to avoid breaking ERPNext forms