### PR TITLE
chore: set payroll period if not exists

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -68,12 +68,18 @@ class SalarySlip(TransactionBase):
 	def autoname(self):
 		self.name = make_autoname(self.series)
 
+	@property
+	def payroll_period(self):
+		if not hasattr(self, "_payroll_period"):
+			self._payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
+
+		return self._payroll_period
+
 	def validate(self):
 		self.status = self.get_status()
 		validate_active_employee(self.employee)
 		self.validate_dates()
 		self.check_existing()
-		self.set_payroll_period()
 
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
@@ -102,10 +108,6 @@ class SalarySlip(TransactionBase):
 					),
 					alert=True,
 				)
-
-	def set_payroll_period(self):
-		if not hasattr(self, "payroll_period"):
-			self.payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
 
 	def set_net_total_in_words(self):
 		doc_currency = self.currency
@@ -236,7 +238,6 @@ class SalarySlip(TransactionBase):
 			if not self.salary_slip_based_on_timesheet:
 				self.get_date_details()
 
-			self.set_payroll_period()
 			joining_date, relieving_date = frappe.get_cached_value(
 				"Employee", self.employee, ("date_of_joining", "relieving_date")
 			)
@@ -1816,9 +1817,6 @@ class SalarySlip(TransactionBase):
 			self.get_date_details()
 		self.pull_emp_details()
 		self.get_working_days_details(for_preview=for_preview)
-
-		if not hasattr(self, "payroll_period"):
-			self.set_payroll_period()
 
 		self.calculate_net_pay()
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1951,8 +1951,6 @@ class SalarySlip(TransactionBase):
 				component.year_to_date = year_to_date
 
 	def get_year_to_date_period(self):
-		self.payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
-
 		if self.payroll_period:
 			period_start_date = self.payroll_period.start_date
 			period_end_date = self.payroll_period.end_date


