### PR TITLE
ci: update required node version to v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
           check-latest: true
 
       - name: Add to Hosts

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 200
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           check-latest: true
 
       - name: Check commit titles


### PR DESCRIPTION
To make builds compatible with https://github.com/frappe/frappe/pull/21370