### PR TITLE
fix: return amount as flt if eval_conditions_and_formula returns None

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -917,9 +917,7 @@ class SalarySlip(TransactionBase):
 		local_data = self.data.copy()
 		local_data.update({"start_date": start_date, "end_date": end_date, "posting_date": posting_date})
 
-		amount = self.eval_condition_and_formula(struct_row, local_data)
-
-		return amount
+		return flt(self.eval_condition_and_formula(struct_row, local_data))
 
 	def get_income_tax_deducted_till_date(self):
 		tax_deducted = 0.0


### PR DESCRIPTION
```
request.js:457 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 53, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1591, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/save.py", line 34, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 316, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 351, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1061, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 926, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 923, in fn
    return method_object(*args, **kwargs)
  File "apps/hrms/hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.py", line 28, in validate
    self.calculate_hra_exemption()
  File "apps/hrms/hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.py", line 43, in calculate_hra_exemption
    hra_exemption = calculate_annual_eligible_hra_exemption(self)
  File "apps/erpnext/erpnext/__init__.py", line 147, in caller
    return frappe.get_attr(overrides[function_path][-1])(*args, **kwargs)
  File "apps/hrms/hrms/regional/india/utils.py", line 37, in calculate_annual_eligible_hra_exemption
    basic_salary_amt, hra_salary_amt = get_component_amt_from_salary_slip(
  File "apps/hrms/hrms/regional/india/utils.py", line 105, in get_component_amt_from_salary_slip
    salary_slip = make_salary_slip(
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/hrms/hrms/payroll/doctype/salary_structure/salary_structure.py", line 325, in make_salary_slip
    doc = get_mapped_doc(
  File "apps/frappe/frappe/model/mapper.py", line 144, in get_mapped_doc
    postprocess(source_doc, target_doc)
  File "apps/hrms/hrms/payroll/doctype/salary_structure/salary_structure.py", line 323, in postprocess
    target.run_method("process_salary_structure", for_preview=for_preview)
  File "apps/frappe/frappe/model/document.py", line 926, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 923, in fn
    return method_object(*args, **kwargs)
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 1823, in process_salary_structure
    self.calculate_net_pay()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 646, in calculate_net_pay
    self.compute_income_tax_breakup()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 765, in compute_income_tax_breakup
    self.compute_annual_deductions_before_tax_calculation()
  File "apps/hrms/hrms/payroll/doctype/salary_slip/salary_slip.py", line 887, in compute_annual_deductions_before_tax_calculation
    future_period_exempted_amount += self.get_amount_from_formula(deduction, sub_period)
TypeError: unsupported operand type(s) for +=: 'float' and 'NoneType'
```