### PR TITLE
feat: leave policy correction

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -32,6 +32,9 @@ class LeavePolicyAssignment(Document):
 		self.grant_leave_alloc_for_employee()
 
 	def set_dates(self):
+		if frappe.flags.in_lpa_correction:
+			return
+
 		if self.assignment_based_on == "Leave Period":
 			self.effective_from, self.effective_to = frappe.db.get_value(
 				"Leave Period", self.leave_period, ["from_date", "to_date"]

--- a/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.js
+++ b/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Leave Policy Correction", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.json
+++ b/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.json
@@ -1,0 +1,130 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2023-06-07 15:35:51.160455",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "employee",
+  "leave_policy_assignment",
+  "existing_leave_policy",
+  "column_break_yhwa",
+  "new_leave_policy",
+  "effective_from",
+  "amended_from",
+  "section_break_hsfw",
+  "remarks"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fieldname": "leave_policy_assignment",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Leave Policy Assignment",
+   "options": "Leave Policy Assignment",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Leave Policy Correction",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_yhwa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_hsfw",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks"
+  },
+  {
+   "fieldname": "new_leave_policy",
+   "fieldtype": "Link",
+   "label": "New Leave Policy",
+   "options": "Leave Policy",
+   "reqd": 1
+  },
+  {
+   "fieldname": "effective_from",
+   "fieldtype": "Date",
+   "label": "Effective From",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "leave_policy_assignment.leave_policy",
+   "fieldname": "existing_leave_policy",
+   "fieldtype": "Link",
+   "label": "Existing Leave Policy",
+   "options": "Leave Policy",
+   "read_only": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "HR-LPC-.###"
+  }
+ ],
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2023-06-07 15:48:05.170874",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Leave Policy Correction",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.py
+++ b/hrms/hr/doctype/leave_policy_correction/leave_policy_correction.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
+from frappe.utils import add_days, getdate
+
+
+class LeavePolicyCorrection(Document):
+	def validate(self):
+		self.effective_from = getdate(self.effective_from)
+		self.validate_effective_from()
+
+	def validate_effective_from(self):
+		existing_lpa = frappe.db.get_value(
+			"Leave Policy Assignment",
+			self.leave_policy_assignment,
+			["effective_from", "effective_to"],
+			as_dict=True,
+		)
+
+		if (
+			getdate(existing_lpa.effective_from) > self.effective_from
+			or getdate(existing_lpa.effective_to) < self.effective_from
+		):
+			frappe.throw(
+				_("Effective from should be between {0} and {1}").format(
+					getdate(existing_lpa.effective_from), getdate(existing_lpa.effective_to)
+				)
+			)
+
+	def on_submit(self):
+		self.revert_older_allocation()
+		self.update_leave_policy_assignment()
+
+	def update_leave_policy_assignment(self):
+		new_lpa = get_mapped_doc(
+			"Leave Policy Assignment",
+			self.leave_policy_assignment,
+			{
+				"Leave Policy Assignment": {
+					"doctype": "Leave Policy Assignment",
+				}
+			},
+		)
+
+		frappe.flags.in_lpa_correction = True
+		frappe.db.set_value(
+			"Leave Policy Assignment",
+			self.leave_policy_assignment,
+			"effective_to",
+			add_days(self.effective_from, -1),
+		)
+
+		new_lpa.effective_from = self.effective_from
+		new_lpa.submit()
+		frappe.flags.in_lpa_correction = False
+
+	def revert_older_allocation(self):
+		leave_allocations = frappe.db.get_all(
+			"Leave Allocation",
+			filters={"leave_policy_assignment": self.leave_policy_assignment},
+			pluck="name",
+		)
+		if not leave_allocations:
+			return
+
+		frappe.db.set_value(
+			"Leave Allocation",
+			{"name": ["in", leave_allocations]},
+			"to_date",
+			add_days(self.effective_from, -1),
+		)
+
+		ll_entries = frappe.db.get_all(
+			"Leave Ledger Entry",
+			filters={
+				"transaction_type": "Leave Allocation",
+				"transaction_name": ["in", leave_allocations],
+				"from_date": [">=", self.effective_from],
+			},
+			pluck="name",
+		)
+
+		for leave_ledger_entry in ll_entries:
+			new_ll = get_mapped_doc(
+				"Leave Ledger Entry",
+				leave_ledger_entry,
+				{
+					"Leave Ledger Entry": {
+						"doctype": "Leave Ledger Entry",
+					}
+				},
+			)
+
+			new_ll.leaves = -(new_ll.leaves)
+			new_ll.submit()

--- a/hrms/hr/doctype/leave_policy_correction/test_leave_policy_correction.py
+++ b/hrms/hr/doctype/leave_policy_correction/test_leave_policy_correction.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestLeavePolicyCorrection(FrappeTestCase):
+	pass


### PR DESCRIPTION
Leave Policy Correction allows users to assign a different leave policy for an employee who already has one assigned.
Currently, if an employee has a policy assigned for a period and has taken leave based on the allocations created out of it, there is no way to cancel or change the leave policy for that user.

![image](https://github.com/frappe/hrms/assets/52111700/8933c505-37a9-4b17-b611-32c1957ca7d4)

Leave Policy Correction does the following:

- Ends the selected leave policy assignment and associated leave allocations on the given effective from date minus 1.
- Reverts all leave ledger entries created by auto allocation from the given date (associated to the selected assignment)
- Creates a new leave policy assignment from the given date with the given new policy