### PR TITLE
fix: incorrect pro-rated earned leave calculation for passed months

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -374,6 +374,28 @@ class TestLeaveAllocation(FrappeTestCase):
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
 		self.assertEqual(leaves_allocated, pro_rated_leave + 1)
 
+	def test_backdated_pro_rated_allocation(self):
+		# leave period started in Jan
+		start_date = getdate("2023-01-01")
+
+		# employee joined mid-month in Mar
+		self.employee.date_of_joining = getdate("2023-03-15")
+		self.employee.save()
+
+		# creating backdated allocation in May
+		frappe.flags.current_date = getdate("2023-05-16")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="First Day",
+			start_date=start_date,
+			rounding="",
+		)
+		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
+
+		# pro-rated leaves should be considered only for the month of DOJ i.e. Mar = 0.548 leaves
+		# and full leaves for the remaining 2 months i.e. Apr and May = 2 leaves
+		self.assertEqual(leaves_allocated, 2.548)
+
 	def test_no_pro_rated_leaves_allocated_before_effective_date(self):
 		start_date = get_first_day(add_months(getdate(), -1))
 		doj = add_days(start_date, 5)
@@ -465,7 +487,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		frappe.flags.current_date = None
 
 
-def create_earned_leave_type(leave_type, allocate_on_day="Last Day"):
+def create_earned_leave_type(leave_type, allocate_on_day="Last Day", rounding=0.5):
 	frappe.delete_doc_if_exists("Leave Type", leave_type, force=1)
 	frappe.delete_doc_if_exists("Leave Type", "Test Earned Leave Type", force=1)
 	frappe.delete_doc_if_exists("Leave Type", "Test Earned Leave Type 2", force=1)
@@ -476,7 +498,7 @@ def create_earned_leave_type(leave_type, allocate_on_day="Last Day"):
 			doctype="Leave Type",
 			is_earned_leave=1,
 			earned_leave_frequency="Monthly",
-			rounding=0.5,
+			rounding=rounding,
 			is_carry_forward=1,
 			allocate_on_day=allocate_on_day,
 			max_leaves_allowed=0,
@@ -505,13 +527,14 @@ def create_leave_period(name, start_date=None):
 def make_policy_assignment(
 	employee,
 	allocate_on_day="Last Day",
+	rounding=0.5,
 	earned_leave_frequency="Monthly",
 	start_date=None,
 	annual_allocation=12,
 	carry_forward=0,
 	assignment_based_on="Leave Period",
 ):
