### PR TITLE
feat(Attendance Regularization): Overwrite Attendance status from Attendance Request record

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -205,10 +205,11 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-09-18 17:26:09.703215",
+ "modified": "2023-05-02 16:38:11.017001",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -256,5 +257,7 @@
  "search_fields": "employee,employee_name,attendance_date,status",
  "sort_field": "modified",
  "sort_order": "DESC",
- "title_field": "employee_name"
+ "states": [],
+ "title_field": "employee_name",
+ "track_changes": 1
 }

--- a/hrms/hr/doctype/attendance_request/attendance_request.js
+++ b/hrms/hr/doctype/attendance_request/attendance_request.js
@@ -10,14 +10,16 @@ frappe.ui.form.on("Attendance Request", {
 			frm.dashboard.clear_headline();
 
 			frm.call("get_attendance_warnings").then((r) => {
-				frm.dashboard.reset();
-				frm.dashboard.add_section(
-					frappe.render_template("attendance_warnings", {
-						warnings: r.message || [],
-					}),
-					__("Attendance Warnings")
-				);
-				frm.dashboard.show();
+				if (r.message?.length) {
+					frm.dashboard.reset();
+					frm.dashboard.add_section(
+						frappe.render_template("attendance_warnings", {
+							warnings: r.message || [],
+						}),
+						__("Attendance Warnings")
+					);
+					frm.dashboard.show();
+				}
 			})
 		}
 	}

