### PR TITLE
refactor: set `fetch_from` for company in Attendance dt and remove unnecessary db calls

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.js
+++ b/hrms/hr/doctype/attendance/attendance.js
@@ -1,15 +1,16 @@
-// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch('employee', 'company', 'company');
-cur_frm.add_fetch('employee', 'employee_name', 'employee_name');
+frappe.ui.form.on("Attendance", {
+	refresh(frm) {
+		if (frm.doc.__islocal && !frm.doc.attendance_date) {
+			frm.set_value("attendance_date", frappe.datetime.get_today());
+		}
 
-cur_frm.cscript.onload = function(doc, cdt, cdn) {
-	if(doc.__islocal) cur_frm.set_value("attendance_date", frappe.datetime.get_today());
-}
-
-cur_frm.fields_dict.employee.get_query = function(doc,cdt,cdn) {
-	return{
-		query: "erpnext.controllers.queries.employee_query"
-	}
-}
+		frm.set_query("employee", () => {
+			return {
+				query: "erpnext.controllers.queries.employee_query"
+			}
+		})
+	},
+})

--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -125,12 +125,14 @@
    "reqd": 1
   },
   {
+   "fetch_from": "employee.company",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
    "oldfieldname": "company",
    "oldfieldtype": "Link",
    "options": "Company",
+   "read_only": 1,
    "remember_last_selected_value": 1,
    "reqd": 1
   },
@@ -205,7 +207,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-02 16:38:11.017001",
+ "modified": "2023-06-15 20:09:21.730465",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -264,7 +264,6 @@ def mark_attendance(
 	late_entry=False,
 	early_exit=False,
 ):
-	company = frappe.db.get_value("Employee", employee, "company")
 	savepoint = "attendance_creation"
 
 	try:
@@ -276,7 +275,6 @@ def mark_attendance(
 				"employee": employee,
 				"attendance_date": attendance_date,
 				"status": status,
-				"company": company,
 				"shift": shift,
 				"leave_type": leave_type,
 				"late_entry": late_entry,
@@ -299,7 +297,6 @@ def mark_bulk_attendance(data):
 	if isinstance(data, str):
 		data = json.loads(data)
 	data = frappe._dict(data)
-	company = frappe.get_value("Employee", data.employee, "company")
 	if not data.unmarked_days:
 		frappe.throw(_("Please select a date."))
 		return
@@ -310,7 +307,6 @@ def mark_bulk_attendance(data):
 			"employee": data.employee,
 			"attendance_date": get_datetime(date),
 			"status": data.status,
-			"company": company,
 		}
 		attendance = frappe.get_doc(doc_dict).insert()
 		attendance.submit()

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -136,8 +136,6 @@ def mark_attendance_and_link_log(
 		return None
 
 	elif attendance_status in ("Present", "Absent", "Half Day"):
-		company = frappe.db.get_value("Employee", employee, "company", cache=True)
-
 		try:
 			frappe.db.savepoint("attendance_creation")
 			attendance = frappe.new_doc("Attendance")
@@ -148,7 +146,6 @@ def mark_attendance_and_link_log(
 					"attendance_date": attendance_date,
 					"status": attendance_status,
 					"working_hours": working_hours,
-					"company": company,
 					"shift": shift,
 					"late_entry": late_entry,
 					"early_exit": early_exit,

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -21,7 +21,8 @@ test_dependencies = ["Shift Type"]
 
 class TestMonthlyAttendanceSheet(FrappeTestCase):
 	def setUp(self):
-		self.employee = make_employee("test_employee@example.com", company="_Test Company")
+		self.company = "_Test Company"
+		self.employee = make_employee("test_employee@example.com", company=self.company)
 		frappe.db.delete("Attendance")
 
 		date = getdate()
@@ -33,8 +34,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	def test_monthly_attendance_sheet_report(self):
 		previous_month_first = get_first_day_for_prev_month()
 
-		company = frappe.db.get_value("Employee", self.employee, "company")
-
 		# mark different attendance status on first 3 days of previous month
 		mark_attendance(self.employee, previous_month_first, "Absent")
 		mark_attendance(self.employee, previous_month_first + relativedelta(days=1), "Present")
@@ -44,7 +43,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 			}
 		)
 		report = execute(filters=filters)
