### PR TITLE
Fix: shift_actual_end should be greater than the last sync time

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -35,7 +35,7 @@ class ShiftType(Document):
 			"skip_auto_attendance": 0,
 			"attendance": ("is", "not set"),
 			"time": (">=", self.process_attendance_after),
-			"shift_actual_end": ("<", self.last_sync_of_checkin),
+			"shift_actual_end": (">", self.last_sync_of_checkin),
 			"shift": self.name,
 		}
 		logs = frappe.db.get_list(


### PR DESCRIPTION
This commit fixes a logical bug in the filters used to fetch Employee check-ins. 

Currently, Auto Attendance does not work correctly because `mark_attendance_and_link_log` in `shift_type.py` does not fetch the complete list of `Employee Checkin`.  Currently, the code looks for check-ins prior to last sync time which is set after a successful sync. 

This should obviously look for check-ins after the last sync and this PR fixes this.


