### PR TITLE
refactor!: Loan App separation changes

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -92,6 +92,22 @@ after_migrate = "hrms.setup.update_select_perm_after_install"
 before_uninstall = "hrms.uninstall.before_uninstall"
 # after_uninstall = "hrms.uninstall.after_uninstall"
 
+# Integration Setup
+# ------------------
+# To set up dependencies/integrations with other apps
+# Name of the app being installed is passed as an argument
+
+# before_app_install = "hrms.utils.before_app_install"
+after_app_install = "hrms.setup.after_app_install"
+
+# Integration Cleanup
+# -------------------
+# To clean up dependencies/integrations with other apps
+# Name of the app being uninstalled is passed as an argument
+
+before_app_uninstall = "hrms.setup.before_app_uninstall"
+# after_app_uninstall = "hrms.utils.after_app_uninstall"
+
 # Desk Notifications
 # ------------------
 # See frappe.core.notifications.get_notification_config
@@ -170,7 +186,6 @@ doc_events = {
 		"validate": "hrms.controllers.employee_boarding_controller.update_employee_boarding_status"
 	},
 	"Task": {"on_update": "hrms.controllers.employee_boarding_controller.update_task"},
-	"Installed Applications": {"on_update": "hrms.setup.update_salary_slip_loans_setup"},
 }
 
 # Scheduled Tasks

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -170,6 +170,7 @@ doc_events = {
 		"validate": "hrms.controllers.employee_boarding_controller.update_employee_boarding_status"
 	},
 	"Task": {"on_update": "hrms.controllers.employee_boarding_controller.update_task"},
+	"Installed Applications": {"on_update": "hrms.setup.update_salary_slip_loans_setup"},
 }
 
 # Scheduled Tasks

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -1,5 +1,5 @@
 [pre_model_sync]
-hrms.patches.v15_0.check_version_compatibility_with_frappe
+hrms.patches.v15_0.check_version_compatibility_with_frappe #2023-06-27
 
 [post_model_sync]
 hrms.patches.post_install.set_payroll_entry_status

--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -60,13 +60,6 @@
   "column_break_25",
   "total_deduction",
   "base_total_deduction",
-  "loan_repayment",
-  "loans",
-  "section_break_43",
-  "total_principal_amount",
-  "total_interest_amount",
-  "column_break_45",
-  "total_loan_repayment",
   "net_pay_info",
   "net_pay",
   "base_net_pay",
@@ -350,52 +343,6 @@
   {
    "fieldname": "column_break_25",
    "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "total_loan_repayment",
-   "fieldname": "loan_repayment",
-   "fieldtype": "Section Break",
-   "label": "Loan Repayment"
-  },
-  {
-   "fieldname": "loans",
-   "fieldtype": "Table",
-   "label": "Employee Loan",
-   "options": "Salary Slip Loan",
-   "print_hide": 1
-  },
-  {
-   "depends_on": "eval:doc.docstatus != 0",
-   "fieldname": "section_break_43",
-   "fieldtype": "Section Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "total_principal_amount",
-   "fieldtype": "Currency",
-   "label": "Total Principal Amount",
-   "options": "Company:company:default_currency",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "total_interest_amount",
-   "fieldtype": "Currency",
-   "label": "Total Interest Amount",
-   "options": "Company:company:default_currency",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_45",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "total_loan_repayment",
-   "fieldtype": "Currency",
-   "label": "Total Loan Repayment",
-   "options": "Company:company:default_currency",
-   "read_only": 1
   },
   {
    "fieldname": "net_pay_info",
@@ -753,7 +700,7 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-02-22 18:23:49.783449",
+ "modified": "2023-06-20 20:04:00.131248",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -28,13 +28,6 @@ from frappe.utils.background_jobs import enqueue
 
 import erpnext
 from erpnext.accounts.utils import get_fiscal_year
-from erpnext.loan_management.doctype.loan_repayment.loan_repayment import (
-	calculate_amounts,
-	create_repayment_entry,
-)
-from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-	process_loan_interest_accrual_for_term_loans,
-)
 from erpnext.utilities.transaction_base import TransactionBase
 
 from hrms.hr.utils import get_holiday_dates_for_employee, validate_active_employee
@@ -50,6 +43,11 @@ from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
 from hrms.payroll.doctype.payroll_period.payroll_period import (
 	get_payroll_period,
 	get_period_factor,
+)
+from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
+	cancel_loan_repayment_entry,
+	make_loan_repayment_entry,
+	set_loan_repayment,
 )
 
 
