### PR TITLE
fix: Job Offer creation for Accepted Job Applicants only

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -26,7 +26,7 @@ frappe.ui.form.on("Job Applicant", {
 			}, __("Create"));
 		}
 
-		if (!frm.doc.__islocal) {
+		if (!frm.doc.__islocal && frm.doc.status == "Accepted") {
 			if (frm.doc.__onload && frm.doc.__onload.job_offer) {
 				$('[data-doctype="Employee Onboarding"]').find("button").show();
 				$('[data-doctype="Job Offer"]').find("button").hide();


### PR DESCRIPTION
Issue : Able to create Job Offer for Rejected Job Applicant

Condition added like Job Offer can only created from Accpeted Job Applicants

Before :
![Screenshot from 2023-07-13 14-57-28](https://github.com/frappe/hrms/assets/43608142/33298041-326f-4c55-96ec-1a825d6942d0)

After Fixes:
![Screenshot from 2023-07-13 14-57-05](https://github.com/frappe/hrms/assets/43608142/739c83bf-92d8-41ae-8ffc-a2bc8fe2d527)


closes #680 