### PR TITLE
fix: employee link fields in payroll reports

### DIFF
--- a/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
+++ b/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
@@ -19,16 +19,14 @@ def get_columns(filters):
 	columns = [
 		{
 			"label": _("Employee"),
-			"options": "Employee",
 			"fieldname": "employee",
 			"fieldtype": "Link",
+			"options": "Employee",
 			"width": 200,
 		},
 		{
 			"label": _("Employee Name"),
-			"options": "Employee",
 			"fieldname": "employee_name",
-			"fieldtype": "Link",
 			"width": 160,
 		},
 		{"label": _("Amount"), "fieldname": "amount", "fieldtype": "Currency", "width": 140},

--- a/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
+++ b/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
@@ -18,16 +18,14 @@ def get_columns(filters):
 	columns = [
 		{
 			"label": _("Employee"),
-			"options": "Employee",
 			"fieldname": "employee",
 			"fieldtype": "Link",
+			"options": "Employee",
 			"width": 200,
 		},
 		{
 			"label": _("Employee Name"),
-			"options": "Employee",
 			"fieldname": "employee_name",
-			"fieldtype": "Link",
 			"width": 160,
 		},
 		{"label": _("PF Account"), "fieldname": "pf_account", "fieldtype": "Data", "width": 140},


### PR DESCRIPTION
There are 2 employee link fields in payroll reports.

**Before**:

Adding a column from the Employee doctype doesn't work:

<img width="1323" alt="image" src="https://github.com/frappe/hrms/assets/24353136/a441ca0b-28fe-4703-bca5-799692f75243">

**After**:

<img width="1323" alt="image" src="https://github.com/frappe/hrms/assets/24353136/9b0ee4cf-b949-4d17-a0be-9c2b0ee14153">

