### PR TITLE
fix: disable conversion to user tz for shift calendar

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -176,6 +176,7 @@ def add_assignments(start, end, conditions=None):
 				"title": cstr(d.employee_name) + ": " + cstr(d.shift_type),
 				"docstatus": d.docstatus,
 				"allDay": 0,
+				"convertToUserTz": 0,
 			}
 			if e not in events:
 				events.append(e)

--- a/hrms/hr/doctype/shift_assignment/shift_assignment_calendar.js
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment_calendar.js
@@ -8,6 +8,7 @@ frappe.views.calendar["Shift Assignment"] = {
 		"id": "name",
 		"docstatus": 1,
 		"allDay": "allDay",
+		"convertToUserTz": "convertToUserTz",
 	},
 	get_events_method: "hrms.hr.doctype.shift_assignment.shift_assignment.get_events"
 }


### PR DESCRIPTION
Depends on: https://github.com/frappe/frappe/pull/20051