### PR TITLE
chore: drop setup.py and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-# frappe -- https://github.com/frappe/frappe is installed via 'bench init'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from setuptools import setup
-
-name = "hrms"
-
-setup()


### PR DESCRIPTION
https://peps.python.org/pep-0517/

`pyproject.toml` is the new standard, no need to have fallbacks for v15. Frappe/ERPNext dropped them already.