### PR TITLE
fix: check if approver is set before sharing doc

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -86,8 +86,8 @@ class LeaveApplication(Document):
 			# notify leave approver about creation
 			if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
 				self.notify_leave_approver()
-
-		share_doc_with_approver(self, self.leave_approver)
+		if self.leave_approver:
+			share_doc_with_approver(self, self.leave_approver)
 
 	def on_submit(self):
 		if self.status in ["Open", "Cancelled"]:

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -86,8 +86,8 @@ class LeaveApplication(Document):
 			# notify leave approver about creation
 			if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
 				self.notify_leave_approver()
-		if self.leave_approver:
-			share_doc_with_approver(self, self.leave_approver)
+
+		share_doc_with_approver(self, self.leave_approver)
 
 	def on_submit(self):
 		if self.status in ["Open", "Cancelled"]:

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -643,6 +643,9 @@ def get_previous_claimed_amount(employee, payroll_period, non_pro_rata=False, co
 
 
 def share_doc_with_approver(doc, user):
+	if not user:
+		return
+
 	# if approver does not have permissions, share
 	if not frappe.has_permission(doc=doc, ptype="submit", user=user):
 		frappe.share.add_docshare(


### PR DESCRIPTION
While creating a leave application, if the employee doesn't have a leave approver set, the document is shared with the leave applicant himself by the share API as the approver is `None`.

The Applicant ends up getting submit permission for leave application accidentally but cannot submit it as the "status" field is read-only and has perm level set.

Video:
https://github.com/frappe/hrms/assets/76736615/580b6ceb-9881-4801-b422-9e428ccf15f3

