### PR TITLE
fix(Payroll JE): link employee & advance reference in advance return entries

### DIFF
--- a/hrms/payroll/doctype/salary_component/test_salary_component.py
+++ b/hrms/payroll/doctype/salary_component/test_salary_component.py
@@ -4,20 +4,20 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-# test_records = frappe.get_test_records('Salary Component')
-
 
 class TestSalaryComponent(FrappeTestCase):
 	pass
 
 
 def create_salary_component(component_name, **args):
-	if not frappe.db.exists("Salary Component", component_name):
-		frappe.get_doc(
-			{
-				"doctype": "Salary Component",
-				"salary_component": component_name,
-				"type": args.get("type") or "Earning",
-				"is_tax_applicable": args.get("is_tax_applicable") or 1,
-			}
-		).insert()
+	if frappe.db.exists("Salary Component", component_name):
+		return frappe.get_doc("Salary Component", component_name)
+
+	return frappe.get_doc(
+		{
+			"doctype": "Salary Component",
+			"salary_component": component_name,
+			"type": args.get("type") or "Earning",
+			"is_tax_applicable": args.get("is_tax_applicable") or 1,
+		}
+	).insert()


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/11

## Before

<img width="1344" alt="advance-salary-before" src="https://github.com/frappe/hrms/assets/24353136/0c648974-10f2-4fab-99d2-cc0e83fabe90">

## After

<img width="1344" alt="advance-salary-after" src="https://github.com/frappe/hrms/assets/24353136/87bda996-df7c-4ef8-96e5-ddf8c0fef965">

<img width="1344" alt="reference" src="https://github.com/frappe/hrms/assets/24353136/37b1a09c-090b-4a3d-af7a-048bcfd70e1e">

P.S: Will cover refactoring in a separate PR: lists being passed around in functions, too many args, unreadable `payable_amount` updates, etc.

- [x] Link Employee Advance doc
- [x] Test