### PR TITLE
fix: exclude carry forwarded leaves while updating leaves after submission

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -100,8 +100,8 @@ class LeaveAllocation(Document):
 			self.validate_leave_days_and_dates()
 
 			leaves_to_be_added = flt(
-				frappe.db.get_value("Leave Allocation", self.name, "new_leaves_allocated")
-				- self.get_existing_leave_count()
+				(self.new_leaves_allocated - self.get_existing_leave_count()),
+				self.precision("new_leaves_allocated"),
 			)
 
 			args = {

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -99,7 +99,7 @@ class LeaveAllocation(Document):
 			# run required validations again since total leaves are being updated
 			self.validate_leave_days_and_dates()
 
-			leaves_to_be_added = (
+			leaves_to_be_added = flt(
 				frappe.db.get_value("Leave Allocation", self.name, "new_leaves_allocated")
 				- self.get_existing_leave_count()
 			)
@@ -123,14 +123,12 @@ class LeaveAllocation(Document):
 				"company": self.company,
 				"leave_type": self.leave_type,
 				"is_carry_forward": 0,
+				"docstatus": 1,
 			},
-			pluck="leaves",
+			fields=["SUM(leaves) as total_leaves"],
 		)
-		total_existing_leaves = 0
-		for entry in ledger_entries:
-			total_existing_leaves += entry
 
-		return total_existing_leaves
+		return ledger_entries[0].total_leaves if ledger_entries else 0
 
 	def validate_against_leave_applications(self):
 		leaves_taken = get_approved_leaves_for_period(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -90,6 +90,7 @@ class LeaveAllocation(Document):
 		if self.carry_forward:
 			self.set_carry_forwarded_leaves_in_previous_allocation(on_cancel=True)
 
+	# nosemgrep: frappe-semgrep-rules.rules.frappe-modifying-but-not-comitting
 	def on_update_after_submit(self):
 		if self.has_value_changed("new_leaves_allocated"):
 			self.validate_against_leave_applications()

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -99,7 +99,11 @@ class LeaveAllocation(Document):
 			# run required validations again since total leaves are being updated
 			self.validate_leave_days_and_dates()
 
-			leaves_to_be_added = self.new_leaves_allocated - self.get_existing_leave_count()
+			leaves_to_be_added = (
+				frappe.db.get_value("Leave Allocation", self.name, "new_leaves_allocated")
+				- self.get_existing_leave_count()
+			)
+
 			args = {
 				"leaves": leaves_to_be_added,
 				"from_date": self.from_date,
@@ -118,6 +122,7 @@ class LeaveAllocation(Document):
 				"employee": self.employee,
 				"company": self.company,
 				"leave_type": self.leave_type,
+				"is_carry_forward": 0,
 			},
 			pluck="leaves",
 		)

--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -358,6 +358,16 @@ class TestLeaveAllocation(FrappeTestCase):
 		leave_allocation.new_leaves_allocated = 40
 		leave_allocation.save()
 		leave_allocation.reload()
+
+		updated_entry = frappe.db.get_all(
+			"Leave Ledger Entry",
+			{"transaction_name": leave_allocation.name},
+			pluck="leaves",
+			order_by="creation desc",
+			limit=1,
+		)
+
+		self.assertEqual(updated_entry[0], 25)
 		self.assertEqual(leave_allocation.total_leaves_allocated, 40)
 
 	def test_leave_addition_after_submit_with_carry_forward(self):
@@ -372,7 +382,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		)
 
 		leave_allocation = create_carry_forwarded_allocation(self.employee, leave_type)
-
+		# 15 new leaves, 15 carry forwarded leaves
 		self.assertEqual(leave_allocation.total_leaves_allocated, 30)
 
 		leave_allocation.new_leaves_allocated = 32
@@ -387,6 +397,7 @@ class TestLeaveAllocation(FrappeTestCase):
 			limit=1,
 		)
 		self.assertEqual(updated_entry[0], 17)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 47)
 
 	def test_leave_subtraction_after_submit(self):
 		leave_allocation = create_leave_allocation(
@@ -399,6 +410,16 @@ class TestLeaveAllocation(FrappeTestCase):
 		leave_allocation.new_leaves_allocated = 10
 		leave_allocation.submit()
 		leave_allocation.reload()
+
+		updated_entry = frappe.db.get_all(
+			"Leave Ledger Entry",
+			{"transaction_name": leave_allocation.name},
+			pluck="leaves",
+			order_by="creation desc",
+			limit=1,
+		)
+
+		self.assertEqual(updated_entry[0], -5)
 		self.assertEqual(leave_allocation.total_leaves_allocated, 10)
 
 	def test_leave_subtraction_after_submit_with_carry_forward(self):
@@ -426,6 +447,7 @@ class TestLeaveAllocation(FrappeTestCase):
 			limit=1,
 		)
 		self.assertEqual(updated_entry[0], -7)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 23)
 
 	def test_validation_against_leave_application_after_submit(self):
 		from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list

