### PR TITLE
ci: bump isort from 5.9.1 to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,8 @@ repos:
       - id: black
         additional_dependencies: ['click==8.0.4']
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.9.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         exclude: ".*setup.py$"


### PR DESCRIPTION
CI failing 

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/24353136/215666538-2be07534-d3d2-47ab-9a36-7d48ee35761e.png">

https://github.com/frappe/hrms/actions/runs/4050618180/jobs/6968170589

This has been fixed in isort's latest release https://github.com/PyCQA/isort/releases/tag/5.12.0