### PR TITLE
fix: earned leaves not allocated on a pro-rata basis

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -3,6 +3,8 @@ from frappe.tests.utils import FrappeTestCase
 from frappe.utils import (
 	add_days,
 	add_months,
+	date_diff,
+	flt,
 	get_first_day,
 	get_last_day,
 	get_year_ending,
@@ -244,32 +246,37 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_allocate_on_date_of_joining(self):
 		"""Tests if assignment with 'Allocate On=Last Day'"""
 		start_date = get_first_day(add_months(getdate(), -1))
+		end_date = get_last_day(start_date)
 		doj = add_days(start_date, 5)
 		current_month_doj = add_days(get_first_day(getdate()), 5)
 
 		self.employee.date_of_joining = doj
 		self.employee.save()
 
-		# Case 1: Allocates 1 leave for the previous month if created on the previous month's day of joining
+		# Case 1: Allocates pro-rated leave for the previous month if created on the previous month's day of joining
 		frappe.flags.current_date = doj
 		leave_policy_assignments = make_policy_assignment(
 			self.employee, allocate_on_day="Date of Joining", start_date=start_date
 		)
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
-		self.assertEqual(leaves_allocated, 1)
 
-		# Case 2: Allocates 1 leave on the current month's day of joining (via scheduler)
-		frappe.flags.current_date = current_month_doj
-		allocate_earned_leaves()
-		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
-		self.assertEqual(leaves_allocated, 2)
+		pro_rated_leave = flt(
+			((date_diff(end_date, doj) + 1) / (date_diff(end_date, start_date) + 1)), 3
+		)
+		self.assertEqual(leaves_allocated, pro_rated_leave)
 
-		# Case 3: Doesn't allocate before the current month's doj (via scheduler)
+		# Case 2: Doesn't allocate before the current month's doj (via scheduler)
 		frappe.flags.current_date = add_days(current_month_doj, -1)
 		allocate_earned_leaves()
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
-		# balance is still 2
-		self.assertEqual(leaves_allocated, 2)
+		# balance is still the same
+		self.assertEqual(leaves_allocated, pro_rated_leave)
+
+		# Case 3: Allocates 1 leave on the current month's day of joining (via scheduler)
+		frappe.flags.current_date = current_month_doj
+		allocate_earned_leaves()
+		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
+		self.assertEqual(leaves_allocated, pro_rated_leave + 1)
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_earned_leave_details_for_dashboard(self):

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -21,6 +21,7 @@ from hrms.hr.doctype.leave_application.leave_application import (
 )
 from hrms.hr.doctype.leave_application.test_leave_application import make_leave_application
 from hrms.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
+	calculate_pro_rated_leaves,
 	create_assignment_for_multiple_employees,
 )
 from hrms.hr.utils import allocate_earned_leaves
@@ -244,7 +245,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(leaves_allocated, 2)
 
 	def test_allocate_on_date_of_joining(self):
-		"""Tests if assignment with 'Allocate On=Last Day'"""
+		"""Tests assignment with 'Allocate On=Date of Joining'"""
 		start_date = get_first_day(add_months(getdate(), -1))
 		end_date = get_last_day(start_date)
 		doj = add_days(start_date, 5)
@@ -259,10 +260,7 @@ class TestLeaveAllocation(FrappeTestCase):
 			self.employee, allocate_on_day="Date of Joining", start_date=start_date
 		)
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
-
-		pro_rated_leave = flt(
-			((date_diff(end_date, doj) + 1) / (date_diff(end_date, start_date) + 1)), 3
-		)
+		pro_rated_leave = calculate_pro_rated_leaves(1, doj, start_date, end_date)
 		self.assertEqual(leaves_allocated, pro_rated_leave)
 
 		# Case 2: Doesn't allocate before the current month's doj (via scheduler)
@@ -277,6 +275,41 @@ class TestLeaveAllocation(FrappeTestCase):
 		allocate_earned_leaves()
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
 		self.assertEqual(leaves_allocated, pro_rated_leave + 1)
+
+	def test_no_pro_rated_leaves_allocated_before_effective_date(self):
+		start_date = get_first_day(add_months(getdate(), -1))
+		doj = add_days(start_date, 5)
+
+		self.employee.date_of_joining = doj
+		self.employee.save()
+
+		# assigning before DOJ
+		frappe.flags.current_date = add_days(doj, -1)
+		leave_policy_assignments = make_policy_assignment(
+			self.employee, allocate_on_day="Date of Joining", start_date=start_date
+		)
+		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
+		self.assertEqual(leaves_allocated, 0.0)
+
+	def test_pro_rated_allocation_via_scheduler(self):
+		start_date = get_first_day(add_months(getdate(), -1))
+		doj = add_days(start_date, 5)
+
+		self.employee.date_of_joining = doj
+		self.employee.save()
+
+		# assigning before DOJ, no leaves allocated initially
+		frappe.flags.current_date = add_days(doj, -1)
+		leave_policy_assignments = make_policy_assignment(
+			self.employee, allocate_on_day="First Day", start_date=start_date
+		)
+
+		# pro-rated leaves allocated during the first month
+		frappe.flags.current_date = add_days(doj, -1)
+		allocate_earned_leaves()
+		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
+		pro_rated_leave = calculate_pro_rated_leaves(1, doj, start_date, get_last_day(start_date))
+		self.assertEqual(leaves_allocated, pro_rated_leave)
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_earned_leave_details_for_dashboard(self):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -16,7 +16,6 @@ from frappe.utils import (
 	get_link_to_form,
 	getdate,
 	nowdate,
-	today,
 )
 
 import erpnext
