### PR TITLE
fix: savepoint policy assignment submission, log errors & inform the user about failures

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -11,6 +11,7 @@ from frappe.model.document import Document
 from frappe.utils import (
 	add_months,
 	cint,
+	comma_and,
 	date_diff,
 	flt,
 	formatdate,
@@ -290,7 +291,31 @@ def create_assignment_for_multiple_employees(employees, data):
 
 		docs_name.append(assignment.name)
 
+	if failed:
+		show_assignment_submission_status(failed)
+
 	return docs_name
+
+
+def show_assignment_submission_status(failed):
+	frappe.clear_messages()
+	assignment_list = [get_link_to_form("Leave Policy Assignment", entry) for entry in failed]
+
+	msg = _("Failed to submit some leave policy assignments:")
+	msg += " " + comma_and(assignment_list, False)
+	msg += "<br><hr><br>"
+	msg += (
+		_("Check {0} for more details")
+		.format("<a href='/app/List/Error Log?reference_doctype=Leave Policy Assignment'>{0}</a>")
+		.format(_("Error Log"))
+	)
+
+	frappe.msgprint(
+		msg,
+		indicator="red",
+		title=_("Submission Failed"),
+		is_minimizable=True,
+	)
 
 
 def get_leave_type_details():

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -302,8 +302,7 @@ def show_assignment_submission_status(failed):
 	assignment_list = [get_link_to_form("Leave Policy Assignment", entry) for entry in failed]
 
 	msg = _("Failed to submit some leave policy assignments:")
-	msg += " " + comma_and(assignment_list, False)
-	msg += "<br><hr><br>"
+	msg += " " + comma_and(assignment_list, False) + "<hr>"
 	msg += (
 		_("Check {0} for more details")
 		.format("<a href='/app/List/Error Log?reference_doctype=Leave Policy Assignment'>{0}</a>")

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment_list.js
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment_list.js
@@ -51,7 +51,7 @@ frappe.listview_settings['Leave Policy Assignment'] = {
 					},
 					get_query() {
 						let filters = {"is_active": 1};
-						if (cur_dialog.fields_dict.company.value)
+						if (cur_dialog?.fields_dict?.company?.value)
 							filters["company"] = cur_dialog.fields_dict.company.value;
 
 						return {


### PR DESCRIPTION
Bulk Leave Policy Assignment submission silently fails and commits. So policy assignment gets submitted even if one of the allocation has failed.

- Savepoint and rollback submission failures 
- Log errors
- Inform the user about failures with links to docs and filtered error log

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/24353136/233442912-cb6599f4-54b8-4e91-b4a3-f0e3c2f8d5e5.png">
