### PR TITLE
fix: round pro-rated leaves instead of using ceil for mid-joinees

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -3,7 +3,6 @@
 
 
 import json
-from math import ceil
 
 import frappe
 from frappe import _, bold
@@ -19,6 +18,7 @@ from frappe.utils import (
 	get_last_day,
 	get_link_to_form,
 	getdate,
+	rounded,
 )
 
 
@@ -260,7 +260,7 @@ def calculate_pro_rated_leaves(
 
 	if is_earned_leave:
 		return flt(leaves, precision)
-	return ceil(leaves)
+	return rounded(leaves)
 
 
 def is_earned_leave_applicable_for_current_month(date_of_joining, allocate_on_day):

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -5,7 +5,7 @@ import unittest
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import get_first_day, getdate
+from frappe.utils import add_months, get_first_day, getdate
 
 from hrms.hr.doctype.leave_application.test_leave_application import get_employee, get_leave_period
 from hrms.hr.doctype.leave_policy.test_leave_policy import create_leave_policy
@@ -33,11 +33,76 @@ class TestLeavePolicyAssignment(FrappeTestCase):
 
 	def test_grant_leaves(self):
 		leave_period = get_leave_period()
-		# allocation = 10
-		leave_policy = create_leave_policy()
+		leave_policy = create_leave_policy(annual_allocation=10)
 		leave_policy.submit()
 
 		self.employee.date_of_joining = get_first_day(leave_period.from_date)
+		self.employee.save()
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Leave Period",
+				"leave_policy": leave_policy.name,
+				"leave_period": leave_period.name,
+			}
+		)
+		assignments = create_assignment_for_multiple_employees([self.employee.name], data)
+		self.assertEqual(
+			frappe.db.get_value("Leave Policy Assignment", assignments[0], "leaves_allocated"),
+			1,
+		)
+
+		allocation = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignments[0]}, "name"
+		)
+
+		leave_alloc_doc = frappe.get_doc("Leave Allocation", allocation)
+
+		self.assertEqual(leave_alloc_doc.new_leaves_allocated, 10)
+		self.assertEqual(leave_alloc_doc.leave_type, "_Test Leave Type")
+		self.assertEqual(getdate(leave_alloc_doc.from_date), getdate(leave_period.from_date))
+		self.assertEqual(getdate(leave_alloc_doc.to_date), getdate(leave_period.to_date))
+		self.assertEqual(leave_alloc_doc.leave_policy, leave_policy.name)
+		self.assertEqual(leave_alloc_doc.leave_policy_assignment, assignments[0])
+
+	def test_allow_to_grant_all_leave_after_cancellation_of_every_leave_allocation(self):
+		leave_period = get_leave_period()
+		leave_policy = create_leave_policy(annual_allocation=10)
+		leave_policy.submit()
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Leave Period",
+				"leave_policy": leave_policy.name,
+				"leave_period": leave_period.name,
+			}
+		)
+		assignments = create_assignment_for_multiple_employees([self.employee.name], data)
+
+		# every leave is allocated no more leave can be granted now
+		self.assertEqual(
+			frappe.db.get_value("Leave Policy Assignment", assignments[0], "leaves_allocated"),
+			1,
+		)
+
+		allocation = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignments[0]}, "name"
+		)
+
+		leave_alloc_doc = frappe.get_doc("Leave Allocation", allocation)
+		leave_alloc_doc.cancel()
+		leave_alloc_doc.delete()
+		self.assertEqual(
+			frappe.db.get_value("Leave Policy Assignment", assignments[0], "leaves_allocated"),
+			0,
+		)
+
+	def test_pro_rated_leave_allocation(self):
+		leave_period = get_leave_period()
+		leave_policy = create_leave_policy(annual_allocation=12)
+		leave_policy.submit()
+
+		self.employee.date_of_joining = add_months(leave_period.from_date, 3)
 		self.employee.save()
 
 		data = {
@@ -45,69 +110,14 @@ class TestLeavePolicyAssignment(FrappeTestCase):
 			"leave_policy": leave_policy.name,
 			"leave_period": leave_period.name,
 		}
