### PR TITLE
feat: Allow ceil & floor functions in salary slip formulae

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2,7 +2,6 @@
 # License: GNU General Public License v3. See license.txt
 
 
-import math
 from datetime import date
 
 import frappe
@@ -12,9 +11,11 @@ from frappe.query_builder import Order
 from frappe.query_builder.functions import Sum
 from frappe.utils import (
 	add_days,
+	ceil,
 	cint,
 	cstr,
 	date_diff,
+	floor,
 	flt,
 	formatdate,
 	get_first_day,
@@ -63,6 +64,8 @@ class SalarySlip(TransactionBase):
 			"round": round,
 			"date": date,
 			"getdate": getdate,
+			"ceil": ceil,
+			"floor": floor,
 		}
 
 	def autoname(self):
@@ -710,7 +713,7 @@ class SalarySlip(TransactionBase):
 		# get taxable_earnings for current period (all days)
 		self.current_taxable_earnings = self.get_taxable_earnings(self.tax_slab.allow_tax_exemption)
 		self.future_structured_taxable_earnings = self.current_taxable_earnings.taxable_earnings * (
-			math.ceil(self.remaining_sub_periods) - 1
+			ceil(self.remaining_sub_periods) - 1
 		)
 
 		current_taxable_earnings_before_exemption = (
@@ -718,7 +721,7 @@ class SalarySlip(TransactionBase):
 			+ self.current_taxable_earnings.amount_exempted_from_income_tax
 		)
 		self.future_structured_taxable_earnings_before_exemption = (
-			current_taxable_earnings_before_exemption * (math.ceil(self.remaining_sub_periods) - 1)
+			current_taxable_earnings_before_exemption * (ceil(self.remaining_sub_periods) - 1)
 		)
 
 		# get taxable_earnings, addition_earnings for current actual payment days
@@ -820,7 +823,7 @@ class SalarySlip(TransactionBase):
 
 		# Future period non taxable earnings
 		future_period_non_taxable_earnings = current_period_non_taxable_earnings * (
-			math.ceil(self.remaining_sub_periods) - 1
+			ceil(self.remaining_sub_periods) - 1
 		)
 
 		non_taxable_earnings = (
@@ -883,12 +886,10 @@ class SalarySlip(TransactionBase):
 		for deduction in self._salary_structure_doc.get("deductions"):
 			if deduction.exempted_from_income_tax:
 				if deduction.amount_based_on_formula:
-					for sub_period in range(1, math.ceil(self.remaining_sub_periods)):
+					for sub_period in range(1, ceil(self.remaining_sub_periods)):
 						future_period_exempted_amount += self.get_amount_from_formula(deduction, sub_period)
 				else:
-					future_period_exempted_amount += deduction.amount * (
-						math.ceil(self.remaining_sub_periods) - 1
-					)
+					future_period_exempted_amount += deduction.amount * (ceil(self.remaining_sub_periods) - 1)
 
 		return (
 			prev_period_exempted_amount + current_period_exempted_amount + future_period_exempted_amount


### PR DESCRIPTION
Components like ESIC don't follow traditional rounding. They need to be rounded up to the next higher rupee.
1.2 -> 2
1.5 -> 2

Allow ceil & floor functions in salary slip `whitelisted_globals` so that it can be used in formulae

Eg: 

Component:
![image](https://github.com/frappe/hrms/assets/24353136/ed1f6c73-b8f2-4b0b-ba2c-5b9f6cc793ee)

Salary Slip:
![image](https://github.com/frappe/hrms/assets/24353136/86af06b2-040e-4a04-8a88-9f0e869ecd06)

**Docs:** https://frappehr.com/docs/v14/user/manual/en/human-resources/salary-component

![image](https://github.com/frappe/hrms/assets/24353136/485184e7-2520-4752-9732-315aa651968c)
