### PR TITLE
fix: midnight shift edge cases

### DIFF
--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -249,14 +249,13 @@ class TestEmployeeCheckin(FrappeTestCase):
 		log.delete()
 
 		# log falls in the second day
-		prev_day = add_days(date, -1)
-		timestamp = datetime.combine(date, get_time("01:30:00"))
+		timestamp = datetime.combine(next_day, get_time("01:30:00"))
 		log = make_checkin(employee, timestamp)
 		self.assertEqual(log.shift, shift_type.name)
-		self.assertEqual(log.shift_start, datetime.combine(prev_day, get_time("23:00:00")))
-		self.assertEqual(log.shift_end, datetime.combine(date, get_time("01:00:00")))
-		self.assertEqual(log.shift_actual_start, datetime.combine(prev_day, get_time("22:00:00")))
-		self.assertEqual(log.shift_actual_end, datetime.combine(date, get_time("02:00:00")))
+		self.assertEqual(log.shift_start, datetime.combine(date, get_time("23:00:00")))
+		self.assertEqual(log.shift_end, datetime.combine(next_day, get_time("01:00:00")))
+		self.assertEqual(log.shift_actual_start, datetime.combine(date, get_time("22:00:00")))
+		self.assertEqual(log.shift_actual_end, datetime.combine(next_day, get_time("02:00:00")))
 
 	def test_consecutive_shift_assignments_overlapping_within_grace_period(self):
 		# test adjustment for start and end times if they are overlapping

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -227,7 +227,8 @@ class TestEmployeeCheckin(FrappeTestCase):
 		# should consider default shift
 		self.assertEqual(log.shift, default_shift.name)
 
