### PR TITLE
fix: make promotion details table non-mandatory

### DIFF
--- a/hrms/hr/doctype/employee_promotion/employee_promotion.json
+++ b/hrms/hr/doctype/employee_promotion/employee_promotion.json
@@ -71,8 +71,7 @@
   {
    "fieldname": "promotion_details",
    "fieldtype": "Table",
-   "options": "Employee Property History",
-   "reqd": 1
+   "options": "Employee Property History"
   },
   {
    "fieldname": "amended_from",
@@ -119,7 +118,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-04-22 18:47:10.168744",
+ "modified": "2023-05-30 15:15:11.806546",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Promotion",

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -41,6 +41,9 @@ def set_employee_name(doc):
 
 
 def update_employee_work_history(employee, details, date=None, cancel=False):
+	if not details:
+		return employee
+
 	if not employee.internal_work_history and not cancel:
 		employee.append(
 			"internal_work_history",


### PR DESCRIPTION
Make promotion details table non-mandatory
Only CTC can be updated without any other branch/dept/designation change