### PR TITLE
fix: remove rounding default for earned leave

### DIFF
--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -169,7 +169,6 @@
    "options": "Monthly\nQuarterly\nHalf-Yearly\nYearly"
   },
   {
-   "default": "0.5",
    "depends_on": "is_earned_leave",
    "fieldname": "rounding",
    "fieldtype": "Select",
@@ -225,7 +224,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2023-01-31 10:19:49.181649",
+ "modified": "2023-05-26 14:15:29.695487",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",


### PR DESCRIPTION
Removing default rounding set as 0.5 in Earned Leave configuration. Users can set the rounding if needed.

Most users need direct allocation without rounding it off
Ex: annual allocation / period = 30 / 12 = 2.5 leaves / month

Some of them aren't aware of what it does so applying it by default makes no sense. 