### PR TITLE
fix: filter out old allocation's carry-forwarded leaves while fetching leave details

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -881,6 +881,9 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 				| (
 					(Ledger.is_carry_forward == 1)
 					& (Ledger.to_date.between(LeaveAllocation.from_date, LeaveAllocation.to_date))
+					# only consider cf leaves from current allocation
+					& (LeaveAllocation.from_date <= date)
+					& (date <= LeaveAllocation.to_date)
 				)
 			)
 		)

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1102,25 +1102,51 @@ class TestLeaveApplication(unittest.TestCase):
 		details = get_leave_allocation_records(employee.name, add_days(cf_expiry, 1), leave_type.name)
 		self.assertEqual(details.get(leave_type.name), expected_data)
 
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_filtered_old_cf_entries_in_get_leave_allocation_records(self):
+		"""Tests whether old cf entries are ignored while fetching current allocation records"""
+		employee = get_employee()
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=90,
+		)
 
-def create_carry_forwarded_allocation(employee, leave_type):
+		# old allocation with cf leaves
+		create_carry_forwarded_allocation(employee, leave_type, date="2019-01-01")
+		# new allocation with cf leaves
+		leave_alloc = create_carry_forwarded_allocation(employee, leave_type)
+		cf_expiry = frappe.db.get_value(
+			"Leave Ledger Entry", {"transaction_name": leave_alloc.name, "is_carry_forward": 1}, "to_date"
+		)
+
+		# test total leaves allocated before cf leave expiry
+		details = get_leave_allocation_records(employee.name, add_days(cf_expiry, -1), leave_type.name)
+		# filters out old CF leaves (15 i.e total 45)
+		self.assertEqual(details[leave_type.name]["total_leaves_allocated"], 30.0)
+
+
+def create_carry_forwarded_allocation(employee, leave_type, date=None):
+	date = date or nowdate()
+
 	# initial leave allocation
 	leave_allocation = create_leave_allocation(
 		leave_type="_Test_CF_leave_expiry",
 		employee=employee.name,
 		employee_name=employee.employee_name,
-		from_date=add_months(nowdate(), -24),
-		to_date=add_months(nowdate(), -12),
+		from_date=add_months(date, -24),
+		to_date=add_months(date, -12),
 		carry_forward=0,
 	)
 	leave_allocation.submit()
 
+	# carry forward leave allocation
 	leave_allocation = create_leave_allocation(
 		leave_type="_Test_CF_leave_expiry",
 		employee=employee.name,
 		employee_name=employee.employee_name,
-		from_date=add_days(nowdate(), -84),
-		to_date=add_days(nowdate(), 100),
+		from_date=add_days(date, -84),
+		to_date=add_days(date, 100),
 		carry_forward=1,
 	)
 	leave_allocation.submit()


### PR DESCRIPTION
## Problem:

While fetching allocation details for leave dashboard, all the previous carry forwarded records are being considered. 
Only the record marked in green should be considered

<img width="480" alt="entries" src="https://user-images.githubusercontent.com/24353136/226913217-25106972-d906-4676-b13a-c1d1a9dcaf33.png">

Causing weird balance calculations 😵‍💫

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/24353136/226821094-2d349a45-f402-46b9-8414-468c9b6e1b2d.png">

Actual balance is 0

<img width="1350" alt="fix" src="https://user-images.githubusercontent.com/24353136/226822256-409101b0-4ac4-4af3-8cc3-f32159a9211b.png">

## Fix

In the cf leaves query, add a condition to make sure only current allocation's leaves are being considered

<img width="480" alt="image" src="https://user-images.githubusercontent.com/24353136/226913995-831b6f8b-dfd5-44cb-ae45-e9b2866c8366.png">

The Ledger Period can vary in case of carry forwarded leaves
Ex: Allocation Period can be - 1st Jan 2023 to 31st Dec 2023
But carry forwarded leaves can have an early expiry (if they have to be used in the first 2-3 months)

So just comparing balance dates with Ledger dates won't help here

Edge case missed while fixing another edge case in https://github.com/frappe/hrms/pull/335

- [x] Tests