### PR TITLE
fix: return if field is not found (+ minor refactor)

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -159,7 +159,12 @@ def get_employee_field_property(employee, fieldname):
 	elif field.fieldtype == "Datetime":
 		value = format_datetime(value)
 
-	return {"value": value, "datatype": field.fieldtype, "label": field.label, "options": field.options}
+	return {
+		"value": value,
+		"datatype": field.fieldtype,
+		"label": field.label,
+		"options": field.options,
+	}
 
 
 def validate_dates(doc, from_date, to_date):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -146,17 +146,20 @@ def update_to_date_in_work_history(employee, cancel):
 
 @frappe.whitelist()
 def get_employee_field_property(employee, fieldname):
-	if employee and fieldname:
-		field = frappe.get_meta("Employee").get_field(fieldname)
-		value = frappe.db.get_value("Employee", employee, fieldname)
-		options = field.options
-		if field.fieldtype == "Date":
-			value = formatdate(value)
-		elif field.fieldtype == "Datetime":
-			value = format_datetime(value)
-		return {"value": value, "datatype": field.fieldtype, "label": field.label, "options": options}
-	else:
-		return False
+	if not (employee and fieldname):
+		return
+
+	field = frappe.get_meta("Employee").get_field(fieldname)
+	if not field:
+		return
+
+	value = frappe.db.get_value("Employee", employee, fieldname)
+	if field.fieldtype == "Date":
+		value = formatdate(value)
+	elif field.fieldtype == "Datetime":
+		value = format_datetime(value)
+
+	return {"value": value, "datatype": field.fieldtype, "label": field.label, "options": field.options}
 
 
 def validate_dates(doc, from_date, to_date):


### PR DESCRIPTION
Ensures `fieldname` is valid before running query to avoid errors like `OperationalError: (1054, "Unknown column 'invalid_fieldname' in 'field list'")`