--- a/hrms/hr/doctype/attendance_request/attendance_request.js
+++ b/hrms/hr/doctype/attendance_request/attendance_request.js
@@ -1,14 +1,24 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
-cur_frm.add_fetch('employee', 'company', 'company');
+frappe.ui.form.on("Attendance Request", {
+	refresh(frm) {
+		frm.trigger("show_attendance_warnings");
+	},
 
-frappe.ui.form.on('Attendance Request', {
-	half_day: function(frm) {
-		if(frm.doc.half_day == 1){
-			frm.set_df_property('half_day_date', 'reqd', true);
-		}
-		else{
-			frm.set_df_property('half_day_date', 'reqd', false);
+	show_attendance_warnings(frm) {
+		if (!frm.is_new() && frm.doc.docstatus === 0) {
+			frm.dashboard.clear_headline();
+
+			frm.call("get_attendance_warnings").then((r) => {
+				frm.dashboard.reset();
+				frm.dashboard.add_section(
+					frappe.render_template("attendance_warnings", {
+						warnings: r.message || [],
+					}),
+					__("Attendance Warnings")
+				);
+				frm.dashboard.show();
+			})
 		}
 	}
 });

--- a/hrms/hr/doctype/attendance_request/attendance_request.json
+++ b/hrms/hr/doctype/attendance_request/attendance_request.json
@@ -48,6 +48,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "employee.company",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
@@ -83,7 +84,8 @@
    "depends_on": "half_day",
    "fieldname": "half_day_date",
    "fieldtype": "Date",
-   "label": "Half Day Date"
+   "label": "Half Day Date",
+   "mandatory_depends_on": "half_day"
   },
   {
    "fieldname": "reason_section",
@@ -119,10 +121,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-16 11:49:26.943173",
+ "modified": "2023-05-03 09:31:53.325203",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance Request",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -185,6 +188,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "employee_name",
  "track_changes": 1
 }

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -86,13 +86,24 @@ class AttendanceRequest(Document):
 		if attendance_name:
 			# update existing attendance, change the status
 			doc = frappe.get_doc("Attendance", attendance_name)
-			if doc.status != status:
-				text = _("changed the status from {0} to {1} via Attendance Request").format(
-					frappe.bold(doc.status), frappe.bold(status)
-				)
+			old_status = doc.status
 
+			if old_status != status:
 				doc.db_set({"status": status, "attendance_request": self.name})
+				text = _("changed the status from {0} to {1} via Attendance Request").format(
+					frappe.bold(old_status), frappe.bold(status)
+				)
 				doc.add_comment(comment_type="Info", text=text)
+
+				frappe.msgprint(
+					_("Updated status from {0} to {1} for date {2} in the attendance record {3}").format(
+						frappe.bold(old_status),
+						frappe.bold(status),
+						frappe.bold(format_date(date)),
+						get_link_to_form("Attendance", doc.name),
+					),
+					title=_("Attendance Updated"),
+				)
 		else:
 			# submit a new attendance record
 			doc = frappe.new_doc("Attendance")
@@ -142,7 +153,7 @@ class AttendanceRequest(Document):
 			{
 				"employee": self.employee,
 				"attendance_date": attendance_date,
-				"docstatus": 1,
+				"docstatus": ("!=", 2),
 			},
 		)
 

--- a/hrms/hr/doctype/attendance_request/attendance_warnings.html
+++ b/hrms/hr/doctype/attendance_request/attendance_warnings.html
@@ -1,0 +1,24 @@
+<div class="form-message yellow">
+	<div>{{__("Attendance for the following dates will be skipped/overwritten on submission")}}</div>
+</div>
+<table class="table table-bordered table-hover">
+	<thead>
+		<tr>
+			<th style="width: 20%">{{ __("Date") }}</th>
+			<th style="width: 20%">{{ __("Action on Submission") }}</th>
+			<th style="width: 20%">{{ __("Reason") }}</th>
+			<th style="width: 20%">{{ __("Existing Record") }}</th>
+		</tr>
+	</thead>
+
+	<tbody>
+	{% for(var i=0; i < warnings.length; i++) { %}
+		<tr>
+			<td class="small">{{ frappe.datetime.str_to_user(warnings[i].date) }}</td>
+			<td class="small"> {{ __(warnings[i].action) }} </td>
+			<td class="small"> {{ __(warnings[i].reason) }} </td>
+			<td class="small"> {{ warnings[i].record }} </td>
+		</tr>
+	{% } %}
+	</tbody>
+</table>

--- a/hrms/hr/doctype/attendance_request/test_attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/test_attendance_request.py
@@ -8,7 +8,12 @@ from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, add_months, get_year_ending, get_year_start, getdate
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
-from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
+from hrms.hr.doctype.attendance_request.attendance_request import OverlappingAttendanceRequestError
+from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
+from hrms.payroll.doctype.salary_slip.test_salary_slip import (
+	make_holiday_list,
+	make_leave_application,
+)
 from hrms.tests.test_utils import get_first_sunday
 
 test_dependencies = ["Employee"]
@@ -19,14 +24,43 @@ class TestAttendanceRequest(FrappeTestCase):
 		for doctype in ["Attendance Request", "Attendance"]:
 			frappe.db.delete(doctype)
 
-		from_date = get_year_start(add_months(getdate(), -1))
-		to_date = get_year_ending(getdate())
+		self.from_date = get_year_start(add_months(getdate(), -1))
+		self.to_date = get_year_ending(getdate())
 		self.holiday_list = make_holiday_list(
-			from_date=from_date, to_date=to_date, add_weekly_offs=False
+			from_date=self.from_date, to_date=self.to_date, add_weekly_offs=False
 		)
 
 		self.employee = get_employee()
 		frappe.db.set_value("Employee", self.employee.name, "holiday_list", self.holiday_list)
+
+	def test_attendance_request_overlap(self):
+		create_attendance_request(employee=self.employee.name, reason="On Duty", company="_Test Company")
+
+		today = getdate()
+		dateranges = [
+			(add_days(today, -2), today),
+			(today, today),
+			(today, add_days(today, 1)),
+			(add_days(today, -2), add_days(today, 2)),
+		]
+		attendance_request = frappe.get_doc(
+			{
+				"doctype": "Attendance Request",
+				"employee": self.employee.name,
+				"reason": "On Duty",
+				"company": "_Test Company",
+			}
+		)
+
+		for entry in dateranges:
+			attendance_request.from_date = entry[0]
+			attendance_request.to_date = entry[1]
+			self.assertRaises(OverlappingAttendanceRequestError, attendance_request.save)
+
+		# no overlap
+		attendance_request.from_date = add_days(today, -3)
+		attendance_request.to_date = add_days(today, -2)
+		attendance_request.save()
 
 	def test_on_duty_attendance_request(self):
 		"Test creation of Attendance from Attendance Request, on duty."
@@ -95,13 +129,36 @@ class TestAttendanceRequest(FrappeTestCase):
 		self.assertEqual(len(records), 1)
 		self.assertEqual(records[0].status, "Present")
 
+	def test_skip_attendance_on_leave(self):
+		frappe.delete_doc_if_exists("Leave Type", "Test Skip Attendance", force=1)
+		leave_type = frappe.get_doc(
+			dict(leave_type_name="Test Skip Attendance", doctype="Leave Type")
+		).insert()
+
+		make_allocation_record(
+			leave_type=leave_type.name, from_date=self.from_date, to_date=self.to_date
+		)
+		today = getdate()
+		make_leave_application(self.employee.name, today, add_days(today, 1), leave_type.name)
+
+		attendance_request = create_attendance_request(
+			employee=self.employee.name, reason="On Duty", company="_Test Company"
+		)
+		records = self.get_attendance_records(attendance_request.name)
+
+		# only 1 attendance marked for yesterday
+		# attendance skipped for today since its a leave
+		self.assertEqual(len(records), 1)
+		self.assertEqual(records[0].attendance_date, add_days(today, -1))
+		self.assertEqual(records[0].status, "Present")
+
 	def get_attendance_records(self, attendance_request: str) -> list[dict]:
 		return frappe.db.get_all(
 			"Attendance",
 			{
 				"attendance_request": attendance_request,
 			},
-			["status", "docstatus"],
+			["status", "docstatus", "attendance_date"],
 		)
 
 


### PR DESCRIPTION
## Problem

Currently, Attendance Request cannot be used for attendance regularization (a feature that enables employees to correct their own attendance)

If an employee is marked absent by auto-attendance and they put in an attendance request for that day, the request submission fails giving a duplicate attendance record error

## Solution

Overwrite Attendance status from the Attendance Request record on submission just like leave application submission resets existing attendance status to "On Leave"

### Comment for overwritten status

<img width="1322" alt="changed status" src="https://user-images.githubusercontent.com/24353136/235837997-d4574716-cadb-446c-8908-04e8cfa2e819.png">

### Attendance warnings

**Problem**:
Attendance request also skips marking attendance for dates with leaves/holidays. This happens on submission so the user isn't aware when they put in a request. 
**Fix**:
Show attendance warnings on the dashboard for skipping/overwriting attendance on these dates:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/24353136/235837510-33b7b9b2-d49e-4335-98c5-06c2d861f991.png">

### Other fixes

- Attendance Request cancellation failing. Same reason: https://github.com/frappe/hrms/pull/478
- Validate overlapping Attendance Requests 
- Refactored tests, added more tests
- Replaced unnecessary client-side code with DocType configurations

Docs: https://frappehr.com/docs/v14/user/manual/en/human-resources/attendance-request/edit-wiki?wiki_page_patch=cffc251f55