### PR TITLE
fix: map the correct date function in tax slab eval globals

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import math
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 import frappe
 from frappe import _, msgprint
@@ -1781,7 +1781,7 @@ def eval_tax_slab_condition(condition, eval_globals=None, eval_locals=None):
 			"float": float,
 			"long": int,
 			"round": round,
-			"date": datetime.date,
+			"date": date,
 			"getdate": getdate,
 		}
 


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/307

**Before**:

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218791258-9881170f-5ec1-4f67-9389-198cf6237f91.png">

**After**:

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/218791083-5014a312-7c0a-4ec9-a71a-c068a757560b.png">
