### PR TITLE
fix: set amount to zero if salary component condition evaluates to False

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -950,7 +950,8 @@ class SalarySlip(TransactionBase):
 			if self.salary_slip_based_on_timesheet and struct_row.salary_component == timesheet_component:
 				continue
 
-			amount = self.eval_condition_and_formula(struct_row, self.data)
+			amount = self.eval_condition_and_formula(struct_row, self.data) or 0
+			
 			if struct_row.statistical_component:
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip


### PR DESCRIPTION
While creating a new salary slip. It is expected that salary components whose values are based on a condition and a formula, return zero when the condition evaluates to **False**.

That is not the case at the moment as the values are set to **None** resulting in the error below when such values are used in subsequent rows: 
![salary_slip_n](https://github.com/frappe/hrms/assets/55623011/23650f72-eb92-4f32-8297-89f6c9e16a1b)

This pr fixes that by setting those values to zero instead. 
File: hrms/hrms/payroll/doctype/salary_slip/salary_slip.py
Line: 953
```amount = self.eval_condition_and_formula(struct_row, self.data) or 0```

Fixes: https://github.com/frappe/hrms/issues/548


