### PR TITLE
fix: respect system precision in leave application dashboard and reports

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -762,6 +762,8 @@ def get_number_of_leave_days(
 def get_leave_details(employee, date):
 	allocation_records = get_leave_allocation_records(employee, date)
 	leave_allocation = {}
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision", cache=True))
+
 	for d in allocation_records:
 		allocation = allocation_records.get(d, frappe._dict())
 		remaining_leaves = get_leave_balance_on(
@@ -776,11 +778,11 @@ def get_leave_details(employee, date):
 		expired_leaves = allocation.total_leaves_allocated - (remaining_leaves + leaves_taken)
 
 		leave_allocation[d] = {
-			"total_leaves": allocation.total_leaves_allocated,
-			"expired_leaves": expired_leaves if expired_leaves > 0 else 0,
-			"leaves_taken": leaves_taken,
-			"leaves_pending_approval": leaves_pending,
-			"remaining_leaves": remaining_leaves,
+			"total_leaves": flt(allocation.total_leaves_allocated, precision),
+			"expired_leaves": flt(expired_leaves, precision) if expired_leaves > 0 else 0,
+			"leaves_taken": flt(leaves_taken, precision),
+			"leaves_pending_approval": flt(leaves_pending, precision),
+			"remaining_leaves": flt(remaining_leaves, precision),
 		}
 
 	# is used in set query


### PR DESCRIPTION
## Leave Application dashboard not respecting system precision:

**Before**:

![image](https://user-images.githubusercontent.com/24353136/218251989-d6bbe324-e921-4e4b-a016-be466e03f6a4.png)

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218251759-fd376f1c-ffbe-4be9-91d9-bbc8963abb14.png">

**After**:

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218251778-aa6c6771-67d5-4f72-9325-e2f984a68cce.png">

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218251688-881a69cb-e42a-43f3-9330-bed88effb722.png">

## Leave Balance reports not respecting system precision:

**Before**:
<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218266213-8501b830-9b15-4a62-884b-dd4d1caae32b.png">

**After**:
<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218266298-db2ecb32-15e8-4645-b8a3-f002b775d158.png">


