### PR TITLE
fix: earned leave exceeding annual allocation

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -410,27 +410,6 @@ def round_earned_leaves(earned_leaves, rounding):
 	return earned_leaves
 
 
-def is_earned_leave_already_allocated(allocation, annual_allocation):
-	from hrms.hr.doctype.leave_policy_assignment.leave_policy_assignment import get_leave_type_details
-
-	leave_type_details = get_leave_type_details()
-	date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
-
-	assignment = frappe.get_doc("Leave Policy Assignment", allocation.leave_policy_assignment)
-	leaves_for_passed_months = assignment.get_leaves_for_passed_months(
-		allocation.leave_type, annual_allocation, leave_type_details, date_of_joining
-	)
-
-	# exclude carry-forwarded leaves while checking for leave allocation for passed months
-	num_allocations = allocation.total_leaves_allocated
-	if allocation.unused_leaves:
-		num_allocations -= allocation.unused_leaves
-
-	if num_allocations >= leaves_for_passed_months:
-		return True
-	return False
-
-
 def get_leave_allocations(date, leave_type):
 	return frappe.db.sql(
 		"""select name, employee, from_date, to_date, leave_policy_assignment, leave_policy

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -334,17 +334,27 @@ def allocate_earned_leaves():
 
 
 def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining):
+	allocation = frappe.get_doc("Leave Allocation", allocation.name)
+	annual_allocation = flt(annual_allocation, allocation.precision("total_leaves_allocated"))
+
 	earned_leaves = get_monthly_earned_leave(
 		date_of_joining, annual_allocation, e_leave_type.earned_leave_frequency, e_leave_type.rounding
 	)
 
-	allocation = frappe.get_doc("Leave Allocation", allocation.name)
 	new_allocation = flt(allocation.total_leaves_allocated) + flt(earned_leaves)
+	new_allocation_without_cf = flt(
+		flt(allocation.get_existing_leave_count()) + flt(earned_leaves),
+		allocation.precision("total_leaves_allocated"),
+	)
 
 	if new_allocation > e_leave_type.max_leaves_allowed and e_leave_type.max_leaves_allowed > 0:
 		new_allocation = e_leave_type.max_leaves_allowed
 
-	if new_allocation != allocation.total_leaves_allocated:
+	if (
+		new_allocation != allocation.total_leaves_allocated
+		# annual allocation as per policy should not be exceeded
+		and new_allocation_without_cf <= annual_allocation
+	):
 		today_date = frappe.flags.current_date or getdate()
 
 		allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)


### PR DESCRIPTION
## Problem

Leave Policy with Earned Leave created
**Annual Allocation (Leave Policy)**: 22
**Rounding (Leave Type)**: 1.0

Monthly earned leave = round(22/12) = round(1.83) = 2
2 leaves get allocated for 11 months, so 22 leaves annual allocation is fulfilled
2 more leaves get allocated in the 12th month, making total leaves = 24 (exceeds annual allocation of 22)

## Solution

While allocating earned leaves, make sure **new allocation without carry forwarded leaves is not exceeding the annual allocation quota**.
Excluding carry forwarding allocations in this check is important since users might have carry forwarded leaves + earned leaves annual allocation.

TODO
- [x] Avoid over allocation during backdated allocation creation (for past months)