--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -71,7 +71,6 @@ class TestLeaveAllocation(FrappeTestCase):
 
 	def test_validation_for_over_allocation(self):
 		leave_type = create_leave_type(leave_type_name="Test Over Allocation", is_carry_forward=1)
-		leave_type.save()
 
 		doc = frappe.get_doc(
 			{
@@ -139,9 +138,9 @@ class TestLeaveAllocation(FrappeTestCase):
 			)
 		).insert()
 
-		leave_type = create_leave_type(leave_type_name="_Test Allocation Validation", is_carry_forward=1)
-		leave_type.max_leaves_allowed = 25
-		leave_type.save()
+		leave_type = create_leave_type(
+			leave_type_name="_Test Allocation Validation", is_carry_forward=1, max_leaves_allowed=25
+		)
 
 		# 15 leaves allocated in this period
 		allocation = create_leave_allocation(
@@ -176,9 +175,9 @@ class TestLeaveAllocation(FrappeTestCase):
 			)
 		).insert()
 
-		leave_type = create_leave_type(leave_type_name="_Test Allocation Validation", is_carry_forward=1)
-		leave_type.max_leaves_allowed = 30
-		leave_type.save()
+		leave_type = create_leave_type(
+			leave_type_name="_Test Allocation Validation", is_carry_forward=1, max_leaves_allowed=30
+		)
 
 		# 15 leaves allocated
 		allocation = create_leave_allocation(
@@ -209,7 +208,6 @@ class TestLeaveAllocation(FrappeTestCase):
 
 	def test_validate_back_dated_allocation_update(self):
 		leave_type = create_leave_type(leave_type_name="_Test_CF_leave", is_carry_forward=1)
-		leave_type.save()
 
 		# initial leave allocation = 15
 		leave_allocation = create_leave_allocation(
@@ -237,10 +235,12 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertRaises(BackDatedAllocationError, leave_allocation.save)
 
 	def test_carry_forward_calculation(self):
-		leave_type = create_leave_type(leave_type_name="_Test_CF_leave", is_carry_forward=1)
-		leave_type.maximum_carry_forwarded_leaves = 10
-		leave_type.max_leaves_allowed = 30
-		leave_type.save()
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave",
+			is_carry_forward=1,
+			maximum_carry_forwarded_leaves=10,
+			max_leaves_allowed=30,
+		)
 
 		# initial leave allocation = 15
 		leave_allocation = create_leave_allocation(
@@ -288,7 +288,6 @@ class TestLeaveAllocation(FrappeTestCase):
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
 		)
-		leave_type.save()
 
 		# initial leave allocation
 		leave_allocation = create_leave_allocation(
@@ -354,12 +353,40 @@ class TestLeaveAllocation(FrappeTestCase):
 		)
 		leave_allocation.submit()
 		leave_allocation.reload()
-		self.assertTrue(leave_allocation.total_leaves_allocated, 15)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 15)
 
 		leave_allocation.new_leaves_allocated = 40
-		leave_allocation.submit()
+		leave_allocation.save()
 		leave_allocation.reload()
-		self.assertTrue(leave_allocation.total_leaves_allocated, 40)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 40)
+
+	def test_leave_addition_after_submit_with_carry_forward(self):
+		from hrms.hr.doctype.leave_application.test_leave_application import (
+			create_carry_forwarded_allocation,
+		)
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			include_holiday=True,
+		)
+
+		leave_allocation = create_carry_forwarded_allocation(self.employee, leave_type)
+
+		self.assertEqual(leave_allocation.total_leaves_allocated, 30)
+
+		leave_allocation.new_leaves_allocated = 32
+		leave_allocation.save()
+		leave_allocation.reload()
+
+		updated_entry = frappe.db.get_all(
+			"Leave Ledger Entry",
+			{"transaction_name": leave_allocation.name},
+			pluck="leaves",
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertEqual(updated_entry[0], 17)
 
 	def test_leave_subtraction_after_submit(self):
 		leave_allocation = create_leave_allocation(
@@ -367,12 +394,38 @@ class TestLeaveAllocation(FrappeTestCase):
 		)
 		leave_allocation.submit()
 		leave_allocation.reload()
-		self.assertTrue(leave_allocation.total_leaves_allocated, 15)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 15)
 
 		leave_allocation.new_leaves_allocated = 10
 		leave_allocation.submit()
 		leave_allocation.reload()
