### PR TITLE
feat(PWA): add Install prompts

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,94 +4,15 @@
 		<ion-router-outlet id="main-content" />
 		<Toasts />
 
-		<!-- Install PWA dialog -->
-		<Dialog
-			:options="{
-				title: 'Install Frappe HR',
-				message:
-					'Get the Frappe HR app on your home screen. It won\'t take up space on your phone!',
-				icon: {
-					name: 'download',
-					appearance: 'primary',
-				},
-				size: 'xs',
-				actions: [
-					{
-						label: 'Install',
-						appearance: 'primary',
-						handler: ({ close }) => {
-							install()
-							close() // closes dialog
-						},
-					},
-				],
-			}"
-			v-model="showDialog"
-		/>
-
-		<Popover :show="iosInstallMessage" placement="bottom-center">
-			<template #body>
-				<div
-					class="mt-1 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
-				>
-					<span class="inline-flex items-center whitespace-nowrap">
-						<span>Install Frappe HR on your iPhone: tap&nbsp;</span>
-						<FeatherIcon name="share" class="h-4 w-4"/>
-						<span>&nbsp;and then Add to Home Screen</span>
-					</span>
-				</div>
-			</template>
-		</Popover>
+		<InstallPrompt />
 	</ion-app>
 </template>
 
 <script setup>
 import { IonApp, IonRouterOutlet } from "@ionic/vue"
-import { ref } from "vue"
 
-import { Toasts, Dialog, Popover, FeatherIcon } from "frappe-ui"
+import { Toasts } from "frappe-ui"
 
 import Menu from "@/components/Menu.vue"
-
-// Initialize deferredPrompt for use later to show browser install prompt.
-const deferredPrompt = ref(null)
-const showDialog = ref(false)
-const iosInstallMessage = ref(false)
-
-const isIos = () => {
-	// Detects if device is on iOS
-	const userAgent = window.navigator.userAgent.toLowerCase();
-	return /iphone|ipad|ipod/.test( userAgent );
-}
-
-// Detects if device is in standalone mode
-const isInStandaloneMode = () => ('standalone' in window.navigator) && (window.navigator.standalone);
-
-// Checks if should display install popup notification:
-if (isIos() && !isInStandaloneMode()) {
-	iosInstallMessage.value = true
-}
-
-window.addEventListener("beforeinstallprompt", (e) => {
-	// Prevent the mini-infobar from appearing on mobile
-	e.preventDefault()
-	// Stash the event so it can be triggered later.
-	deferredPrompt.value = e
-	if (isIos() && !isInStandaloneMode()) {
-		iosInstallMessage.value = true
-	} else {
-		showDialog.value = true
-	}
-	// Optionally, send analytics event that PWA install promo was shown.
-	console.log(`'beforeinstallprompt' event was fired.`)
-})
-
-window.addEventListener("appinstalled", () => {
-	showDialog.value = false
-	deferredPrompt.value = null
-})
-
-async function install() {
-	deferredPrompt.value.prompt()
-}
+import InstallPrompt from "@/components/InstallPrompt.vue"
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,6 +28,20 @@
 			}"
 			v-model="showDialog"
 		/>
+
+		<Popover :show="iosInstallMessage" placement="bottom-center">
+			<template #body>
+				<div
+					class="mt-1 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
+				>
+					<span class="inline-flex items-center whitespace-nowrap">
+						<span>Install Frappe HR on your iPhone: tap&nbsp;</span>
+						<FeatherIcon name="share" class="h-4 w-4"/>
+						<span>&nbsp;and then Add to Home Screen</span>
+					</span>
+				</div>
+			</template>
+		</Popover>
 	</ion-app>
 </template>
 
@@ -35,20 +49,39 @@
 import { IonApp, IonRouterOutlet } from "@ionic/vue"
 import { ref } from "vue"
 
-import { Toasts, Dialog } from "frappe-ui"
+import { Toasts, Dialog, Popover, FeatherIcon } from "frappe-ui"
 
 import Menu from "@/components/Menu.vue"
 
 // Initialize deferredPrompt for use later to show browser install prompt.
 const deferredPrompt = ref(null)
 const showDialog = ref(false)
