### PR TITLE
fix(UX): enable Variable Based on Taxable Salary if Is Income Tax Component is enabled

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.js
+++ b/hrms/payroll/doctype/salary_component/salary_component.js
@@ -38,6 +38,11 @@ frappe.ui.form.on('Salary Component', {
 			frm.set_value("is_flexible_benefit", 0);
 		}
 	},
+	is_income_tax_component: function(frm) {
+		if (cint(frm.doc.is_income_tax_component)) {
+			frm.set_value("variable_based_on_taxable_salary", 1);
+		}
+	},
 	variable_based_on_taxable_salary: function(frm) {
 		if(frm.doc.variable_based_on_taxable_salary){
 			set_value_for_condition_and_formula(frm);

--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -115,7 +115,7 @@
   },
   {
    "default": "0",
-   "description": "If selected, the value specified or calculated in this component will not contribute to the earnings or deductions. However, it's value can be referenced by other components that can be added or deducted. ",
+   "description": "If enabled, the value specified or calculated in this component will not contribute to the earnings or deductions. However, it's value can be referenced by other components that can be added or deducted. ",
    "fieldname": "statistical_component",
    "fieldtype": "Check",
    "label": "Statistical Component"
@@ -160,6 +160,7 @@
   {
    "default": "0",
    "depends_on": "eval:doc.type == \"Deduction\"",
+   "description": "If enabled, the component will be considered as a tax component and the amount will be auto-calculated as per the configured income tax slabs",
    "fieldname": "variable_based_on_taxable_salary",
    "fieldtype": "Check",
    "label": "Variable Based On Taxable Salary",
@@ -232,6 +233,7 @@
   {
    "default": "0",
    "depends_on": "eval:doc.type == \"Deduction\"",
+   "description": "If enabled, the component is considered in the Income Tax Deductions report",
    "fieldname": "is_income_tax_component",
    "fieldtype": "Check",
    "label": "Is Income Tax Component"
@@ -255,7 +257,7 @@
   {
    "default": "1",
    "depends_on": "eval:!doc.statistical_component",
-   "description": "If checked, the component will not be displayed in the salary slip if the amount is zero",
+   "description": "If enabled, the component will not be displayed in the salary slip if the amount is zero",
    "fieldname": "remove_if_zero_valued",
    "fieldtype": "Check",
    "label": "Remove if Zero Valued"
@@ -264,7 +266,7 @@
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-06-21 15:11:53.582800",
+ "modified": "2023-07-31 13:35:37.413696",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",

--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -233,7 +233,7 @@
   {
    "default": "0",
    "depends_on": "eval:doc.type == \"Deduction\"",
-   "description": "If enabled, the component is considered in the Income Tax Deductions report",
+   "description": "If enabled, the component will be considered in the Income Tax Deductions report",
    "fieldname": "is_income_tax_component",
    "fieldtype": "Check",
    "label": "Is Income Tax Component"

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -9,6 +9,11 @@ from frappe.model.naming import append_number_if_name_exists
 class SalaryComponent(Document):
 	def validate(self):
 		self.validate_abbr()
+		self.set_tax_component()
+
+	def set_tax_component(self):
+		if self.is_income_tax_component:
+			self.variable_based_on_taxable_salary = 1
 
 	def on_update(self):
 		self.invalidate_cache()


### PR DESCRIPTION
**Problem**

Users enable **Is Income Tax Component** but miss enabling **Variable Based On Taxable Salary** which actually calculates the tax and sets it. 

<img width="1329" alt="image" src="https://github.com/frappe/hrms/assets/24353136/22b233b9-3c54-40cb-8c65-b1ad6a8932ce">

This Is Income Tax Component checkbox is not used anywhere in the code, except for fetching income tax components in **Income Tax Deductions** report. Other than that it has no effect. 

**Fix**:

Enable Variable Based on Taxable Salary if Is Income Tax Component is checked.
Also added descriptions to tax fields

<img width="1329" alt="image" src="https://github.com/frappe/hrms/assets/24353136/2d68d750-3ced-46c4-88fd-4ec75d3b3ff5">
