### PR TITLE
fix: Create Salary Slips button not visible on failure

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -128,9 +128,13 @@ frappe.ui.form.on('Payroll Entry', {
 	add_context_buttons: function (frm) {
 		if (frm.doc.salary_slips_submitted || (frm.doc.__onload && frm.doc.__onload.submitted_ss)) {
 			frm.events.add_bank_entry_button(frm);
-		} else if (frm.doc.salary_slips_created && frm.doc.status != 'Queued') {
-			frm.add_custom_button(__("Submit Salary Slip"), function () {
+		} else if (frm.doc.salary_slips_created && frm.doc.status !== "Queued") {
+			frm.add_custom_button(__("Submit Salary Slip"), function() {
 				submit_salary_slip(frm);
+			}).addClass("btn-primary");
+		} else if (!frm.doc.salary_slips_created && frm.doc.status === "Failed") {
+			frm.add_custom_button(__("Create Salary Slips"), function() {
+				frm.trigger("create_salary_slips");
 			}).addClass("btn-primary");
 		}
 	},

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1099,8 +1099,9 @@ def log_payroll_failure(process, payroll_entry, error):
 
 
 def create_salary_slips_for_employees(employees, args, publish_progress=True):
+	payroll_entry = frappe.get_doc("Payroll Entry", args.payroll_entry)
+
 	try:
-		payroll_entry = frappe.get_doc("Payroll Entry", args.payroll_entry)
 		salary_slips_exist_for = get_existing_salary_slips(employees, args)
 		count = 0
 


### PR DESCRIPTION
Create Salary Slips button not visible on failure