-	def test_fetch_shift_spanning_over_two_days(self):
+	def test_fetch_night_shift_for_assignment_without_end_date(self):
+		"""Tests if shift is correctly fetched in logs when assignment has no end date"""
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
 		shift_type = setup_shift_type(
 			shift_type="Midnight Shift", start_time="23:00:00", end_time="01:00:00"
@@ -238,24 +239,69 @@ class TestEmployeeCheckin(FrappeTestCase):
 
 		# log falls in the first day
 		timestamp = datetime.combine(date, get_time("23:00:00"))
-		log = make_checkin(employee, timestamp)
-
-		self.assertEqual(log.shift, shift_type.name)
-		self.assertEqual(log.shift_start, datetime.combine(date, get_time("23:00:00")))
-		self.assertEqual(log.shift_end, datetime.combine(next_day, get_time("01:00:00")))
-		self.assertEqual(log.shift_actual_start, datetime.combine(date, get_time("22:00:00")))
-		self.assertEqual(log.shift_actual_end, datetime.combine(next_day, get_time("02:00:00")))
-
-		log.delete()
+		log_in = make_checkin(employee, timestamp)
 
 		# log falls in the second day
 		timestamp = datetime.combine(next_day, get_time("01:30:00"))
-		log = make_checkin(employee, timestamp)
-		self.assertEqual(log.shift, shift_type.name)
-		self.assertEqual(log.shift_start, datetime.combine(date, get_time("23:00:00")))
-		self.assertEqual(log.shift_end, datetime.combine(next_day, get_time("01:00:00")))
-		self.assertEqual(log.shift_actual_start, datetime.combine(date, get_time("22:00:00")))
-		self.assertEqual(log.shift_actual_end, datetime.combine(next_day, get_time("02:00:00")))
+		log_out = make_checkin(employee, timestamp)
+
+		for log in [log_in, log_out]:
+			self.assertEqual(log.shift, shift_type.name)
+			self.assertEqual(log.shift_start, datetime.combine(date, get_time("23:00:00")))
+			self.assertEqual(log.shift_end, datetime.combine(next_day, get_time("01:00:00")))
+			self.assertEqual(log.shift_actual_start, datetime.combine(date, get_time("22:00:00")))
+			self.assertEqual(log.shift_actual_end, datetime.combine(next_day, get_time("02:00:00")))
+
+	def test_fetch_night_shift_on_assignment_boundary(self):
+		"""
+		Tests if shift is correctly fetched in logs when assignment starts and ends on the same day
+		"""
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift", start_time="23:00:00", end_time="07:00:00"
+		)
+		date = getdate()
+		next_day = add_days(date, 1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# IN log falls on the first day
+		start_timestamp = datetime.combine(date, get_time("23:00:00"))
+		log_in = make_checkin(employee, start_timestamp)
+
+		# OUT log falls on the second day
+		end_timestamp = datetime.combine(next_day, get_time("7:00:00"))
+		log_out = make_checkin(employee, end_timestamp)
+
+		for log in [log_in, log_out]:
+			self.assertEqual(log.shift, shift_type.name)
+			self.assertEqual(log.shift_start, start_timestamp)
+			self.assertEqual(log.shift_end, end_timestamp)
+
+	def test_night_shift_not_fetched_outside_assignment_boundary(self):
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift", start_time="23:00:00", end_time="07:00:00"
+		)
+		date = getdate()
+		next_day = add_days(date, 1)
+		prev_day = add_days(date, -1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# shift not applicable on next day's start time
+		log = make_checkin(employee, datetime.combine(next_day, get_time("23:00:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on current day's end time
+		log = make_checkin(employee, datetime.combine(date, get_time("07:00:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on prev day's start time
+		log = make_checkin(employee, datetime.combine(prev_day, get_time("23:00:00")))
+		self.assertIsNone(log.shift)
 
 	def test_consecutive_shift_assignments_overlapping_within_grace_period(self):
 		# test adjustment for start and end times if they are overlapping

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -95,24 +95,30 @@ def has_overlapping_timings(shift_1: str, shift_2: str) -> bool:
 	"""
 	Accepts two shift types and checks whether their timings are overlapping
 	"""
-	curr_shift = frappe.db.get_value("Shift Type", shift_1, ["start_time", "end_time"], as_dict=True)
-	overlapping_shift = frappe.db.get_value(
-		"Shift Type", shift_2, ["start_time", "end_time"], as_dict=True
-	)
+	if shift_1 == shift_2:
+		return True
+
+	s1 = frappe.db.get_value("Shift Type", shift_1, ["start_time", "end_time"], as_dict=True)
+	s2 = frappe.db.get_value("Shift Type", shift_2, ["start_time", "end_time"], as_dict=True)
 
 	if (
-		(
-			curr_shift.start_time > overlapping_shift.start_time
-			and curr_shift.start_time < overlapping_shift.end_time
-		)
-		or (
-			curr_shift.end_time > overlapping_shift.start_time
-			and curr_shift.end_time < overlapping_shift.end_time
-		)
-		or (
-			curr_shift.start_time <= overlapping_shift.start_time
-			and curr_shift.end_time >= overlapping_shift.end_time
-		)
+		# shift 1 spans across 2 days
+		s1.start_time > s1.end_time
+		and s1.start_time < s2.end_time
+		or s1.start_time > s1.end_time
+		and s2.start_time < s1.end_time
+		or s1.start_time > s1.end_time
+		and s2.start_time > s2.end_time
+		or
+		# both shifts fall on the same day
+		s1.start_time < s2.end_time
+		and s2.start_time < s1.end_time
+		or
+		# shift 2 spans across 2 days
+		s1.start_time < s2.end_time
+		and s2.start_time > s2.end_time
+		or s2.start_time < s1.end_time
+		and s2.start_time > s2.end_time
 	):
 		return True
 	return False

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -206,17 +206,15 @@ def get_shift_for_time(shifts: List[Dict], for_timestamp: datetime) -> Dict:
 			valid_shifts.append(shift_details)
 
 	valid_shifts.sort(key=lambda x: x["actual_start"])
-
-	if len(valid_shifts) > 1:
-		_adjust_overlapping_shifts(valid_shifts)
+	_adjust_overlapping_shifts(valid_shifts)
 
 	return get_exact_shift(valid_shifts, for_timestamp)
 
 
 def _is_shift_outside_assignment_period(shift_details: dict, assignment: dict) -> bool:
 	"""
-	If log's date is greater than shift assignment's end date,
-	checks whether its a midnight shift or not
+	Compares shift's actual start and end dates with assignment dates
+	and returns True is shift is outside assignment period
 	"""
 	if shift_details.actual_start.date() < assignment.start_date:
 		return True

--- a/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
@@ -124,7 +124,7 @@ class TestShiftAssignment(FrappeTestCase):
 		)
 		self.assertRaises(OverlappingShiftError, shift2.insert)
 
-	def test_overlap_validation_for_shifts_on_same_day_with_overlapping_timeslots(self):
+	def test_overlap_for_shifts_on_same_day_with_overlapping_timeslots(self):
 		employee = make_employee("test_shift_assignment@example.com", company="_Test Company")
 
 		# shift setup for 8-12
@@ -134,8 +134,6 @@ class TestShiftAssignment(FrappeTestCase):
 
 		# shift setup for 11-15
 		shift_type = setup_shift_type(shift_type="Shift 2", start_time="11:00:00", end_time="15:00:00")
-		date = getdate()
-
 		shift2 = frappe.get_doc(
 			{
 				"doctype": "Shift Assignment",
@@ -146,6 +144,43 @@ class TestShiftAssignment(FrappeTestCase):
 			}
 		)
 		self.assertRaises(OverlappingShiftError, shift2.insert)
+
+	def test_overlap_for_midnight_shifts(self):
+		employee = make_employee("test_shift_assignment@example.com", company="_Test Company")
+		date = getdate()
+
+		overlapping_shifts = [
+			# s1(start, end), s2(start, end)
+			[("22:00:00", "02:00:00"), ("21:00:00", "23:00:00")],
+			[("22:00:00", "02:00:00"), ("01:00:00", "03:00:00")],
+			[("22:00:00", "02:00:00"), ("20:00:00", "01:00:00")],
+			[("01:00:00", "02:00:00"), ("01:30:00", "03:00:00")],
+			[("01:00:00", "02:00:00"), ("22:00:00", "03:00:00")],
+			[("21:00:00", "23:00:00"), ("22:00:00", "03:00:00")],
+		]
+
+		for i, pair in enumerate(overlapping_shifts):
+			s1 = setup_shift_type(shift_type=f"Shift 1-{i}", start_time=pair[0][0], end_time=pair[0][1])
+			s2 = setup_shift_type(shift_type=f"Shift 2-{i}", start_time=pair[1][0], end_time=pair[1][1])
+
+			assignment1 = make_shift_assignment(s1.name, employee, date)
+			assignment = make_shift_assignment(s2.name, employee, date, do_not_submit=True)
+
+			self.assertRaises(OverlappingShiftError, assignment.insert)
+
+			assignment1.cancel()
+
+		shift_type = setup_shift_type(shift_type="Shift 1", start_time="20:00:00", end_time="01:00:00")
+		make_shift_assignment(shift_type.name, employee, date)
+
+		# no overlap
+		shift_type = setup_shift_type(shift_type="Shift 2", start_time="15:00:00", end_time="20:00:00")
+		assignment = make_shift_assignment(shift_type, employee, date)
+
+		# no overlap
+		shift_type.update({"start_time": "02:00:00", "end_time": "3:00:00"})
+		shift_type.save()
+		assignment = make_shift_assignment(shift_type, employee, date)
 
 	def test_multiple_shift_assignments_for_same_day(self):
 		employee = make_employee("test_shift_assignment@example.com", company="_Test Company")

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -508,7 +508,7 @@ def setup_shift_type(**args):
 	return shift_type
 
 
-def make_shift_assignment(shift_type, employee, start_date, end_date=None):
+def make_shift_assignment(shift_type, employee, start_date, end_date=None, do_not_submit=False):
 	shift_assignment = frappe.get_doc(
 		{
 			"doctype": "Shift Assignment",
@@ -518,7 +518,8 @@ def make_shift_assignment(shift_type, employee, start_date, end_date=None):
 			"start_date": start_date,
 			"end_date": end_date,
 		}
-	).insert()
-	shift_assignment.submit()
+	)
+	if not do_not_submit:
+		shift_assignment.submit()
 
 	return shift_assignment


### PR DESCRIPTION
## Problem

**Midnight Shift:** 20:00:00 - 02:00:00

<img width="1352" alt="image" src="https://github.com/frappe/hrms/assets/24353136/d4a3cedf-d3c5-4f71-b8aa-0d5568572e64">

Shift Request submitted for 24th May

<img width="1352" alt="image" src="https://github.com/frappe/hrms/assets/24353136/35ecc87a-739b-410b-8508-44f988acb7b8">

Check IN log fetches the shift properly on 24th May:

<img width="1352" alt="image" src="https://github.com/frappe/hrms/assets/24353136/7049523a-4900-467f-adb5-a2d0a97b8b2d">

Check OUT is on 25th May. On that date, no shift is assigned, so shift fetching fails:

<img width="1352" alt="image" src="https://github.com/frappe/hrms/assets/24353136/e3596893-6aa2-432c-9bdc-e28087fcd462">

## Fix

Although the shift is not assigned for the 25th, the 24th's shift is getting over on the 25th, so the shift should be fetched in the OUT log. 

`get_shifts_for_date` returns the shifts with end date >= timestamp. Fetch valid shift assignments from 1 day ago too to handle the midnight shift scenario.

After fix:

<img width="1352" alt="image" src="https://github.com/frappe/hrms/assets/24353136/36c34306-1e22-4895-8ad1-38ceb96e6559">

- [x] Fix false positive duplicate assignment check in case of midnight shifts
- [x] Tests 