### PR TITLE
fix: group checkin logs by shift start time

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -42,9 +42,7 @@ class ShiftType(Document):
 			"Employee Checkin", fields="*", filters=filters, order_by="employee,time"
 		)
 
-		for key, group in itertools.groupby(
-			logs, key=lambda x: (x["employee"], x["shift_actual_start"])
-		):
+		for key, group in itertools.groupby(logs, key=lambda x: (x["employee"], x["shift_start"])):
 			single_shift_logs = list(group)
 			(
 				attendance_status,
@@ -58,7 +56,7 @@ class ShiftType(Document):
 			mark_attendance_and_link_log(
 				single_shift_logs,
 				attendance_status,
-				key[1].date(),
+				single_shift_logs[0].shift_actual_start.date(),
 				working_hours,
 				late_entry,
 				early_exit,


### PR DESCRIPTION
## Problem

If the shift type's configuration for **Begin check-in before shift start time (in minutes)** is changed while the shift is going on, the OUT employee checkin log sets a different `shift_actual_start` than the IN type log. 

While marking auto-attendance, logs are grouped by `employee` and `shift_actual_start`. Since this timestamp is different for Check IN and Check OUT, the attendance only considers checkin log and marks the employee as absent even though checkout log is present.

## Fix

Group logs by shift start time instead of shift actual start to make sure same shift logs are together and attendance marking works fine. Shift Start timestamp is not affected by configuration changes in shift type