### PR TITLE
fix: don't send interview feedback reminder for upcoming interviews

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -7,7 +7,7 @@ import datetime
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cstr, flt, get_datetime, get_link_to_form
+from frappe.utils import cstr, flt, get_datetime, get_link_to_form, getdate, today, get_time, now
 
 
 class DuplicateInterviewRoundError(frappe.ValidationError):
@@ -217,8 +217,9 @@ def send_daily_feedback_reminder():
 	interview_feedback_template = frappe.get_doc(
 		"Email Template", reminder_settings.feedback_reminder_notification_template
 	)
+
 	interviews = frappe.get_all(
-		"Interview", filters={"status": ["in", ["Under Review", "Pending"]], "docstatus": ["!=", 2]}
+		"Interview", filters={"status": ["in", ["Under Review", "Pending"]], "docstatus": ["!=", 2], "scheduled_on": [ ">=", getdate(today())], "to_time": [ ">", get_time(now())]}
 	)
 
 	for entry in interviews:

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -219,11 +219,12 @@ def send_daily_feedback_reminder():
 	)
 
 	interviews = frappe.get_all(
-		"Interview", filters={
+		"Interview", 
+		filters={
 			"status": "Under Review", 
 			"docstatus": ["!=", 2], 
 			"scheduled_on": ["<=", getdate()], 
-			"to_time": ["<=", now_time()],
+			"to_time": ["<=", nowtime()],
 		}
 	)
 

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -219,7 +219,12 @@ def send_daily_feedback_reminder():
 	)
 
 	interviews = frappe.get_all(
-		"Interview", filters={"status": "Under Review", "docstatus": ["!=", 2], "scheduled_on": [ "<=", getdate(today())], "to_time": [ ">", get_time(now())]}
+		"Interview", filters={
+			"status": "Under Review", 
+			"docstatus": ["!=", 2], 
+			"scheduled_on": ["<=", getdate()], 
+			"to_time": [ "<=", now_time()]
+		}
 	)
 
 	for entry in interviews:

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -219,7 +219,7 @@ def send_daily_feedback_reminder():
 	)
 
 	interviews = frappe.get_all(
-		"Interview", filters={"status": ["in", ["Under Review", "Pending"]], "docstatus": ["!=", 2], "scheduled_on": [ ">=", getdate(today())], "to_time": [ ">", get_time(now())]}
+		"Interview", filters={"status": "Under Review", "docstatus": ["!=", 2], "scheduled_on": [ "<=", getdate(today())], "to_time": [ ">", get_time(now())]}
 	)
 
 	for entry in interviews:

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -223,7 +223,7 @@ def send_daily_feedback_reminder():
 			"status": "Under Review", 
 			"docstatus": ["!=", 2], 
 			"scheduled_on": ["<=", getdate()], 
-			"to_time": [ "<=", now_time()]
+			"to_time": ["<=", now_time()],
 		}
 	)
 

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -219,13 +219,13 @@ def send_daily_feedback_reminder():
 	)
 
 	interviews = frappe.get_all(
-		"Interview", 
+		"Interview",
 		filters={
-			"status": "Under Review", 
-			"docstatus": ["!=", 2], 
-			"scheduled_on": ["<=", getdate()], 
+			"status": "Under Review",
+			"docstatus": ["!=", 2],
+			"scheduled_on": ["<=", getdate()],
 			"to_time": ["<=", nowtime()],
-		}
+		},
 	)
 
 	for entry in interviews:

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -7,7 +7,7 @@ import datetime
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cstr, flt, get_datetime, get_link_to_form, getdate, today, get_time, now
+from frappe.utils import cstr, flt, get_datetime, get_link_to_form, getdate, nowtime
 
 
 class DuplicateInterviewRoundError(frappe.ValidationError):

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -76,7 +76,9 @@ class TestInterview(unittest.TestCase):
 
 		job_applicant = create_job_applicant()
 		scheduled_on = add_days(getdate(), -4)
-		create_interview_and_dependencies(job_applicant.name, scheduled_on=scheduled_on)
+		interview = create_interview_and_dependencies(
+			job_applicant.name, scheduled_on=scheduled_on, status="Under Review"
+		)
 
 		frappe.db.sql("DELETE FROM `tabEmail Queue`")
 		send_daily_feedback_reminder()
@@ -106,7 +108,13 @@ class TestInterview(unittest.TestCase):
 
 
 def create_interview_and_dependencies(
-	job_applicant, scheduled_on=None, from_time=None, to_time=None, designation=None, save=1
+	job_applicant,
+	scheduled_on=None,
+	from_time=None,
+	to_time=None,
+	designation=None,
+	status=None,
+	save=True,
 ):
 	if designation:
 		designation = create_designation(designation_name="_Test_Sales_manager").name
@@ -127,6 +135,9 @@ def create_interview_and_dependencies(
 
 	interview.append("interview_details", {"interviewer": interviewer_1.name})
 	interview.append("interview_details", {"interviewer": interviewer_2.name})
+
+	if status:
+		interview.status = status
 
 	if save:
 		interview.save()


### PR DESCRIPTION
Issue : Getting Interview Feedback Reminder for upcomming Interviews

These following emails are raised against upcomming interviews.
![Screenshot from 2023-07-14 09-18-15](https://github.com/frappe/hrms/assets/43608142/1aa37f27-522d-4f7c-8c17-3dd2829e9bfb)

Condition added like sending feedback reminder for completed interviews only.

fixes #687 