### PR TITLE
fix: consider cases for partially consumed carry-forwarded and new leaves with carry-forwarded expiry

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -945,12 +945,7 @@ def get_remaining_leaves(
 
 	if cf_expiry and allocation.unused_leaves:
 		# allocation contains both carry forwarded and new leaves
-		cf_leaves_taken = get_leaves_for_period(
-			allocation.employee, allocation.leave_type, allocation.from_date, cf_expiry
-		)
-		new_leaves_taken = get_leaves_for_period(
-			allocation.employee, allocation.leave_type, add_days(cf_expiry, 1), allocation.to_date
-		)
+		new_leaves_taken, cf_leaves_taken = get_new_and_cf_leaves_taken(allocation, cf_expiry)
 
 		if getdate(date) > getdate(cf_expiry):
 			# carry forwarded leaves have expired
@@ -973,6 +968,24 @@ def get_remaining_leaves(
 
 	remaining_leaves = _get_remaining_leaves(leave_balance_for_consumption, allocation.to_date)
 	return frappe._dict(leave_balance=leave_balance, leave_balance_for_consumption=remaining_leaves)
+
+
+def get_new_and_cf_leaves_taken(allocation: Dict, cf_expiry: str) -> Tuple[float, float]:
+	"""returns new leaves taken and carry forwarded leaves taken within an allocation period based on cf leave expiry"""
+	cf_leaves_taken = get_leaves_for_period(
+		allocation.employee, allocation.leave_type, allocation.from_date, cf_expiry
+	)
+	new_leaves_taken = get_leaves_for_period(
+		allocation.employee, allocation.leave_type, add_days(cf_expiry, 1), allocation.to_date
+	)
+
+	# using abs because leaves taken is a -ve number in the ledger
+	if abs(cf_leaves_taken) > allocation.unused_leaves:
+		# adjust the excess leaves in new_leaves_taken
+		new_leaves_taken += -(abs(cf_leaves_taken) - allocation.unused_leaves)
+		cf_leaves_taken = -allocation.unused_leaves
+
+	return new_leaves_taken, cf_leaves_taken
 
 
 def get_leaves_for_period(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -949,7 +949,7 @@ def get_remaining_leaves(
 	if cf_expiry and allocation.unused_leaves:
 		if getdate(date) > getdate(cf_expiry):
 			# carry forwarded leave expiry date passed
-			cf_leaves = remaining_cf_leaves = 0
+			cf_leaves = remaining_cf_leaves = flt(leaves_taken)
 		else:
 			cf_leaves = flt(allocation.unused_leaves) + flt(leaves_taken)
 			remaining_cf_leaves = _get_remaining_leaves(cf_leaves, cf_expiry)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -864,6 +864,7 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 			Min(Ledger.from_date).as_("from_date"),
 			Max(Ledger.to_date).as_("to_date"),
 			Ledger.leave_type,
+			Ledger.employee,
 		)
 		.where(
 			(Ledger.from_date <= date)
@@ -903,6 +904,7 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 					"unused_leaves": d.cf_leaves,
 					"new_leaves_allocated": d.new_leaves,
 					"leave_type": d.leave_type,
+					"employee": d.employee,
 				}
 			),
 		)
@@ -947,11 +949,15 @@ def get_remaining_leaves(
 
 	# balance for carry forwarded leaves
 	if cf_expiry and allocation.unused_leaves:
+		cf_leaves_taken = get_leaves_for_period(
+			allocation.employee, allocation.leave_type, allocation.from_date, cf_expiry
+		)
+
 		if getdate(date) > getdate(cf_expiry):
 			# carry forwarded leave expiry date passed
-			cf_leaves = remaining_cf_leaves = flt(leaves_taken)
+			cf_leaves = remaining_cf_leaves = flt(cf_leaves_taken)
 		else:
-			cf_leaves = flt(allocation.unused_leaves) + flt(leaves_taken)
+			cf_leaves = flt(allocation.unused_leaves) + flt(cf_leaves_taken)
 			remaining_cf_leaves = _get_remaining_leaves(cf_leaves, cf_expiry)
 
 		leave_balance = flt(allocation.new_leaves_allocated) + flt(cf_leaves)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -943,25 +943,33 @@ def get_remaining_leaves(
 
 		return remaining_leaves
 
-	leave_balance = leave_balance_for_consumption = flt(allocation.total_leaves_allocated) + flt(
-		leaves_taken
-	)
-
-	# balance for carry forwarded leaves
 	if cf_expiry and allocation.unused_leaves:
+		# allocation contains both carry forwarded and new leaves
 		cf_leaves_taken = get_leaves_for_period(
 			allocation.employee, allocation.leave_type, allocation.from_date, cf_expiry
 		)
+		new_leaves_taken = get_leaves_for_period(
+			allocation.employee, allocation.leave_type, add_days(cf_expiry, 1), allocation.to_date
+		)
 
 		if getdate(date) > getdate(cf_expiry):
-			# carry forwarded leave expiry date passed
-			cf_leaves = remaining_cf_leaves = flt(cf_leaves_taken)
+			# carry forwarded leaves have expired
+			cf_leaves = remaining_cf_leaves = 0
 		else:
 			cf_leaves = flt(allocation.unused_leaves) + flt(cf_leaves_taken)
 			remaining_cf_leaves = _get_remaining_leaves(cf_leaves, cf_expiry)
 
-		leave_balance = flt(allocation.new_leaves_allocated) + flt(cf_leaves)
-		leave_balance_for_consumption = flt(allocation.new_leaves_allocated) + flt(remaining_cf_leaves)
+		# new leaves allocated - new leaves taken + cf leave balance
+		# Note: `new_leaves_taken` is added here because its already a -ve number in the ledger
+		leave_balance = (flt(allocation.new_leaves_allocated) + flt(new_leaves_taken)) + flt(cf_leaves)
+		leave_balance_for_consumption = (
+			flt(allocation.new_leaves_allocated) + flt(new_leaves_taken)
+		) + flt(remaining_cf_leaves)
+	else:
+		# allocation only contains newly allocated leaves
+		leave_balance = leave_balance_for_consumption = flt(allocation.total_leaves_allocated) + flt(
+			leaves_taken
+		)
 
 	remaining_leaves = _get_remaining_leaves(leave_balance_for_consumption, allocation.to_date)
 	return frappe._dict(leave_balance=leave_balance, leave_balance_for_consumption=remaining_leaves)

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -29,6 +29,7 @@ from hrms.hr.doctype.leave_application.leave_application import (
 	get_leave_allocation_records,
 	get_leave_balance_on,
 	get_leave_details,
+	get_new_and_cf_leaves_taken,
 )
 from hrms.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
 	create_assignment_for_multiple_employees,
@@ -991,6 +992,46 @@ class TestLeaveApplication(unittest.TestCase):
 			"leaves_taken": 4.0,
 			"leaves_pending_approval": 0.0,
 			"remaining_leaves": 12.0,
+		}
+
+		self.assertEqual(leave_details["leave_allocation"][leave_type.name], expected_data)
+
+	@set_holiday_list("Holiday List w/o Weekly Offs", "_Test Company")
+	def test_leave_details_with_application_across_cf_expiry_2(self):
+		"""Tests the same case as above but with leave days greater than cf leaves allocated"""
+		employee = get_employee()
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=90,
+		).insert()
+
+		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
+		cf_expiry = frappe.db.get_value(
+			"Leave Ledger Entry", {"transaction_name": leave_alloc.name, "is_carry_forward": 1}, "to_date"
+		)
+
+		# leave application across cf expiry, 20 days leave
+		application = make_leave_application(
+			employee.name,
+			add_days(cf_expiry, -16),
+			add_days(cf_expiry, 3),
+			leave_type.name,
+		)
+
+		# 15 cf leaves and 5 new leaves should be consumed
+		# after adjustment of the actual days breakup (17 and 3) because only 15 cf leaves have been allocated
+		new_leaves_taken, cf_leaves_taken = get_new_and_cf_leaves_taken(leave_alloc, cf_expiry)
+		self.assertEqual(new_leaves_taken, -5.0)
+		self.assertEqual(cf_leaves_taken, -15.0)
+
+		leave_details = get_leave_details(employee.name, add_days(cf_expiry, 4))
+		expected_data = {
+			"total_leaves": 30.0,
+			"expired_leaves": 0,
+			"leaves_taken": 20.0,
+			"leaves_pending_approval": 0.0,
+			"remaining_leaves": 10.0,
 		}
 
 		self.assertEqual(leave_details["leave_allocation"][leave_type.name], expected_data)

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -975,6 +975,7 @@ class TestLeaveApplication(unittest.TestCase):
 			"unused_leaves": 15.0,
 			"new_leaves_allocated": 15.0,
 			"leave_type": leave_type.name,
+			"employee": employee.name,
 		}
 		self.assertEqual(details.get(leave_type.name), expected_data)
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1710,7 +1710,7 @@ def make_payroll_period():
 			pp = create_payroll_period(company=company, name=company_based_payroll_period[company])
 
 
