### PR TITLE
fix: check working hours threshold for Absent before Half Day

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -96,15 +96,17 @@ class ShiftType(Document):
 			early_exit = True
 
 		if (
-			self.working_hours_threshold_for_half_day
-			and total_working_hours < self.working_hours_threshold_for_half_day
-		):
-			return "Half Day", total_working_hours, late_entry, early_exit, in_time, out_time
-		if (
 			self.working_hours_threshold_for_absent
 			and total_working_hours < self.working_hours_threshold_for_absent
 		):
 			return "Absent", total_working_hours, late_entry, early_exit, in_time, out_time
+
+		if (
+			self.working_hours_threshold_for_half_day
+			and total_working_hours < self.working_hours_threshold_for_half_day
+		):
+			return "Half Day", total_working_hours, late_entry, early_exit, in_time, out_time
+
 		return "Present", total_working_hours, late_entry, early_exit, in_time, out_time
 
 	def mark_absent_for_dates_with_no_attendance(self, employee):

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -141,37 +141,8 @@ class TestShiftType(FrappeTestCase):
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
 		shift_type = setup_shift_type(
 			shift_type="Half Day + Absent Test",
-			working_hours_threshold_for_half_day=1,
-			working_hours_threshold_for_absent=2,
-		)
-		date = getdate()
-		make_shift_assignment(shift_type.name, employee, date)
-
-		timestamp = datetime.combine(date, get_time("08:00:00"))
-		log_in = make_checkin(employee, timestamp)
-		self.assertEqual(log_in.shift, shift_type.name)
-
-		timestamp = datetime.combine(date, get_time("08:45:00"))
-		log_out = make_checkin(employee, timestamp)
-		self.assertEqual(log_out.shift, shift_type.name)
-
-		shift_type.process_auto_attendance()
-
-		attendance = frappe.db.get_value(
-			"Attendance", {"shift": shift_type.name}, ["status", "working_hours"], as_dict=True
-		)
-		self.assertEqual(attendance.status, "Half Day")
-		self.assertEqual(attendance.working_hours, 0.75)
-
-	def test_working_hours_threshold_for_absent_and_half_day_2(self):
-		# considers absent over half day
-		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
-
-		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
-		shift_type = setup_shift_type(
-			shift_type="Half Day + Absent Test",
-			working_hours_threshold_for_half_day=1,
-			working_hours_threshold_for_absent=2,
+			working_hours_threshold_for_half_day=2,
+			working_hours_threshold_for_absent=1,
 		)
 		date = getdate()
 		make_shift_assignment(shift_type.name, employee, date)
@@ -181,6 +152,35 @@ class TestShiftType(FrappeTestCase):
 		self.assertEqual(log_in.shift, shift_type.name)
 
 		timestamp = datetime.combine(date, get_time("09:30:00"))
+		log_out = make_checkin(employee, timestamp)
+		self.assertEqual(log_out.shift, shift_type.name)
+
+		shift_type.process_auto_attendance()
+
+		attendance = frappe.db.get_value(
+			"Attendance", {"shift": shift_type.name}, ["status", "working_hours"], as_dict=True
+		)
+		self.assertEqual(attendance.status, "Half Day")
+		self.assertEqual(attendance.working_hours, 1.5)
+
+	def test_working_hours_threshold_for_absent_and_half_day_2(self):
+		# considers absent over half day
+		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
+
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Half Day + Absent Test",
+			working_hours_threshold_for_half_day=2,
+			working_hours_threshold_for_absent=1,
+		)
+		date = getdate()
+		make_shift_assignment(shift_type.name, employee, date)
+
+		timestamp = datetime.combine(date, get_time("08:00:00"))
+		log_in = make_checkin(employee, timestamp)
+		self.assertEqual(log_in.shift, shift_type.name)
+
+		timestamp = datetime.combine(date, get_time("08:45:00"))
 		log_out = make_checkin(employee, timestamp)
 		self.assertEqual(log_out.shift, shift_type.name)
 


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/343

Continuing https://github.com/frappe/hrms/pull/354

The threshold for marking an employee as absent is always going to be lesser than the threshold for Half Day. Check absent threshold before half day.

Ex: 

## Case 1

HD Threshold = 7.5
A Threshold = 4

Working Hours = 1.7

Attendance should be marked Absent, not Half Day

## Case 2

HD Threshold = 7.5
A Threshold = 4

Working Hours = 5

Attendance should be marked as Half Day, not Absent

## Case 3

HD Threshold = 0
A Threshold = 4

Working Hours = 2

Attendance should be marked as Absent, Half day threshold isn't checked

## Case 4

HD Threshold = 4
A Threshold = 0

Working Hours = 2

Attendance should be marked as Half day since absent threshold is not set

## Case 5

HD Threshold = 7.5
A Threshold = 4

Working Hours = 7.5

Present because the employee is not missing the absent threshold nor the half day threshold