-		self.assertTrue(leave_allocation.total_leaves_allocated, 10)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 10)
+
+	def test_leave_subtraction_after_submit_with_carry_forward(self):
+		from hrms.hr.doctype.leave_application.test_leave_application import (
+			create_carry_forwarded_allocation,
+		)
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			include_holiday=True,
+		)
+
+		leave_allocation = create_carry_forwarded_allocation(self.employee, leave_type)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 30)
+
+		leave_allocation.new_leaves_allocated = 8
+		leave_allocation.save()
+
+		updated_entry = frappe.db.get_all(
+			"Leave Ledger Entry",
+			{"transaction_name": leave_allocation.name},
+			pluck="leaves",
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertEqual(updated_entry[0], -7)
 
 	def test_validation_against_leave_application_after_submit(self):
 		from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -703,7 +703,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		create_carry_forwarded_allocation(employee, leave_type)
 		details = get_leave_balance_on(
@@ -754,7 +754,6 @@ class TestLeaveApplication(unittest.TestCase):
 		employee = get_employee()
 
 		leave_type = create_leave_type(leave_type_name="Test Leave Type 1")
-		leave_type.save()
 
 		leave_allocation = create_leave_allocation(
 			employee=employee.name, employee_name=employee.employee_name, leave_type=leave_type.name
@@ -797,7 +796,6 @@ class TestLeaveApplication(unittest.TestCase):
 			expire_carry_forwarded_leaves_after_days=90,
 			include_holiday=True,
 		)
-		leave_type.submit()
 
 		create_carry_forwarded_allocation(employee, leave_type)
 
@@ -836,7 +834,6 @@ class TestLeaveApplication(unittest.TestCase):
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
 		)
-		leave_type.submit()
 
 		create_carry_forwarded_allocation(employee, leave_type)
 
@@ -937,7 +934,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
 		cf_expiry = frappe.db.get_value(
@@ -970,7 +967,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
 		cf_expiry = frappe.db.get_value(
@@ -1004,7 +1001,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
 		cf_expiry = frappe.db.get_value(
@@ -1046,7 +1043,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
 		cf_expiry = frappe.db.get_value(
@@ -1080,7 +1077,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
-		).insert()
+		)
 
 		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
 		cf_expiry = frappe.db.get_value(

--- a/hrms/hr/doctype/leave_type/test_leave_type.py
+++ b/hrms/hr/doctype/leave_type/test_leave_type.py
@@ -9,7 +9,8 @@ test_records = frappe.get_test_records("Leave Type")
 def create_leave_type(**args):
 	args = frappe._dict(args)
 	if frappe.db.exists("Leave Type", args.leave_type_name):
-		return frappe.get_doc("Leave Type", args.leave_type_name)
+		frappe.delete_doc("Leave Type", args.leave_type_name)
+
 	leave_type = frappe.get_doc(
 		{
 			"doctype": "Leave Type",
@@ -23,10 +24,14 @@ def create_leave_type(**args):
 			"expire_carry_forwarded_leaves_after_days": args.expire_carry_forwarded_leaves_after_days or 0,
 			"encashment_threshold_days": args.encashment_threshold_days or 5,
 			"earning_component": "Leave Encashment",
+			"max_leaves_allowed": args.max_leaves_allowed,
+			"maximum_carry_forwarded_leaves": args.maximum_carry_forwarded_leaves,
 		}
 	)
 
 	if leave_type.is_ppl:
 		leave_type.fraction_of_daily_salary_per_leave = args.fraction_of_daily_salary_per_leave or 0.5
+
+	leave_type.insert()
 
 	return leave_type

--- a/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
@@ -155,7 +155,6 @@ class TestEmployeeLeaveBalance(unittest.TestCase):
 	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_opening_balance_considers_carry_forwarded_leaves(self):
 		leave_type = create_leave_type(leave_type_name="_Test_CF_leave_expiry", is_carry_forward=1)
-		leave_type.insert()
 
 		# 30 leaves allocated for first half of the year
 		allocation1 = make_allocation_record(

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -301,7 +301,6 @@ class TestSalarySlip(FrappeTestCase):
 		make_leave_application(emp_id, first_sunday, add_days(first_sunday, 3), "Leave Without Pay")
 
 		leave_type_ppl = create_leave_type(leave_type_name="Test Partially Paid Leave", is_ppl=1)
-		leave_type_ppl.save()
 
 		alloc = create_leave_allocation(
 			employee=emp_id,


### PR DESCRIPTION
## Problem

15 leaves allocated with 5 carry forwarded leaves

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/224264964-e5d97bc7-d4b9-4979-bbe2-07d166529832.png">

Changed 15 leaves allocated to 10

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/224265367-4caa11b2-33dd-4b34-941b-7fd64ef5631d.png">

New leaves allocated should be 10 not 5, 

<img width="1326" alt="incorrect-balance" src="https://user-images.githubusercontent.com/24353136/224265743-7c3b57a8-b311-4e50-839d-f1aeaf38ef34.png">

The intermediate leave ledger entry created on updating new leaves allocated is also considering carry forwarded leaves while finding out the difference to update existing allocation:

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/224266025-ff0a4622-cd1c-4384-9dbe-112db7412d45.png">

## Fix

Ledger entry should only consider new leaves allocated and exclude carry forwarded leaves while computing difference

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/224267741-6a753157-85a8-42fa-8cf2-5e143ea2996e.png">

Leave balance is rectified:

<img width="1326" alt="leave-balance-after" src="https://user-images.githubusercontent.com/24353136/224267994-e0c9d194-9b29-400b-a2d9-bd63aa170e28.png">
