### PR TITLE
fix: Order skills in Interview Feedback Doctype same as skills of Interview Round DocType

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -248,7 +248,9 @@ def send_daily_feedback_reminder():
 
 @frappe.whitelist()
 def get_expected_skill_set(interview_round):
-	return frappe.get_all("Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx asc")
+	return frappe.get_all(
+		"Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx asc"
+	)
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -248,7 +248,7 @@ def send_daily_feedback_reminder():
 
 @frappe.whitelist()
 def get_expected_skill_set(interview_round):
-	return frappe.get_all("Expected Skill Set", filters={"parent": interview_round}, fields=["skill"])
+	return frappe.get_all("Expected Skill Set", filters={"parent": interview_round}, fields=["skill"],order_by="idx asc")
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -249,7 +249,7 @@ def send_daily_feedback_reminder():
 @frappe.whitelist()
 def get_expected_skill_set(interview_round):
 	return frappe.get_all(
-		"Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx asc"
+		"Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx"
 	)
 
 

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -248,7 +248,7 @@ def send_daily_feedback_reminder():
 
 @frappe.whitelist()
 def get_expected_skill_set(interview_round):
-	return frappe.get_all("Expected Skill Set", filters={"parent": interview_round}, fields=["skill"],order_by="idx asc")
+	return frappe.get_all("Expected Skill Set", filters={"parent": interview_round}, fields=["skill"], order_by="idx asc")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Fix the order of skills listed in the `Skill Assessment` section of the `Interview Feedback` DocType.

Screenshots


- `Expected Skillset` section of the `Interview Round` DocType.

<img width="1040" alt="Screenshot 2023-09-03 at 5 04 22 PM" src="https://github.com/frappe/hrms/assets/69882648/700c7b9f-4256-4d41-a083-850cebaea490">

- `Skill Assessment` section of the `Interview Feedback` DocType 

<img width="1054" alt="Screenshot 2023-09-03 at 5 05 07 PM" src="https://github.com/frappe/hrms/assets/69882648/09aabbc7-fd00-43eb-b881-1c306abbc9f9">


**Proposed solution:**

Update the `get_expected_skill_set` whitelist method to fetch the skills in order as entered in `Interview Round`

**Issue**: #846 