### PR TITLE
fix: don't allow manual updates for earned leave allocation after submission

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -34,6 +34,13 @@ frappe.ui.form.on("Leave Allocation", {
 				});
 			}
 		}
+
+		if (!frm.doc.__islocal && frm.doc.leave_policy_assignment) {
+			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
+				if (cint(r?.is_earned_leave))
+					frm.set_df_property("new_leaves_allocated", "read_only", 1);
+			});
+		}
 	},
 
 	expire_allocation: function(frm) {


### PR DESCRIPTION
## Problem

Earned Leaves are auto-allocated via scheduler based on the annual allocation set in policy assignment. 
Manually updating **New Leaves Allocated** field makes no sense here, since leaves are automatically computed and allocated based on set frequency.
This can mess up the balance and calculation. Also, this validation is essential to overcome other problems like https://github.com/frappe/hrms/pull/397

## Solution

Make the **New Leaves Allocated** field read-only if:

- Leave Type has "_Is Earned Leave_" enabled and
- Leave Allocation is linked to Leave Policy Assignment

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/24353136/226290077-b9248aaf-dd16-44db-8328-4278d38183aa.png">

Validate the same case on the server-side in `on_update_after_submit`

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/24353136/226290159-26b8e861-90b7-42f2-9a49-e4bb4bad02f0.png">
