### PR TITLE
fix: update statistical component value in default data

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -953,13 +953,11 @@ class SalarySlip(TransactionBase):
 				continue
 
 			amount = self.eval_condition_and_formula(struct_row, self.data)
-
 			if struct_row.statistical_component:
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip
 
 				self.default_data[struct_row.abbr] = amount
-
 				if struct_row.depends_on_payment_days:
 					payment_days_amount = (
 						flt(amount) * flt(self.payment_days) / cint(self.total_working_days)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -957,14 +957,15 @@ class SalarySlip(TransactionBase):
 			if struct_row.statistical_component:
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip
+
+				self.default_data[struct_row.abbr] = amount
+
 				if struct_row.depends_on_payment_days:
 					payment_days_amount = (
 						flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
 						if self.total_working_days
 						else 0
 					)
-
-					self.default_data[struct_row.abbr] = amount
 					self.data[struct_row.abbr] = flt(payment_days_amount, struct_row.precision("amount"))
 
 			else:


### PR DESCRIPTION
Issue: 

Total earnings for taxation, gets calculated on components default amount. 

<img width="667" alt="Screenshot 2023-05-12 at 12 27 33 PM" src="https://github.com/frappe/erpnext/assets/3784093/fd21ad88-e959-42a2-a11e-24be6ea6fe62">

But for statistical components, the system was not setting default value, which results into wrong data calculations

<img width="696" alt="Screenshot 2023-05-12 at 12 36 03 PM" src="https://github.com/frappe/erpnext/assets/3784093/fa81ffcf-4e47-4c83-b4fc-ee71ecd7b58a">

Fix:
Set default value for statistical components too!

Before Fix:

```
{
    'taxable_earnings': 66205.0, 
    'additional_income': 0, 
    'additional_income_with_full_tax': 0, 
    'flexi_benefits': 0
}
```

After Fix:

```
{
    'taxable_earnings': 38500.0, 
    'additional_income': 0, 
    'additional_income_with_full_tax': 0, 
    'flexi_benefits': 0
}
```






