### PR TITLE
fix: handle missing deductions while making bank entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -655,7 +655,7 @@ class PayrollEntry(Document):
 					if statistical_component != 1:
 						if process_payroll_accounting_entry_based_on_employee:
 							self.set_employee_based_payroll_payable_entries(
-								"deduction", salary_slip.employee, sal_detail.amount
+								"deductions", salary_slip.employee, sal_detail.amount
 							)
 
 						salary_slip_total -= sal_detail.amount
@@ -691,6 +691,9 @@ class PayrollEntry(Document):
 		if self.employee_based_payroll_payable_entries:
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
 				je_payment_amount = employee_details["earnings"] - employee_details["deduction"]
+				je_payment_amount = employee_details.get("earnings") - (
+					employee_details.get("deductions") or 0
+				)
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(
 					self.payment_account, je_payment_amount, company_currency, currencies
 				)


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/331
Encountered after https://github.com/frappe/hrms/pull/228

Also incorrect attribute referenced: `deduction` instead of `deductions`