@@ -126,7 +124,8 @@ class SalarySlip(TransactionBase):
 		else:
 			self.set_status()
 			self.update_status(self.name)
-			self.make_loan_repayment_entry()
+
+			make_loan_repayment_entry(self)
 
 			if not frappe.flags.via_payroll_entry and not frappe.flags.in_patch:
 				email_salary_slip = cint(
@@ -159,7 +158,8 @@ class SalarySlip(TransactionBase):
 		self.set_status()
 		self.update_status()
 		self.update_payment_status_for_gratuity()
-		self.cancel_loan_repayment_entry()
+
+		cancel_loan_repayment_entry(self)
 
 	def on_trash(self):
 		from frappe.model.naming import revert_series_if_last
@@ -643,7 +643,8 @@ class SalarySlip(TransactionBase):
 		if self.salary_structure:
 			self.calculate_component_amounts("deductions")
 
-		self.set_loan_repayment()
+		set_loan_repayment(self)
+
 		self.set_precision_for_component_amounts()
 		self.set_net_pay()
 		self.compute_income_tax_breakup()
@@ -653,7 +654,9 @@ class SalarySlip(TransactionBase):
 		self.base_total_deduction = flt(
 			flt(self.total_deduction) * flt(self.exchange_rate), self.precision("base_total_deduction")
 		)
-		self.net_pay = flt(self.gross_pay) - (flt(self.total_deduction) + flt(self.total_loan_repayment))
+		self.net_pay = flt(self.gross_pay) - (
+			flt(self.total_deduction) + flt(self.get("total_loan_repayment"))
+		)
 		self.rounded_total = rounded(self.net_pay)
 		self.base_net_pay = flt(
 			flt(self.net_pay) * flt(self.exchange_rate), self.precision("base_net_pay")
@@ -1675,100 +1678,6 @@ class SalarySlip(TransactionBase):
 
 		return joining_date, relieving_date
 
-	def set_loan_repayment(self):
-		self.total_loan_repayment = 0
-		self.total_interest_amount = 0
-		self.total_principal_amount = 0
-
-		if not self.get("loans"):
-			for loan in self.get_loan_details():
-
-				amounts = calculate_amounts(loan.name, self.posting_date, "Regular Payment")
-
-				if amounts["interest_amount"] or amounts["payable_principal_amount"]:
-					self.append(
-						"loans",
-						{
-							"loan": loan.name,
-							"total_payment": amounts["interest_amount"] + amounts["payable_principal_amount"],
-							"interest_amount": amounts["interest_amount"],
-							"principal_amount": amounts["payable_principal_amount"],
-							"loan_account": loan.loan_account,
-							"interest_income_account": loan.interest_income_account,
-						},
-					)
-
-		for payment in self.get("loans"):
-			amounts = calculate_amounts(payment.loan, self.posting_date, "Regular Payment")
-			total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
-			if payment.total_payment > total_amount:
-				frappe.throw(
-					_(
-						"""Row {0}: Paid amount {1} is greater than pending accrued amount {2} against loan {3}"""
-					).format(
-						payment.idx,
-						frappe.bold(payment.total_payment),
-						frappe.bold(total_amount),
-						frappe.bold(payment.loan),
-					)
-				)
-
-			self.total_interest_amount += payment.interest_amount
-			self.total_principal_amount += payment.principal_amount
-
-			self.total_loan_repayment += payment.total_payment
-
-	def get_loan_details(self):
-		loan_details = frappe.get_all(
-			"Loan",
-			fields=["name", "interest_income_account", "loan_account", "loan_type", "is_term_loan"],
-			filters={
-				"applicant": self.employee,
-				"docstatus": 1,
-				"repay_from_salary": 1,
-				"company": self.company,
-			},
-		)
-
-		if loan_details:
-			for loan in loan_details:
-				if loan.is_term_loan:
-					process_loan_interest_accrual_for_term_loans(
-						posting_date=self.posting_date, loan_type=loan.loan_type, loan=loan.name
-					)
-
-		return loan_details
-
-	def make_loan_repayment_entry(self):
-		payroll_payable_account = get_payroll_payable_account(self.company, self.payroll_entry)
-		for loan in self.loans:
-			if loan.total_payment:
-				repayment_entry = create_repayment_entry(
-					loan.loan,
-					self.employee,
-					self.company,
-					self.posting_date,
-					loan.loan_type,
-					"Regular Payment",
-					loan.interest_amount,
-					loan.principal_amount,
-					loan.total_payment,
-					payroll_payable_account=payroll_payable_account,
-				)
-
-				repayment_entry.save()
-				repayment_entry.submit()
-
-				frappe.db.set_value(
-					"Salary Slip Loan", loan.name, "loan_repayment_entry", repayment_entry.name
-				)
-
-	def cancel_loan_repayment_entry(self):
-		for loan in self.loans:
-			if loan.loan_repayment_entry:
-				repayment_entry = frappe.get_doc("Loan Repayment", loan.loan_repayment_entry)
-				repayment_entry.cancel()
-
 	def email_salary_slip(self):
 		receiver = frappe.db.get_value("Employee", self.employee, "prefered_email")
 		payroll_settings = frappe.get_single("Payroll Settings")
@@ -1850,7 +1759,9 @@ class SalarySlip(TransactionBase):
 			if hasattr(self, "deductions"):
 				for deduction in self.deductions:
 					self.total_deduction += flt(deduction.amount, deduction.precision("amount"))
-			self.net_pay = flt(self.gross_pay) - flt(self.total_deduction) - flt(self.total_loan_repayment)
+			self.net_pay = (
+				flt(self.gross_pay) - flt(self.total_deduction) - flt(self.get("total_loan_repayment"))
+			)
 		self.set_base_totals()
 
 	def set_base_totals(self):
@@ -2019,19 +1930,6 @@ def get_salary_component_data(component):
 		],
 		as_dict=1,
 	)
