### PR TITLE
feat(UX): Add option to disable consolidating leave types in balance reports

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -2,53 +2,60 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.query_reports["Employee Leave Balance"] = {
-	"filters": [
+	filters: [
 		{
-			"fieldname": "from_date",
-			"label": __("From Date"),
-			"fieldtype": "Date",
-			"reqd": 1,
-			"default": frappe.defaults.get_default("year_start_date")
+			fieldname: "from_date",
+			label: __("From Date"),
+			fieldtype: "Date",
+			reqd: 1,
+			default: frappe.defaults.get_default("year_start_date")
 		},
 		{
-			"fieldname": "to_date",
-			"label": __("To Date"),
-			"fieldtype": "Date",
-			"reqd": 1,
-			"default": frappe.defaults.get_default("year_end_date")
+			fieldname: "to_date",
+			label: __("To Date"),
+			fieldtype: "Date",
+			reqd: 1,
+			default: frappe.defaults.get_default("year_end_date")
 		},
 		{
-			"fieldname": "company",
-			"label": __("Company"),
-			"fieldtype": "Link",
-			"options": "Company",
-			"reqd": 1,
-			"default": frappe.defaults.get_user_default("Company")
+			label: __("Company"),
+			fieldname: "company",
+			fieldtype: "Link",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company")
 		},
 		{
-			"fieldname": "department",
-			"label": __("Department"),
-			"fieldtype": "Link",
-			"options": "Department",
+			fieldname: "department",
+			label: __("Department"),
+			fieldtype: "Link",
+			options: "Department",
 		},
 		{
-			"fieldname": "employee",
-			"label": __("Employee"),
-			"fieldtype": "Link",
-			"options": "Employee",
+			fieldname: "employee",
+			label: __("Employee"),
+			fieldtype: "Link",
+			options: "Employee",
 		},
 		{
-			"fieldname": "employee_status",
-			"label": __("Employee Status"),
-			"fieldtype": "Select",
-			"options": [
+			fieldname: "employee_status",
+			label: __("Employee Status"),
+			fieldtype: "Select",
+			options: [
 				"",
 				{ "value": "Active", "label": __("Active") },
 				{ "value": "Inactive", "label": __("Inactive") },
 				{ "value": "Suspended", "label": __("Suspended") },
 				{ "value": "Left", "label": __("Left") },
 			],
-			"default": "Active",
+			default: "Active",
+		},
+		{
+			fieldname: "consolidate_leave_types",
+			label: __("Consolidate Leave Types"),
+			fieldtype: "Check",
+			default: 1,
+			depends_on: "eval: !doc.employee",
 		}
 	],
 

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -278,6 +278,9 @@ def get_chart_data(data: List, filters: Filters) -> Dict:
 	datasets = []
 	employee_data = data
 
+	if not data:
+		return None
+
 	if data and filters.employee:
 		get_dataset_for_chart(employee_data, datasets, labels)
 

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -24,7 +24,7 @@ def execute(filters: Optional[Filters] = None) -> Tuple:
 
 	columns = get_columns()
 	data = get_data(filters)
-	charts = get_chart_data(data)
+	charts = get_chart_data(data, filters)
 	return columns, data, None, charts
 
 
@@ -89,7 +89,7 @@ def get_data(filters: Filters) -> List:
 	conditions = get_conditions(filters)
 
 	user = frappe.session.user
-	department_approver_map = get_department_leave_approver_map(filters.get("department"))
+	department_approver_map = get_department_leave_approver_map(filters.department)
 
 	active_employees = frappe.get_list(
 		"Employee",
@@ -98,22 +98,26 @@ def get_data(filters: Filters) -> List:
 	)
 
 	precision = cint(frappe.db.get_single_value("System Settings", "float_precision", cache=True))
+	consolidate_leave_types = len(active_employees) > 1 and filters.consolidate_leave_types
+	row = None
+
 	data = []
 
 	for leave_type in leave_types:
-		if len(active_employees) > 1:
+		if consolidate_leave_types:
 			data.append({"leave_type": leave_type})
 		else:
 			row = frappe._dict({"leave_type": leave_type})
 
 		for employee in active_employees:
-
 			leave_approvers = department_approver_map.get(employee.department_name, []).append(
 				employee.leave_approver
 			)
 
-			if len(active_employees) > 1:
+			if consolidate_leave_types:
 				row = frappe._dict()
+			else:
+				row = frappe._dict({"leave_type": leave_type})
 
 			row.employee = employee.name
 			row.employee_name = employee.employee_name
@@ -167,17 +171,17 @@ def get_opening_balance(
 def get_conditions(filters: Filters) -> Dict:
 	conditions = {}
 
-	if filters.get("employee"):
-		conditions["name"] = filters.get("employee")
+	if filters.employee:
+		conditions["name"] = filters.employee
 
-	if filters.get("company"):
-		conditions["company"] = filters.get("company")
+	if filters.company:
+		conditions["company"] = filters.company
 
-	if filters.get("department"):
-		conditions["department"] = filters.get("department")
+	if filters.department:
+		conditions["department"] = filters.department
 
-	if filters.get("employee_status"):
-		conditions["status"] = filters.get("employee_status")
+	if filters.employee_status:
+		conditions["status"] = filters.employee_status
 
 	return conditions
 
@@ -269,12 +273,12 @@ def get_leave_ledger_entries(
 	return records
 
 
-def get_chart_data(data: List) -> Dict:
+def get_chart_data(data: List, filters: Filters) -> Dict:
 	labels = []
 	datasets = []
 	employee_data = data
 
-	if data and data[0].get("employee_name"):
+	if data and filters.employee:
 		get_dataset_for_chart(employee_data, datasets, labels)
 
 	chart = {


### PR DESCRIPTION
## Problem:

The Leave Balance report consolidates data based on leave types. If you are using inline filters in the datatable, you will lose out on the Leave Type reference for each row. Eg: Applying a filter on an added column (custom) shift type.

![Kapture 2023-02-16 at 14 15 31](https://user-images.githubusercontent.com/24353136/219313769-281396b8-792c-486c-ade8-c9ca1f6f2555.gif)

## Solution

Add an option "**Consolidate Leave Type**" to disable the consolidated view. Users might also want to export the data with leave-type references for each row. In this case, they can disable this checkbox and export

<img width="1340" alt="consolidate-disabled" src="https://user-images.githubusercontent.com/24353136/219314016-fa1c05c9-ea86-4dbb-a193-f768c5f92a14.png">

<img width="1340" alt="consolidate-enabled" src="https://user-images.githubusercontent.com/24353136/219313961-c232d277-4d51-4653-b461-981babe04a99.png">
