### PR TITLE
fix: consider company filter while setting tax components

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -162,7 +162,8 @@
    "depends_on": "eval:doc.type == \"Deduction\"",
    "fieldname": "variable_based_on_taxable_salary",
    "fieldtype": "Check",
-   "label": "Variable Based On Taxable Salary"
+   "label": "Variable Based On Taxable Salary",
+   "search_index": 1
   },
   {
    "depends_on": "eval:doc.statistical_component != 1",
@@ -263,7 +264,7 @@
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-01 16:57:46.413627",
+ "modified": "2023-06-21 15:11:53.582800",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -9,6 +9,8 @@ from frappe.model.naming import append_number_if_name_exists
 class SalaryComponent(Document):
 	def validate(self):
 		self.validate_abbr()
+
+	def on_update(self):
 		self.invalidate_cache()
 
 	def validate_abbr(self):

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
+import frappe
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 
@@ -9,6 +9,7 @@ from frappe.model.naming import append_number_if_name_exists
 class SalaryComponent(Document):
 	def validate(self):
 		self.validate_abbr()
+		self.invalidate_cache()
 
 	def validate_abbr(self):
 		if not self.salary_component_abbr:
@@ -22,3 +23,9 @@ class SalaryComponent(Document):
 			separator="_",
 			filters={"name": ["!=", self.name]},
 		)
+
+	def invalidate_cache(self):
+		keys_to_detete = ["tax_components"]
+
+		for key in keys_to_detete:
+			frappe.cache().delete_key(key)

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -27,4 +27,4 @@ class SalaryComponent(Document):
 		)
 
 	def invalidate_cache(self):
-		frappe.cache().delete_key("tax_components")
+		frappe.cache().delete_value("tax_components")

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -25,7 +25,4 @@ class SalaryComponent(Document):
 		)
 
 	def invalidate_cache(self):
-		keys_to_detete = ["tax_components"]
-
-		for key in keys_to_detete:
-			frappe.cache().delete_key(key)
+		frappe.cache().delete_key("tax_components")

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1160,10 +1160,10 @@ class SalarySlip(TransactionBase):
 
 	def get_tax_components(self) -> list:
 		if frappe.flags.in_test:
-			tax_components = self._get_company_wise_tax_components()
+			tax_components = self._fetch_company_wise_tax_components()
 		else:
 			tax_components = frappe.cache().get_value(
-				"tax_components", self._get_company_wise_tax_components
+				"tax_components", self._fetch_company_wise_tax_components
 			)
 
 		if self.company in tax_components:
@@ -1171,7 +1171,7 @@ class SalarySlip(TransactionBase):
 		else:
 			return tax_components.get("default", [])
 
-	def _get_company_wise_tax_components(self):
+	def _fetch_company_wise_tax_components(self):
 		tax_components = {}
 		sc = frappe.qb.DocType("Salary Component")
 		sca = frappe.qb.DocType("Salary Component Account")

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1158,7 +1158,7 @@ class SalarySlip(TransactionBase):
 			tax_row = get_salary_component_data(d)
 			self.update_component_row(tax_row, tax_amount, "deductions")
 
-	def get_tax_components(self):
+	def get_tax_components(self) -> list:
 		def _get_tax_components():
 			tax_components = {}
 			sc = frappe.qb.DocType("Salary Component")
@@ -1190,7 +1190,7 @@ class SalarySlip(TransactionBase):
 		if self.company in tax_components:
 			return tax_components[self.company]
 		else:
-			return tax_components["default"]
+			return tax_components.get("default", [])
 
 	def update_component_row(
 		self,

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1160,14 +1160,10 @@ class SalarySlip(TransactionBase):
 
 	def get_tax_components(self) -> list:
 		"""
-		Fetches the tax components for a company.
-
-		Returns a list of tax components specific to the company. If no tax components are defined for the company, it returns the default tax components.
-
 		Returns:
-		    list: A list of tax components.
-
-
+		        list: A list of tax components specific to the company.
+		        If no tax components are defined for the company,
+		        it returns the default tax components.
 		"""
 
 		tax_components = frappe.cache().get_value(
@@ -1180,8 +1176,6 @@ class SalarySlip(TransactionBase):
 
 	def _fetch_company_wise_tax_components(self) -> dict:
 		"""
-		Fetches the tax components for each company.
-
 		Returns:
 		    dict: A dictionary containing tax components grouped by company.
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1175,10 +1175,10 @@ class SalarySlip(TransactionBase):
 				.where(sc.variable_based_on_taxable_salary == 1)
 			).run(as_dict=True)
 
-			for d in compoents:
-				key = d.company if d.company else "default"
+			for component in compoents:
+				key = component.company if component.company else "default"
 				tax_components.setdefault(key, [])
-				tax_components[key].append(d.name)
+				tax_components[key].append(component.name)
 
 			return tax_components
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1146,6 +1146,13 @@ class SalarySlip(TransactionBase):
 
 		if not tax_components:
 			tax_components = self.get_tax_components()
+			frappe.msgprint(
+				_(
+					"Added tax components from the Salary Component master as the salary structure didn't have any tax component."
+				),
+				indicator="blue",
+				alert=True,
+			)
 
 		if tax_components and self.payroll_period and self.salary_structure:
 			self.tax_slab = self.get_income_tax_slabs()

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1165,7 +1165,7 @@ class SalarySlip(TransactionBase):
 		Returns a list of tax components specific to the company. If no tax components are defined for the company, it returns the default tax components.
 
 		Returns:
-		        list: A list of tax components.
+		    list: A list of tax components.
 
 
 		"""
@@ -1180,13 +1180,13 @@ class SalarySlip(TransactionBase):
 
 	def _fetch_company_wise_tax_components(self) -> dict:
 		"""
-		    Fetches the tax components for each company.
+		Fetches the tax components for each company.
 
-		    Returns:
-		dict: A dictionary containing tax components grouped by company.
+		Returns:
+		    dict: A dictionary containing tax components grouped by company.
 
-		    Raises:
-		        None
+		Raises:
+		    None
 		"""
 
 		tax_components = {}

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1351,7 +1351,7 @@ class TestSalarySlip(FrappeTestCase):
 			base=40000,
 		)
 
-		make_income_tax_compoents()
+		make_income_tax_components()
 
 		salary_slip = make_salary_slip(salary_structure_doc.name, employee=emp, posting_date=nowdate())
 
@@ -1390,7 +1390,7 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertListEqual(tax_component, ["_Test TDS"])
 
 
-def make_income_tax_compoents():
+def make_income_tax_components():
 	tax_components = [
 		{
 			"salary_component": "_Test TDS",

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1351,28 +1351,7 @@ class TestSalarySlip(FrappeTestCase):
 			base=40000,
 		)
 
-		def _make_income_tax_compoent():
-			tax_components = [
-				{
-					"salary_component": "_Test TDS",
-					"abbr": "T_TDS",
-					"type": "Deduction",
-					"depends_on_payment_days": 0,
-					"variable_based_on_taxable_salary": 0,
-					"round_to_the_nearest_integer": 1,
-				},
-				{
-					"salary_component": "_Test Income Tax",
-					"abbr": "T_IT",
-					"type": "Deduction",
-					"depends_on_payment_days": 0,
-					"variable_based_on_taxable_salary": 0,
-					"round_to_the_nearest_integer": 1,
-				},
-			]
-			make_salary_component(tax_components, False, company_list=[])
-
-		_make_income_tax_compoent()
+		make_income_tax_compoents()
 
 		salary_slip = make_salary_slip(salary_structure_doc.name, employee=emp, posting_date=nowdate())
 
@@ -1393,7 +1372,6 @@ class TestSalarySlip(FrappeTestCase):
 		)
 		test_tds.variable_based_on_taxable_salary = 1
 		test_tds.save()
-		test_tds.load_from_db()
 
 		# validate tax component is configurations
 		self.assertEqual(test_tds.variable_based_on_taxable_salary, 1)
@@ -1403,13 +1381,35 @@ class TestSalarySlip(FrappeTestCase):
 		income_tax = frappe.get_doc("Salary Component", "_Test Income Tax")
 		income_tax.variable_based_on_taxable_salary = 1
 		income_tax.save()
-		income_tax.load_from_db()
+
 		self.assertEqual(income_tax.variable_based_on_taxable_salary, 1)
 
 		# Validate tax component matching company criteria is added in salary slip
 		tax_component = salary_slip.get_tax_components()
 		self.assertEqual(test_tds.accounts[0].company, salary_slip.company)
 		self.assertListEqual(tax_component, ["_Test TDS"])
+
+
+def make_income_tax_compoents():
+	tax_components = [
+		{
+			"salary_component": "_Test TDS",
+			"abbr": "T_TDS",
+			"type": "Deduction",
+			"depends_on_payment_days": 0,
+			"variable_based_on_taxable_salary": 0,
+			"round_to_the_nearest_integer": 1,
+		},
+		{
+			"salary_component": "_Test Income Tax",
+			"abbr": "T_IT",
+			"type": "Deduction",
+			"depends_on_payment_days": 0,
+			"variable_based_on_taxable_salary": 0,
+			"round_to_the_nearest_integer": 1,
+		},
+	]
+	make_salary_component(tax_components, False, company_list=[])
 
 
 def get_no_of_days():


### PR DESCRIPTION
### Issue
If a tax component is not defined on salary structure then at the run time the system pulls a tax component based on the attribute "Variable Based On Taxable Salary". While doing this, the system does not consider the company set on the salary slip.

#### Salary Structure w/o Income Tax component
<img width="1327" alt="Screenshot 2023-06-22 at 11 14 17 AM" src="https://github.com/frappe/hrms/assets/3784093/3eee937d-2d9c-4be3-86f6-8d5bbee1b486">

#### There are three salary components, configured for Variable Based On Taxable Salary with different companies
<img width="1300" alt="Screenshot 2023-06-22 at 11 17 45 AM" src="https://github.com/frappe/hrms/assets/3784093/92ca077d-cc66-4459-8209-0c2e216ac504">

### The system adds all three  components in salary slip, without validating company
<img width="1046" alt="Screenshot 2023-06-22 at 11 20 08 AM" src="https://github.com/frappe/hrms/assets/3784093/f8c777cf-ca25-4fb9-beef-1160528da561">

<img width="1073" alt="Screenshot 2023-06-22 at 11 14 04 AM" src="https://github.com/frappe/hrms/assets/3784093/80cad476-a967-4eeb-8029-606ed7c9d1c7">


### Fix

Consider company filter while adding income tax component.

<img width="1308" alt="Screenshot 2023-06-22 at 11 23 20 AM" src="https://github.com/frappe/hrms/assets/3784093/5b50a457-b318-4e67-b691-c04a18c4fa5a">


<img width="1291" alt="Screenshot 2023-06-22 at 11 23 14 AM" src="https://github.com/frappe/hrms/assets/3784093/279c112f-0415-4ced-8893-075c8b801502">





