### PR TITLE
refactor(UX): Leave Application form enhancements

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -104,11 +104,15 @@ frappe.ui.form.on("Leave Application", {
 			frm.set_intro(__("Fill the form and save it"));
 		}
 
-		if (!frm.doc.employee && frappe.defaults.get_user_permissions()) {
-			const perm = frappe.defaults.get_user_permissions();
-			if (perm && perm["Employee"]) {
-				frm.set_value("employee", perm["Employee"].map(perm_doc => perm_doc.doc)[0]);
-			}
+		frm.trigger("set_employee");
+	},
+
+	async set_employee(frm) {
+		if (frm.doc.employee) return;
+
+		const employee = await hrms.get_current_employee(frm);
+		if (employee) {
+			frm.set_value("employee", employee);
 		}
 	},
 

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -1,9 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch('employee', 'employee_name', 'employee_name');
-cur_frm.add_fetch('employee', 'company', 'company');
-
 frappe.ui.form.on("Leave Application", {
 	setup: function(frm) {
 		frm.set_query("leave_approver", function() {
@@ -18,6 +15,7 @@ frappe.ui.form.on("Leave Application", {
 
 		frm.set_query("employee", erpnext.queries.employee);
 	},
+
 	onload: function(frm) {
 		// Ignore cancellation of doctype on cancel all.
 		frm.ignore_doctypes_on_cancel_all = ["Leave Ledger Entry"];
@@ -41,17 +39,18 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	validate: function(frm) {
-		if (frm.doc.from_date == frm.doc.to_date && frm.doc.half_day == 1) {
+		if (frm.doc.from_date === frm.doc.to_date && cint(frm.doc.half_day)) {
 			frm.doc.half_day_date = frm.doc.from_date;
-		} else if (frm.doc.half_day == 0) {
+		} else if (frm.doc.half_day === 0) {
 			frm.doc.half_day_date = "";
 		}
-		frm.toggle_reqd("half_day_date", frm.doc.half_day == 1);
+		frm.toggle_reqd("half_day_date", cint(frm.doc.half_day));
 	},
 
 	make_dashboard: function(frm) {
-		var leave_details;
+		let leave_details;
 		let lwps;
+
 		if (frm.doc.employee) {
 			frappe.call({
 				method: "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
@@ -61,32 +60,34 @@ frappe.ui.form.on("Leave Application", {
 					date: frm.doc.from_date || frm.doc.posting_date
 				},
 				callback: function(r) {
-					if (!r.exc && r.message['leave_allocation']) {
-						leave_details = r.message['leave_allocation'];
+					if (!r.exc && r.message["leave_allocation"]) {
+						leave_details = r.message["leave_allocation"];
 					}
-					if (!r.exc && r.message['leave_approver']) {
-						frm.set_value('leave_approver', r.message['leave_approver']);
+					if (!r.exc && r.message["leave_approver"]) {
+						frm.set_value("leave_approver", r.message["leave_approver"]);
 					}
 					lwps = r.message["lwps"];
 				}
 			});
+
 			$("div").remove(".form-dashboard-section.custom");
+
 			frm.dashboard.add_section(
-				frappe.render_template('leave_application_dashboard', {
+				frappe.render_template("leave_application_dashboard", {
 					data: leave_details
 				}),
 				__("Allocated Leaves")
 			);
 			frm.dashboard.show();
-			let allowed_leave_types = Object.keys(leave_details);
 
-			// lwps should be allowed, lwps don't have any allocation
+			let allowed_leave_types = Object.keys(leave_details);
+			// lwps should be allowed for selection as they don't have any allocation
 			allowed_leave_types = allowed_leave_types.concat(lwps);
 
-			frm.set_query('leave_type', function() {
+			frm.set_query("leave_type", function() {
 				return {
 					filters: [
-						['leave_type_name', 'in', allowed_leave_types]
+						["leave_type_name", "in", allowed_leave_types]
 					]
 				};
 			});
@@ -97,15 +98,16 @@ frappe.ui.form.on("Leave Application", {
 		if (frm.is_new()) {
 			frm.trigger("calculate_total_days");
 		}
-		cur_frm.set_intro("");
+
+		frm.set_intro("");
 		if (frm.doc.__islocal && !in_list(frappe.user_roles, "Employee")) {
 			frm.set_intro(__("Fill the form and save it"));
 		}
 
 		if (!frm.doc.employee && frappe.defaults.get_user_permissions()) {
 			const perm = frappe.defaults.get_user_permissions();
-			if (perm && perm['Employee']) {
-				frm.set_value('employee', perm['Employee'].map(perm_doc => perm_doc.doc)[0]);
+			if (perm && perm["Employee"]) {
+				frm.set_value("employee", perm["Employee"].map(perm_doc => perm_doc.doc)[0]);
 			}
 		}
 	},
@@ -156,8 +158,8 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	half_day_datepicker: function(frm) {
-		frm.set_value('half_day_date', '');
-		var half_day_datepicker = frm.fields_dict.half_day_date.datepicker;
+		frm.set_value("half_day_date", "");
+		let half_day_datepicker = frm.fields_dict.half_day_date.datepicker;
 		half_day_datepicker.update({
 			minDate: frappe.datetime.str_to_obj(frm.doc.from_date),
 			maxDate: frappe.datetime.str_to_obj(frm.doc.to_date)
@@ -177,9 +179,9 @@ frappe.ui.form.on("Leave Application", {
 				},
 				callback: function (r) {
 					if (!r.exc && r.message) {
-						frm.set_value('leave_balance', r.message);
+						frm.set_value("leave_balance", r.message);
 					} else {
-						frm.set_value('leave_balance', "0");
+						frm.set_value("leave_balance", "0");
 					}
 				}
 			});
@@ -188,18 +190,17 @@ frappe.ui.form.on("Leave Application", {
 
 	calculate_total_days: function(frm) {
 		if (frm.doc.from_date && frm.doc.to_date && frm.doc.employee && frm.doc.leave_type) {
-
-			var from_date = Date.parse(frm.doc.from_date);
-			var to_date = Date.parse(frm.doc.to_date);
+			let from_date = Date.parse(frm.doc.from_date);
+			let to_date = Date.parse(frm.doc.to_date);
 
 			if (to_date < from_date) {
 				frappe.msgprint(__("To Date cannot be less than From Date"));
-				frm.set_value('to_date', '');
+				frm.set_value("to_date", "");
 				return;
 			}
 			// server call is done to include holidays in leave days calculations
 			return frappe.call({
-				method: 'hrms.hr.doctype.leave_application.leave_application.get_number_of_leave_days',
+				method: "hrms.hr.doctype.leave_application.leave_application.get_number_of_leave_days",
 				args: {
 					"employee": frm.doc.employee,
 					"leave_type": frm.doc.leave_type,
@@ -210,7 +211,7 @@ frappe.ui.form.on("Leave Application", {
 				},
 				callback: function(r) {
 					if (r && r.message) {
-						frm.set_value('total_leave_days', r.message);
+						frm.set_value("total_leave_days", r.message);
 						frm.trigger("get_leave_balance");
 					}
 				}
@@ -220,15 +221,14 @@ frappe.ui.form.on("Leave Application", {
 
 	set_leave_approver: function(frm) {
 		if (frm.doc.employee) {
-			// server call is done to include holidays in leave days calculations
 			return frappe.call({
-				method: 'hrms.hr.doctype.leave_application.leave_application.get_leave_approver',
+				method: "hrms.hr.doctype.leave_application.leave_application.get_leave_approver",
 				args: {
 					"employee": frm.doc.employee,
 				},
 				callback: function(r) {
 					if (r && r.message) {
-						frm.set_value('leave_approver', r.message);
+						frm.set_value("leave_approver", r.message);
 					}
 				}
 			});

--- a/hrms/hr/doctype/leave_application/leave_application.json
+++ b/hrms/hr/doctype/leave_application/leave_application.json
@@ -60,6 +60,7 @@
    "search_index": 1
   },
   {
+   "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -254,7 +255,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2023-08-01 22:43:53.067995",
+ "modified": "2023-08-01 22:45:57.851854",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Application",

--- a/hrms/hr/doctype/leave_application/leave_application.json
+++ b/hrms/hr/doctype/leave_application/leave_application.json
@@ -13,8 +13,8 @@
   "employee_name",
   "column_break_4",
   "leave_type",
+  "company",
   "department",
-  "leave_balance",
   "section_break_5",
   "from_date",
   "to_date",
@@ -23,18 +23,18 @@
   "total_leave_days",
   "column_break1",
   "description",
+  "leave_balance",
   "section_break_7",
   "leave_approver",
   "leave_approver_name",
-  "column_break_18",
-  "status",
-  "salary_slip",
-  "sb10",
-  "posting_date",
   "follow_via_email",
+  "column_break_18",
+  "posting_date",
+  "status",
+  "sb_other_details",
+  "salary_slip",
   "color",
   "column_break_17",
-  "company",
   "letter_head",
   "amended_from"
  ],
@@ -97,7 +97,8 @@
   },
   {
    "fieldname": "section_break_5",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Dates & Reason"
   },
   {
    "fieldname": "from_date",
@@ -148,7 +149,8 @@
   },
   {
    "fieldname": "section_break_7",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Approval"
   },
   {
    "fieldname": "leave_approver",
@@ -176,10 +178,6 @@
    "options": "Open\nApproved\nRejected\nCancelled",
    "permlevel": 1,
    "reqd": 1
-  },
-  {
-   "fieldname": "sb10",
-   "fieldtype": "Section Break"
   },
   {
    "default": "Today",
@@ -243,6 +241,12 @@
    "options": "Leave Application",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "sb_other_details",
+   "fieldtype": "Section Break",
+   "label": "Other Details"
   }
  ],
  "icon": "fa fa-calendar",
@@ -250,10 +254,11 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2020-05-18 13:00:41.577327",
+ "modified": "2023-08-01 22:43:53.067995",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Application",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -333,6 +338,7 @@
  "search_fields": "employee,employee_name,leave_type,from_date,to_date,total_leave_days",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "timeline_field": "employee",
  "title_field": "employee_name"
 }

--- a/hrms/hr/doctype/leave_application/leave_application_dashboard.html
+++ b/hrms/hr/doctype/leave_application/leave_application_dashboard.html
@@ -4,22 +4,23 @@
 	<thead>
 		<tr>
 			<th style="width: 16%">{{ __("Leave Type") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Total Allocated Leave(s)") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Expired Leave(s)") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Used Leave(s)") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Leave(s) Pending Approval") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Available Leave(s)") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Total Allocated Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Expired Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Used Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Leaves Pending Approval") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Available Leaves") }}</th>
 		</tr>
 	</thead>
 	<tbody>
 		{% for(const [key, value] of Object.entries(data)) { %}
+			{% let color = cint(value["remaining_leaves"]) > 0 ? "green" : "red" %}
 			<tr>
 				<td> {%= key %} </td>
 				<td class="text-right"> {%= value["total_leaves"] %} </td>
 				<td class="text-right"> {%= value["expired_leaves"] %} </td>
 				<td class="text-right"> {%= value["leaves_taken"] %} </td>
 				<td class="text-right"> {%= value["leaves_pending_approval"] %} </td>
-				<td class="text-right"> {%= value["remaining_leaves"] %} </td>
+				<td class="text-right" style="color: {{ color }}"> {%= value["remaining_leaves"] %} </td>
 			</tr>
 		{% } %}
 	</tbody>

--- a/hrms/public/js/utils.js
+++ b/hrms/public/js/utils.js
@@ -16,5 +16,13 @@ $.extend(hrms, {
 		if (cint(frm.doc.salary_slip_based_on_timesheet)) {
 			frm.set_value("payroll_frequency", "");
 		}
-	}
+	},
+
+	get_current_employee: async (frm) => {
+		const employee = (
+			await frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+		)?.message?.name;
+
+		return employee;
+	},
 })


### PR DESCRIPTION
## Before:

- Fields all over the place
- Sections don't have labels

<details>
<summary>Screenshot (Before)</summary>

![leave-application-before](https://github.com/frappe/hrms/assets/24353136/006b55ab-ad97-466c-8d25-d9d4c8099829)


</details>

## After:

- Added labels to sections
- Moved less-used fields to the bottom in a collapsed section: Salary Slip, Color, Letter Head
- Moved company field up, since it is fetched from Employee
- Moved **Leave Balance Before Application** in the dates section
- Follow via Email, Posting Date, and Status are meant for the approver so kept them together in the Approval section.

![leave-application-cleaned](https://github.com/frappe/hrms/assets/24353136/ee49758d-d280-4b4b-9bc5-4815943751e8)

- If an employee is filling up their own leave application, they have to select the employee. Unnecessary step. The form now fetches the session user's linked employee.
- Cleaned up `leave_application.js`
- Color code leave balances to reduce cognitive load:

<img width="1018" alt="image" src="https://github.com/frappe/hrms/assets/24353136/16a4f95a-8cec-4d66-8e83-3c8481bf56d7">

