### PR TITLE
fix(Shift Attendance): rename enable_grace_period fields as enable_marking

### DIFF
--- a/hrms/hr/report/shift_attendance/shift_attendance.py
+++ b/hrms/hr/report/shift_attendance/shift_attendance.py
@@ -238,9 +238,9 @@ def get_query(filters):
 			checkin.shift_end,
 			checkin.shift_actual_start,
 			checkin.shift_actual_end,
-			shift_type.enable_entry_grace_period,
+			shift_type.enable_late_entry_marking,
 			shift_type.late_entry_grace_period,
-			shift_type.enable_exit_grace_period,
+			shift_type.enable_early_exit_marking,
 			shift_type.early_exit_grace_period,
 		)
 		.where(attendance.docstatus == 1)
@@ -306,7 +306,7 @@ def convert_datetime_to_time_for_same_date(start, end):
 def update_late_entry(entry, consider_grace_period):
 	if consider_grace_period:
 		if entry.late_entry:
-			entry_grace_period = entry.late_entry_grace_period if entry.enable_entry_grace_period else 0
+			entry_grace_period = entry.late_entry_grace_period if entry.enable_late_entry_marking else 0
 			start_time = entry.shift_start + timedelta(minutes=entry_grace_period)
 			entry.late_entry_hrs = entry.in_time - start_time
 	elif entry.in_time and entry.in_time > entry.shift_start:
@@ -319,7 +319,7 @@ def update_late_entry(entry, consider_grace_period):
 def update_early_exit(entry, consider_grace_period):
 	if consider_grace_period:
 		if entry.early_exit:
-			exit_grace_period = entry.early_exit_grace_period if entry.enable_exit_grace_period else 0
+			exit_grace_period = entry.early_exit_grace_period if entry.enable_early_exit_marking else 0
 			end_time = entry.shift_end - timedelta(minutes=exit_grace_period)
 			entry.early_exit_hrs = end_time - entry.out_time
 	elif entry.out_time and entry.out_time < entry.shift_end:

--- a/hrms/hr/report/shift_attendance/test_shift_attendance.py
+++ b/hrms/hr/report/shift_attendance/test_shift_attendance.py
@@ -32,8 +32,8 @@ class TestShiftAttendance(FrappeTestCase):
 			end_time="12:00:00",
 			working_hours_threshold_for_half_day=2,
 			working_hours_threshold_for_absent=1,
-			enable_entry_grace_period=1,
-			enable_exit_grace_period=1,
+			enable_late_entry_marking=1,
+			enable_early_exit_marking=1,
 			process_attendance_after="2023-01-01",
 			last_sync_of_checkin="2023-01-04 04:00:00",
 		)
@@ -43,8 +43,8 @@ class TestShiftAttendance(FrappeTestCase):
 			end_time="02:00:00",
 			working_hours_threshold_for_half_day=2,
 			working_hours_threshold_for_absent=1,
-			enable_entry_grace_period=1,
-			enable_exit_grace_period=1,
+			enable_late_entry_marking=1,
+			enable_early_exit_marking=1,
 			process_attendance_after="2023-01-01",
 			last_sync_of_checkin="2023-01-04 04:00:00",
 		)


### PR DESCRIPTION
Update Shift Attendance Report with `enable_late_entry_marking` and `enable_early_exit_marking` instead of `enable_entry_grace_period` and `enable_exit_grace_period` respectively.

See: https://github.com/frappe/hrms/pull/803