### PR TITLE
fix: add missing project field in expense taxes and map project in gl entries

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -160,6 +160,7 @@ class ExpenseClaim(AccountsController):
 						"against_voucher_type": self.doctype,
 						"against_voucher": self.name,
 						"cost_center": self.cost_center,
+						"project": self.project,
 					},
 					item=self,
 				)
@@ -175,6 +176,7 @@ class ExpenseClaim(AccountsController):
 						"debit_in_account_currency": data.sanctioned_amount,
 						"against": self.employee,
 						"cost_center": data.cost_center or self.cost_center,
+						"project": data.project or self.project,
 					},
 					item=data,
 				)
@@ -241,7 +243,8 @@ class ExpenseClaim(AccountsController):
 						"debit": tax.tax_amount,
 						"debit_in_account_currency": tax.tax_amount,
 						"against": self.employee,
-						"cost_center": self.cost_center,
+						"cost_center": tax.cost_center or self.cost_center,
+						"project": tax.project or self.project,
 						"against_voucher_type": self.doctype,
 						"against_voucher": self.name,
 					},

--- a/hrms/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+++ b/hrms/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
@@ -17,7 +17,8 @@
   "total",
   "accounting_dimensions_section",
   "cost_center",
-  "dimension_col_break"
+  "dimension_col_break",
+  "project"
  ],
  "fields": [
   {
@@ -96,17 +97,25 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-10-26 20:27:36.027728",
+ "modified": "2023-06-26 13:06:28.555076",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Taxes and Charges",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Continuing https://github.com/frappe/hrms/pull/623

The default accounting dimension "project" was missing in the Expense Claim Detail child table. Hence the project was not getting mapped against child table gl entries.

Also, added a project field to the tax table and mapped it in gl entry creation. 

<img width="1350" alt="image" src="https://github.com/frappe/hrms/assets/24353136/4fd9fb1f-aec3-4844-8fcc-e6debe6b887f">

<img width="1350" alt="image" src="https://github.com/frappe/hrms/assets/24353136/356c8658-b5c1-43d1-9092-05ecd0789016">