-
-
-def get_payroll_payable_account(company, payroll_entry):
-	if payroll_entry:
-		payroll_payable_account = frappe.db.get_value(
-			"Payroll Entry", payroll_entry, "payroll_payable_account"
-		)
-	else:
-		payroll_payable_account = frappe.db.get_value(
-			"Company", company, "default_payroll_payable_account"
-		)
-
-	return payroll_payable_account
 
 
 def calculate_tax_by_tax_slab(

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from typing import TYPE_CHECKING
+
+import frappe
+from frappe import _
+
+if TYPE_CHECKING:
+	from hrms.payroll.doctype.salary_slip.salary_slip import SalarySlip
+
+
+def if_lending_app_installed(function):
+	"""Decorator to check if lending app is installed"""
+
+	def wrapper(*args, **kwargs):
+		if "lending" in frappe.get_installed_apps():
+			return function(*args, **kwargs)
+		return
+
+	return wrapper
+
+
+@if_lending_app_installed
+def set_loan_repayment(doc: "SalarySlip"):
+	from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
+
+	doc.total_loan_repayment = 0
+	doc.total_interest_amount = 0
+	doc.total_principal_amount = 0
+
+	if not doc.get("loans"):
+		for loan in _get_loan_details(doc):
+			amounts = calculate_amounts(loan.name, doc.posting_date, "Regular Payment")
+
+			if amounts["interest_amount"] or amounts["payable_principal_amount"]:
+				doc.append(
+					"loans",
+					{
+						"loan": loan.name,
+						"total_payment": amounts["interest_amount"] + amounts["payable_principal_amount"],
+						"interest_amount": amounts["interest_amount"],
+						"principal_amount": amounts["payable_principal_amount"],
+						"loan_account": loan.loan_account,
+						"interest_income_account": loan.interest_income_account,
+					},
+				)
+
+	for payment in doc.get("loans"):
+		amounts = calculate_amounts(payment.loan, doc.posting_date, "Regular Payment")
+		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
+		if payment.total_payment > total_amount:
+			frappe.throw(
+				_(
+					"""Row {0}: Paid amount {1} is greater than pending accrued amount {2} against loan {3}"""
+				).format(
+					payment.idx,
+					frappe.bold(payment.total_payment),
+					frappe.bold(total_amount),
+					frappe.bold(payment.loan),
+				)
+			)
+
+		doc.total_interest_amount += payment.interest_amount
+		doc.total_principal_amount += payment.principal_amount
+		doc.total_loan_repayment += payment.total_payment
+
+
+def _get_loan_details(doc: "SalarySlip"):
+	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+		process_loan_interest_accrual_for_term_loans,
+	)
+
+	loan_details = frappe.get_all(
+		"Loan",
+		fields=["name", "interest_income_account", "loan_account", "loan_type", "is_term_loan"],
+		filters={
+			"applicant": doc.employee,
+			"docstatus": 1,
+			"repay_from_salary": 1,
+			"company": doc.company,
+		},
+	)
+
+	if loan_details:
+		for loan in loan_details:
+			if loan.is_term_loan:
+				process_loan_interest_accrual_for_term_loans(
+					posting_date=doc.posting_date, loan_type=loan.loan_type, loan=loan.name
+				)
+
+	return loan_details
+
+
+@if_lending_app_installed
+def make_loan_repayment_entry(doc: "SalarySlip"):
+	from lending.loan_management.doctype.loan_repayment.loan_repayment import create_repayment_entry
+
+	payroll_payable_account = get_payroll_payable_account(doc.company, doc.payroll_entry)
+	for loan in doc.loans:
+		if not loan.total_payment:
+			continue
+
+		repayment_entry = create_repayment_entry(
+			loan.loan,
+			doc.employee,
+			doc.company,
+			doc.posting_date,
+			loan.loan_type,
+			"Regular Payment",
+			loan.interest_amount,
+			loan.principal_amount,
+			loan.total_payment,
+			payroll_payable_account=payroll_payable_account,
+		)
+
+		repayment_entry.save()
+		repayment_entry.submit()
+
+		frappe.db.set_value("Salary Slip Loan", loan.name, "loan_repayment_entry", repayment_entry.name)
+
+
+@if_lending_app_installed
+def cancel_loan_repayment_entry(doc: "SalarySlip"):
+	for loan in doc.loans:
+		if loan.loan_repayment_entry:
+			repayment_entry = frappe.get_doc("Loan Repayment", loan.loan_repayment_entry)
+			repayment_entry.cancel()
+
+
+def get_payroll_payable_account(company, payroll_entry):
+	if payroll_entry:
+		payroll_payable_account = frappe.db.get_value(
+			"Payroll Entry", payroll_entry, "payroll_payable_account"
+		)
+	else:
+		payroll_payable_account = frappe.db.get_value(
+			"Company", company, "default_payroll_payable_account"
+		)
+
+	return payroll_payable_account

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -37,6 +37,7 @@ from hrms.payroll.doctype.employee_tax_exemption_declaration.test_employee_tax_e
 )
 from hrms.payroll.doctype.payroll_entry.payroll_entry import get_month_details
 from hrms.payroll.doctype.salary_slip.salary_slip import make_salary_slip_from_timesheet
