### PR TITLE
perf: faster Payroll :- Part 2 (salary slip)

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -159,6 +159,10 @@ doc_events = {
 			"hrms.overrides.company.set_default_hr_accounts",
 		],
 	},
+	"Holiday List": {
+		"on_update": "hrms.utils.holiday_list.invalidate_cache",
+		"on_trash": "hrms.utils.holiday_list.invalidate_cache",
+	},
 	"Timesheet": {"validate": "hrms.hr.utils.validate_active_employee"},
 	"Payment Entry": {
 		"on_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -1305,3 +1305,7 @@ def get_leave_approver(employee):
 		)
 
 	return leave_approver
+
+
+def on_doctype_update():
+	frappe.db.add_index("Leave Application", ["employee", "from_date", "to_date"])

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -48,3 +48,7 @@ class LeaveType(Document):
 			self.fraction_of_daily_salary_per_leave < 0 or self.fraction_of_daily_salary_per_leave > 1
 		):
 			frappe.throw(_("The fraction of Daily Salary per Leave should be between 0 and 1"))
+
+	def clear_cache(self):
+		frappe.cache.delete_value("leave_type_map")
+		return super().clear_cache()

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -50,5 +50,7 @@ class LeaveType(Document):
 			frappe.throw(_("The fraction of Daily Salary per Leave should be between 0 and 1"))
 
 	def clear_cache(self):
-		frappe.cache.delete_value("leave_type_map")
+		from hrms.payroll.doctype.salary_slip.salary_slip import LEAVE_TYPE_MAP
+
+		frappe.cache.delete_value(LEAVE_TYPE_MAP)
 		return super().clear_cache()

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -561,16 +561,16 @@ def get_sal_slip_total_benefit_given(employee, payroll_period, component=False):
 	return total_given_benefit_amount
 
 
-def get_holiday_dates_for_employee(employee, start_date, end_date, holiday_list=None):
+def get_holiday_dates_for_employee(employee, start_date, end_date):
 	"""return a list of holiday dates for the given employee between start_date and end_date"""
 	# return only date
-	holidays = get_holidays_for_employee(employee, start_date, end_date, holiday_list=holiday_list)
+	holidays = get_holidays_for_employee(employee, start_date, end_date)
 
 	return [cstr(h.holiday_date) for h in holidays]
 
 
 def get_holidays_for_employee(
-	employee, start_date, end_date, holiday_list=None, raise_exception=True, only_non_weekly=False
+	employee, start_date, end_date, raise_exception=True, only_non_weekly=False
 ):
 	"""Get Holidays for a given employee
 
@@ -582,8 +582,7 @@ def get_holidays_for_employee(
 
 	return: list of dicts with `holiday_date` and `description`
 	"""
-	if not holiday_list:
-		holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception)
+	holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception)
 
 	if not holiday_list:
 		return []

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -561,16 +561,16 @@ def get_sal_slip_total_benefit_given(employee, payroll_period, component=False):
 	return total_given_benefit_amount
 
 
-def get_holiday_dates_for_employee(employee, start_date, end_date):
+def get_holiday_dates_for_employee(employee, start_date, end_date, holiday_list=None):
 	"""return a list of holiday dates for the given employee between start_date and end_date"""
 	# return only date
-	holidays = get_holidays_for_employee(employee, start_date, end_date)
+	holidays = get_holidays_for_employee(employee, start_date, end_date, holiday_list=holiday_list)
 
 	return [cstr(h.holiday_date) for h in holidays]
 
 
 def get_holidays_for_employee(
-	employee, start_date, end_date, raise_exception=True, only_non_weekly=False
+	employee, start_date, end_date, holiday_list=None, raise_exception=True, only_non_weekly=False
 ):
 	"""Get Holidays for a given employee
 
@@ -582,7 +582,8 @@ def get_holidays_for_employee(
 
 	return: list of dicts with `holiday_date` and `description`
 	"""
-	holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception)
+	if not holiday_list:
+		holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception)
 
 	if not holiday_list:
 		return []

--- a/hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py
+++ b/hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py
@@ -158,10 +158,10 @@ class EmployeeBenefitApplication(Document):
 def get_max_benefits(employee, on_date):
 	sal_struct = get_assigned_salary_structure(employee, on_date)
 	if sal_struct:
-		max_benefits = frappe.db.get_value("Salary Structure", sal_struct, "max_benefits")
+		max_benefits = frappe.db.get_value("Salary Structure", sal_struct, "max_benefits", cache=True)
 		if max_benefits > 0:
 			return max_benefits
-	return False
+	return 0
 
 
 @frappe.whitelist()

--- a/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
+++ b/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
@@ -120,11 +120,10 @@ def get_benefit_pro_rata_ratio_amount(employee, on_date, sal_struct):
 
 	if total_pro_rata_max > 0:
 		for sal_struct_row in sal_struct.get("earnings"):
