### PR TITLE
fix: allow optional tax component addition & removal

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1150,7 +1150,13 @@ class SalarySlip(TransactionBase):
 			else:
 				self.other_deduction_components.append(d.salary_component)
 
+		# consider manually added tax component
 		if not tax_components:
+			tax_components = [
+				d.salary_component for d in self.get("deductions") if d.variable_based_on_taxable_salary
+			]
+
+		if self.is_new() and not tax_components:
 			tax_components = self.get_tax_components()
 			frappe.msgprint(
 				_(


### PR DESCRIPTION
These fixes are only meant for salary structure assignments that have a tax slab set but the structure does not have any tax component.

- If there are no tax components in the existing structure, the system fetches the company's tax components and adds them to the slip. 
- There could be 2 tax components configured and the user might want to choose one of them or none. Some companies allow employees to choose which months to deduct tax in (let's say only 6 months from the year, tax amount gets adjusted accordingly).
- **Fix 1**: In that case, allow them to remove the automatically added component. Fetch company components only if the doc is new.
- **Fix 2:** After removing, if they want to add the component back, recalculate the tax amount.