### PR TITLE
chores:job openings status changes

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -42,5 +42,11 @@ frappe.ui.form.on('Job Opening', {
 	},
 	company: function(frm) {
 		frm.set_value('designation', "");
+	},
+	status:function(frm){
+		if(frm.doc.status=="Closed")
+		{
+			frm.set_value("publish",0)
+		}
 	}
 });


### PR DESCRIPTION
Issue Link : [https://github.com/frappe/hrms/issues/272](https://github.com/frappe/hrms/issues/272)

Fixed:
- If job opening status closed automatically, then publish on website will be disabled.