### PR TITLE
fix: Check employee status for validating salary slip with relieving date lesser than start date

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,8 +466,8 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
-		employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
+			employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
 			elif relieving_date < getdate(self.start_date) and employee_status != "Left":

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -470,7 +470,7 @@ class SalarySlip(TransactionBase):
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
-			elif relieving_date < getdate(self.start_date) and employee_status != 'Left':
+			elif relieving_date < getdate(self.start_date) and employee_status != "Left":
 				frappe.throw(_("Employee relieved on {0} must be set as 'Left'").format(relieving_date))
 
 		payment_days = date_diff(end_date, start_date) + 1

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,7 +466,7 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
-		employee_status = froggy.get_cached_value("Employee", self.employee, "status")
+		employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,10 +466,11 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
+		employee_status = froggy.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
-			elif relieving_date < getdate(self.start_date):
+			elif relieving_date < getdate(self.start_date) and employee_status != 'Left':
 				frappe.throw(_("Employee relieved on {0} must be set as 'Left'").format(relieving_date))
 
 		payment_days = date_diff(end_date, start_date) + 1


### PR DESCRIPTION
Check whether employee status is set as "Left" before throwing error