-def make_holiday_list(list_name=None, from_date=None, to_date=None):
+def make_holiday_list(list_name=None, from_date=None, to_date=None, add_weekly_offs=True):
 	fiscal_year = get_fiscal_year(nowdate(), company=erpnext.get_default_company())
 	name = list_name or "Salary Slip Test Holiday List"
 
@@ -1722,10 +1722,13 @@ def make_holiday_list(list_name=None, from_date=None, to_date=None):
 			"holiday_list_name": name,
 			"from_date": from_date or fiscal_year[1],
 			"to_date": to_date or fiscal_year[2],
-			"weekly_off": "Sunday",
 		}
 	).insert()
-	holiday_list.get_weekly_off_dates()
+
+	if add_weekly_offs:
+		holiday_list.weekly_off = "Sunday"
+		holiday_list.get_weekly_off_dates()
+
 	holiday_list.save()
 	holiday_list = holiday_list.name
 


### PR DESCRIPTION
Extending the edge cases from https://github.com/frappe/hrms/pull/335

**Setup**:
16 new leaves allocated + 5 carry forwarded leaves that will expire on 28-02-2023
Total 21 leaves allocated

## Case 3: Leave Application across carry forwarded leave expiry

<img width="1326" alt="cf-leaves" src="https://user-images.githubusercontent.com/24353136/223956868-7724fd50-c4f9-4ce8-ab27-7c9f49de931d.png">

**Before**:

<img width="1326" alt="cf-leave-expiry-before" src="https://user-images.githubusercontent.com/24353136/223959736-00dedb59-1638-4fc9-b1c7-9c782add2610.png">

**After:**

<img width="1326" alt="cf-leave-fixed" src="https://user-images.githubusercontent.com/24353136/223958197-0a632670-ce4c-4adc-97f6-818136a716af.png">

## Case 4: Leave Application after carry forwarded leave expiry

Leave Application created after carry forwarded leave expiry date (28-02-2023)

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/223960117-82d076ff-8bec-4d08-b740-cfd1863a25b6.png">

**Before**:

<img width="1326" alt="cf-case-4-before" src="https://user-images.githubusercontent.com/24353136/223961714-e97de5cc-1ae0-4f35-a8ab-5fdb6421d2c9.png">

**After**:

<img width="1326" alt="cf-case-4-after" src="https://user-images.githubusercontent.com/24353136/223961741-dd7ec950-9f42-4de6-8be7-bbcbd0e2cf0d.png">

- [x] Consider case of more leaves consumed than allocated cf leaves within the cf leave period