-		leave_policy_assignments = create_assignment_for_multiple_employees(
-			[self.employee.name], frappe._dict(data)
-		)
-		self.assertEqual(
-			frappe.db.get_value("Leave Policy Assignment", leave_policy_assignments[0], "leaves_allocated"),
-			1,
+		assignments = create_assignment_for_multiple_employees([self.employee.name], frappe._dict(data))
+
+		allocation = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignments[0]}, "new_leaves_allocated"
 		)
 
-		leave_allocation = frappe.get_list(
-			"Leave Allocation",
-			filters={
-				"employee": self.employee.name,
-				"leave_policy": leave_policy.name,
-				"leave_policy_assignment": leave_policy_assignments[0],
-				"docstatus": 1,
-			},
-		)[0]
-		leave_alloc_doc = frappe.get_doc("Leave Allocation", leave_allocation)
-
-		self.assertEqual(leave_alloc_doc.new_leaves_allocated, 10)
-		self.assertEqual(leave_alloc_doc.leave_type, "_Test Leave Type")
-		self.assertEqual(getdate(leave_alloc_doc.from_date), getdate(leave_period.from_date))
-		self.assertEqual(getdate(leave_alloc_doc.to_date), getdate(leave_period.to_date))
-		self.assertEqual(leave_alloc_doc.leave_policy, leave_policy.name)
-		self.assertEqual(leave_alloc_doc.leave_policy_assignment, leave_policy_assignments[0])
-
-	def test_allow_to_grant_all_leave_after_cancellation_of_every_leave_allocation(self):
-		leave_period = get_leave_period()
-		# create the leave policy with leave type "_Test Leave Type", allocation = 10
-		leave_policy = create_leave_policy()
-		leave_policy.submit()
-
-		data = {
-			"assignment_based_on": "Leave Period",
-			"leave_policy": leave_policy.name,
-			"leave_period": leave_period.name,
-		}
-		leave_policy_assignments = create_assignment_for_multiple_employees(
-			[self.employee.name], frappe._dict(data)
-		)
-
-		# every leave is allocated no more leave can be granted now
-		self.assertEqual(
-			frappe.db.get_value("Leave Policy Assignment", leave_policy_assignments[0], "leaves_allocated"),
-			1,
-		)
-		leave_allocation = frappe.get_list(
-			"Leave Allocation",
-			filters={
-				"employee": self.employee.name,
-				"leave_policy": leave_policy.name,
-				"leave_policy_assignment": leave_policy_assignments[0],
-				"docstatus": 1,
-			},
-		)[0]
-
-		leave_alloc_doc = frappe.get_doc("Leave Allocation", leave_allocation)
-		leave_alloc_doc.cancel()
-		leave_alloc_doc.delete()
-		self.assertEqual(
-			frappe.db.get_value("Leave Policy Assignment", leave_policy_assignments[0], "leaves_allocated"),
-			0,
-		)
+		# pro-rated leave allocation for 9 months
+		self.assertEqual(allocation, 9)
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)


### PR DESCRIPTION
## Problem

**Leave Period**: 01-01-2022 - 31-12-2022
**DOJ for employee**: 01-12-2022
**Annual leave allocation**: 12

As per the leave policy assignment of 12 annual leaves, the employee should get only 1 pro-rated leave for the month of December. But the employee gets 2 leaves instead.

<img width="1350" alt="image" src="https://github.com/frappe/hrms/assets/24353136/f2013f2e-332a-4411-bd2a-7277622e1594">

Here's the pro-rata calculation:

leaves = (actual_period / complete_period) * leaves
leaves = (31 / 365) * 12 = 0.08493150684 * 12 = 1.01917808208

And the pro-rated calculation returns ceil(pro rated leaves) = ceil(1.01917808208) = 2

## Fix

`ceil` doesn't make sense here since the employee ends up getting one additional leave for a minor decimal value.

Use `rounded` for fairer allocation with rounding up/down.

<img width="1350" alt="image" src="https://github.com/frappe/hrms/assets/24353136/7fe78999-1652-4ec5-b121-c4defe780b6d">


TODO (Feature): A better rounding mechanism for more control (maybe in v15):
- Do not round
- Conventional rounding (up or down) to the nearest day (1.2 -> 1, 1.5 -> 2) - followed right now
- Conventional rounding (up or down) to the nearest half day (1.2 -> 1.5, 1.6 -> 2)