### PR TITLE
fix!: use prefered email with other email fields as fallback for leave notification

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -32,6 +32,7 @@ from hrms.hr.utils import (
 	share_doc_with_approver,
 	validate_active_employee,
 )
+from hrms.utils import get_employee_email
 
 
 class LeaveDayBlockedError(frappe.ValidationError):
@@ -501,8 +502,9 @@ class LeaveApplication(Document):
 			self.half_day_date = None
 
 	def notify_employee(self):
-		employee = frappe.get_doc("Employee", self.employee)
-		if not employee.user_id:
+		employee_email = get_employee_email(self.employee)
+
+		if not employee_email:
 			return
 
 		parent_doc = frappe.get_doc("Leave Application", self.name)
@@ -519,7 +521,7 @@ class LeaveApplication(Document):
 			{
 				# for post in messages
 				"message": message,
-				"message_to": employee.user_id,
+				"message_to": employee_email,
 				# for email
 				"subject": email_template.subject,
 				"notify": "employee",

--- a/hrms/utils/__init__.py
+++ b/hrms/utils/__init__.py
@@ -32,3 +32,19 @@ def get_date_range(start_date: str, end_date: str) -> list[str]:
 	"""returns list of dates between start and end dates"""
 	no_of_days = date_diff(end_date, start_date) + 1
 	return [add_days(start_date, i) for i in range(no_of_days)]
+
+
+def get_employee_email(employee_id: str) -> str | None:
+	employee_emails = frappe.db.get_value(
+		"Employee",
+		employee_id,
+		["prefered_email", "user_id", "company_email", "personal_email"],
+		as_dict=True,
+	)
+
+	return (
+		employee_emails.prefered_email
+		or employee_emails.user_id
+		or employee_emails.company_email
+		or employee_emails.personal_email
+	)


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/644

**Before**: Leave notifications used to send emails on employee's `user_id`. This forces users to create user id for every employee.

**After**: Use prefered email field  (because that's what it's supposed to be used for) from the employee master for sending emails and use other fields as fallback emails

Marking this as a breaking change because `user_id` is not used as the first email field anymore and if prefered email is set in the employee, user id will not be considered.

https://github.com/frappe/hrms/wiki/Migration-Guide-to-Frappe-HR-nightly-version-(future-v15)-%5BWIP%5D#email-notifications-in-leave