### PR TITLE
fix: mark employees absent 1 day after `actual_end` time instead of `actual_start`

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -193,7 +193,7 @@ class ShiftType(Document):
 
 		shift_details = get_shift_details(self.name, get_datetime(self.last_sync_of_checkin))
 		last_shift_time = (
-			shift_details.actual_start if shift_details else get_datetime(self.last_sync_of_checkin)
+			shift_details.actual_end if shift_details else get_datetime(self.last_sync_of_checkin)
 		)
 
 		# check if shift is found for 1 day before the last sync of checkin

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -199,7 +199,7 @@ class ShiftType(Document):
 		# check if shift is found for 1 day before the last sync of checkin
 		# absentees are auto-marked 1 day after the shift to wait for any manual attendance records
 		prev_shift = get_employee_shift(employee, last_shift_time - timedelta(days=1), True, "reverse")
-		if prev_shift:
+		if prev_shift and prev_shift.name == self.name:
 			end_date = (
 				min(prev_shift.start_datetime.date(), relieving_date)
 				if relieving_date

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -309,6 +309,51 @@ class TestShiftType(FrappeTestCase):
 		)
 		self.assertEqual(attendance, "Absent")
 
+	def test_do_not_mark_absent_before_shift_actual_end_time(self):
+		"""
+		Tests employee is not marked absent for a shift spanning 2 days
+		before its actual end time
+		"""
+		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
+
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		curr_date = getdate()
+
+		# this shift's valid checkout period (+60 mins) will be till 00:30:00 today, so it goes beyond a day
+		shift_type = setup_shift_type(
+			shift_type="Test Absent", start_time="15:00:00", end_time="23:30:00"
+		)
+		shift_type.last_sync_of_checkin = datetime.combine(curr_date, get_time("00:30:00"))
+		shift_type.save()
+
+		# assign shift for yesterday, actual end time is today at 00:30:00
+		prev_date = add_days(getdate(), -1)
+		make_shift_assignment(shift_type.name, employee, prev_date)
+
+		# make logs
+		timestamp = datetime.combine(prev_date, get_time("15:00:00"))
+		log = make_checkin(employee, timestamp)
+		timestamp = datetime.combine(prev_date, get_time("23:30:00"))
+		log = make_checkin(employee, timestamp)
+
+		# last sync of checkin is 00:30:00 and the checkin logs are not applicable for attendance yet
+		# so it should not mark the employee as absent either
+		shift_type.process_auto_attendance()
+		attendance = frappe.db.get_value(
+			"Attendance", {"attendance_date": prev_date, "employee": employee}, "status"
+		)
+		self.assertIsNone(attendance)
+
+		# update last sync
+		shift_type.last_sync_of_checkin = datetime.combine(curr_date, get_time("01:00:00"))
+		shift_type.save()
+		shift_type.process_auto_attendance()
+		# employee marked present considering checkins
+		attendance = frappe.db.get_value(
+			"Attendance", {"attendance_date": prev_date, "employee": employee}, "status"
+		)
+		self.assertEquals(attendance, "Present")
+
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_skip_marking_absent_on_a_holiday(self):
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")


### PR DESCRIPTION
## Problem 1

Afternoon shift:
15:00 - 23:30
But the actual check-in checkout valid period is: 13:00 - 01:30 (the next day)

<img width="1307" alt="image" src="https://github.com/frappe/hrms/assets/24353136/e5ab7bac-44d7-4fab-9485-f9dad6215d3c">

Employee has shift assignment on 18th July for afternoon shifts and valid check-ins within shift period, with the correct shift set:

<img width="1307" alt="image" src="https://github.com/frappe/hrms/assets/24353136/8d7380f5-9ef2-4767-8735-7fabc56b8db3">

Last sync of check-in set to: 19-07-2023 01:30:00

Auto attendance job marks employee as absent inspite of having correct checkins:

<img width="1307" alt="image" src="https://github.com/frappe/hrms/assets/24353136/b7731a4f-b0f6-4440-839e-367ff8e9455d">

<img width="1063" alt="image" src="https://github.com/frappe/hrms/assets/24353136/5b7ef1a9-585c-457f-8728-d0a44dce47f4">

## Solution 1

Checkin logs having actual end time < last sync of checkin are considered for attendance. Since the actual end time for these logs is 19-07-2023 01:30 and last sync (01:30) has not passed this time yet, these logs aren't considered for attendance.

However, after all the logs are processed, the auto-attendance job marks employees with missing attendance records as Absent. This job was considering valid shifts up to 1 day prior based on the **Actual Start** time and marking these employees as absent. 

However, for shifts spanning across 2 days, actual start and end times are on different days. So this incorrectly marks the employee as absent. Consider **Actual End** time instead of start for marking employees as absent only after their check-in logs have been entirely processed.

## Problem 2

The employee has a shift assigned on the 18th and a different shift type set as Default Shift

<img width="1311" alt="image" src="https://github.com/frappe/hrms/assets/24353136/028900d1-c7c9-4bc0-a644-c0417bce31f2">

While marking absent  at 19-07-2023 01:30, when the job tries to find the `prev_shift` (1 day prior) it finds the Default Shift and considers end date based on it:

https://github.com/frappe/hrms/blob/f350529ea383eb6fe48bce9251cb64ebdbb6078d/hrms/hr/doctype/shift_type/shift_type.py#L199-L207

This part never checks whether the `prev_shift` found is actually the same as the shift for which attendance is being marked. So even after adding solution 1, it marks the employee as absent on the 18th by showing it as attendance for the "Afternoon shift". However, it's actually for the General Shift. 

## Solution 2

Explicitly check if the `prev_shift` found is the same as the shift type for which attendance is being marked to avoid this conflict.

## After

No attendance record created for 19-07-2023 01:30 
Employee marked present at 01:31 considering all relevant logs, after shift is over:

<img width="1311" alt="image" src="https://github.com/frappe/hrms/assets/24353136/fc7c6006-a0ae-4368-8c23-840d5b04cd8f">
