### PR TITLE
fix: `validate_attendance` in payroll entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -837,7 +837,9 @@ class PayrollEntry(Document):
 		employee_details = self.get_employee_and_attendance_details()
 
 		for emp in self.employees:
-			details = next((details for details in employee_details if details["name"] == emp.employee), None)
+			details = next(
+				(details for details in employee_details if details["name"] == emp.employee), None
+			)
 
 			if not details:
 				continue

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -837,14 +837,14 @@ class PayrollEntry(Document):
 		employee_details = self.get_employee_and_attendance_details()
 
 		for emp in self.employees:
-			details = next((details for details in employee_details if details["name"] == emp.name), None)
+			details = next((details for details in employee_details if details["name"] == emp.employee), None)
 
 			if not details:
 				continue
 
 			start_date = self.start_date
 
-			if details.get("date_of_joining") > self.start_date:
+			if details.get("date_of_joining") > getdate(self.start_date):
 				start_date = details.get("date_of_joining")
 
 			holidays = self.get_holiday_list_based_count(


### PR DESCRIPTION
Introduced via: https://github.com/frappe/hrms/pull/417

Fails due to invalid attribute call `emp.name`.
https://github.com/frappe/hrms/blob/1c74d41e7d10837f7ffb42144d8756713593c830/hrms/payroll/doctype/payroll_entry/payroll_entry.py#L840

**Before**
![before_change](https://github.com/frappe/hrms/assets/54097382/9469ca55-d989-43fe-aceb-557e16586d3d)

**After**
![after_change](https://github.com/frappe/hrms/assets/54097382/3b6cdd73-34cc-4de6-ba4b-3de8f8623327)

Closes #566