### PR TITLE
 ci: dont run tests on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [develop, version-14-hotfix, version-14]
-    paths-ignore:
-      - "**.css"
-      - "**.js"
-      - "**.md"
-      - "**.html"
-      - "**.csv"
-
   pull_request:
     paths-ignore:
       - "**.css"


### PR DESCRIPTION
Rationale:
- PRs already run test by merging PR in develop branch (this is how
  github works)
- Running tests on practically identical code JUST after merge rarely
  helps. This has found failures from conflicting changes maybe once or
  twice a year. That much CO2 is not justified.
- It already runs once a day so you have good enough granuarilty to
  bisect if required.
