### PR TITLE
fix: shift request cancellation failing

### DIFF
--- a/hrms/hr/doctype/shift_request/shift_request.py
+++ b/hrms/hr/doctype/shift_request/shift_request.py
@@ -50,8 +50,8 @@ class ShiftRequest(Document):
 			)
 
 	def on_cancel(self):
-		shift_assignment_list = frappe.get_list(
-			"Shift Assignment", {"employee": self.employee, "shift_request": self.name}
+		shift_assignment_list = frappe.db.get_all(
+			"Shift Assignment", {"employee": self.employee, "shift_request": self.name, "docstatus": 1}
 		)
 		if shift_assignment_list:
 			for shift in shift_assignment_list:

--- a/hrms/hr/doctype/shift_request/test_shift_request.py
+++ b/hrms/hr/doctype/shift_request/test_shift_request.py
@@ -48,6 +48,7 @@ class TestShiftRequest(FrappeTestCase):
 			"Shift Assignment", filters={"shift_request": shift_request.name}, fieldname="docstatus"
 		)
 		self.assertEqual(shift_assignment_docstatus, 2)
+		self.assertEqual(shift_request.docstatus, 2)
 
 	def test_shift_request_approver_perms(self):
 		setup_shift_type(shift_type="Day Shift")


### PR DESCRIPTION
**Problem**: Shift Request cancellation failed because the framework code for cancelling linked documents first cancels the shift assignment. Then tries to cancel the shift request, which is now trying to cancel a cancelled shift assignment `on_cancel` hook

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/24353136/235077565-9f1c23ba-f7fa-4fb5-b44e-dcab1b322e04.png">

**Fix**: Attempt cancelling only submitted assignments. Cannot remove `on_cancel` handler because the framework cancellation is only triggered from client-side.