-	leave_type = create_earned_leave_type("Test Earned Leave", allocate_on_day)
+	leave_type = create_earned_leave_type("Test Earned Leave", allocate_on_day, rounding)
 	leave_period = create_leave_period("Test Earned Leave Period", start_date=start_date)
 	leave_policy = frappe.get_doc(
 		{

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -203,6 +203,36 @@ class LeavePolicyAssignment(Document):
 
 			return period_end_date
 
+		def _calculate_leaves_for_passed_months(consider_current_month):
+			monthly_earned_leave = get_monthly_earned_leave(
+				date_of_joining,
+				annual_allocation,
+				leave_details.earned_leave_frequency,
+				leave_details.rounding,
+				pro_rated=False,
+			)
+
+			period_end_date = _get_pro_rata_period_end_date(consider_current_month)
+
+			if self.effective_from < date_of_joining <= period_end_date:
+				# if the employee joined within the allocation period in some previous month,
+				# calculate pro-rated leave for that month
+				# and normal monthly earned leave for remaining passed months
+				leaves = get_monthly_earned_leave(
+					date_of_joining,
+					annual_allocation,
+					leave_details.earned_leave_frequency,
+					leave_details.rounding,
+					get_first_day(date_of_joining),
+					get_last_day(date_of_joining),
+				)
+
+				leaves += monthly_earned_leave * (months_passed - 1)
+			else:
+				leaves = monthly_earned_leave * months_passed
+
+			return leaves
+
 		consider_current_month = is_earned_leave_applicable_for_current_month(
 			date_of_joining, leave_details.allocate_on_day
 		)
@@ -210,16 +240,7 @@ class LeavePolicyAssignment(Document):
 		months_passed = _get_months_passed(current_date, from_date, consider_current_month)
 
 		if months_passed > 0:
-			period_end_date = _get_pro_rata_period_end_date(consider_current_month)
-			monthly_earned_leave = get_monthly_earned_leave(
-				date_of_joining,
-				annual_allocation,
-				leave_details.earned_leave_frequency,
-				leave_details.rounding,
-				self.effective_from,
-				period_end_date,
-			)
-			new_leaves_allocated = monthly_earned_leave * months_passed
+			new_leaves_allocated = _calculate_leaves_for_passed_months(consider_current_month)
 		else:
 			new_leaves_allocated = 0
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -365,7 +365,10 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 	annual_allocation = flt(annual_allocation, allocation.precision("total_leaves_allocated"))
 
 	earned_leaves = get_monthly_earned_leave(
-		date_of_joining, annual_allocation, e_leave_type.earned_leave_frequency, e_leave_type.rounding
+		date_of_joining,
+		annual_allocation,
+		e_leave_type.earned_leave_frequency,
+		e_leave_type.rounding,
 	)
 
 	new_allocation = flt(allocation.total_leaves_allocated) + flt(earned_leaves)
@@ -404,20 +407,23 @@ def get_monthly_earned_leave(
 	rounding,
 	period_start_date=None,
 	period_end_date=None,
+	pro_rated=True,
 ):
 	earned_leaves = 0.0
 	divide_by_frequency = {"Yearly": 1, "Half-Yearly": 2, "Quarterly": 4, "Monthly": 12}
 	if annual_leaves:
 		earned_leaves = flt(annual_leaves) / divide_by_frequency[frequency]
 
-		if not (period_start_date or period_end_date):
-			today_date = frappe.flags.current_date or getdate()
-			period_end_date = get_last_day(today_date)
-			period_start_date = get_first_day(today_date)
+		if pro_rated:
+			if not (period_start_date or period_end_date):
+				today_date = frappe.flags.current_date or getdate()
+				period_end_date = get_last_day(today_date)
+				period_start_date = get_first_day(today_date)
 
-		earned_leaves = calculate_pro_rated_leaves(
-			earned_leaves, date_of_joining, period_start_date, period_end_date, is_earned_leave=True
-		)
+			earned_leaves = calculate_pro_rated_leaves(
+				earned_leaves, date_of_joining, period_start_date, period_end_date, is_earned_leave=True
+			)
+
 		earned_leaves = round_earned_leaves(earned_leaves, rounding)
 
 	return earned_leaves


### PR DESCRIPTION
## Background

When an employee joins after the leave allocation period has started, policy assignment for earned leave allocates leaves for the past months.

Ex: 

**Annual allocation** = 30

<img width="1324" alt="image" src="https://github.com/frappe/hrms/assets/24353136/2d7e385c-176b-45de-883b-ce7591766593">

**"Allocate On"** in leave type = first day of the month

<img width="1296" alt="image" src="https://github.com/frappe/hrms/assets/24353136/9eada4fe-bb8d-47bd-a6c9-3a746369a1b6">

**Allocation Period** = 1st Jan 2023 - 31st Dec 2023

<img width="1324" alt="assignment" src="https://github.com/frappe/hrms/assets/24353136/d314606d-51a3-4c8e-9c53-c76d0aced464">

**Employee DOJ** = 15th Feb 2023

In this case, when policy assignment is created in the latter months, the system allocates earned leaves for the past months (if created in May, it should allocate 2.5 leaves for the last 4 months that have already passed: Feb to May = 2.5 * 4 = 10)

## Issue

The above logic should also calculate pro-rated leaves. i.e. if the employee is joining mid-month in some past month, they should get only half leaves for that month. **But this should only pro-rate leaves for that month, not the entire period i.e. Jan to May**

Currently, pro-rated leave calculation for passed months considers 
start = allocation period start = 1st Jan 2023
and end = current month's end date = 31st May 2023

So pro-rated leave is calculated as:

monthly_leave * actual period / complete period = * 2.5 * 106 / 151 = 1.75
And this is multiplied by the number of months = 1.75 * 4 = 7

<img width="1338" alt="pro-rate-incorrect" src="https://github.com/frappe/hrms/assets/24353136/20d5de4b-dc29-4af5-8b05-ab2f2a84edc9">

## Fix

This should actually only calculate pro-rated leave for the month of Feb and consider whole 2.5 leaves for other months:

<img width="1324" alt="pro-rate-corrected" src="https://github.com/frappe/hrms/assets/24353136/f22707bb-6980-464c-be46-52a9893cc007">

PS: Earned leave code is getting messier day by day with more and more edge cases 🥲
Time to separate it out in a class to avoid passing parameters all over the code and reusing the code for bg job as well as past months' calculations. Will do this in another PR.