### PR TITLE
fix: do not pull exchange rate if its already set

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.js
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.js
@@ -97,6 +97,8 @@ frappe.ui.form.on("Salary Slip", {
 			if (frm.doc.currency) {
 				var from_currency = frm.doc.currency;
 				if (from_currency != company_currency) {
+					if (frm.doc.exchange_rate && frm.doc.exchange_rate !==1){ return; }
+
 					frm.events.hide_loan_section(frm);
 					frappe.call({
 						method: "erpnext.setup.utils.get_exchange_rate",


### PR DESCRIPTION
Problem: After creating salary slip from payroll entry the system is not setting the exchange rate in the salary slip mentioned from the payroll entry.

Fix: In multi-currency, pull exchange rate on Salary Slip only if exchange rate is no already set