### PR TITLE
Fix: wrong for_timestamp for next shift

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -377,7 +377,7 @@ def get_employee_shift_timings(
 	curr_shift = get_employee_shift(employee, for_timestamp, consider_default_shift, "forward")
 	if curr_shift:
 		next_shift = get_employee_shift(
-			employee, curr_shift.start_datetime + timedelta(days=1), consider_default_shift, "forward"
+			employee, for_timestamp + timedelta(days=1), consider_default_shift, "forward"
 		)
 	prev_shift = get_employee_shift(
 		employee, for_timestamp + timedelta(days=-1), consider_default_shift, "reverse"

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,8 +466,8 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
-		employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
+			employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
 			elif relieving_date < getdate(self.start_date) and employee_status != "Left":

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -470,7 +470,7 @@ class SalarySlip(TransactionBase):
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
-			elif relieving_date < getdate(self.start_date) and employee_status != 'Left':
+			elif relieving_date < getdate(self.start_date) and employee_status != "Left":
 				frappe.throw(_("Employee relieved on {0} must be set as 'Left'").format(relieving_date))
 
 		payment_days = date_diff(end_date, start_date) + 1

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,7 +466,7 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
-		employee_status = froggy.get_cached_value("Employee", self.employee, "status")
+		employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -466,10 +466,11 @@ class SalarySlip(TransactionBase):
 				return
 
 		end_date = getdate(self.end_date)
+		employee_status = froggy.get_cached_value("Employee", self.employee, "status")
 		if relieving_date:
 			if getdate(self.start_date) <= relieving_date <= getdate(self.end_date):
 				end_date = relieving_date
-			elif relieving_date < getdate(self.start_date):
+			elif relieving_date < getdate(self.start_date) and employee_status != 'Left':
 				frappe.throw(_("Employee relieved on {0} must be set as 'Left'").format(relieving_date))
 
 		payment_days = date_diff(end_date, start_date) + 1


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Page-format-for-ERPNext-docs

- Contribution Guide => https://github.com/frappe/erpnext/wiki/Contribution-Guidelines

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

it was getting wrong actual shift start and end time for next shift

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
