### PR TITLE
feat: Add warning when installing without running server

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -84,7 +84,7 @@ jinja = {
 # Installation
 # ------------
 
-# before_install = "hrms.install.before_install"
+before_install = "hrms.install.before_install"
 after_install = "hrms.install.after_install"
 after_migrate = "hrms.setup.update_select_perm_after_install"
 

--- a/hrms/install.py
+++ b/hrms/install.py
@@ -3,6 +3,22 @@ import click
 from hrms.setup import after_install as setup
 
 
+def before_install():
+	from frappe.utils.connections import check_connection
+
+	service_status = check_connection(redis_services=["redis_cache"])
+	are_services_running = all(service_status.values())
+
+	if not are_services_running:
+		for service in service_status:
+			if not service_status.get(service, True):
+				click.secho(f"Service {service} is not running.", fg="red")
+
+		click.secho("Please ensure that the server is running before installing HRMS.", fg="red")
+		click.secho("See: https://github.com/frappe/hrms/issues/369#issuecomment-1463632514", fg="red")
+		raise click.Abort()
+
+
 def after_install():
 	try:
 		print("Setting up Frappe HR...")


### PR DESCRIPTION
As mentioned in #369 #511 #533 https://github.com/frappe/hrms/issues/798#issuecomment-1685248970, installing HRMS is not possible if the server is not running, contrary to the other apps. This might (and actually does) lead to confusion, because the error message can be difficult to parse.

Because this issue will probably not be “fixed” soon (see: last 3 comments here https://github.com/frappe/hrms/issues/369#issuecomment-1463632514), I believe it's better to **show a clear error message**.

Detecting whether the server is running is done using the following code taken from `frappe/migrate.py`:
https://github.com/frappe/frappe/blob/173605fe2c16f8bed2710a6c3e9d6d064cf152de/frappe/migrate.py#L150-L156

> [!WARNING]
> I did *not* check whether my change breaks things like **Frappe Docker**, I _only_ checked the **manual CLI install**.
