### PR TITLE
fix(patch): run payroll entry status patch for null status only

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -3,6 +3,7 @@ hrms.patches.v15_0.check_version_compatibility_with_frappe
 hrms.patches.v14_0.update_performance_module_changes
 
 [post_model_sync]
+hrms.patches.post_install.set_payroll_entry_status
 hrms.patches.v1_0.rearrange_employee_fields
 hrms.patches.v1_0.update_allocate_on_in_leave_type
 hrms.patches.v14_0.create_custom_field_for_appraisal_template

--- a/hrms/patches/post_install/set_payroll_entry_status.py
+++ b/hrms/patches/post_install/set_payroll_entry_status.py
@@ -1,18 +1,14 @@
 import frappe
-from frappe.query_builder import Case
 
 
 def execute():
 	PayrollEntry = frappe.qb.DocType("Payroll Entry")
 
-	(
-		frappe.qb.update(PayrollEntry)
-		.set(
-			"status",
-			Case()
-			.when(PayrollEntry.docstatus == 0, "Draft")
-			.when(PayrollEntry.docstatus == 1, "Submitted")
-			.else_("Cancelled"),
-		)
-		.where((PayrollEntry.status.notin(["Queued", "Failed"])))
-	).run()
+	status = (
+		frappe.qb.terms.Case()
+		.when(PayrollEntry.docstatus == 0, "Draft")
+		.when(PayrollEntry.docstatus == 1, "Submitted")
+		.else_("Cancelled")
+	)
+
+	(frappe.qb.update(PayrollEntry).set("status", status).where(PayrollEntry.status.isnull())).run()


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/395

Membership check fails for null values in `status` column. Instead of checking if status is not in a particular list, directly apply update query for rows where `status` is `null`

Re-run the post install patch to update status for existing payroll entries