### PR TITLE
fix(Salary Slip): handle line boundaries characters in formulae

### DIFF
--- a/hrms/payroll/utils.py
+++ b/hrms/payroll/utils.py
@@ -1,0 +1,26 @@
+# import frappe
+
+
+def sanitize_expression(string: str | None = None) -> str | None:
+	"""
+	Removes leading and trailing whitespace and merges multiline strings into a single line.
+
+	Args:
+	    string (str, None): The string expression to be sanitized. Defaults to None.
+
+	Returns:
+	    str or None: The sanitized string expression or None if the input string is None.
+
+	Example:
+	    expression = "\r\n    gross_pay > 10000\n    "
+	    sanitized_expr = sanitize_expression(expression)
+
+	"""
+
+	if not string:
+		return None
+
+	parts = string.strip().splitlines()
+	string = " ".join(parts)
+
+	return string


### PR DESCRIPTION

### Issue: The system not considering line boundaries character
Before evaluating formulas or conditions, the system use to replace newline character `\n` but its not considering `\r\n`.

To fix the issue, added a function to sanitise condition and formula string. The function uses `splitlines` method to remove all the line boundaries characters. 

ref: https://www.geeksforgeeks.org/python-string-splitlines-method/

![2023-07-04 12 30 35](https://github.com/frappe/erpnext/assets/3784093/74d00b4c-221a-4214-b711-eb73e4dac896)

