### PR TITLE
chore: set payroll period if not exists

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1945,8 +1945,6 @@ class SalarySlip(TransactionBase):
 				component.year_to_date = year_to_date
 
 	def get_year_to_date_period(self):
-		self.payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
-
 		if self.payroll_period:
 			period_start_date = self.payroll_period.start_date
 			period_end_date = self.payroll_period.end_date

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -68,12 +68,18 @@ class SalarySlip(TransactionBase):
 	def autoname(self):
 		self.name = make_autoname(self.series)
 
+	@property
+	def payroll_period(self):
+		if not hasattr(self, "_payroll_period"):
+			self._payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
+
+		return self._payroll_period
+
 	def validate(self):
 		self.status = self.get_status()
 		validate_active_employee(self.employee)
 		self.validate_dates()
 		self.check_existing()
-		self.set_payroll_period()
 
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
@@ -102,9 +108,6 @@ class SalarySlip(TransactionBase):
 					),
 					alert=True,
 				)
-
-	def set_payroll_period(self):
-		self.payroll_period = get_payroll_period(self.start_date, self.end_date, self.company)
 
 	def set_net_total_in_words(self):
 		doc_currency = self.currency
@@ -233,7 +236,6 @@ class SalarySlip(TransactionBase):
 			if not self.salary_slip_based_on_timesheet:
 				self.get_date_details()
 
-			self.set_payroll_period()
 			joining_date, relieving_date = frappe.get_cached_value(
 				"Employee", self.employee, ("date_of_joining", "relieving_date")
 			)
@@ -1809,9 +1811,6 @@ class SalarySlip(TransactionBase):
 			self.get_date_details()
 		self.pull_emp_details()
 		self.get_working_days_details(for_preview=for_preview)
-
-		if not hasattr(self, "payroll_period"):
-			self.set_payroll_period()
 
 		self.calculate_net_pay()
 


### PR DESCRIPTION
### App Versions
```
{
	"erpnext": "14.0.0-dev",
	"frappe": "15.0.0-dev",
	"hrms": "15.0.0-dev",
	"payments": "0.0.1"
}
```

### Route
```
Form/Salary Slip/Sal Slip/HR-EMP-00008/00001
```

### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 53, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1591, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 307, in run_doc_method
    response = doc.run_method(method)
  File "apps/frappe/frappe/model/document.py", line 926, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 923, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 1837, in process_salary_based_on_working_days
    self.calculate_net_pay()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 626, in calculate_net_pay
    self.calculate_component_amounts("earnings")
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 939, in calculate_component_amounts
    self.add_employee_benefits()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 1103, in add_employee_benefits
    self.adjust_benefits_in_last_payroll_period(self.payroll_period)
AttributeError: 'SalarySlip' object has no attribute 'payroll_period'
```