### PR TITLE
fix: set default to zero on salary component.

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -955,7 +955,7 @@ class SalarySlip(TransactionBase):
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip
 
-				self.default_data[struct_row.abbr] = amount or 0
+				self.default_data[struct_row.abbr] = flt(amount)
 				if struct_row.depends_on_payment_days:
 					joining_date, relieving_date = self.get_joining_and_relieving_dates()
 					payment_days_amount = (

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -955,7 +955,7 @@ class SalarySlip(TransactionBase):
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip
 
-				self.default_data[struct_row.abbr] = amount
+				self.default_data[struct_row.abbr] = amount or 0
 				if struct_row.depends_on_payment_days:
 					joining_date, relieving_date = self.get_joining_and_relieving_dates()
 					payment_days_amount = (


### PR DESCRIPTION
Current behaviour sets default value on salary components to `amount` which equals `None` in some cases. This causes 'Unsupported operand for `Nonetype` error when the salary component values are used in formulae in subsequent salary component rows.
![salary_slip_n](https://github.com/frappe/hrms/assets/55623011/4d329734-efb7-4557-b96e-c976c552845a)

Fixes: https://github.com/frappe/hrms/issues/548