### PR TITLE
fix: incorrect leave balance after carry-forwarded leave expiry

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -840,6 +840,7 @@ def get_leave_balance_on(
 def get_leave_allocation_records(employee, date, leave_type=None):
 	"""Returns the total allocated leaves and carry forwarded leaves based on ledger entries"""
 	Ledger = frappe.qb.DocType("Leave Ledger Entry")
+	LeaveAllocation = frappe.qb.DocType("Leave Allocation")
 
 	cf_leave_case = (
 		frappe.qb.terms.Case().when(Ledger.is_carry_forward == "1", Ledger.leaves).else_(0)
@@ -853,6 +854,8 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 
 	query = (
 		frappe.qb.from_(Ledger)
+		.inner_join(LeaveAllocation)
+		.on(Ledger.transaction_name == LeaveAllocation.name)
 		.select(
 			sum_cf_leaves,
 			sum_new_leaves,
@@ -862,12 +865,21 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 		)
 		.where(
 			(Ledger.from_date <= date)
-			& (Ledger.to_date >= date)
 			& (Ledger.docstatus == 1)
 			& (Ledger.transaction_type == "Leave Allocation")
 			& (Ledger.employee == employee)
 			& (Ledger.is_expired == 0)
 			& (Ledger.is_lwp == 0)
+			& (
+				# newly allocated leave's end date is same as the leave allocation's to date
+				((Ledger.is_carry_forward == 0) & (Ledger.to_date >= date))
+				# carry forwarded leave's end date won't be same as the leave allocation's to date
+				# it's between the leave allocation's from and to date
+				| (
+					(Ledger.is_carry_forward == 1)
+					& (Ledger.to_date.between(LeaveAllocation.from_date, LeaveAllocation.to_date))
+				)
+			)
 		)
 	)
 

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -825,7 +825,9 @@ def get_leave_balance_on(
 	allocation = allocation_records.get(leave_type, frappe._dict())
 
 	end_date = allocation.to_date if cint(consider_all_leaves_in_the_allocation_period) else date
-	cf_expiry = get_allocation_expiry_for_cf_leaves(employee, leave_type, to_date, date)
+	cf_expiry = get_allocation_expiry_for_cf_leaves(
+		employee, leave_type, to_date, allocation.from_date
+	)
 
 	leaves_taken = get_leaves_for_period(employee, leave_type, allocation.from_date, end_date)
 
@@ -945,8 +947,12 @@ def get_remaining_leaves(
 
 	# balance for carry forwarded leaves
 	if cf_expiry and allocation.unused_leaves:
-		cf_leaves = flt(allocation.unused_leaves) + flt(leaves_taken)
-		remaining_cf_leaves = _get_remaining_leaves(cf_leaves, cf_expiry)
+		if getdate(date) > getdate(cf_expiry):
+			# carry forwarded leave expiry date passed
+			cf_leaves = remaining_cf_leaves = 0
+		else:
+			cf_leaves = flt(allocation.unused_leaves) + flt(leaves_taken)
+			remaining_cf_leaves = _get_remaining_leaves(cf_leaves, cf_expiry)
 
 		leave_balance = flt(allocation.new_leaves_allocated) + flt(cf_leaves)
 		leave_balance_for_consumption = flt(allocation.new_leaves_allocated) + flt(remaining_cf_leaves)

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -923,6 +923,35 @@ class TestLeaveApplication(unittest.TestCase):
 		self.assertEqual(leave_allocation["remaining_leaves"], 26)
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_leave_details_with_expired_cf_leaves(self):
+		employee = get_employee()
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=90,
+		).insert()
+
+		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
+		cf_expiry = frappe.db.get_value(
+			"Leave Ledger Entry", {"transaction_name": leave_alloc.name, "is_carry_forward": 1}, "to_date"
+		)
+
+		# all leaves available before cf leave expiry
+		leave_details = get_leave_details(employee.name, add_days(cf_expiry, -1))
+		self.assertEqual(leave_details["leave_allocation"][leave_type.name]["remaining_leaves"], 30.0)
+
+		# cf leaves expired
+		leave_details = get_leave_details(employee.name, add_days(cf_expiry, 1))
+		expected_data = {
+			"total_leaves": 30.0,
+			"expired_leaves": 15.0,
+			"leaves_taken": 0.0,
+			"leaves_pending_approval": 0.0,
+			"remaining_leaves": 15.0,
+		}
+		self.assertEqual(leave_details["leave_allocation"][leave_type.name], expected_data)
+
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_leave_allocation_records(self):
 		"""Tests if total leaves allocated before and after carry forwarded leave expiry is same"""
 		employee = get_employee()

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -699,8 +699,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		)
-		leave_type.insert()
+		).insert()
 
 		create_carry_forwarded_allocation(employee, leave_type)
 		details = get_leave_balance_on(

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -925,16 +925,21 @@ class TestLeaveApplication(unittest.TestCase):
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_leave_allocation_records(self):
+		"""Tests if total leaves allocated before and after carry forwarded leave expiry is same"""
 		employee = get_employee()
 		leave_type = create_leave_type(
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		)
-		leave_type.insert()
+		).insert()
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
-		details = get_leave_allocation_records(employee.name, getdate(), leave_type.name)
+		cf_expiry = frappe.db.get_value(
+			"Leave Ledger Entry", {"transaction_name": leave_alloc.name, "is_carry_forward": 1}, "to_date"
+		)
+
+		# test total leaves allocated before cf leave expiry
+		details = get_leave_allocation_records(employee.name, add_days(cf_expiry, -1), leave_type.name)
 		expected_data = {
 			"from_date": getdate(leave_alloc.from_date),
 			"to_date": getdate(leave_alloc.to_date),
@@ -943,6 +948,11 @@ class TestLeaveApplication(unittest.TestCase):
 			"new_leaves_allocated": 15.0,
 			"leave_type": leave_type.name,
 		}
+		self.assertEqual(details.get(leave_type.name), expected_data)
+
+		# test leaves allocated after carry forwarded leaves expiry, should be same thoroughout allocation period
+		# cf leaves should show up under expired or taken leaves later
+		details = get_leave_allocation_records(employee.name, add_days(cf_expiry, 1), leave_type.name)
 		self.assertEqual(details.get(leave_type.name), expected_data)
 
 


### PR DESCRIPTION
## Problem

Leave Type with Expire Carry Forwarded Leaves set

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/24353136/220518852-c582d511-2801-4c4c-990a-89488fce4fe5.png">

Leave Allocation with carry forwarded leaves

![leave-alloc](https://user-images.githubusercontent.com/24353136/220519437-54c4da01-7092-446d-8855-1b1b885763da.png)

Leave application where the date range is still within the carry forward period. 5 days of leave has been approved in earlier this year to clear carried forward leave. Hence, it came to balance of 16 days

![image](https://user-images.githubusercontent.com/24353136/220519027-df0bbab4-1b49-4289-b50c-10563a0f78c7.png)

Since the selected leave date is outside of the active period of carried forward leave, the total allocated leaves show only 16 days granted based on standard allocation. The problem is that the system uses 16 days to deduct previously approved 5 days of leave (where the employee applied to clear their carried forward allocation), resulting in an incorrect balance of 11 days:

![image](https://user-images.githubusercontent.com/24353136/220519235-837a5388-afa0-42f6-afd0-9702176e74df.png)

## Fix

- Total Allocated Leaves should not show a reduced value after cf leave expiry. (21 should not become 16, it should still show up as 16 and the 5 leaves should show up under **Leaves Taken** or **Expired** after cf expiry.
- Calculate correct cf expiry in the entire allocation period
- Ignore remaining leaves calculation for cf leaves after expiry

### Case 1: Carry-forwarded leaves taken

**Before Expiry:** 21 leaves allocated, 5 used, 16 remaining

<img width="1331" alt="leave-app" src="https://user-images.githubusercontent.com/24353136/220520141-94ea0116-63bf-4616-932f-122d73f5b9aa.png">

**After Expiry:** Same
21 leaves allocated (original), 5 used, 16 remaining

<img width="1331" alt="leave-app-2" src="https://user-images.githubusercontent.com/24353136/220520234-9ec91f81-646e-44f4-b3f2-740901c848bc.png">

## Case 2: Carry-forwarded leaves expired

**Before Expiry:**

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/24353136/220520524-92432156-29b3-4938-b792-a17f25c4025c.png">

**After Expiry:** 5 leaves show up under expired

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/24353136/220520601-aa5a8216-73a9-4530-a8ab-a955e3720670.png">