-			pay_against_benefit_claim, max_benefit_amount = frappe.db.get_value(
+			pay_against_benefit_claim, max_benefit_amount = frappe.get_cached_value(
 				"Salary Component",
 				sal_struct_row.salary_component,
-				("pay_against_benefit_claim", "max_benefit_amount"),
-				cache=True,
+				["pay_against_benefit_claim", "max_benefit_amount"],
 			)
 
 			if sal_struct_row.is_flexible_benefit == 1 and pay_against_benefit_claim != 1:

--- a/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
+++ b/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
@@ -174,7 +174,14 @@ def get_total_benefit_dispensed(employee, sal_struct, sal_slip_start_date, payro
 		{"employee": employee, "payroll_period": payroll_period.name, "docstatus": 1},
 	)
 	if application:
-		application_obj = frappe.get_cached_doc("Employee Benefit Application", application)
+		application_obj = frappe.db.get_value(
+			"Employee Benefit Application",
+			application,
+			("pro_rata_dispensed_amount", "max_benefits", "remaining_benefit"),
+			as_dict=True,
+			cache=True,
+		)
+
 		pro_rata_amount = (
 			application_obj.pro_rata_dispensed_amount
 			+ application_obj.max_benefits

--- a/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
+++ b/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
@@ -106,11 +106,10 @@ def get_benefit_pro_rata_ratio_amount(employee, on_date, sal_struct):
 	benefit_amount_total = 0
 	for sal_struct_row in sal_struct.get("earnings"):
 		try:
-			pay_against_benefit_claim, max_benefit_amount = frappe.db.get_value(
+			pay_against_benefit_claim, max_benefit_amount = frappe.get_cached_value(
 				"Salary Component",
 				sal_struct_row.salary_component,
-				("pay_against_benefit_claim", "max_benefit_amount"),
-				cache=True,
+				["pay_against_benefit_claim", "max_benefit_amount"],
 			)
 		except TypeError:
 			# show the error in tests?
@@ -174,12 +173,11 @@ def get_total_benefit_dispensed(employee, sal_struct, sal_slip_start_date, payro
 		{"employee": employee, "payroll_period": payroll_period.name, "docstatus": 1},
 	)
 	if application:
-		application_obj = frappe.db.get_value(
+		application_obj = frappe.get_cached_value(
 			"Employee Benefit Application",
 			application,
-			("pro_rata_dispensed_amount", "max_benefits", "remaining_benefit"),
+			["pro_rata_dispensed_amount", "max_benefits", "remaining_benefit"],
 			as_dict=True,
-			cache=True,
 		)
 
 		pro_rata_amount = (

--- a/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
+++ b/hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py
@@ -109,19 +109,23 @@ def get_benefit_pro_rata_ratio_amount(employee, on_date, sal_struct):
 			pay_against_benefit_claim, max_benefit_amount = frappe.db.get_value(
 				"Salary Component",
 				sal_struct_row.salary_component,
-				["pay_against_benefit_claim", "max_benefit_amount"],
+				("pay_against_benefit_claim", "max_benefit_amount"),
+				cache=True,
 			)
 		except TypeError:
 			# show the error in tests?
 			frappe.throw(_("Unable to find Salary Component {0}").format(sal_struct_row.salary_component))
+
 		if sal_struct_row.is_flexible_benefit == 1 and pay_against_benefit_claim != 1:
 			total_pro_rata_max += max_benefit_amount
+
 	if total_pro_rata_max > 0:
 		for sal_struct_row in sal_struct.get("earnings"):
 			pay_against_benefit_claim, max_benefit_amount = frappe.db.get_value(
 				"Salary Component",
 				sal_struct_row.salary_component,
-				["pay_against_benefit_claim", "max_benefit_amount"],
+				("pay_against_benefit_claim", "max_benefit_amount"),
+				cache=True,
 			)
 
 			if sal_struct_row.is_flexible_benefit == 1 and pay_against_benefit_claim != 1:
@@ -170,7 +174,7 @@ def get_total_benefit_dispensed(employee, sal_struct, sal_slip_start_date, payro
 		{"employee": employee, "payroll_period": payroll_period.name, "docstatus": 1},
 	)
 	if application:
-		application_obj = frappe.get_doc("Employee Benefit Application", application)
+		application_obj = frappe.get_cached_doc("Employee Benefit Application", application)
 		pro_rata_amount = (
 			application_obj.pro_rata_dispensed_amount
 			+ application_obj.max_benefits
@@ -189,19 +193,22 @@ def get_total_benefit_dispensed(employee, sal_struct, sal_slip_start_date, payro
 def get_last_payroll_period_benefits(
 	employee, sal_slip_start_date, sal_slip_end_date, payroll_period, sal_struct
 ):
-	max_benefits = get_max_benefits(employee, payroll_period.end_date)
-	if not max_benefits:
-		max_benefits = 0
+	if sal_struct:
+		max_benefits = sal_struct.max_benefits
+	else:
+		max_benefits = get_max_benefits(employee, payroll_period.end_date)
+
 	remaining_benefit = max_benefits - get_total_benefit_dispensed(
 		employee, sal_struct, sal_slip_start_date, payroll_period
 	)
+
 	if remaining_benefit > 0:
 		have_remaining = True
 		# Set the remaining benefits to flexi non pro-rata component in the salary structure
 		salary_components_array = []
 		for d in sal_struct.get("earnings"):
 			if d.is_flexible_benefit == 1:
-				salary_component = frappe.get_doc("Salary Component", d.salary_component)
+				salary_component = frappe.get_cached_doc("Salary Component", d.salary_component)
 				if salary_component.pay_against_benefit_claim == 1:
 					claimed_amount = get_benefit_claim_amount(
 						employee, payroll_period.start_date, sal_slip_end_date, d.salary_component

--- a/hrms/payroll/doctype/employee_other_income/employee_other_income.json
+++ b/hrms/payroll/doctype/employee_other_income/employee_other_income.json
@@ -6,7 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "employee_details_section",
+  "employee_section",
   "employee",
   "employee_name",
   "amended_from",
@@ -25,7 +25,8 @@
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "payroll_period",
@@ -33,7 +34,8 @@
    "in_list_view": 1,
    "label": "Payroll Period",
    "options": "Payroll Period",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_3",
@@ -45,7 +47,8 @@
    "in_list_view": 1,
    "label": "Company",
    "options": "Company",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "source",
@@ -79,7 +82,7 @@
   {
    "fieldname": "employee_section",
    "fieldtype": "Section Break",
-   "label": "Employee"
+   "label": "Employee Details"
   },
   {
    "fieldname": "income_source_details_section",
@@ -93,7 +96,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-05 12:00:57.942233",
+ "modified": "2023-04-24 15:32:19.086167",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Employee Other Income",

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -389,7 +389,7 @@ let make_bank_entry = function (frm) {
 		return frappe.call({
 			method: "run_doc_method",
 			args: {
-				method: "make_payment_entry",
+				method: "make_bank_entry",
 				dt: "Payroll Entry",
 				dn: frm.doc.name
 			},

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -775,7 +775,7 @@ class PayrollEntry(Document):
 		return exchange_rate, amount
 
 	@frappe.whitelist()
-	def make_payment_entry(self):
+	def make_bank_entry(self):
 		self.check_permission("write")
 		self.employee_based_payroll_payable_entries = {}
 		employee_wise_accounting_enabled = frappe.db.get_single_value(

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -109,7 +109,7 @@ class TestPayrollEntry(FrappeTestCase):
 			company=company.name,
 			cost_center="Main - _TC",
 		)
-		payroll_entry.make_payment_entry()
+		payroll_entry.make_bank_entry()
 
 		salary_slip = frappe.db.get_value("Salary Slip", {"payroll_entry": payroll_entry.name}, "name")
 		salary_slip = frappe.get_doc("Salary Slip", salary_slip)
@@ -400,7 +400,7 @@ class TestPayrollEntry(FrappeTestCase):
 			payment_account="Cash - _TC",
 		)
 		payroll_entry.reload()
-		payroll_entry.make_payment_entry()
+		payroll_entry.make_bank_entry()
 
 		# submit the bank entry journal voucher
 		jv = frappe.db.get_value(
@@ -703,7 +703,7 @@ def make_payroll_entry(**args):
 	payroll_entry.submit()
 	payroll_entry.submit_salary_slips()
 	if payroll_entry.get_sal_slip_list(ss_status=1):
-		payroll_entry.make_payment_entry()
+		payroll_entry.make_bank_entry()
 
 	return payroll_entry
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -586,7 +586,7 @@ class TestPayrollEntry(FrappeTestCase):
 			cost_center="Main - _TC",
 		)
 		payroll_entry.reload()
-		payroll_entry.make_payment_entry()
+		payroll_entry.make_bank_entry()
 
 		debit_entries = frappe.db.get_all(
 			"Journal Entry Account",

--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_months, cint, date_diff, flt, formatdate, getdate, month_diff
+from frappe.utils.caching import redis_cache
 
 from hrms.hr.utils import get_holiday_dates_for_employee
 
@@ -14,6 +15,10 @@ class PayrollPeriod(Document):
 	def validate(self):
 		self.validate_from_to_dates("start_date", "end_date")
 		self.validate_overlap()
+
+	def clear_cache(self):
+		get_payroll_period.clear_cache()
+		return super().clear_cache()
 
 	def validate_overlap(self):
 		query = """
@@ -79,6 +84,7 @@ def get_payroll_period_days(start_date, end_date, employee, company=None):
 	return False, False, False
 
 
+@redis_cache()
 def get_payroll_period(from_date, to_date, company):
 	PayrollPeriod = frappe.qb.DocType("Payroll Period")
 

--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -110,11 +110,12 @@ def get_period_factor(
 
 	if not joining_date and not relieving_date:
 		joining_date, relieving_date = frappe.db.get_value(
-			"Employee", employee, ["date_of_joining", "relieving_date"]
+			"Employee", employee, ("date_of_joining", "relieving_date"), cache=True
 		)
 
 	if getdate(joining_date) > getdate(period_start):
 		period_start = joining_date
+
 	if relieving_date and getdate(relieving_date) < getdate(period_end):
 		period_end = relieving_date
 		if month_diff(period_end, start_date) > 1:

--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -109,8 +109,8 @@ def get_period_factor(
 	period_start, period_end = payroll_period.start_date, payroll_period.end_date
 
 	if not joining_date and not relieving_date:
-		joining_date, relieving_date = frappe.db.get_value(
-			"Employee", employee, ("date_of_joining", "relieving_date"), cache=True
+		joining_date, relieving_date = frappe.get_cached_value(
+			"Employee", employee, ["date_of_joining", "relieving_date"]
 		)
 
 	if getdate(joining_date) > getdate(period_start):

--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -96,13 +96,22 @@ def get_payroll_period(from_date, to_date, company):
 
 
 def get_period_factor(
-	employee, start_date, end_date, payroll_frequency, payroll_period, depends_on_payment_days=0
+	employee,
+	start_date,
+	end_date,
+	payroll_frequency,
+	payroll_period,
+	depends_on_payment_days=0,
+	joining_date=None,
+	relieving_date=None,
 ):
 	# TODO if both deduct checked update the factor to make tax consistent
 	period_start, period_end = payroll_period.start_date, payroll_period.end_date
-	joining_date, relieving_date = frappe.db.get_value(
-		"Employee", employee, ["date_of_joining", "relieving_date"]
-	)
+
+	if not joining_date and not relieving_date:
+		joining_date, relieving_date = frappe.db.get_value(
+			"Employee", employee, ["date_of_joining", "relieving_date"]
+		)
 
 	if getdate(joining_date) > getdate(period_start):
 		period_start = joining_date

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -15,8 +15,10 @@ class SalaryComponent(Document):
 		if self.is_income_tax_component:
 			self.variable_based_on_taxable_salary = 1
 
-	def on_update(self):
-		self.invalidate_cache()
+	def clear_cache(self):
+		frappe.cache.delete_value("salary_component_values")
+		frappe.cache.delete_value("tax_components_by_company")
+		return super().clear_cache()
 
 	def validate_abbr(self):
 		if not self.salary_component_abbr:
@@ -30,6 +32,3 @@ class SalaryComponent(Document):
 			separator="_",
 			filters={"name": ["!=", self.name]},
 		)
-
-	def invalidate_cache(self):
-		frappe.cache().delete_value("tax_components")

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -16,8 +16,13 @@ class SalaryComponent(Document):
 			self.variable_based_on_taxable_salary = 1
 
 	def clear_cache(self):
-		frappe.cache.delete_value("salary_component_values")
-		frappe.cache.delete_value("tax_components_by_company")
+		from hrms.payroll.doctype.salary_slip.salary_slip import (
+			SALARY_COMPONENT_VALUES,
+			TAX_COMPONENTS_BY_COMPANY,
+		)
+
+		frappe.cache.delete_value(SALARY_COMPONENT_VALUES)
+		frappe.cache.delete_value(TAX_COMPONENTS_BY_COMPANY)
 		return super().clear_cache()
 
 	def validate_abbr(self):

--- a/hrms/payroll/doctype/salary_detail/salary_detail.json
+++ b/hrms/payroll/doctype/salary_detail/salary_detail.json
@@ -41,7 +41,8 @@
    "in_list_view": 1,
    "label": "Component",
    "options": "Salary Component",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "columns": 1,
@@ -250,7 +251,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-01-17 13:04:44.167515",
+ "modified": "2023-04-19 17:04:29.651168",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",

--- a/hrms/payroll/doctype/salary_detail/salary_detail.json
+++ b/hrms/payroll/doctype/salary_detail/salary_detail.json
@@ -77,7 +77,8 @@
    "in_list_view": 1,
    "label": "Is Tax Applicable",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -97,7 +98,8 @@
    "fieldtype": "Check",
    "label": "Variable Based On Taxable Salary",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -208,7 +210,8 @@
    "fieldname": "exempted_from_income_tax",
    "fieldtype": "Check",
    "label": "Exempted from Income Tax",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "collapsible": 1,
@@ -251,7 +254,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-04-19 17:04:29.651168",
+ "modified": "2023-04-24 11:17:11.397523",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -182,7 +182,8 @@
    "fieldtype": "Link",
    "label": "Payroll Entry",
    "options": "Payroll Entry",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fetch_from": "employee.company",
@@ -214,12 +215,14 @@
   {
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date"
+   "label": "Start Date",
+   "search_index": 1
   },
   {
    "fieldname": "end_date",
    "fieldtype": "Date",
-   "label": "End Date"
+   "label": "End Date",
+   "search_index": 1
   },
   {
    "fieldname": "salary_structure",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -562,7 +562,7 @@ class SalarySlip(TransactionBase):
 
 			leave = leaves.get(d)
 			if leave:
-				if str(d) in holidays and not leave.include_holiday:
+				if getdate(d) in holidays and not leave.include_holiday:
 					continue
 
 				equivalent_lwp_count = 0

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1741,7 +1741,7 @@ class SalarySlip(TransactionBase):
 				exemption_proof = frappe.db.get_value(
 					"Employee Tax Exemption Proof Submission",
 					{"employee": self.employee, "payroll_period": self.payroll_period.name, "docstatus": 1},
-					["exemption_amount"],
+					"exemption_amount",
 					cache=True,
 				)
 				if exemption_proof:
@@ -1750,7 +1750,7 @@ class SalarySlip(TransactionBase):
 				declaration = frappe.db.get_value(
 					"Employee Tax Exemption Declaration",
 					{"employee": self.employee, "payroll_period": self.payroll_period.name, "docstatus": 1},
-					["total_exemption_amount"],
+					"total_exemption_amount",
 					cache=True,
 				)
 				if declaration:
@@ -2024,6 +2024,7 @@ def generate_password_for_pdf(policy_template, employee):
 
 
 def get_salary_component_data(component):
+	# get_cached_value doesn't work here due to alias "name as salary_component"
 	return frappe.db.get_value(
 		"Salary Component",
 		component,

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -97,13 +97,7 @@ class SalarySlip(TransactionBase):
 	@property
 	def payroll_period(self):
 		if not hasattr(self, "__payroll_period"):
-			if frappe.flags.in_test:
-				self.__payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
-			else:
-				self.__payroll_period = frappe.cache().hget("payroll_period", "payroll_period")
-				if not self.__payroll_period:
-					self.__payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
-					frappe.cache().hset("payroll_period", "payroll_period", self.__payroll_period)
+			self.__payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
 
 		return self.__payroll_period
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -377,6 +377,7 @@ class SalarySlip(TransactionBase):
 				"payroll_based_on",
 				"include_holidays_in_total_working_days",
 				"daily_wages_fraction_for_half_day",
+				"consider_unmarked_attendance_as",
 			),
 			as_dict=1,
 		)
@@ -436,10 +437,7 @@ class SalarySlip(TransactionBase):
 			if payroll_settings.payroll_based_on == "Attendance":
 				self.payment_days -= flt(absent)
 
-			consider_unmarked_attendance_as = (
-				frappe.db.get_single_value("Payroll Settings", "consider_unmarked_attendance_as", cache=True)
-				or "Present"
-			)
+			consider_unmarked_attendance_as = payroll_settings.consider_unmarked_attendance_as or "Present"
 
 			if (
 				payroll_settings.payroll_based_on == "Attendance"
@@ -695,7 +693,7 @@ class SalarySlip(TransactionBase):
 	def set_salary_structure_assignement(self):
 		start_date = getdate(self.start_date)
 		date_to_validate = self.joining_date if self.joining_date > start_date else start_date
-		self._salary_structure_assignment = frappe.get_value(
+		self._salary_structure_assignment = frappe.db.get_value(
 			"Salary Structure Assignment",
 			{
 				"employee": self.employee,
@@ -1093,7 +1091,7 @@ class SalarySlip(TransactionBase):
 		data = frappe._dict()
 		employee = frappe.get_cached_doc("Employee", self.employee).as_dict()
 
-		if not hasattr(self, "salary_structure_assignment"):
+		if not hasattr(self, "_salary_structure_assignment"):
 			self.set_salary_structure_assignement()
 
 		data.update(self._salary_structure_assignment)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -131,7 +131,7 @@ class SalarySlip(TransactionBase):
 		self.add_leave_balances()
 
 		max_working_hours = frappe.db.get_single_value(
-			"Payroll Settings", "max_working_hours_against_timesheet", cache=True
+			"Payroll Settings", "max_working_hours_against_timesheet"
 		)
 		if max_working_hours:
 			if self.salary_slip_based_on_timesheet and (self.total_working_hours > int(max_working_hours)):
@@ -161,7 +161,7 @@ class SalarySlip(TransactionBase):
 
 			if not frappe.flags.via_payroll_entry and not frappe.flags.in_patch:
 				email_salary_slip = cint(
-					frappe.db.get_single_value("Payroll Settings", "email_salary_slip_to_employee", cache=True)
+					frappe.db.get_single_value("Payroll Settings", "email_salary_slip_to_employee")
 				)
 				if email_salary_slip:
 					self.email_salary_slip()
@@ -222,7 +222,7 @@ class SalarySlip(TransactionBase):
 			frappe.throw(_("Cannot create Salary Slip for Employee who has left before Payroll Period"))
 
 	def is_rounding_total_disabled(self):
-		return cint(frappe.db.get_single_value("Payroll Settings", "disable_rounded_total", cache=True))
+		return cint(frappe.db.get_single_value("Payroll Settings", "disable_rounded_total"))
 
 	def check_existing(self):
 		if not self.salary_slip_based_on_timesheet:
@@ -1978,9 +1978,7 @@ class SalarySlip(TransactionBase):
 	def add_leave_balances(self):
 		self.set("leave_details", [])
 
-		if frappe.db.get_single_value(
-			"Payroll Settings", "show_leave_balances_in_salary_slip", cache=True
-		):
+		if frappe.db.get_single_value("Payroll Settings", "show_leave_balances_in_salary_slip"):
 			from hrms.hr.doctype.leave_application.leave_application import get_leave_details
 
 			leave_details = get_leave_details(self.employee, self.end_date)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -366,7 +366,7 @@ class SalarySlip(TransactionBase):
 				self, self._salary_structure_doc.salary_component, wages_amount
 			)
 
-		make_salary_slip(self._salary_structure_doc.name, self, from_salary_slip=True)
+		make_salary_slip(self._salary_structure_doc.name, self)
 
 	def get_working_days_details(self, lwp=None, for_preview=0):
 		payroll_settings = frappe.get_cached_value(
@@ -1782,7 +1782,7 @@ class SalarySlip(TransactionBase):
 		return total
 
 	def email_salary_slip(self):
-		receiver = frappe.db.get_value("Employee", self.employee, "prefered_email")
+		receiver = frappe.db.get_value("Employee", self.employee, "prefered_email", cache=True)
 		payroll_settings = frappe.get_single("Payroll Settings")
 		message = "Please see attachment"
 		password = None
@@ -1836,7 +1836,7 @@ class SalarySlip(TransactionBase):
 
 	def pull_emp_details(self):
 		emp = frappe.db.get_value(
-			"Employee", self.employee, ["bank_name", "bank_ac_no", "salary_mode"], as_dict=1
+			"Employee", self.employee, ["bank_name", "bank_ac_no", "salary_mode"], as_dict=1, cache=True
 		)
 		if emp:
 			self.mode_of_payment = emp.salary_mode

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1834,13 +1834,13 @@ class SalarySlip(TransactionBase):
 		self.calculate_net_pay()
 
 	def pull_emp_details(self):
-		emp = frappe.db.get_value(
-			"Employee", self.employee, ["bank_name", "bank_ac_no", "salary_mode"], as_dict=1, cache=True
+		account_details = frappe.get_cached_value(
+			"Employee", self.employee, ["bank_name", "bank_ac_no", "salary_mode"], as_dict=1
 		)
-		if emp:
-			self.mode_of_payment = emp.salary_mode
-			self.bank_name = emp.bank_name
-			self.bank_account_no = emp.bank_ac_no
+		if account_details:
+			self.mode_of_payment = account_details.salary_mode
+			self.bank_name = account_details.bank_name
+			self.bank_account_no = account_details.bank_ac_no
 
 	@frappe.whitelist()
 	def process_salary_based_on_working_days(self):

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -31,7 +31,7 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.utilities.transaction_base import TransactionBase
 
-from hrms.hr.utils import get_holiday_dates_for_employee, validate_active_employee
+from hrms.hr.utils import validate_active_employee
 from hrms.payroll.doctype.additional_salary.additional_salary import get_additional_salaries
 from hrms.payroll.doctype.employee_benefit_application.employee_benefit_application import (
 	get_benefit_component_amount,
@@ -51,6 +51,7 @@ from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
 	set_loan_repayment,
 )
 from hrms.payroll.utils import sanitize_expression
+from hrms.utils.holiday_list import get_holiday_dates_between
 
 
 class SalarySlip(TransactionBase):
@@ -533,9 +534,7 @@ class SalarySlip(TransactionBase):
 		holiday_dates = frappe.cache().hget("holidays", key)
 
 		if not holiday_dates:
-			holiday_dates = get_holiday_dates_for_employee(
-				self.employee, start_date, end_date, holiday_list
-			)
+			holiday_dates = get_holiday_dates_between(holiday_list, start_date, end_date)
 			frappe.cache().hset("holidays", key, holiday_dates)
 
 		return holiday_dates

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1144,8 +1144,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		prev_period = math.ceil(remaining_sub_periods)
 
-		# annual_tax = 347580
-		anual_tax = 2, 52, 540
+		annual_tax = 2, 52, 540
 		monthly_tax_amount = 30124
 		monthly_earnings = 152800
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -297,6 +297,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		first_sunday = get_first_sunday()
 
+		# 3 days LWP
 		make_leave_application(emp_id, first_sunday, add_days(first_sunday, 3), "Leave Without Pay")
 
 		leave_type_ppl = create_leave_type(leave_type_name="Test Partially Paid Leave", is_ppl=1)
@@ -311,9 +312,14 @@ class TestSalarySlip(FrappeTestCase):
 		alloc.save()
 		alloc.submit()
 
-		# two day leave ppl with fraction_of_daily_salary_per_leave = 0.5 equivalent to single day lwp
+		# 1.5 day leave ppl with fraction_of_daily_salary_per_leave = 0.5 equivalent to single day lwp = 0.75
 		make_leave_application(
-			emp_id, add_days(first_sunday, 4), add_days(first_sunday, 5), "Test Partially Paid Leave"
+			emp_id,
+			add_days(first_sunday, 4),
+			add_days(first_sunday, 5),
+			"Test Partially Paid Leave",
+			half_day=True,
+			half_day_date=add_days(first_sunday, 4),
 		)
 
 		ss = make_employee_salary_slip(
@@ -322,12 +328,12 @@ class TestSalarySlip(FrappeTestCase):
 			"Test Payment Based On Leave Application",
 		)
 
-		self.assertEqual(ss.leave_without_pay, 4)
+		self.assertEqual(ss.leave_without_pay, 3.75)
 
 		days_in_month = no_of_days[0]
 		no_of_holidays = no_of_days[1]
 
-		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 4)
+		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 3.75)
 
 	@change_settings("Payroll Settings", {"payroll_based_on": "Attendance"})
 	def test_payment_days_in_salary_slip_based_on_timesheet(self):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1144,9 +1144,9 @@ class TestSalarySlip(FrappeTestCase):
 
 		prev_period = math.ceil(remaining_sub_periods)
 
-		annual_tax = 2, 52, 540
-		monthly_tax_amount = 30124
-		monthly_earnings = 152800
+		annual_tax = 93288
+		monthly_tax_amount = 7774.0
+		monthly_earnings = 77800
 
 		# Get Salary Structure Assignment
 		ssa = frappe.get_value(
@@ -1167,7 +1167,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 		for deduction in salary_slip.deductions:
 			if deduction.salary_component == "TDS":
-				self.assertEqual(deduction.amount, 30123.0)
+				self.assertEqual(deduction.amount, 7691.0)
 
 		frappe.db.sql("DELETE FROM `tabPayroll Period` where company = '_Test Company'")
 		frappe.db.sql("DELETE FROM `tabIncome Tax Slab` where currency = 'INR'")

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1088,8 +1088,8 @@ class TestSalarySlip(FrappeTestCase):
 		payroll_period = create_payroll_period(
 			name="_Test Payroll Period for Tax",
 			company="_Test Company",
-			start_date="2022-04-01",
-			end_date="2023-03-31",
+			start_date="2023-04-01",
+			end_date="2024-03-31",
 		)
 
 		emp = make_employee(
@@ -1113,7 +1113,7 @@ class TestSalarySlip(FrappeTestCase):
 				"Monthly",
 				company="_Test Company",
 				employee=emp,
-				from_date="2022-04-01",
+				from_date="2023-04-01",
 				payroll_period=payroll_period,
 				test_tax=True,
 				currency="INR",
@@ -1127,7 +1127,7 @@ class TestSalarySlip(FrappeTestCase):
 					"employee": emp,
 					"salary_structure": salary_structure_doc.name,
 					"docstatus": 1,
-					"start_date": [">=", "2022-04-01"],
+					"start_date": [">=", "2023-04-01"],
 				},
 			)
 			== 0
@@ -1135,8 +1135,8 @@ class TestSalarySlip(FrappeTestCase):
 
 		remaining_sub_periods = get_period_factor(
 			emp,
-			get_first_day("2022-10-01"),
-			get_last_day("2022-10-01"),
+			get_first_day("2023-10-01"),
+			get_last_day("2023-10-01"),
 			"Monthly",
 			payroll_period,
 			depends_on_payment_days=0,
@@ -1144,9 +1144,10 @@ class TestSalarySlip(FrappeTestCase):
 
 		prev_period = math.ceil(remaining_sub_periods)
 
-		annual_tax = 93288
-		monthly_tax_amount = 7774.0
-		monthly_earnings = 77800
+		# annual_tax = 347580
+		anual_tax = 2, 52, 540
+		monthly_tax_amount = 30124
+		monthly_earnings = 152800
 
 		# Get Salary Structure Assignment
 		ssa = frappe.get_value(
@@ -1163,11 +1164,11 @@ class TestSalarySlip(FrappeTestCase):
 
 		# Create Salary Slip
 		salary_slip = make_salary_slip(
-			salary_structure_doc.name, employee=employee_doc.name, posting_date=getdate("2022-10-01")
+			salary_structure_doc.name, employee=employee_doc.name, posting_date=getdate("2023-10-01")
 		)
 		for deduction in salary_slip.deductions:
 			if deduction.salary_component == "TDS":
-				self.assertEqual(deduction.amount, 7691.0)
+				self.assertEqual(deduction.amount, 30123.0)
 
 		frappe.db.sql("DELETE FROM `tabPayroll Period` where company = '_Test Company'")
 		frappe.db.sql("DELETE FROM `tabIncome Tax Slab` where currency = 'INR'")

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -35,7 +35,13 @@ from hrms.payroll.doctype.employee_tax_exemption_declaration.test_employee_tax_e
 	create_payroll_period,
 )
 from hrms.payroll.doctype.payroll_entry.payroll_entry import get_month_details
-from hrms.payroll.doctype.salary_slip.salary_slip import make_salary_slip_from_timesheet
+from hrms.payroll.doctype.salary_slip.salary_slip import (
+	HOLIDAYS_BETWEEN_DATES,
+	LEAVE_TYPE_MAP,
+	SALARY_COMPONENT_VALUES,
+	TAX_COMPONENTS_BY_COMPANY,
+	make_salary_slip_from_timesheet,
+)
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from hrms.tests.test_utils import get_first_sunday
@@ -2254,7 +2260,10 @@ def mark_attendance(
 
 
 def clear_cache():
-	frappe.cache.delete_value("holidays_between_dates")
-	frappe.cache.delete_value("leave_type_map")
-	frappe.cache.delete_value("salary_component_values")
-	frappe.cache.delete_value("tax_components_by_company")
+	for key in [
+		HOLIDAYS_BETWEEN_DATES,
+		LEAVE_TYPE_MAP,
+		SALARY_COMPONENT_VALUES,
+		TAX_COMPONENTS_BY_COMPANY,
+	]:
+		frappe.cache().delete_value(key)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -45,10 +45,12 @@ class TestSalarySlip(FrappeTestCase):
 	def setUp(self):
 		setup_test()
 		frappe.flags.pop("via_payroll_entry", None)
+		clear_cache()
 
 	def tearDown(self):
 		frappe.db.set_single_value("Payroll Settings", "include_holidays_in_total_working_days", 0)
 		frappe.set_user("Administrator")
+		clear_cache()
 
 	def test_employee_status_inactive(self):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
@@ -2249,3 +2251,10 @@ def mark_attendance(
 	attendance.flags.ignore_validate = ignore_validate
 	attendance.insert()
 	attendance.submit()
+
+
+def clear_cache():
+	frappe.cache.delete_value("holidays_between_dates")
+	frappe.cache.delete_value("leave_type_map")
+	frappe.cache.delete_value("salary_component_values")
+	frappe.cache.delete_value("tax_components_by_company")

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -343,6 +343,7 @@ def make_salary_slip(
 		postprocess,
 		ignore_child_tables=True,
 		ignore_permissions=ignore_permissions,
+		cached=True,
 	)
 
 	if cint(as_print):

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -305,8 +305,12 @@ def make_salary_slip(
 	print_format=None,
 	for_preview=0,
 	ignore_permissions=False,
+	from_salary_slip=False,
 ):
 	def postprocess(source, target):
+		if from_salary_slip:
+			return
+
 		if employee:
 			employee_details = frappe.db.get_value(
 				"Employee", employee, ["employee_name", "branch", "designation", "department"], as_dict=1

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -305,24 +305,10 @@ def make_salary_slip(
 	print_format=None,
 	for_preview=0,
 	ignore_permissions=False,
-	from_salary_slip=False,
 ):
 	def postprocess(source, target):
-		if from_salary_slip:
-			return
-
-		if employee:
-			employee_details = frappe.db.get_value(
-				"Employee", employee, ["employee_name", "branch", "designation", "department"], as_dict=1
-			)
-			target.employee = employee
-			target.employee_name = employee_details.employee_name
-			target.branch = employee_details.branch
-			target.designation = employee_details.designation
-			target.department = employee_details.department
-
-			if posting_date:
-				target.posting_date = posting_date
+		if employee and posting_date:
+			target.posting_date = posting_date
 
 		target.run_method("process_salary_structure", for_preview=for_preview)
 

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -307,8 +307,10 @@ def make_salary_slip(
 	ignore_permissions=False,
 ):
 	def postprocess(source, target):
-		if employee and posting_date:
-			target.posting_date = posting_date
+		if employee:
+			target.employee = employee
+			if posting_date:
+				target.posting_date = posting_date
 
 		target.run_method("process_salary_structure", for_preview=for_preview)
 

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -9,3 +9,7 @@ def get_holiday_dates_between(holiday_list: str, start_date: str, end_date: str)
 		.where((Holiday.parent == holiday_list) & (Holiday.holiday_date.between(start_date, end_date)))
 		.orderby(Holiday.holiday_date)
 	).run(pluck=True)
+
+
+def invalidate_cache(doc, method=None):
+	frappe.cache.delete_value("holidays_between_dates")

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -12,4 +12,6 @@ def get_holiday_dates_between(holiday_list: str, start_date: str, end_date: str)
 
 
 def invalidate_cache(doc, method=None):
-	frappe.cache.delete_value("holidays_between_dates")
+	from hrms.payroll.doctype.salary_slip.salary_slip import HOLIDAYS_BETWEEN_DATES
+
+	frappe.cache.delete_value(HOLIDAYS_BETWEEN_DATES)


### PR DESCRIPTION
#### Test data 500 employees

### Before optimisation
Time required : 150 sec

<img width="817" alt="Screenshot 2023-04-25 at 3 57 10 PM" src="https://user-images.githubusercontent.com/3784093/234252115-59a4c552-af9e-49f6-bf24-9de107205e83.png">

### After optimisation
Time required : 38 sec
<img width="697" alt="Screenshot 2023-04-25 at 4 05 43 PM" src="https://user-images.githubusercontent.com/3784093/234252232-2bfd7349-10b2-4e34-be73-e2554e3e6239.png">


---
Test results for dataset of **7k**, the execution time is **646** seconds

<img width="765" alt="Screenshot 2023-05-31 at 10 59 25 AM" src="https://github.com/frappe/hrms/assets/3784093/75787935-4642-431f-8903-21fcf7cf6087">



