### PR TITLE
fix: don't overwrite the default date format

### DIFF
--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -613,8 +613,6 @@ def set_single_defaults():
 			except frappe.ValidationError:
 				pass
 
-	frappe.db.set_default("date_format", "dd-mm-yyyy")
-
 
 def get_post_install_patches():
 	return (


### PR DESCRIPTION
Frappe HR sets the default date format directly, circumventing the **System Settings**. This way, in **System Settings** it may be set to "dd.mm.yyyy" while the default used is "dd-mm-yyyy"