### PR TITLE
fix(UX): Add a role profile by default

### DIFF
--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -20,6 +20,7 @@ def after_install():
 	set_single_defaults()
 	update_erpnext_access()
 	run_post_install_patches()
+	create_default_role_profiles()
 
 
 def before_uninstall():
@@ -683,3 +684,22 @@ def delete_custom_fields(custom_fields):
 		)
 
 		frappe.clear_cache(doctype=doctype)
+
+
+def create_default_role_profiles():
+	for role_profile_name, roles in DEFAULT_ROLE_PROFILES.items():
+		role_profile = frappe.new_doc("Role Profile")
+		role_profile.role_profile = role_profile_name
+		for role in roles:
+			role_profile.append("roles", {"role": role})
+
+		role_profile.insert(ignore_permissions=True)
+
+
+DEFAULT_ROLE_PROFILES = {
+	"HR": [
+		"HR User",
+		"HR Manager",
+		"Leave Approver",
+	],
+}

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -19,8 +19,8 @@ def after_install():
 	add_non_standard_user_types()
 	set_single_defaults()
 	update_erpnext_access()
-	run_post_install_patches()
 	create_default_role_profiles()
+	run_post_install_patches()
 
 
 def before_uninstall():
@@ -701,5 +701,6 @@ DEFAULT_ROLE_PROFILES = {
 		"HR User",
 		"HR Manager",
 		"Leave Approver",
+		"Expense Approver",
 	],
 }


### PR DESCRIPTION
- Adding new user using quick entry creates a user with no roles at all, so when they log in they can't access desk or do anything meaningful.
- In FW we've added role profile and warning about missing roles.
- In ERPNext and other apps we should include role profiles by default which can be later customized if required.


Related but not fixed here:
- "Employee" role needs more work than a simple role profile, because it's linked with Employee doctype but can't be set manually. Also the creation of employee right now is KINDA unintuitive. If user is to be created for employee then both actions can be done from one form * somehow *.