@@ -64,7 +63,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_detailed_view(self):
 		previous_month_first = get_first_day_for_prev_month()
-		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		# attendance with shift
 		mark_attendance(self.employee, previous_month_first, "Absent", "Day Shift")
@@ -80,7 +78,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 			}
 		)
 		report = execute(filters=filters)
@@ -101,7 +99,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_single_shift_with_leaves_in_detailed_view(self):
 		previous_month_first = get_first_day_for_prev_month()
-		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		# attendance with shift
 		mark_attendance(self.employee, previous_month_first, "Absent", "Day Shift")
@@ -116,7 +113,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 			}
 		)
 		report = execute(filters=filters)
@@ -133,7 +130,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_single_leave_record(self):
 		previous_month_first = get_first_day_for_prev_month()
-		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		# attendance without shift
 		mark_attendance(self.employee, previous_month_first, "On Leave")
@@ -142,7 +138,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 			}
 		)
 		report = execute(filters=filters)
@@ -157,7 +153,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_summarized_view(self):
 		previous_month_first = get_first_day_for_prev_month()
-		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		# attendance with shift
 		mark_attendance(self.employee, previous_month_first, "Absent", "Day Shift")
@@ -184,7 +179,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 				"summarized_view": 1,
 			}
 		)
@@ -207,7 +202,6 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_attendance_with_group_by_filter(self):
 		previous_month_first = get_first_day_for_prev_month()
-		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		# attendance with shift
 		mark_attendance(self.employee, previous_month_first, "Absent", "Day Shift")
@@ -223,7 +217,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 				"group_by": "Department",
 			}
 		)
@@ -247,9 +241,8 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	def test_attendance_with_employee_filter(self):
 		previous_month_first = get_first_day_for_prev_month()
 
-		company = frappe.db.get_value("Employee", self.employee, "company")
-		employee2 = make_employee("test_employee2@example.com", company="_Test Company")
-		employee3 = make_employee("test_employee3@example.com", company="_Test Company")
+		employee2 = make_employee("test_employee2@example.com", company=self.company)
+		employee3 = make_employee("test_employee3@example.com", company=self.company)
 
 		# mark different attendance status on first 3 days of previous month for employee1
 		mark_attendance(self.employee, previous_month_first, "Absent")
@@ -270,7 +263,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 				"employee": self.employee,
 			}
 		)
@@ -294,9 +287,8 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 	def test_attendance_with_employee_filter_and_summarized_view(self):
 		previous_month_first = get_first_day_for_prev_month()
 
-		company = frappe.db.get_value("Employee", self.employee, "company")
-		employee2 = make_employee("test_employee2@example.com", company="_Test Company")
-		employee3 = make_employee("test_employee3@example.com", company="_Test Company")
+		employee2 = make_employee("test_employee2@example.com", company=self.company)
+		employee3 = make_employee("test_employee3@example.com", company=self.company)
 
 		# mark different attendance status on first 3 days of previous month for employee1
 		mark_attendance(self.employee, previous_month_first, "Absent")
@@ -317,7 +309,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 				"employee": self.employee,
 				"summarized_view": 1,
 			}
@@ -347,12 +339,11 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		# execute report without attendance record
 		previous_month_first = get_first_day_for_prev_month()
 
-		company = frappe.db.get_value("Employee", self.employee, "company")
 		filters = frappe._dict(
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": company,
+				"company": self.company,
 				"group_by": "Department",
 			}
 		)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -2139,7 +2139,6 @@ def mark_attendance(
 	late_entry=False,
 	early_exit=False,
 ):
-	company = frappe.db.get_value("Employee", employee, "company")
 	attendance = frappe.new_doc("Attendance")
 	attendance.update(
 		{
@@ -2147,7 +2146,6 @@ def mark_attendance(
 			"employee": employee,
 			"attendance_date": attendance_date,
 			"status": status,
-			"company": company,
 			"shift": shift,
 			"leave_type": leave_type,
 			"late_entry": late_entry,


### PR DESCRIPTION
- Set `fetch_from` for `company` field in Attendance to fetch it from the employee master
- Remove unnecessary db calls for doing so
- refactor old deprecated code in `attendance.js`