+const iosInstallMessage = ref(false)
+
+const isIos = () => {
+	// Detects if device is on iOS
+	const userAgent = window.navigator.userAgent.toLowerCase();
+	return /iphone|ipad|ipod/.test( userAgent );
+}
+
+// Detects if device is in standalone mode
+const isInStandaloneMode = () => ('standalone' in window.navigator) && (window.navigator.standalone);
+
+// Checks if should display install popup notification:
+if (isIos() && !isInStandaloneMode()) {
+	iosInstallMessage.value = true
+}
 
 window.addEventListener("beforeinstallprompt", (e) => {
 	// Prevent the mini-infobar from appearing on mobile
 	e.preventDefault()
 	// Stash the event so it can be triggered later.
 	deferredPrompt.value = e
-	showDialog.value = true
+	if (isIos() && !isInStandaloneMode()) {
+		iosInstallMessage.value = true
+	} else {
+		showDialog.value = true
+	}
 	// Optionally, send analytics event that PWA install promo was shown.
 	console.log(`'beforeinstallprompt' event was fired.`)
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,14 +3,62 @@
 		<Menu />
 		<ion-router-outlet id="main-content" />
 		<Toasts />
+
+		<!-- Install PWA dialog -->
+		<Dialog
+			:options="{
+				title: 'Install Frappe HR',
+				message:
+					'Get the Frappe HR app on your home screen. It won\'t take up space on your phone!',
+				icon: {
+					name: 'download',
+					appearance: 'primary',
+				},
+				size: 'xs',
+				actions: [
+					{
+						label: 'Install',
+						appearance: 'primary',
+						handler: ({ close }) => {
+							install()
+							close() // closes dialog
+						},
+					},
+				],
+			}"
+			v-model="showDialog"
+		/>
 	</ion-app>
 </template>
 
 <script setup>
 import { IonApp, IonRouterOutlet } from "@ionic/vue"
-import { defineComponent } from "vue"
+import { ref } from "vue"
 
-import { Toasts } from "frappe-ui"
+import { Toasts, Dialog } from "frappe-ui"
 
 import Menu from "@/components/Menu.vue"
+
+// Initialize deferredPrompt for use later to show browser install prompt.
+const deferredPrompt = ref(null)
+const showDialog = ref(false)
+
+window.addEventListener("beforeinstallprompt", (e) => {
+	// Prevent the mini-infobar from appearing on mobile
+	e.preventDefault()
+	// Stash the event so it can be triggered later.
+	deferredPrompt.value = e
+	showDialog.value = true
+	// Optionally, send analytics event that PWA install promo was shown.
+	console.log(`'beforeinstallprompt' event was fired.`)
+})
+
+window.addEventListener("appinstalled", () => {
+	showDialog.value = false
+	deferredPrompt.value = null
+})
+
+async function install() {
+	deferredPrompt.value.prompt()
+}
 </script>

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -4,16 +4,13 @@
 		:options="{
 			title: 'Install Frappe HR',
 			message:
-				'Get the Frappe HR app on your home screen. It won\'t take up space on your phone!',
-			icon: {
-				name: 'download',
-				appearance: 'primary',
-			},
+				'Get the Frappe HR app on your home screen. It won\'t take up any space on your phone!',
 			size: 'xs',
 			actions: [
 				{
 					label: 'Install',
 					appearance: 'primary',
+					'icon-left': 'download',
 					handler: ({ close }) => {
 						install()
 						close() // closes dialog
@@ -25,10 +22,10 @@
 	/>
 
 	<!-- iOS installation info message -->
-	<Popover :show="iosInstallMessage" placement="bottom-center">
+	<Popover :show="iosInstallMessage" placement="bottom">
 		<template #body>
 			<div
-				class="mt-1 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
+				class="mt-[90vh] mx-2 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
 			>
 				<span class="inline-flex items-center whitespace-nowrap">
 					<span>Install Frappe HR on your iPhone: tap&nbsp;</span>

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -25,11 +25,11 @@
 	<Popover :show="iosInstallMessage" placement="bottom">
 		<template #body>
 			<div
-				class="mt-[90vh] mx-2 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
+				class="mt-[90vh] mx-2 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-blue-700 shadow-xl"
 			>
 				<span class="inline-flex items-center whitespace-nowrap">
 					<span>Install Frappe HR on your iPhone: tap&nbsp;</span>
-					<FeatherIcon name="share" class="h-4 w-4" />
+					<FeatherIcon name="share" class="h-4 w-4 text-gray-700" />
 					<span>&nbsp;and then Add to Home Screen</span>
 				</span>
 			</div>

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -1,0 +1,90 @@
+<template>
+	<!-- Install PWA dialog -->
+	<Dialog
+		:options="{
+			title: 'Install Frappe HR',
+			message:
+				'Get the Frappe HR app on your home screen. It won\'t take up space on your phone!',
+			icon: {
+				name: 'download',
+				appearance: 'primary',
+			},
+			size: 'xs',
+			actions: [
+				{
+					label: 'Install',
+					appearance: 'primary',
+					handler: ({ close }) => {
+						install()
+						close() // closes dialog
+					},
+				},
+			],
+		}"
+		v-model="showDialog"
+	/>
+
+	<!-- iOS installation info message -->
+	<Popover :show="iosInstallMessage" placement="bottom-center">
+		<template #body>
+			<div
+				class="mt-1 text-center rounded-xl bg-blue-100 px-3 py-5 text-xs text-gray-900 shadow-xl"
+			>
+				<span class="inline-flex items-center whitespace-nowrap">
+					<span>Install Frappe HR on your iPhone: tap&nbsp;</span>
+					<FeatherIcon name="share" class="h-4 w-4" />
+					<span>&nbsp;and then Add to Home Screen</span>
+				</span>
+			</div>
+		</template>
+	</Popover>
+</template>
+
+<script setup>
+import { ref } from "vue"
+
+import { Dialog, Popover, FeatherIcon } from "frappe-ui"
+
+// Initialize deferredPrompt for use later to show browser install prompt.
+const deferredPrompt = ref(null)
+const showDialog = ref(false)
+const iosInstallMessage = ref(false)
+
+const isIos = () => {
+	// Detects if device is on iOS
+	const userAgent = window.navigator.userAgent.toLowerCase()
+	return /iphone|ipad|ipod/.test(userAgent)
+}
+
+// Detects if device is in standalone mode
+const isInStandaloneMode = () =>
+	"standalone" in window.navigator && window.navigator.standalone
+
+// Checks if should display install popup notification:
+if (isIos() && !isInStandaloneMode()) {
+	iosInstallMessage.value = true
+}
+
+window.addEventListener("beforeinstallprompt", (e) => {
+	// Prevent the mini-infobar from appearing on mobile
+	e.preventDefault()
+	// Stash the event so it can be triggered later.
+	deferredPrompt.value = e
+	if (isIos() && !isInStandaloneMode()) {
+		iosInstallMessage.value = true
+	} else {
+		showDialog.value = true
+	}
+	// Optionally, send analytics event that PWA install promo was shown.
+	console.log(`'beforeinstallprompt' event was fired.`)
+})
+
+window.addEventListener("appinstalled", () => {
+	showDialog.value = false
+	deferredPrompt.value = null
+})
+
+async function install() {
+	deferredPrompt.value.prompt()
+}
+</script>


### PR DESCRIPTION
https://web.dev/customize-install/

### Any browser (updated in https://github.com/frappe/hrms/commit/4a04b4554940f7bce66d0c9702998df19b8b296f) vs. iOS (updated in https://github.com/frappe/hrms/commit/12cd4f58aac1768387879d2d107857461cce7a46)

<img width="334" alt="image" src="https://github.com/frappe/hrms/assets/24353136/b87ef6e9-16c3-4898-ac11-a2a2be72a111">
<img width="337" alt="image" src="https://github.com/frappe/hrms/assets/24353136/857ac226-442f-4b50-9962-f47e652df378">



**iOS**

Safari doesn't support `window.addEventListener("beforeinstallprompt")`. So the installation cannot be triggered. Show a popover explaining how to install the app on iOS

**Firefox** requires an extension 😔

TODO: Add docs for compatibility

<img width="771" alt="image" src="https://github.com/frappe/hrms/assets/24353136/a93e6d74-c0c5-4055-877e-40f2fa9793d5">

Ref: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Installing
`no-docs`