### PR TITLE
Hide route field in `Job Opening`

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -101,7 +101,8 @@
    "fieldname": "route",
    "fieldtype": "Data",
    "label": "Route",
-   "unique": 1
+   "unique": 1,
+   "hidden":1
   },
   {
    "description": "Job profile, qualifications required etc.",


### PR DESCRIPTION
As `route` field is unique in the `DocType:Job Opening`, and it is generated based on `Job Title`, it can be misleading to display the field to the user.

Issue: https://github.com/frappe/hrms/issues/260

**Solution**
- Hide the `route` field.