### PR TITLE
fix: Consider relieving date while calculating lwp

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -515,6 +515,12 @@ class SalarySlip(TransactionBase):
 		lwp = 0
 		absent = 0
 
+		joining_date, relieving_date = self.get_joining_and_relieving_dates()
+
+		end_date = self.end_date
+		if relieving_date:
+			end_date = relieving_date
+
 		daily_wages_fraction_for_half_day = (
 			flt(frappe.db.get_value("Payroll Settings", None, "daily_wages_fraction_for_half_day")) or 0.5
 		)
@@ -538,7 +544,7 @@ class SalarySlip(TransactionBase):
 				(attendance.status.isin(["Absent", "Half Day", "On Leave"]))
 				& (attendance.employee == self.employee)
 				& (attendance.docstatus == 1)
-				& (attendance.attendance_date.between(self.start_date, self.end_date))
+				& (attendance.attendance_date.between(self.start_date, end_date))
 			)
 		).run(as_dict=1)
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -349,7 +349,9 @@ class SalarySlip(TransactionBase):
 			return
 
 		holidays = self.get_holidays_for_employee(self.start_date, self.end_date)
-		working_days_list = [add_days(self.start_date, day) for day in range(0, working_days)]
+		working_days_list = [
+			add_days(getdate(self.start_date), days=day) for day in range(0, working_days)
+		]
 
 		if not cint(include_holidays_in_total_working_days):
 			working_days_list = [i for i in working_days_list if i not in holidays]
@@ -504,7 +506,7 @@ class SalarySlip(TransactionBase):
 			if relieving_date and d > relieving_date:
 				continue
 
-			leave = get_lwp_or_ppl_for_date(str(d), self.employee, holidays)
+			leave = get_lwp_or_ppl_for_date(formatdate(d), self.employee, holidays)
 
 			if leave:
 				equivalent_lwp_count = 0

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -3,7 +3,7 @@
 
 
 import math
-from datetime import date, timedelta
+from datetime import date
 
 import frappe
 from frappe import _, msgprint
@@ -2127,14 +2127,6 @@ def set_missing_values(time_sheet, target):
 	target.posting_date = doc.modified
 	target.total_working_hours = doc.total_hours
 	target.append("timesheets", {"time_sheet": doc.name, "working_hours": doc.total_hours})
-
-
-def date_range(start=None, end=None):
-	if start and end:
-		delta = end - start  # as timedelta
-		days = [str(start + timedelta(days=i)) for i in range(delta.days + 1)]
-		return days
-	return []
 
 
 def throw_error_message(row, error, title, description=None):

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -502,12 +502,10 @@ class SalarySlip(TransactionBase):
 		)
 
 		for d in working_days_list:
-			# date = add_days(cstr(getdate(self.start_date)), d)
 			if relieving_date and d > relieving_date:
 				continue
 
-			leave = get_lwp_or_ppl_for_date(formatdate(d), self.employee, holidays)
-
+			leave = get_lwp_or_ppl_for_date(str(d), self.employee, holidays)
 			if leave:
 				equivalent_lwp_count = 0
 				is_half_day_leave = cint(leave[0].is_half_day)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1227,6 +1227,35 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 1), 126126.0)
 		self.assertEqual(flt(salary_slip.total_income_tax, 0), 137592)
 
+	@change_settings("Payroll Settings", {"payroll_based_on": "Leave"})
+	def test_lwp_calculation_based_on_relieving_date(self):
+		emp_id = make_employee("test_lwp_based_on_relieving_date@salary.com")
+		frappe.db.set_value("Employee", emp_id, {"relieving_date": None, "status": "Active"})
+		frappe.db.set_value("Leave Type", "Leave Without Pay", "include_holiday", 0)
+
+		month_start_date = get_first_day(nowdate())
+		first_sunday = get_first_sunday(for_date=month_start_date)
+		relieving_date = add_days(first_sunday, 10)
+		leave_start_date = add_days(first_sunday, 16)
+		leave_end_date = add_days(leave_start_date, 2)
+
+		make_leave_application(emp_id, leave_start_date, leave_end_date, "Leave Without Pay")
+
+		frappe.db.set_value("Employee", emp_id, {"relieving_date": relieving_date, "status": "Left"})
+
+		ss = make_employee_salary_slip(
+			"test_lwp_based_on_relieving_date@salary.com",
+			"Monthly",
+			"Test Payment Based On Leave Application",
+		)
+
+		holidays = ss.get_holidays_for_employee(month_start_date, relieving_date)
+		days_between_start_and_relieving = date_diff(relieving_date, month_start_date) + 1
+
+		self.assertEqual(ss.leave_without_pay, 0)
+
+		self.assertEqual(ss.payment_days, (days_between_start_and_relieving - len(holidays)))
+
 
 def get_no_of_days():
 	no_of_days_in_month = calendar.monthrange(getdate(nowdate()).year, getdate(nowdate()).month)


### PR DESCRIPTION
### Scenario :

The employee has approved leave application of type LWP for three days from 22nd to 24th. But the employee left the organisation before that say on 15th of the month.

- Future dated approved Leave Application
<img width="1334" alt="Screenshot 2023-03-08 at 7 09 54 PM" src="https://user-images.githubusercontent.com/3784093/223727806-de6b02a6-bbbb-400f-959e-30dfd28493a9.png">


- Relieving date for employee

<img width="1295" alt="Screenshot 2023-03-08 at 5 26 31 PM" src="https://user-images.githubusercontent.com/3784093/223707364-e6443eae-091e-43d0-9a7f-2e687ca81a42.png">

### Issue
Though employee left before, the system still consider its future dated leave application while calculating salary. Due to this, instead of getting payment for 11 days, the employee receiving payment for only 8 days  (11 - 3) 

#### Payment days calculation before fix
<img width="1066" alt="Screenshot 2023-03-08 at 7 09 35 PM" src="https://user-images.githubusercontent.com/3784093/223727907-52fe20eb-aa1b-4549-8b4d-a89bee04cd8b.png">


### Resolution
Calculate LWP based on relieving date (if applicable)

#### Payment days calculation after fix

<img width="1065" alt="Screenshot 2023-03-08 at 5 26 22 PM" src="https://user-images.githubusercontent.com/3784093/223707561-b7398f8d-0acd-4085-9754-93929e0c1835.png">





