### PR TITLE
fix: allow checkin at the same time as last checkout

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -30,7 +30,7 @@ class EmployeeCheckin(Document):
 				"employee": self.employee,
 				"time": self.time,
 				"name": ("!=", self.name),
-				"log_type": ("!=", self.log_type),
+				"log_type": self.log_type,
 			},
 		)
 		if doc:

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -25,7 +25,13 @@ class EmployeeCheckin(Document):
 
 	def validate_duplicate_log(self):
 		doc = frappe.db.exists(
-			"Employee Checkin", {"employee": self.employee, "time": self.time, "name": ["!=", self.name]}
+			"Employee Checkin",
+			{
+				"employee": self.employee,
+				"time": self.time,
+				"name": ("!=", self.name),
+				"log_type": ("!=", self.log_type),
+			},
 		)
 		if doc:
 			doc_link = frappe.get_desk_link("Employee Checkin", doc)


### PR DESCRIPTION
It was not possible to create a new **Employee Checkin** at the same time as the last checkout. Imagine employees checking out and in at the same time, for example because they start working on a different project. If this cannot happen at the same time, they will lose one minute (or second) of working time with every switch.

To resolve this, I propose to filter for `"log_type": self.log_type` when looking for duplicates.