### PR TITLE
perf: Auto Attendance processing

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.json
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.json
@@ -26,7 +26,8 @@
    "fieldtype": "Link",
    "label": "Employee",
    "options": "Employee",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fetch_from": "employee.employee_name",
@@ -48,7 +49,8 @@
    "fieldtype": "Link",
    "label": "Shift",
    "options": "Shift Type",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_4",
@@ -107,10 +109,11 @@
   }
  ],
  "links": [],
- "modified": "2020-07-08 11:02:32.660986",
+ "modified": "2023-05-12 14:52:22.660264",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -203,6 +206,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "title_field": "employee_name",
  "track_changes": 1
 }

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -136,7 +136,7 @@ def mark_attendance_and_link_log(
 		return None
 
 	elif attendance_status in ("Present", "Absent", "Half Day"):
-		employee_doc = frappe.get_doc("Employee", employee)
+		company = frappe.db.get_value("Employee", employee, "company", cache=True)
 		duplicate = get_duplicate_attendance_record(employee, attendance_date, shift)
 		overlapping = get_overlapping_shift_attendance(employee, attendance_date, shift)
 
@@ -147,7 +147,7 @@ def mark_attendance_and_link_log(
 				"attendance_date": attendance_date,
 				"status": attendance_status,
 				"working_hours": working_hours,
-				"company": employee_doc.company,
+				"company": company,
 				"shift": shift,
 				"late_entry": late_entry,
 				"early_exit": early_exit,

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -286,7 +286,7 @@ def get_employee_shift(
 	shift_details = get_shift_for_timestamp(employee, for_timestamp)
 
 	# if shift assignment is not found, consider default shift
-	default_shift = frappe.db.get_value("Employee", employee, "default_shift")
+	default_shift = frappe.db.get_value("Employee", employee, "default_shift", cache=True)
 	if not shift_details and consider_default_shift:
 		shift_details = get_shift_details(default_shift, for_timestamp)
 
@@ -462,7 +462,18 @@ def get_shift_details(shift_type_name: str, for_timestamp: datetime = None) -> D
 	if for_timestamp is None:
 		for_timestamp = now_datetime()
 
-	shift_type = frappe.get_doc("Shift Type", shift_type_name)
+	shift_type = frappe.get_cached_value(
+		"Shift Type",
+		shift_type_name,
+		[
+			"name",
+			"start_time",
+			"end_time",
+			"begin_check_in_before_shift_start_time",
+			"allow_check_out_after_shift_end_time",
+		],
+		as_dict=1,
+	)
 	shift_actual_start = shift_type.start_time - timedelta(
 		minutes=shift_type.begin_check_in_before_shift_start_time
 	)

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -188,7 +188,6 @@ class ShiftType(Document):
 		assigned_employees = frappe.get_all("Shift Assignment", filters=filters, pluck="employee")
 
 		if consider_default_shift:
-			filters = {"default_shift": self.name, "status": ["!=", "Inactive"]}
 			default_shift_employees = self.get_employees_with_default_shift(from_date)
 
 			return list(set(assigned_employees + default_shift_employees))
@@ -196,7 +195,7 @@ class ShiftType(Document):
 
 	def get_employees_with_default_shift(self, from_date=None):
 		default_shift_employees = frappe.get_all(
-			"Employee", filters={"default_shift": self.name, "status": ("!=", "Inactive")}, pluck="name"
+			"Employee", filters={"default_shift": self.name, "status": "Active"}, pluck="name"
 		)
 
 		# exclude employees from default shift list if any other valid shift assignment exists

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -151,7 +151,7 @@ class ShiftType(Document):
 		return: start date = max of `process_attendance_after` and DOJ
 		return: end date = min of shift before `last_sync_of_checkin` and Relieving Date
 		"""
-		date_of_joining, relieving_date, employee_creation = frappe.db.get_value(
+		date_of_joining, relieving_date, employee_creation = frappe.get_cached_value(
 			"Employee", employee, ["date_of_joining", "relieving_date", "creation"]
 		)
 
@@ -235,7 +235,7 @@ class ShiftType(Document):
 
 
 def process_auto_attendance_for_all_shifts():
-	shift_list = frappe.get_all("Shift Type", "name", {"enable_auto_attendance": "1"}, as_list=True)
+	shift_list = frappe.get_all("Shift Type", filters={"enable_auto_attendance": "1"}, pluck="name")
 	for shift in shift_list:
-		doc = frappe.get_doc("Shift Type", shift[0])
+		doc = frappe.get_cached_doc("Shift Type", shift)
 		doc.process_auto_attendance()

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -341,7 +341,7 @@ class TestShiftType(FrappeTestCase):
 
 		default_shift = setup_shift_type()
 		employee = make_employee(
-			"test_employee_checkin@example.com", company="_Test Company", shift_type=default_shift.name
+			"test_employee_checkin@example.com", company="_Test Company", default_shift=default_shift.name
 		)
 
 		assigned_shift = setup_shift_type(shift_type="Test Absent with no Attendance")
@@ -355,11 +355,15 @@ class TestShiftType(FrappeTestCase):
 		log_out = make_checkin(employee, timestamp)
 
 		default_shift.process_auto_attendance()
-		attendance = frappe.db.get_value("Attendance", {"employee": employee}, "status")
+		attendance = frappe.db.get_value(
+			"Attendance", {"employee": employee, "shift": default_shift.name}, "status"
+		)
 		self.assertIsNone(attendance)
 
 		assigned_shift.process_auto_attendance()
-		attendance = frappe.db.get_value("Attendance", {"employee": employee}, "status")
+		attendance = frappe.db.get_value(
+			"Attendance", {"employee": employee, "shift": assigned_shift.name}, "status"
+		)
 		self.assertEqual(attendance, "Present")
 
 	def test_get_start_and_end_dates(self):


### PR DESCRIPTION
Auto attendance job times out with scale.

## Before:

<img width="764" alt="perf-auto-attendance-before" src="https://github.com/frappe/hrms/assets/24353136/450010f5-9029-42b4-a58f-02f29ace0761">

## After:

Tested with data: 1000 employees, 10,000 check-ins

<img width="764" alt="perf-after" src="https://github.com/frappe/hrms/assets/24353136/d7929940-bc06-408c-9a34-3244ffc4a2ac">

Optimizations:
- Added simple indexing on widely queried columns to avoid full table scans: Shift Type and Employee in Employee Checkin
- get_doc -> db_exists or get_value
- db.get_all -> db.exists or get_value
- Caching: get_cached_doc / get_cached_value / get_value with db_cache (as per use case_

