### PR TITLE
ci: specify correct branch for PRs and push events

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -8,7 +8,7 @@ sudo apt-get -y install redis-server libcups2-dev -qq
 
 pip install frappe-bench
 
-git clone https://github.com/frappe/frappe --branch develop --depth 1
+git clone https://github.com/frappe/frappe --branch "$BRANCH_TO_CLONE" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site
@@ -40,7 +40,7 @@ sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
 bench get-app payments
-bench get-app https://github.com/frappe/erpnext --branch develop
+bench get-app https://github.com/frappe/erpnext --branch "$BRANCH_TO_CLONE" --resolve-deps
 bench setup requirements --dev
 
 bench start &> bench_run_logs.txt &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,26 @@ name: CI
 
 on:
   push:
-    branches:
-      - develop
+    branches: [develop, version-14-hotfix, version-14]
+    paths-ignore:
+      - "**.css"
+      - "**.js"
+      - "**.md"
+      - "**.html"
+      - "**.csv"
+
   pull_request:
-    branches:
-      - develop
+    paths-ignore:
+      - "**.css"
+      - "**.js"
+      - "**.md"
+      - "**.html"
+      - "**.csv"
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"
+env:
+    HR_BRANCH: ${{ github.base_ref || github.ref_name }}
 
 concurrency:
   group: develop-${{ github.event.number }}
@@ -87,6 +99,8 @@ jobs:
       - name: Install
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+        env:
+          BRANCH_TO_CLONE: ${{ env.HR_BRANCH }}
 
 
       - name: Run Tests


### PR DESCRIPTION
Specify the correct branch for PRs and push events so that each version gets tested with compatible versions of other apps (frappe/erpnext)

eg: 
- HR's develop CI runs with Frappe & ERPNext's develop
- HR's version-14-hotfix CI runs with Frappe & ERPNext's version-14-hotfix