+from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from hrms.tests.test_utils import get_first_sunday
 
@@ -584,14 +585,15 @@ class TestSalarySlip(FrappeTestCase):
 		email_queue = frappe.db.a_row_exists("Email Queue")
 		self.assertTrue(email_queue)
 
+	@if_lending_app_installed
 	def test_loan_repayment_salary_slip(self):
-		from erpnext.loan_management.doctype.loan.test_loan import (
+		from lending.loan_management.doctype.loan.test_loan import (
 			create_loan,
 			create_loan_accounts,
 			create_loan_type,
 			make_loan_disbursement_entry,
 		)
-		from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 			process_loan_interest_accrual_for_term_loans,
 		)
 

--- a/hrms/payroll/workspace/salary_payout/salary_payout.json
+++ b/hrms/payroll/workspace/salary_payout/salary_payout.json
@@ -1,13 +1,15 @@
 {
  "charts": [],
- "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Your Shortcuts</b></span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Slip\",\"col\":3}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Payroll Entry\",\"col\":3}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Register\",\"col\":3}},{\"type\":\"spacer\",\"data\":{\"col\":12}},{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Transactions &amp; Reports</b></span>\",\"col\":12}},{\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Payroll\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Incentives\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Loans\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Accounting\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Accounting Reports\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Payroll Reports\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Deduction Reports\",\"col\":4}}]",
+ "content": "[{\"id\":\"jvTZ8RvO42\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Your Shortcuts</b></span>\",\"col\":12}},{\"id\":\"hNVIisuaFR\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Slip\",\"col\":3}},{\"id\":\"6XUIWHJ3jI\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Payroll Entry\",\"col\":3}},{\"id\":\"yjIBi3GMoo\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Register\",\"col\":3}},{\"id\":\"ORKhwX-uqw\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"gGURwviUAZ\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Transactions &amp; Reports</b></span>\",\"col\":12}},{\"id\":\"m7ibJXxzpl\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"U-jv2v4nCv\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll\",\"col\":4}},{\"id\":\"LG69O3ku4y\",\"type\":\"card\",\"data\":{\"card_name\":\"Incentives\",\"col\":4}},{\"id\":\"kOuItimoNm\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting\",\"col\":4}},{\"id\":\"UJqBhPqNZd\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting Reports\",\"col\":4}},{\"id\":\"eNZuk6i-jy\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll Reports\",\"col\":4}},{\"id\":\"ll91Zs2cbx\",\"type\":\"card\",\"data\":{\"card_name\":\"Deduction Reports\",\"col\":4}}]",
  "creation": "2022-08-20 16:43:32.769568",
+ "custom_blocks": [],
  "docstatus": 0,
  "doctype": "Workspace",
  "for_user": "",
  "hide_custom": 0,
  "icon": "income",
  "idx": 0,
+ "is_hidden": 0,
  "label": "Salary Payout",
  "links": [
   {
@@ -92,44 +94,6 @@
    "label": "Retention Bonus",
    "link_count": 0,
    "link_to": "Retention Bonus",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Loans",
-   "link_count": 3,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Loan Type",
-   "link_count": 0,
-   "link_to": "Loan Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Loan Application",
-   "link_count": 0,
-   "link_to": "Loan Application",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Loan",
-   "link_count": 0,
-   "link_to": "Loan",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -385,10 +349,11 @@
    "type": "Link"
   }
  ],
- "modified": "2022-09-21 12:27:38.631110",
+ "modified": "2023-06-27 13:09:28.191836",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Payout",
+ "number_cards": [],
  "owner": "Administrator",
  "parent_page": "Payroll",
  "public": 1,

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -26,6 +26,7 @@ def after_install():
 
 def before_uninstall():
 	delete_custom_fields(get_custom_fields())
+	delete_custom_fields(SALARY_SLIP_LOAN_FIELDS)
 	delete_company_fixtures()
 
 
@@ -292,35 +293,6 @@ def get_custom_fields():
 				"insert_after": "buying",
 			},
 		],
