### PR TITLE
fix: get income tax slab only if tax compoents are applicable

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -621,9 +621,10 @@ class SalarySlip(TransactionBase):
 		if self.salary_structure:
 			self.calculate_component_amounts("earnings")
 
-		if self.payroll_period and self.salary_structure:
-			self.tax_slab = self.get_income_tax_slabs()
-			self.compute_taxable_earnings_for_year()
+		# get remaining numbers of sub-period (period for which one salary is processed)
+		self.remaining_sub_periods = get_period_factor(
+			self.employee, self.start_date, self.end_date, self.payroll_frequency, self.payroll_period
+		)[1]
 
 		self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
 		self.base_gross_pay = flt(
@@ -700,11 +701,6 @@ class SalarySlip(TransactionBase):
 		)
 
 	def compute_current_and_future_taxable_earnings(self):
-		# get remaining numbers of sub-period (period for which one salary is processed)
-		self.remaining_sub_periods = get_period_factor(
-			self.employee, self.start_date, self.end_date, self.payroll_frequency, self.payroll_period
-		)[1]
-
 		# get taxable_earnings for current period (all days)
 		self.current_taxable_earnings = self.get_taxable_earnings(self.tax_slab.allow_tax_exemption)
 		self.future_structured_taxable_earnings = self.current_taxable_earnings.taxable_earnings * (
@@ -744,6 +740,9 @@ class SalarySlip(TransactionBase):
 		if not self.payroll_period:
 			return
 
+		self.standard_tax_exemption_amount = 0
+		self.tax_exemption_declaration = 0
+
 		self.non_taxable_earnings = self.compute_non_taxable_earnings()
 
 		self.ctc = self.compute_ctc()
@@ -754,13 +753,14 @@ class SalarySlip(TransactionBase):
 
 		self.deductions_before_tax_calculation = self.compute_annual_deductions_before_tax_calculation()
 
-		self.standard_tax_exemption_amount = (
-			self.tax_slab.standard_tax_exemption_amount if self.tax_slab.allow_tax_exemption else 0.0
-		)
+		if hasattr(self, "tax_slab"):
+			self.standard_tax_exemption_amount = (
+				self.tax_slab.standard_tax_exemption_amount if self.tax_slab.allow_tax_exemption else 0.0
+			)
 
-		self.tax_exemption_declaration = (
-			self.get_total_exemption_amount() - self.standard_tax_exemption_amount
-		)
+			self.tax_exemption_declaration = (
+				self.get_total_exemption_amount() - self.standard_tax_exemption_amount
+			)
 
 		self.annual_taxable_amount = self.total_earnings - (
 			self.non_taxable_earnings
@@ -1124,6 +1124,10 @@ class SalarySlip(TransactionBase):
 				for d in frappe.get_all("Salary Component", filters={"variable_based_on_taxable_salary": 1})
 				if d.name not in self.other_deduction_components
 			]
+
+		if tax_components and self.payroll_period and self.salary_structure:
+			self.tax_slab = self.get_income_tax_slabs()
+			self.compute_taxable_earnings_for_year()
 
 		self.component_based_veriable_tax = {}
 		for d in tax_components:

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -622,9 +622,10 @@ class SalarySlip(TransactionBase):
 			self.calculate_component_amounts("earnings")
 
 		# get remaining numbers of sub-period (period for which one salary is processed)
-		self.remaining_sub_periods = get_period_factor(
-			self.employee, self.start_date, self.end_date, self.payroll_frequency, self.payroll_period
-		)[1]
+		if self.payroll_period:
+			self.remaining_sub_periods = get_period_factor(
+				self.employee, self.start_date, self.end_date, self.payroll_frequency, self.payroll_period
+			)[1]
 
 		self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
 		self.base_gross_pay = flt(

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1164,7 +1164,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 		for deduction in salary_slip.deductions:
 			if deduction.salary_component == "TDS":
-				self.assertEqual(deduction.amount, 7732.0)
+				self.assertEqual(deduction.amount, 7691.0)
 
 		frappe.db.sql("DELETE FROM `tabPayroll Period` where company = '_Test Company'")
 		frappe.db.sql("DELETE FROM `tabIncome Tax Slab` where currency = 'INR'")
@@ -1211,7 +1211,7 @@ class TestSalarySlip(FrappeTestCase):
 			salary_structure_doc.name, employee=employee_doc.name, posting_date=payroll_period.start_date
 		)
 
-		monthly_tax_amount = 11466.0
+		monthly_tax_amount = 11403.6
 
 		self.assertEqual(salary_slip.ctc, 1226000.0)
 		self.assertEqual(salary_slip.income_from_other_sources, 10000.0)
@@ -1221,10 +1221,10 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(salary_slip.tax_exemption_declaration, 100000.0)
 		self.assertEqual(salary_slip.deductions_before_tax_calculation, 2400.0)
 		self.assertEqual(salary_slip.annual_taxable_amount, 1073600.0)
-		self.assertEqual(flt(salary_slip.income_tax_deducted_till_date, 1), monthly_tax_amount)
-		self.assertEqual(flt(salary_slip.current_month_income_tax, 1), monthly_tax_amount)
-		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 1), 126126.0)
-		self.assertEqual(flt(salary_slip.total_income_tax, 0), 137592)
+		self.assertEqual(flt(salary_slip.income_tax_deducted_till_date, 2), monthly_tax_amount)
+		self.assertEqual(flt(salary_slip.current_month_income_tax, 2), monthly_tax_amount)
+		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 2), 125439.65)
+		self.assertEqual(flt(salary_slip.total_income_tax, 2), 136843.25)
 
 	@change_settings("Payroll Settings", {"payroll_based_on": "Leave"})
 	def test_lwp_calculation_based_on_relieving_date(self):


### PR DESCRIPTION
Issue: The system is throwing error to set Tax Slab on salary slip though non of salary components defined for variable tax

![J7WJN8F](https://user-images.githubusercontent.com/3784093/225303664-0f23138a-211e-4f91-b104-a6a2dda8f93b.png)
