### PR TITLE
fix: skip absent marking for an Inactive employee

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -63,7 +63,7 @@ class ShiftType(Document):
 				self.name,
 			)
 
-		for employee in self.get_assigned_employee(self.process_attendance_after, True):
+		for employee in self.get_assigned_employees(self.process_attendance_after, True):
 			self.mark_absent_for_dates_with_no_attendance(employee)
 
 	def get_employee_checkins(self) -> list[dict]:
@@ -225,7 +225,7 @@ class ShiftType(Document):
 			)
 		).run(pluck=True)
 
-	def get_assigned_employee(self, from_date=None, consider_default_shift=False):
+	def get_assigned_employees(self, from_date=None, consider_default_shift=False):
 		filters = {"shift_type": self.name, "docstatus": "1", "status": "Active"}
 		if from_date:
 			filters["start_date"] = (">=", from_date)
@@ -234,9 +234,12 @@ class ShiftType(Document):
 
 		if consider_default_shift:
 			default_shift_employees = self.get_employees_with_default_shift(filters)
+			assigned_employees = set(assigned_employees + default_shift_employees)
 
-			return list(set(assigned_employees + default_shift_employees))
-		return assigned_employees
+		# exclude inactive employees
+		inactive_employees = frappe.db.get_all("Employee", {"status": "Inactive"}, pluck="name")
+
+		return set(assigned_employees) - set(inactive_employees)
 
 	def get_employees_with_default_shift(self, filters: dict) -> list:
 		default_shift_employees = frappe.get_all(

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -331,7 +331,7 @@ class TestShiftType(FrappeTestCase):
 		)
 		self.assertIsNone(attendance)
 
-	def test_skip_marking_absent_for_a_fallback_default_shift(self):
+	def test_skip_absent_marking_for_a_fallback_default_shift(self):
 		"""
 		Tests if an employee is not marked absent for default shift
 		when they have a valid shift assignment of another type.
@@ -365,6 +365,21 @@ class TestShiftType(FrappeTestCase):
 			"Attendance", {"employee": employee, "shift": assigned_shift.name}, "status"
 		)
 		self.assertEqual(attendance, "Present")
+
+	def test_skip_absent_marking_for_inactive_employee(self):
+		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
+
+		shift = setup_shift_type()
+		employee = make_employee("test_inactive_employee@example.com", company="_Test Company")
+		date = getdate()
+		make_shift_assignment(shift.name, employee, date)
+
+		# mark employee as Inactive
+		frappe.db.set_value("Employee", employee, "status", "Inactive")
+
+		shift.process_auto_attendance()
+		attendance = frappe.db.get_value("Attendance", {"employee": employee}, "status")
+		self.assertIsNone(attendance)
 
 	def test_get_start_and_end_dates(self):
 		date = getdate()


### PR DESCRIPTION
Extending https://github.com/frappe/hrms/pull/657

Job still fails while marking employees with no attendance as absent.