### PR TITLE
feat: change `introduction` to field type `Text Editor` on `Appointment Letter` && `Appointment Letter Template`

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -9,3 +9,4 @@ hrms.patches.post_install.update_performance_module_changes #2023-04-17
 hrms.patches.v14_0.update_ess_user_access #2023-08-14
 execute:frappe.db.set_default("date_format", frappe.db.get_single_value("System Settings", "date_format"))
 hrms.patches.v14_0.create_vehicle_service_item
+hrms.patches.v14_0.change_appointment_letter_introduction_to_texteditor #28th August 2023

--- a/hrms/patches/v14_0/change_appointment_letter_introduction_to_texteditor.py
+++ b/hrms/patches/v14_0/change_appointment_letter_introduction_to_texteditor.py
@@ -1,0 +1,22 @@
+import frappe
+
+def execute():
+    try:
+        doc_types = ['Appointment Letter', 'Appointment Letter Template']
+        
+        field_name = 'introduction'
+        
+        for doc_type in doc_types:
+            meta = frappe.get_meta(doc_type)
+            
+            if field_name in [field.fieldname for field in meta.fields]:
+                for field in meta.fields:
+                    if field.fieldname == field_name:
+                        field.fieldtype = 'Text Editor'
+                        field.save()
+                        break
+            else:
+                print(f"Field '{field_name}' not found in '{doc_type}' DocType.")
+    
+    except Exception as e:
+        print(f"Error: {e}")


### PR DESCRIPTION
The *introduction* field on `Appointment Letter` and `Appointment Letter Template` a data field type providing no styling options.

Previously:
![image](https://github.com/frappe/hrms/assets/55623011/e9384af2-2632-4144-9642-6f88d3098852)

After change:
![image](https://github.com/frappe/hrms/assets/55623011/3c6ba6e4-1a6d-44db-8b26-9ad7ad58f46a)


Closes: https://github.com/frappe/hrms/issues/774