### PR DESCRIPTION
```
### App Versions
```
{
	"erpnext": "14.0.0-dev",
	"frappe": "15.0.0-dev",
	"hrms": "15.0.0-dev",
	"payments": "0.0.1"
}
```
### Route
```
Form/Salary Slip/Sal Slip/HR-EMP-00008/00001
```
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 53, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1591, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 307, in run_doc_method
    response = doc.run_method(method)
  File "apps/frappe/frappe/model/document.py", line 926, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 923, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 1837, in process_salary_based_on_working_days
    self.calculate_net_pay()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 626, in calculate_net_pay
    self.calculate_component_amounts("earnings")
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 939, in calculate_component_amounts
    self.add_employee_benefits()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 1103, in add_employee_benefits
    self.adjust_benefits_in_last_payroll_period(self.payroll_period)
AttributeError: 'SalarySlip' object has no attribute 'payroll_period'

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"docs": "{\"name\":\"Sal Slip/HR-EMP-00008/00001\",\"owner\":\"Administrator\",\"creation\":\"2023-05-12 14:54:29.111911\",\"modified\":\"2023-05-12 14:54:47.068878\",\"modified_by\":\"Administrator\",\"docstatus\":0,\"idx\":0,\"employee\":\"HR-EMP-00008\",\"employee_name\":\"Test LWP\",\"posting_date\":\"2023-04-30\",\"status\":\"Draft\",\"company\":\"Frappe Technologies Pvt Ltd\",\"currency\":\"INR\",\"exchange_rate\":1,\"payroll_frequency\":\"Monthly\",\"start_date\":\"2023-04-01\",\"end_date\":\"2023-04-30\",\"salary_structure\":\"LWP Calc 1\",\"mode_of_payment\":\"\",\"salary_slip_based_on_timesheet\":0,\"deduct_tax_for_unclaimed_employee_benefits\":0,\"deduct_tax_for_unsubmitted_tax_exemption_proof\":0,\"total_working_days\":30,\"unmarked_days\":0,\"leave_without_pay\":3,\"absent_days\":0,\"payment_days\":25,\"total_working_hours\":0,\"hour_rate\":0,\"base_hour_rate\":0,\"gross_pay\":26666.659999999996,\"base_gross_pay\":26666.66,\"gross_year_to_date\":26666.66,\"base_gross_year_to_date\":0,\"total_deduction\":319.44,\"base_total_deduction\":319.44,\"total_principal_amount\":0,\"total_interest_amount\":0,\"total_loan_repayment\":0,\"net_pay\":26347.219999999998,\"base_net_pay\":26347.22,\"rounded_total\":26347,\"base_rounded_total\":26347,\"year_to_date\":26347.22,\"base_year_to_date\":0,\"month_to_date\":26347.22,\"base_month_to_date\":0,\"total_in_words\":\"INR Twenty Six Thousand, Three Hundred And Forty Seven only.\",\"base_total_in_words\":\"INR Twenty Six Thousand, Three Hundred And Forty Seven only.\",\"ctc\":378666.66,\"income_from_other_sources\":0,\"total_earnings\":378666.66,\"non_taxable_earnings\":0,\"standard_tax_exemption_amount\":0,\"tax_exemption_declaration\":50000,\"deductions_before_tax_calculation\":0,\"annual_taxable_amount\":328666.66,\"income_tax_deducted_till_date\":119.44441666666656,\"current_month_income_tax\":119.44441666666656,\"future_income_tax_deductions\":1313.8885833333322,\"total_income_tax\":1433.3329999999987,\"doctype\":\"Salary Slip\",\"leave_details\":[],\"loans\":[],\"timesheets\":[],\"earnings\":[{\"name\":\"new-salary-slip-1\",\"docstatus\":0,\"idx\":1,\"salary_component\":\"Basic\",\"abbr\":\"B\",\"amount\":13333.33,\"year_to_date\":0,\"is_recurring_additional_salary\":0,\"statistical_component\":0,\"depends_on_payment_days\":1,\"exempted_from_income_tax\":0,\"is_tax_applicable\":1,\"is_flexible_benefit\":0,\"variable_based_on_taxable_salary\":0,\"do_not_include_in_total\":0,\"deduct_full_tax_on_selected_payroll_date\":0,\"amount_based_on_formula\":0,\"default_amount\":16000,\"additional_amount\":0,\"tax_on_flexible_benefit\":0,\"tax_on_additional_salary\":0,\"parent\":\"Sal Slip/HR-EMP-00008/00001\",\"parentfield\":\"earnings\",\"parenttype\":\"Salary Slip\",\"doctype\":\"Salary Detail\",\"__islocal\":1},{\"name\":\"new-salary-slip-2\",\"docstatus\":0,\"idx\":2,\"salary_component\":\"House Rent Allowance\",\"abbr\":\"HRA\",\"amount\":6666.66,\"year_to_date\":0,\"is_recurring_additional_salary\":0,\"statistical_component\":0,\"depends_on_payment_days\":0,\"exempted_from_income_tax\":0,\"is_tax_applicable\":1,\"is_flexible_benefit\":0,\"variable_based_on_taxable_salary\":0,\"do_not_include_in_total\":0,\"deduct_full_tax_on_selected_payroll_date\":0,\"amount_based_on_formula\":0,\"default_amount\":8000,\"additional_amount\":0,\"tax_on_flexible_benefit\":0,\"tax_on_additional_salary\":0,\"parent\":\"Sal Slip/HR-EMP-00008/00001\",\"parentfield\":\"earnings\",\"parenttype\":\"Salary Slip\",\"doctype\":\"Salary Detail\",\"__islocal\":1},{\"name\":\"new-salary-slip-3\",\"docstatus\":0,\"idx\":3,\"salary_component\":\"Special Allowance\",\"abbr\":\"SA\",\"amount\":6666.67,\"year_to_date\":0,\"is_recurring_additional_salary\":0,\"statistical_component\":0,\"depends_on_payment_days\":0,\"exempted_from_income_tax\":0,\"is_tax_applicable\":1,\"is_flexible_benefit\":0,\"variable_based_on_taxable_salary\":0,\"do_not_include_in_total\":0,\"deduct_full_tax_on_selected_payroll_date\":0,\"amount_based_on_formula\":0,\"default_amount\":8000,\"additional_amount\":0,\"tax_on_flexible_benefit\":0,\"tax_on_additional_salary\":0,\"parent\":\"Sal Slip/HR-EMP-00008/00001\",\"parentfield\":\"earnings\",\"parenttype\":\"Salary Slip\",\"doctype\":\"Salary Detail\",\"__islocal\":1}],\"deductions\":[{\"name\":\"new-salary-slip-4\",\"docstatus\":0,\"idx\":1,\"salary_component\":\"Professional Tax\",\"abbr\":\"PT\",\"amount\":200,\"year_to_date\":0,\"is_recurring_additional_salary\":0,\"statistical_component\":0,\"depends_on_payment_days\":0,\"exempted_from_income_tax\":1,\"is_tax_applicable\":1,\"is_flexible_benefit\":0,\"variable_based_on_taxable_salary\":0,\"do_not_include_in_total\":0,\"deduct_full_tax_on_selected_payroll_date\":0,\"amount_based_on_formula\":0,\"default_amount\":200,\"additional_amount\":0,\"tax_on_flexible_benefit\":0,\"tax_on_additional_salary\":0,\"parent\":\"Sal Slip/HR-EMP-00008/00001\",\"parentfield\":\"deductions\",\"parenttype\":\"Salary Slip\",\"doctype\":\"Salary Detail\",\"__islocal\":1},{\"name\":\"new-salary-slip-6\",\"docstatus\":0,\"idx\":2,\"salary_component\":\"Income Tax\",\"abbr\":\"IT\",\"amount\":119.44,\"year_to_date\":0,\"is_recurring_additional_salary\":0,\"statistical_component\":0,\"depends_on_payment_days\":0,\"exempted_from_income_tax\":0,\"is_tax_applicable\":1,\"is_flexible_benefit\":0,\"variable_based_on_taxable_salary\":1,\"do_not_include_in_total\":0,\"deduct_full_tax_on_selected_payroll_date\":0,\"amount_based_on_formula\":0,\"default_amount\":119.44441666666656,\"additional_amount\":0,\"tax_on_flexible_benefit\":0,\"tax_on_additional_salary\":0,\"parent\":\"Sal Slip/HR-EMP-00008/00001\",\"parentfield\":\"deductions\",\"parenttype\":\"Salary Slip\",\"doctype\":\"Salary Detail\",\"__islocal\":1}],\"__unsaved\":1,\"__onload\":{\"load_after_mapping\":true}}",
		"method": "process_salary_based_on_working_days"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/run_doc_method"
}
```
### Response Data
```
{
	"exception": "AttributeError: 'SalarySlip' object has no attribute 'payroll_period'",
	"_server_messages": "[\"{\\\"message\\\": \\\"Leave Without Pay does not match with approved Leave records\\\", \\\"title\\\": \\\"Message\\\"}\"]"
}
```
```