### PR TITLE
fix: cannot customize Employee Advance due to document states property

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.json
+++ b/hrms/hr/doctype/employee_advance/employee_advance.json
@@ -200,7 +200,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-01-17 19:33:52.345823",
+ "modified": "2023-03-21 18:24:06.416439",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Advance",
@@ -240,22 +240,18 @@
  "states": [
   {
    "color": "Red",
-   "custom": 1,
    "title": "Draft"
   },
   {
    "color": "Green",
-   "custom": 1,
    "title": "Paid"
   },
   {
    "color": "Orange",
-   "custom": 1,
    "title": "Unpaid"
   },
   {
    "color": "Blue",
-   "custom": 1,
    "title": "Claimed"
   },
   {
@@ -268,7 +264,6 @@
   },
   {
    "color": "Red",
-   "custom": 1,
    "title": "Cancelled"
   }
  ],


### PR DESCRIPTION
**Problem**:

Unable to customize Employee Advance because of the "custom" property exported into the DocType JSON accidentally (might be a framework bug)

Closes: https://github.com/frappe/hrms/issues/355

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/24353136/226613819-7a275473-e470-4c6d-a686-3f0a541a23aa.png">

Duplicate status rows with weird idx:

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/24353136/226613671-576cdc63-ab42-497a-8cd8-194b0659ba03.png">


**Fix**:

![Kapture 2023-03-21 at 18 29 31](https://user-images.githubusercontent.com/24353136/226613356-d10533a9-ffbc-4bc2-ba5d-efca949d0d52.gif)


