### PR TITLE
fix: employee & grade filters not considered while allocating leaves via Leave Control Panel

### DIFF
--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
@@ -11,10 +11,20 @@ from frappe.utils import cint, comma_and, cstr, flt
 class LeaveControlPanel(Document):
 	def get_employees(self):
 		conditions, values = [], []
-		for field in ["company", "employment_type", "branch", "designation", "department", "employee"]:
+		for field in [
+			"company",
+			"employment_type",
+			"branch",
+			"designation",
+			"department",
+			"employee",
+			"employee_grade",
+		]:
 			if self.get(field):
 				if field == "employee":
 					conditions.append("name=%s")
+				elif field == "employee_grade":
+					conditions.append("grade=%s")
 				else:
 					conditions.append("{0}=%s".format(field))
 

--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
@@ -11,7 +11,7 @@ from frappe.utils import cint, comma_and, cstr, flt
 class LeaveControlPanel(Document):
 	def get_employees(self):
 		conditions, values = [], []
-		for field in ["company", "employment_type", "branch", "designation", "department","employee"]:
+		for field in ["company", "employment_type", "branch", "designation", "department", "employee"]:
 			if self.get(field):
 				if field == "employee":
 					conditions.append("name=%s")

--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
@@ -11,9 +11,13 @@ from frappe.utils import cint, comma_and, cstr, flt
 class LeaveControlPanel(Document):
 	def get_employees(self):
 		conditions, values = [], []
-		for field in ["company", "employment_type", "branch", "designation", "department"]:
+		for field in ["company", "employment_type", "branch", "designation", "department","employee"]:
 			if self.get(field):
-				conditions.append("{0}=%s".format(field))
+				if field == "employee":
+					conditions.append("name=%s")
+				else:
+					conditions.append("{0}=%s".format(field))
+
 				values.append(self.get(field))
 
 		condition_str = " and " + " and ".join(conditions) if len(conditions) else ""


### PR DESCRIPTION
Field employee not included in get_employees conditions (fetch only specific employee), field already exists "employee"

## Problem:

Leave Control Panel has an employee field in filters but it doesn't apply that filter while allocating leaves

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235621261-11b3c592-52ba-4e4b-af47-e5c87ddd80fd.png">

So leaves get allocated to all the employees meeting other criteria:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235621472-e2ca754d-c745-4876-ae1c-e28ad32b90b1.png">

## Fix:

Consider employee filter while allocating leaves:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235621597-d5a905ca-3eb4-4ea4-9dff-3e405ab71db5.png">

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235621691-a13091a9-a510-423f-9c6e-7667cde4b3e6.png">

