### PR TITLE
fix: add missing accounting dimension field for project in Expense Claim Detail

### DIFF
--- a/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -17,7 +17,8 @@
   "sanctioned_amount",
   "accounting_dimensions_section",
   "cost_center",
-  "dimension_col_break"
+  "dimension_col_break",
+  "project"
  ],
  "fields": [
   {
@@ -114,17 +115,24 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-11-26 14:23:45.539922",
+ "modified": "2023-06-24 00:56:08.900677",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Detail",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
The default accounting dimension project field was missing in the Expense Claim Detail child table. Adding it.

<img width="1332" alt="image" src="https://github.com/frappe/hrms/assets/24353136/ca112aaa-026e-4fa1-a122-a9706267c628">
