### PR TITLE
fix: handle when deductions are absent in salary slip

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -471,7 +471,7 @@ class PayrollEntry(Document):
 				}
 				"""
 				for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-					payable_amount = employee_details.get("earnings") - employee_details.get("deductions")
+					payable_amount = employee_details.get("earnings") - ( employee_details.get("deductions") or 0 )
 
 					accounting_entry, payable_amount = self.get_accounting_entries_and_payable_amount(
 						payroll_payable_account,

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -471,7 +471,7 @@ class PayrollEntry(Document):
 				}
 				"""
 				for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-					payable_amount = employee_details.get("earnings") - ( employee_details.get("deductions") or 0 )
+					payable_amount = employee_details.get("earnings") - (employee_details.get("deductions") or 0)
 
 					accounting_entry, payable_amount = self.get_accounting_entries_and_payable_amount(
 						payroll_payable_account,


### PR DESCRIPTION
**steps to reproduce**
1]Payroll Settings : Process Payroll Accounting Entry based on Employee : checked 
2]Create payroll with employees such that salary slip has no deductions 
3] in payroll try to submit salary slip. it gives error

**Traceback with variables (most recent call last):**
```
  File "apps/hrms/hrms/payroll/doctype/payroll_entry/payroll_entry.py", line 1118, in submit_salary_slips_for_employees
    payroll_entry.make_accrual_jv_entry()
      payroll_entry = <PayrollEntry: HR-PRUN-2023-00001-4 docstatus=1>
      salary_slips = (('Sal Slip/HR0026/00002', 'نايان موفيز باتهان'), ('Sal Slip/HR0053/00002', 'محمد أحمد عارف'))
      publish_progress = False
      submitted = [<SalarySlip: Sal Slip/HR0026/00002 docstatus=1>, <SalarySlip: Sal Slip/HR0053/00002 docstatus=1>]
      unsubmitted = []
      count = 2
      entry = ('Sal Slip/HR0053/00002', 'محمد أحمد عارف')
      salary_slip = <SalarySlip: Sal Slip/HR0053/00002 docstatus=1>
      e = TypeError("unsupported operand type(s) for -: 'float' and 'NoneType'")
  File "apps/hrms/hrms/payroll/doctype/payroll_entry/payroll_entry.py", line 474, in make_accrual_jv_entry
    payable_amount = employee_details.get("earnings") - employee_details.get("deductions")
```

**Fix:** employee_details.get("deductions") or 0

![2023-02-01_18-43_1](https://user-images.githubusercontent.com/29812965/216053141-232b16c7-213f-4be7-866f-3e58db86c7a5.png)
![2023-02-01_18-43](https://user-images.githubusercontent.com/29812965/216053165-0766c74f-e7d7-4d9d-97ed-186acb0f3ab1.png)
![image](https://user-images.githubusercontent.com/29812965/216053288-9c3dc41c-790d-42f4-9663-2539f3c3b83c.png)

Encountered after https://github.com/frappe/hrms/pull/228