@@ -24,6 +23,10 @@ from erpnext import get_company_currency
 from erpnext.setup.doctype.employee.employee import (
 	InactiveEmployeeStatusError,
 	get_holiday_list_for_employee,
+)
+
+from hrms.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
+	calculate_pro_rated_leaves,
 )
 
 
@@ -278,7 +281,7 @@ def generate_leave_encashment():
 
 		leave_allocation = frappe.get_all(
 			"Leave Allocation",
-			filters={"to_date": add_days(today(), -1), "leave_type": ("in", leave_type)},
+			filters={"to_date": add_days(getdate(), -1), "leave_type": ("in", leave_type)},
 			fields=[
 				"employee",
 				"leave_period",
@@ -295,14 +298,12 @@ def generate_leave_encashment():
 def allocate_earned_leaves():
 	"""Allocate earned leaves to Employees"""
 	e_leave_types = get_earned_leaves()
-	today = getdate()
+	today = frappe.flags.current_date or getdate()
 
 	for e_leave_type in e_leave_types:
-
 		leave_allocations = get_leave_allocations(today, e_leave_type.name)
 
 		for allocation in leave_allocations:
-
 			if not allocation.leave_policy_assignment and not allocation.leave_policy:
 				continue
 
@@ -319,22 +320,35 @@ def allocate_earned_leaves():
 				filters={"parent": leave_policy, "leave_type": e_leave_type.name},
 				fieldname=["annual_allocation"],
 			)
+			date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 
 			from_date = allocation.from_date
 
 			if e_leave_type.allocate_on_day == "Date of Joining":
-				from_date = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
+				from_date = date_of_joining
 
 			if check_effective_date(
 				from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day
 			):
-				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type)
+				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining)
 
 
-def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type):
+def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining):
+	def _calculate_pro_rated_leaves(earned_leaves):
+		today_date = frappe.flags.current_date or getdate()
+		period_end_date = get_last_day(today_date)
+		period_start_date = get_first_day(today_date)
+
+		if period_start_date <= date_of_joining <= period_end_date:
+			return calculate_pro_rated_leaves(
+				earned_leaves, date_of_joining, period_start_date, period_end_date
+			)
+		return earned_leaves
+
 	earned_leaves = get_monthly_earned_leave(
 		annual_allocation, e_leave_type.earned_leave_frequency, e_leave_type.rounding
 	)
+	earned_leaves = _calculate_pro_rated_leaves(earned_leaves)
 
 	allocation = frappe.get_doc("Leave Allocation", allocation.name)
 	new_allocation = flt(allocation.total_leaves_allocated) + flt(earned_leaves)
@@ -343,7 +357,7 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 		new_allocation = e_leave_type.max_leaves_allowed
 
 	if new_allocation != allocation.total_leaves_allocated:
-		today_date = today()
+		today_date = frappe.flags.current_date or getdate()
 
 		allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
 		create_additional_leave_ledger_entry(allocation, earned_leaves, today_date)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -640,11 +640,14 @@ class SalarySlip(TransactionBase):
 				# since row for statistical component is not added to salary slip
 				if struct_row.depends_on_payment_days:
 					joining_date, relieving_date = self.get_joining_and_relieving_dates()
-					default_data[struct_row.abbr] = amount
-					data[struct_row.abbr] = flt(
-						(flt(amount) * flt(self.payment_days) / cint(self.total_working_days)),
-						struct_row.precision("amount"),
+					payment_days_amount = (
+						flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
+						if self.total_working_days
+						else 0
 					)
+
+					default_data[struct_row.abbr] = amount
+					data[struct_row.abbr] = flt(payment_days_amount, struct_row.precision("amount"))
 
 			elif amount or struct_row.amount_based_on_formula and amount is not None:
 				default_amount = self.eval_condition_and_formula(struct_row, default_data)


### PR DESCRIPTION
## Before

- **Leave Policy of 21 Earned Leaves**:

    <img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218308707-11167ce3-2a82-4e20-aecc-dbcc47b408ea.png">

- Employee's DOJ is 24th Jan 2023
- According to 21 Leaves, monthly earned leave = 21/12 = 1.75. The employee is allocated all 1.75 leaves in spite of working only for 8 days of the month

  <img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218308948-cab6792b-4354-46a1-8cbe-e9791b6a631a.png">


## After

- Calculated pro-rated leave for the months passed so far 
- 1.75 * (8/31) = 1.75 * 0.26 = 0.45

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218308873-cc15dc60-ef88-4639-b815-2cae5c7f1878.png">

