### PR TITLE
enabling multi currencies when creating journal entries from payroll entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -502,7 +502,7 @@ class PayrollEntry(Document):
 				)
 
 			journal_entry.set("accounts", accounts)
-			company_currency = frappe.db.get_value("Company",self.company,"default_currency")
+			company_currency = frappe.db.get_value("Company",self.company, "default_currency")
 			currencies.append(self.currency)
 			if company_currency != self.currency:
 				currencies.append(company_currency)
@@ -737,7 +737,7 @@ class PayrollEntry(Document):
 				)
 			)
 
-		company_currency = frappe.db.get_value("Company",self.company,"default_currency")
+		company_currency = frappe.db.get_value("Company", self.company, "default_currency")
 		currencies.append(self.currency)
 		if company_currency != self.currency:
 			currencies.append(company_currency)

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -502,6 +502,10 @@ class PayrollEntry(Document):
 				)
 
 			journal_entry.set("accounts", accounts)
+			company_currency = frappe.db.get_value("Company",self.company,"default_currency")
+			currencies.append(self.currency)
+			if company_currency != self.currency:
+				currencies.append(company_currency)
 			if len(currencies) > 1:
 				multi_currency = 1
 			journal_entry.multi_currency = multi_currency
@@ -733,6 +737,10 @@ class PayrollEntry(Document):
 				)
 			)
 
+		company_currency = frappe.db.get_value("Company",self.company,"default_currency")
+		currencies.append(self.currency)
+		if company_currency != self.currency:
+			currencies.append(company_currency)
 		if len(currencies) > 1:
 			multi_currency = 1
 


### PR DESCRIPTION
fixing currencies's counting in create_journal_entry() function, then enabling multi currencies when creating journal entry from payroll entry if the company default currency and payroll entry currency are not the same.