### PR TITLE
fix: do not pull exchange rate on SS if exchange rate is defined on payroll entry

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.js
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.js
@@ -94,11 +94,15 @@ frappe.ui.form.on("Salary Slip", {
 
 	set_exchange_rate: function(frm, company_currency) {
 		if (frm.doc.docstatus === 0) {
+
+			if(frm.doc.payroll_entry && frm.doc.exchange_rate) {
+				frm.set_df_property('exchange_rate', 'read_only', 1)
+				return
+			}
+
 			if (frm.doc.currency) {
 				var from_currency = frm.doc.currency;
 				if (from_currency != company_currency) {
-					if (frm.doc.exchange_rate && frm.doc.exchange_rate !==1){ return; }
-
 					frm.events.hide_loan_section(frm);
 					frappe.call({
 						method: "erpnext.setup.utils.get_exchange_rate",


### PR DESCRIPTION
Before fix:
https://github.com/frappe/hrms/assets/3784093/34ae5345-27f9-4990-9e19-326e3e264910


After fix:
https://github.com/frappe/hrms/assets/3784093/8df0d884-6ecb-48e1-bee1-8ae8fef924bf