-		"Loan": [
-			{
-				"default": "0",
-				"depends_on": 'eval:doc.applicant_type=="Employee"',
-				"fieldname": "repay_from_salary",
-				"fieldtype": "Check",
-				"label": "Repay From Salary",
-				"insert_after": "status",
-			},
-		],
-		"Loan Repayment": [
-			{
-				"default": "0",
-				"fetch_from": "against_loan.repay_from_salary",
-				"fieldname": "repay_from_salary",
-				"fieldtype": "Check",
-				"label": "Repay From Salary",
-				"insert_after": "is_term_loan",
-			},
-			{
-				"depends_on": "eval:doc.repay_from_salary",
-				"fieldname": "payroll_payable_account",
-				"fieldtype": "Link",
-				"label": "Payroll Payable Account",
-				"mandatory_depends_on": "eval:doc.repay_from_salary",
-				"options": "Account",
-				"insert_after": "rate_of_interest",
-			},
-		],
 	}
 
 
@@ -335,6 +307,10 @@ def update_salary_slip_loans_setup(installed_apps, event=None):
 	on lending app install/uninstall
 	TODO: ideally a hook in the framework to take action on any app install/uninstall
 	"""
+	if not frappe.db.exists("DocType", "Salary Slip"):
+		# hrms is uninstalling
+		return
+
 	prev_installed_apps = installed_apps.get_doc_before_save()
 
 	prev_installed_app_names = [app.app_name for app in prev_installed_apps.installed_applications]
@@ -798,5 +774,34 @@ SALARY_SLIP_LOAN_FIELDS = {
 			"read_only": 1,
 			"insert_after": "loan_cb_1",
 		},
-	]
+	],
+	"Loan": [
+		{
+			"default": "0",
+			"depends_on": 'eval:doc.applicant_type=="Employee"',
+			"fieldname": "repay_from_salary",
+			"fieldtype": "Check",
+			"label": "Repay From Salary",
+			"insert_after": "status",
+		},
+	],
+	"Loan Repayment": [
+		{
+			"default": "0",
+			"fetch_from": "against_loan.repay_from_salary",
+			"fieldname": "repay_from_salary",
+			"fieldtype": "Check",
+			"label": "Repay From Salary",
+			"insert_after": "is_term_loan",
+		},
+		{
+			"depends_on": "eval:doc.repay_from_salary",
+			"fieldname": "payroll_payable_account",
+			"fieldtype": "Link",
+			"label": "Payroll Payable Account",
+			"mandatory_depends_on": "eval:doc.repay_from_salary",
+			"options": "Account",
+			"insert_after": "rate_of_interest",
+		},
+	],
 }

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -329,6 +329,32 @@ def create_salary_slip_loan_fields():
 		create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
 
 
+def update_salary_slip_loans_setup(installed_apps, event=None):
+	"""
+	hack: called through hooks, creates/deletes salary slip loan custom fields
+	on lending app install/uninstall
+	TODO: ideally a hook in the framework to take action on any app install/uninstall
+	"""
+	prev_installed_apps = installed_apps.get_doc_before_save()
+
+	prev_installed_app_names = [app.app_name for app in prev_installed_apps.installed_applications]
+	installed_app_names = [app.app_name for app in installed_apps.installed_applications]
+
+	def _is_lending_installed():
+		return "lending" in installed_app_names and "lending" not in prev_installed_app_names
+
+	def _is_lending_uninstalled():
+		return "lending" not in installed_app_names and "lending" in prev_installed_app_names
+
+	if _is_lending_installed():
+		print("Updating payroll setup for loans")
+		create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
+
+	elif _is_lending_uninstalled():
+		print("Updating payroll setup for loans")
+		delete_custom_fields(SALARY_SLIP_LOAN_FIELDS)
+
+
 def make_fixtures():
 	records = [
 		# expense claim type
@@ -679,7 +705,10 @@ def run_post_install_patches():
 		frappe.flags.in_patch = False
 
 
-def delete_custom_fields(custom_fields):
+def delete_custom_fields(custom_fields: dict):
+	"""
+	:param custom_fields: a dict like `{'Salary Slip': [{fieldname: 'loans', ...}]}`
+	"""
 	for doctype, fields in custom_fields.items():
 		frappe.db.delete(
 			"Custom Field",

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -301,34 +301,22 @@ def create_salary_slip_loan_fields():
 		create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
 
 
-def update_salary_slip_loans_setup(installed_apps, event=None):
-	"""
-	hack: called through hooks, creates/deletes salary slip loan custom fields
-	on lending app install/uninstall
-	TODO: ideally a hook in the framework to take action on any app install/uninstall
-	"""
-	if not frappe.db.exists("DocType", "Salary Slip"):
-		# hrms is uninstalling
+def after_app_install(app_name):
+	"""Set up loan integration with payroll"""
+	if app_name != "lending":
 		return
 
-	prev_installed_apps = installed_apps.get_doc_before_save()
+	print("Updating payroll setup for loans")
+	create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
 
-	prev_installed_app_names = [app.app_name for app in prev_installed_apps.installed_applications]
-	installed_app_names = [app.app_name for app in installed_apps.installed_applications]
 
-	def _is_lending_installed():
-		return "lending" in installed_app_names and "lending" not in prev_installed_app_names
+def before_app_uninstall(app_name):
+	"""Clean up loan integration with payroll"""
+	if app_name != "lending":
+		return
 
-	def _is_lending_uninstalled():
-		return "lending" not in installed_app_names and "lending" in prev_installed_app_names
-
-	if _is_lending_installed():
-		print("Updating payroll setup for loans")
-		create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
-
-	elif _is_lending_uninstalled():
-		print("Updating payroll setup for loans")
-		delete_custom_fields(SALARY_SLIP_LOAN_FIELDS)
+	print("Updating payroll setup for loans")
+	delete_custom_fields(SALARY_SLIP_LOAN_FIELDS)
 
 
 def make_fixtures():

--- a/hrms/subscription_utils.py
+++ b/hrms/subscription_utils.py
@@ -91,7 +91,6 @@ def update_erpnext_workspaces(disable: bool = True):
 		"CRM",
 		"ERPNext Integrations",
 		"ERPNext Settings",
-		"Loans",
 		"Manufacturing",
 		"Quality",
 		"Selling",


### PR DESCRIPTION
The loan module is being separated from ERPNext in https://github.com/frappe/erpnext/pull/35522. Changes in hrms to handle the same:

- Remove loan standard fields from Salary Slip dt
- On `hrms` installation: add custom fields if the `lending` app is installed
- On `lending` app install/uninstall: add custom fields for loans in `hrms`
- Make the `lending` app a soft dependency
	- add decorator to check if lending app is installed
	- run salary slip loan functions only if lending app is installed
- refactor(tests): fix imports and run loan tests only if lending app is installed.
<hr>

- [x] create hook in the framework for app install/uninstall & refactor hook usage
- [x] clean up workspaces
- [x] Separate CI job with lending app installed on site to test hrms integration with loan (will add in a separate PR once separation PRs get merged. All tests passing on local)

https://github.com/frappe/hrms/wiki/Migration-Guide-to-Frappe-HR-nightly-version-(future-v15)-%5BWIP%5D#payroll-loans