### PR TITLE
feat: skip auto attendance on any validation error, log error and continue processing

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -37,8 +37,9 @@ class ShiftType(Document):
 		for key, group in itertools.groupby(logs, key=lambda x: (x["employee"], x["shift_start"])):
 			single_shift_logs = list(group)
 			attendance_date = single_shift_logs[0].shift_actual_start.date()
+			employee = key[0]
 
-			if not self.should_mark_attendance(key[0], attendance_date):
+			if not self.should_mark_attendance(employee, attendance_date):
 				continue
 
 			(


### PR DESCRIPTION
## Problem

Currently, auto attendance is skipped for duplicate/overlapping attendance records. However, if attendance marking fails due to some other validation error, the job completely fails and attendance is not processed for any employee.

eg: If some employee is marked as Inactive, the attendance marking job fails and attendance is not marked for anyone.

## Solution

Catch any validation error for attendance and skip attendance for all such records. Log errors in employee check-in and continue marking attendance for the remaining employees/logs.

<img width="1090" alt="image" src="https://github.com/frappe/hrms/assets/24353136/d2d876ac-a860-4a67-97ff-0efd051dcd4d">

`no-docs`: more of a backend change than a user-facing change so doesn't need docs IMO.