### PR TITLE
fix: Make result required in interview feedback

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -109,7 +109,8 @@ frappe.ui.form.on('Interview', {
 					fieldname: 'result',
 					fieldtype: 'Select',
 					options: ['', 'Cleared', 'Rejected'],
-					label: __('Result')
+					label: __('Result'),
+					reqd: 1,
 				},
 				{
 					fieldname: 'feedback',


### PR DESCRIPTION

In the `DocType:Interview`, upon clicking the button `Submit Feedback` the pop-up appears to add the feedback for the particular interview. While adding the skill assessment, if user forgot to select `result` option, error is thrown `Missing value for interview feedback: Result`.

**Screenshots**
<img width="800" alt="Screenshot 2023-07-21 at 4 04 22 PM" src="https://github.com/frappe/hrms/assets/28840468/edfa309b-3405-4ce7-bcec-7daacbbe65a0">

<img width="577" alt="Screenshot 2023-07-21 at 4 03 58 PM" src="https://github.com/frappe/hrms/assets/28840468/bf4a3870-4a8c-4fde-9f12-ea6e6711261a">

**Proposed solution**:
- Make result field required.

Issue : #718 