### PR TITLE
fix: filter employees based on company in Salary Structure Assignment

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -6,6 +6,9 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		frm.set_query("employee", function() {
 			return {
 				query: "erpnext.controllers.queries.employee_query",
+				filters: {
+					company: frm.doc.company,
+				}
 			}
 		});
 		frm.set_query("salary_structure", function() {

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -3,14 +3,7 @@
 
 frappe.ui.form.on('Salary Structure Assignment', {
 	setup: function(frm) {
-		frm.set_query("employee", function() {
-			return {
-				query: "erpnext.controllers.queries.employee_query",
-				filters: {
-					company: frm.doc.company,
-				}
-			}
-		});
+		frm.trigger("set_employee_filter");
 		frm.set_query("salary_structure", function() {
 			return {
 				filters: {
@@ -58,6 +51,25 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		if(frm.doc.__onload){
 			frm.unhide_earnings_and_taxation_section = frm.doc.__onload.earning_and_deduction_entries_does_not_exists;
 			frm.trigger("set_earnings_and_taxation_section_visibility");
+		}
+	},
+
+	set_employee_filter: function(frm) {
+		var filters = {}
+
+		if (frm.doc.salary_structure) {
+			filters["company"] = frm.doc.company;
+		}
+
+		frm.set_query("employee", function() {
+			return {
+				query: "erpnext.controllers.queries.employee_query",
+				filters: filters
+			}
+		});
+
+		if (!frm.doc.salary_structure) {
+			frm.add_fetch("employee", "company", "company");
 		}
 	},
 


### PR DESCRIPTION
### Issue:

On Salary Structure Assignment, employee field not considering company 

 - For employee HR-EMP-00010, the company is set to Test Comp
   <img width="1324" alt="Screenshot 2023-06-22 at 3 00 25 PM" src="https://github.com/frappe/hrms/assets/3784093/55d34c2e-4818-465c-afa9-ec169f1f32f1">

 - On Salary Structure Assignment, the company is set as Frappe Technologies Pvt Ltd. though the system is allowing to select employee HR-EMP-00010
    <img width="1296" alt="Screenshot 2023-06-22 at 3 02 55 PM" src="https://github.com/frappe/hrms/assets/3784093/1c2ebdc4-36b0-4ad8-9619-337d6b58bd6a">


# Fix

Filter employee selection based on company

<img width="1295" alt="Screenshot 2023-06-22 at 2 57 50 PM" src="https://github.com/frappe/hrms/assets/3784093/2e4a9805-fc01-4af0-989b-0a1a5105dd80">

