### PR TITLE
Leave application add more possible leave types

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -786,7 +786,7 @@ def get_leave_details(employee, date):
 		}
 
 	# is used in set query
-	lwp = frappe.get_list("Leave Type", filters={"is_lwp": 1}, pluck="name")
+	lwp = frappe.get_list("Leave Type", or_filters={"is_lwp": 1,"allow_over_allocation":1}, pluck="name")
 
 	return {
 		"leave_allocation": leave_allocation,


### PR DESCRIPTION
allow leave types that have allow_over_allocation true to be available in dropdown list in leave application, types which are not lwp like sick leave in some countries, they are not lwp and do not require leave allocation. all leave types that have allow_over_allocation set as true should be available to the employee  in leave application.

