### PR TITLE
feat: Mark Auto Attendance on Holidays

### DIFF
--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -258,36 +258,6 @@ class TestEmployeeCheckin(FrappeTestCase):
 		self.assertEqual(log.shift_actual_start, datetime.combine(prev_day, get_time("22:00:00")))
 		self.assertEqual(log.shift_actual_end, datetime.combine(date, get_time("02:00:00")))
 
-	def test_no_shift_fetched_on_holiday_as_per_shift_holiday_list(self):
-		date = getdate()
-		from_date = get_year_start(date)
-		to_date = get_year_ending(date)
-		holiday_list = make_holiday_list(from_date=from_date, to_date=to_date)
-
-		employee = make_employee("test_shift_with_holiday@example.com", company="_Test Company")
-		setup_shift_type(shift_type="Test Holiday Shift", holiday_list=holiday_list)
-
-		first_sunday = get_first_sunday(holiday_list, for_date=date)
-		timestamp = datetime.combine(first_sunday, get_time("08:00:00"))
-		log = make_checkin(employee, timestamp)
-
-		self.assertIsNone(log.shift)
-
-	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
-	def test_no_shift_fetched_on_holiday_as_per_employee_holiday_list(self):
-		employee = make_employee("test_shift_with_holiday@example.com", company="_Test Company")
-		shift_type = setup_shift_type(shift_type="Test Holiday Shift")
-		shift_type.holiday_list = None
-		shift_type.save()
-
-		date = getdate()
-
-		first_sunday = get_first_sunday(self.holiday_list, for_date=date)
-		timestamp = datetime.combine(first_sunday, get_time("08:00:00"))
-		log = make_checkin(employee, timestamp)
-
-		self.assertIsNone(log.shift)
-
 	def test_consecutive_shift_assignments_overlapping_within_grace_period(self):
 		# test adjustment for start and end times if they are overlapping
 		# within "begin_check_in_before_shift_start_time" and "allow_check_out_after_shift_end_time" periods

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -11,9 +11,6 @@ from frappe.model.document import Document
 from frappe.query_builder import Criterion
 from frappe.utils import cstr, get_datetime, get_link_to_form, get_time, getdate, now_datetime
 
-from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
-from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
-
 from hrms.hr.utils import validate_active_employee
 
 
@@ -276,7 +273,7 @@ def get_employee_shift(
 	consider_default_shift: bool = False,
 	next_shift_direction: str = None,
 ) -> Dict:
-	"""Returns a Shift Type for the given employee on the given date. (excluding the holidays)
+	"""Returns a Shift Type for the given employee on the given date
 
 	:param employee: Employee for which shift is required.
 	:param for_timestamp: DateTime on which shift is required
@@ -292,10 +289,6 @@ def get_employee_shift(
 	default_shift = frappe.db.get_value("Employee", employee, "default_shift")
 	if not shift_details and consider_default_shift:
 		shift_details = get_shift_details(default_shift, for_timestamp)
-
-	# if its a holiday, reset
-	if shift_details and is_holiday_date(employee, shift_details):
-		shift_details = None
 
 	# if no shift is found, find next or prev shift assignment based on direction
 	if not shift_details and next_shift_direction:
@@ -352,17 +345,6 @@ def get_prev_or_next_shift(
 					break
 
 	return shift_details or {}
-
-
-def is_holiday_date(employee: str, shift_details: Dict) -> bool:
-	holiday_list_name = frappe.db.get_value(
-		"Shift Type", shift_details.shift_type.name, "holiday_list"
-	)
-
-	if not holiday_list_name:
-		holiday_list_name = get_holiday_list_for_employee(employee, False)
-
-	return holiday_list_name and is_holiday(holiday_list_name, shift_details.start_datetime.date())
 
 
 def get_employee_shift_timings(

--- a/hrms/hr/doctype/shift_type/shift_type.json
+++ b/hrms/hr/doctype/shift_type/shift_type.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "prompt",
  "creation": "2018-04-13 16:22:52.954783",
  "doctype": "DocType",
@@ -15,6 +16,7 @@
   "working_hours_calculation_based_on",
   "begin_check_in_before_shift_start_time",
   "allow_check_out_after_shift_end_time",
+  "mark_auto_attendance_on_holidays",
   "column_break_10",
   "working_hours_threshold_for_half_day",
   "working_hours_threshold_for_absent",
@@ -156,12 +158,21 @@
    "fieldname": "last_sync_of_checkin",
    "fieldtype": "Datetime",
    "label": "Last Sync of Checkin"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, auto attendance will be marked on holidays if Employee Checkins exist",
+   "fieldname": "mark_auto_attendance_on_holidays",
+   "fieldtype": "Check",
+   "label": "Mark Auto Attendance on Holidays"
   }
  ],
- "modified": "2019-07-30 01:05:24.660666",
+ "links": [],
+ "modified": "2023-05-02 11:49:20.020685",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Type",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -200,5 +211,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
## Problem:

Shift doesn't get set in Employee Checkin if the date is a holiday. The system used to fetch the shift and reset it if the date was a holiday. Because of this, attendance doesn't get marked on a holiday.

## Solution

### Fetch shift in checkin on holidays too
If employee checkin exists for the day, it means that the employee worked on that day. So attendance should get marked despite being a holiday. Fetch shift in checkin irrespective of whether the date is a holiday or not

### Mark auto attendance on holidays

With the change mentioned above, system will start marking attendance on holidays because checkins have the shift set. But this did not happen earlier, companies might want to have control over whether to allow this or not. 

So, added a setting **Mark Auto Attendance on Holidays** in Shift Type. (Explicit is better than implicit)

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235601923-d37a5073-2123-4338-b31a-237b73274b96.png">

Docs: https://frappehr.com/docs/v14/user/manual/en/human-resources/shift_type

Also closes https://github.com/frappe/hrms/issues/383