### PR TITLE
perf: refactor `get_all_nodes` in Org Chart

### DIFF
--- a/hrms/hr/page/organizational_chart/test_organizational_chart.py
+++ b/hrms/hr/page/organizational_chart/test_organizational_chart.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import unittest
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.setup.doctype.employee.test_employee import make_employee
+
+from hrms.hr.page.organizational_chart.organizational_chart import get_children
+from hrms.tests.test_utils import create_company
+
+
+class TestOrganizationalChart(FrappeTestCase):
+	def setUp(self):
+		self.company = create_company("Test Org Chart").name
+		frappe.db.delete("Employee", {"company": self.company})
+
+	def test_get_children(self):
+		company = create_company("Test Org Chart").name
+		emp1 = make_employee("testemp1@mail.com", company=self.company)
+		emp2 = make_employee("testemp2@mail.com", company=self.company, reports_to=emp1)
+		emp3 = make_employee("testemp3@mail.com", company=self.company, reports_to=emp1)
+		make_employee("testemp4@mail.com", company=self.company, reports_to=emp2)
+
+		# root node
+		children = get_children(company=self.company)
+		self.assertEqual(len(children), 1)
+		self.assertEqual(children[0].id, emp1)
+		self.assertEqual(children[0].connections, 3)
+
+		# root's children
+		children = get_children(parent=emp1, company=self.company)
+		self.assertEqual(len(children), 2)
+		self.assertEqual(children[0].id, emp2)
+		self.assertEqual(children[0].connections, 1)
+		self.assertEqual(children[1].id, emp3)
+		self.assertEqual(children[1].connections, 0)


### PR DESCRIPTION
## Before

<img width="1440" alt="get-all-nodes-before" src="https://user-images.githubusercontent.com/24353136/236383131-e41d9c44-2027-43b0-b9d6-62dcbf5bf704.png">

<img width="1440" alt="get-children-before" src="https://user-images.githubusercontent.com/24353136/236383142-dd20a5a0-0082-4a17-a99c-9e632356b2d6.png">

## After

The org chart was permission sensitive earlier but it makes more sense to show the chart as it is without applying permissions since it's supposed to show the entire org. 

- Replaced `get_list` with `get_all`
- Since `get_list` was used in the earlier implementation, the number of connections had to be dynamically calculated without relying on `lft`, `rgt` attributes of the tree. Now its a straightforward query

Tested with ~1700 employees

`get_children` - **4.85 s -> 0.02853 s**
`get_all_nodes` - **11.07 s -> 0.68129 s**

<img width="1440" alt="get-all-nodes-after" src="https://user-images.githubusercontent.com/24353136/236383162-41f50887-ba2a-4b83-bb2d-dd902bdfa867.png">

<img width="1440" alt="get-children-after" src="https://user-images.githubusercontent.com/24353136/236383176-6acabc34-d846-47fc-a7aa-4861587e4341.png">

Will cover client-side optimizations in a separate PR.