### PR TITLE
feat: earned leave allocation on next month beginning

### DIFF
--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -218,13 +218,13 @@
    "fieldname": "allocate_on_day",
    "fieldtype": "Select",
    "label": "Allocate on Day",
-   "options": "First Day\nLast Day\nDate of Joining"
+   "options": "First Day\nLast Day\nDate of Joining\nFirst Day(Next Month)"
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2023-05-26 14:15:29.695487",
+ "modified": "2023-08-11 09:31:06.255340",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -499,7 +499,12 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 		"First Day": get_first_day(today),
 		"Last Day": get_last_day(today),
 		"Date of Joining": from_date,
+		"First Day(Next Month)": add_days(get_last_day(add_days(today, -1)), 1)
 	}[allocate_on_day]
+
+	if allocate_on_day == "First Day(Next Month)":
+		if expected_date.month != today.month:
+			return False
 
 	if expected_date.day == today.day:
 		if frequency == "Monthly":

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -499,7 +499,7 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 		"First Day": get_first_day(today),
 		"Last Day": get_last_day(today),
 		"Date of Joining": from_date,
-		"First Day(Next Month)": add_days(get_last_day(add_days(today, -1)), 1)
+		"First Day(Next Month)": add_days(get_last_day(add_days(today, -1)), 1),
 	}[allocate_on_day]
 
 	if allocate_on_day == "First Day(Next Month)":


### PR DESCRIPTION
![image](https://github.com/frappe/hrms/assets/52111700/80d4a029-2fa1-4551-82ab-82c413ee631c)

This PR gives users the ability to allocated earned leave of last month on the beginning of next month.