### PR TITLE
fix: consider `curr_shift` to retrieve `prev_shift` when possible

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -362,7 +362,10 @@ def get_employee_shift_timings(
 			employee, curr_shift.start_datetime + timedelta(days=1), consider_default_shift, "forward"
 		)
 	prev_shift = get_employee_shift(
-		employee, for_timestamp + timedelta(days=-1), consider_default_shift, "reverse"
+		employee,
+		(curr_shift.end_datetime if curr_shift else for_timestamp) + timedelta(days=-1),
+		consider_default_shift,
+		"reverse",
 	)
 
 	if curr_shift:


### PR DESCRIPTION
### Issue

Employee had shift assignment for **Security - Night** with **Security** (Day) set as the default shift. This led to different computation of `prev_shift` based on the **IN** and **OUT** timestamp.



#### Values of `prev_shift`
##### For the **IN** timestamp:
```json
{
 "actual_end": "2023-04-19 08:00:00",
 "actual_start": "2023-04-18 18:00:00",
 "end_datetime": "2023-04-19 07:00:00",
 "shift_type": {
  "allow_check_out_after_shift_end_time": 60,
  "begin_check_in_before_shift_start_time": 60,
  "end_time": "7:00:00",
  "name": "Security - Night",
  "start_time": "19:00:00"
 },
 "start_datetime": "2023-04-18 19:00:00"
}
```
##### For the **OUT** timestamp:
```json
{
 "actual_end": "2023-04-20 08:00:00",
 "actual_start": "2023-04-19 18:00:00",
 "end_datetime": "2023-04-20 07:00:00",
 "shift_type": {
  "allow_check_out_after_shift_end_time": 60,
  "begin_check_in_before_shift_start_time": 60,
  "end_time": "7:00:00",
  "name": "Security - Night",
  "start_time": "19:00:00"
 },
 "start_datetime": "2023-04-19 19:00:00"
}
```

Most important thing to note here are the **Start** and **Actual Start** values. The dates are 18-19 for the IN timestamp and 19-20 for the OUT timestamp. This is inconsistent behaviour. Previous shift should depend on current shift's end datetime (-1 day) when possible, instead of depending on `for_timestamp`.

This is the root cause of issues like https://github.com/frappe/hrms/pull/480

### Solution

Because the `prev_shift` is now based on `curr_shift` instead of `for_timestamp` when `curr_shift` is available, it will be consistent for the same `curr_shift`. Now, `prev_shift` returns the same value in both cases:


```json
{
 "actual_end": "2023-04-20 08:00:00",
 "actual_start": "2023-04-19 18:00:00",
 "end_datetime": "2023-04-20 07:00:00",
 "shift_type": {
  "allow_check_out_after_shift_end_time": 60,
  "begin_check_in_before_shift_start_time": 60,
  "end_time": "7:00:00",
  "name": "Security - Night",
  "start_time": "19:00:00"
 },
 "start_datetime": "2023-04-19 19:00:00"
}
```

Sponsored by @aakvatech