### PR TITLE
refactor(PWA): upgrade frappe-ui to espresso

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
 		"@ionic/vue-router": "^7.2.1",
 		"dayjs": "^1.11.7",
 		"feather-icons": "^4.28.0",
-		"frappe-ui": "^0.0.112",
+		"frappe-ui": "^0.1.1",
 		"vue": "^3.2.25",
 		"vue-router": "^4.0.12"
 	},

--- a/frontend/src/components/BaseLayout.vue
+++ b/frontend/src/components/BaseLayout.vue
@@ -39,7 +39,7 @@
 						</div>
 
 						<div class="mt-5">
-							<h2 class="text-2xl font-bold text-gray-900">
+							<h2 class="text-xl font-bold text-gray-900">
 								{{ props.pageTitle }}
 							</h2>
 

--- a/frontend/src/components/BaseLayout.vue
+++ b/frontend/src/components/BaseLayout.vue
@@ -6,7 +6,7 @@
 					<div class="flex flex-col bg-white shadow-sm p-4">
 						<div class="flex flex-row justify-between items-center">
 							<ion-menu-toggle class="flex flex-col items-center">
-								<Button appearance="minimal" class="!px-0 !py-0">
+								<Button variant="ghost" class="!px-0 !py-0">
 									<FeatherIcon name="menu" class="h-6 w-6" />
 								</Button>
 							</ion-menu-toggle>
@@ -25,10 +25,14 @@
 										</span>
 									</span>
 								</router-link>
-								<router-link :to="{ name: 'Profile' }">
+								<router-link
+									:to="{ name: 'Profile' }"
+									class="flex flex-col items-center"
+								>
 									<Avatar
-										:imageURL="user.data.user_image"
+										:image="user.data.user_image"
 										:label="user.data.first_name"
+										size="xl"
 									/>
 								</router-link>
 							</div>

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -22,8 +22,8 @@
 		<div
 			class="h-40 w-full flex flex-col items-center justify-center gap-5 p-4 mb-5"
 		>
-			<div class="flex flex-col gap-1 items-center justify-center">
-				<div class="font-bold text-2xl">
+			<div class="flex flex-col gap-1.5 items-center justify-center">
+				<div class="font-bold text-xl">
 					{{ dayjs(checkinTimestamp).format("hh:mm:ss a") }}
 				</div>
 				<div class="font-medium text-gray-500 text-sm">

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -4,8 +4,7 @@
 			{{ `Last ${lastLogType} was at ${lastLogTime}` }}
 		</div>
 		<Button
-			class="mt-2 mb-1 py-2 shadow-sm"
-			expand="block"
+			class="mt-2 mb-1 drop-shadow-sm py-5 text-sm"
 			id="open-checkin-modal"
 			@click="checkinTimestamp = dayjs().format('YYYY-MM-DD HH:mm:ss')"
 		>
@@ -32,7 +31,7 @@
 			</div>
 			<Button
 				variant="solid"
-				class="py-2 w-full"
+				class="w-full py-5 text-sm"
 				@click="submitLog(nextAction.action)"
 			>
 				Confirm {{ nextAction.label }}

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col">
-		<div class="font-medium text-sm text-gray-500" v-if="lastLog">
+		<div class="font-medium text-xs text-gray-500 mt-1.5" v-if="lastLog">
 			{{ `Last ${lastLogType} was at ${lastLogTime}` }}
 		</div>
 		<Button

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -1,10 +1,10 @@
 <template>
 	<div class="flex flex-col">
-		<div class="font-medium text-xs text-gray-500 mt-1.5" v-if="lastLog">
+		<div class="font-medium text-sm text-gray-500 mt-1.5" v-if="lastLog">
 			{{ `Last ${lastLogType} was at ${lastLogTime}` }}
 		</div>
 		<Button
-			class="mt-2 mb-1 drop-shadow-sm py-5 text-sm"
+			class="mt-2 mb-1 drop-shadow-sm py-5 text-base"
 			id="open-checkin-modal"
 			@click="checkinTimestamp = dayjs().format('YYYY-MM-DD HH:mm:ss')"
 		>

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -31,7 +31,7 @@
 				</div>
 			</div>
 			<Button
-				appearance="primary"
+				variant="solid"
 				class="py-2 w-full"
 				@click="submitLog(nextAction.action)"
 			>

--- a/frontend/src/components/EmployeeAdvanceBalance.vue
+++ b/frontend/src/components/EmployeeAdvanceBalance.vue
@@ -17,7 +17,7 @@
 			v-slot="{ navigate }"
 		>
 			<div class="flex flex-col bg-white w-full py-5 px-3.5 mt-0 border-none">
-				<Button @click="navigate" appearance="secondary" class="py-2">
+				<Button @click="navigate" variant="subtle" class="py-2">
 					Request an Advance
 				</Button>
 			</div>

--- a/frontend/src/components/EmployeeAdvanceBalance.vue
+++ b/frontend/src/components/EmployeeAdvanceBalance.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="flex flex-col bg-white rounded-lg mt-5 overflow-auto"
+		class="flex flex-col bg-white rounded mt-5 overflow-auto"
 		v-if="props.items?.length"
 	>
 		<router-link

--- a/frontend/src/components/EmployeeAdvanceBalance.vue
+++ b/frontend/src/components/EmployeeAdvanceBalance.vue
@@ -17,7 +17,7 @@
 			v-slot="{ navigate }"
 		>
 			<div class="flex flex-col bg-white w-full py-5 px-3.5 mt-0 border-none">
-				<Button @click="navigate" variant="subtle" class="py-5 text-sm">
+				<Button @click="navigate" variant="subtle" class="py-5 text-base">
 					Request an Advance
 				</Button>
 			</div>

--- a/frontend/src/components/EmployeeAdvanceBalance.vue
+++ b/frontend/src/components/EmployeeAdvanceBalance.vue
@@ -17,7 +17,7 @@
 			v-slot="{ navigate }"
 		>
 			<div class="flex flex-col bg-white w-full py-5 px-3.5 mt-0 border-none">
-				<Button @click="navigate" variant="subtle" class="py-2">
+				<Button @click="navigate" variant="subtle" class="py-5 text-sm">
 					Request an Advance
 				</Button>
 			</div>

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -28,7 +28,12 @@
 				</div>
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
-				<Badge :colorMap="colorMap" :label="props.doc.status" />
+				<Badge
+					variant="subtle"
+					:theme="colorMap[props.doc.status]"
+					:label="props.doc.status"
+					size="sm"
+				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>
 		</div>
@@ -66,10 +71,10 @@ const props = defineProps({
 
 const colorMap = {
 	Paid: "green",
-	Unpaid: "yellow",
+	Unpaid: "orange",
 	Claimed: "blue",
 	Returned: "gray",
-	"Partly Claimed and Returned": "yellow",
+	"Partly Claimed and Returned": "orange",
 }
 
 const currency = computed(() => getCurrencySymbol(props.doc.currency))

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -2,21 +2,21 @@
 	<div class="flex flex-col w-full justify-center gap-2.5">
 		<div class="flex flex-row items-center justify-between">
 			<div class="flex flex-row items-start gap-3 grow">
-				<WalletIcon class="h-4 w-4 mt-0.5 text-gray-500" />
-				<div class="flex flex-col items-start">
+				<WalletIcon class="h-4 w-4 mt-1 text-gray-500" />
+				<div class="flex flex-col items-start gap-1">
 					<div
 						v-if="props.doc.balance_amount"
-						class="text-xl font-bold text-gray-800 leading-6"
+						class="text-lg font-bold text-gray-800 leading-6"
 					>
 						{{ `${currency} ${props.doc.balance_amount} /` }}
 						<span class="text-gray-600">
 							{{ `${currency} ${props.doc.paid_amount}` }}
 						</span>
 					</div>
-					<div v-else class="text-xl font-bold text-gray-800 leading-6">
+					<div v-else class="text-lg font-bold text-gray-800 leading-6">
 						{{ `${currency} ${props.doc.advance_amount}` }}
 					</div>
-					<div class="text-sm font-normal text-gray-500">
+					<div class="text-xs font-normal text-gray-500">
 						<span>
 							{{ props.doc.purpose }}
 						</span>

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -29,7 +29,7 @@
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
 				<Badge
-					variant="subtle"
+					variant="outline"
 					:theme="colorMap[props.doc.status]"
 					:label="props.doc.status"
 					size="md"

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -32,7 +32,7 @@
 					variant="subtle"
 					:theme="colorMap[props.doc.status]"
 					:label="props.doc.status"
-					size="sm"
+					size="md"
 				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>

--- a/frontend/src/components/EmployeeAvatar.vue
+++ b/frontend/src/components/EmployeeAvatar.vue
@@ -3,7 +3,7 @@
 		<Avatar
 			v-if="employee"
 			:label="employee?.employee_name"
-			:imageURL="employee?.image"
+			:image="employee?.image"
 			:size="props.size"
 		/>
 		<div class="text-base text-gray-800 grow">
@@ -14,7 +14,7 @@
 	<Avatar
 		v-else
 		:label="employee?.employee_name"
-		:imageURL="employee?.image"
+		:image="employee?.image"
 		:size="props.size"
 	/>
 </template>

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="text-sm text-gray-500 rounded-lg flex flex-col items-center bg-gray-100 p-5"
+		class="text-sm text-gray-500 rounded flex flex-col items-center bg-gray-100 p-5"
 	>
 		{{ props.message }}
 	</div>

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,6 +1,9 @@
 <template>
 	<div
-		class="text-sm text-gray-500 rounded flex flex-col items-center bg-gray-100 p-5"
+		class="flex flex-col items-center rounded p-5 text-sm text-gray-600"
+		:class="[
+			props.isTableField ? 'border-2 border-dashed border-gray-300 mt-5' : '',
+		]"
 	>
 		{{ props.message }}
 	</div>
@@ -9,5 +12,6 @@
 <script setup>
 const props = defineProps({
 	message: { type: String },
+	isTableField: { type: Boolean, default: false },
 })
 </script>

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -17,7 +17,7 @@
 		>
 			<div class="flex flex-row justify-between items-center">
 				<div class="flex flex-row items-start gap-3">
-					<Input
+					<FormControl
 						type="checkbox"
 						class="mt-[0.5px]"
 						v-model="advance.selected"
@@ -42,7 +42,7 @@
 					<span class="text-normal">
 						{{ currency }}
 					</span>
-					<Input
+					<FormControl
 						type="number"
 						class="w-20"
 						v-model="advance.allocated_amount"

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -19,7 +19,7 @@
 		>
 			<div class="flex flex-row justify-between items-center">
 				<div class="flex flex-row items-start gap-3">
-					<FormControl
+					<Input
 						type="checkbox"
 						class="mt-[0.5px]"
 						v-model="advance.selected"
@@ -44,7 +44,7 @@
 					<span class="text-normal">
 						{{ currency }}
 					</span>
-					<FormControl
+					<Input
 						type="number"
 						class="w-20"
 						v-model="advance.allocated_amount"

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -1,6 +1,8 @@
 <template>
 	<div class="flex flex-row justify-between items-center">
-		<h2 class="text-lg font-semibold text-gray-800">Settle against Advances</h2>
+		<h2 class="text-base font-semibold text-gray-800">
+			Settle against Advances
+		</h2>
 	</div>
 
 	<div class="flex flex-col gap-2.5" v-if="expenseClaim.advances?.length">

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -19,7 +19,7 @@
 		>
 			<div class="flex flex-row justify-between items-center">
 				<div class="flex flex-row items-start gap-3">
-					<Input
+					<FormControl
 						type="checkbox"
 						class="mt-[0.5px]"
 						v-model="advance.selected"

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -19,17 +19,17 @@
 				<div class="flex flex-row items-start gap-3">
 					<Input
 						type="checkbox"
-						class="mt-0.5"
+						class="mt-[0.5px]"
 						v-model="advance.selected"
 						:disabled="isReadOnly"
 					/>
 
-					<div class="flex flex-col items-start gap-1">
-						<div class="text-lg font-semibold text-gray-800">
+					<div class="flex flex-col items-start gap-1.5">
+						<div class="text-base font-semibold text-gray-800">
 							{{ advance.purpose || advance.employee_advance }}
 						</div>
 						<div class="flex flex-row items-center gap-3 justify-between">
-							<div class="text-sm font-normal text-gray-500">
+							<div class="text-xs font-normal text-gray-500">
 								{{
 									`Unclaimed Amount: ${currency} ${advance.unclaimed_amount}`
 								}}

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -10,7 +10,7 @@
 		<div
 			v-for="advance in expenseClaim.advances"
 			:key="advance.name"
-			class="flex flex-col bg-white border shadow-sm rounded-lg p-3.5"
+			class="flex flex-col bg-white border shadow-sm rounded p-3.5"
 			:class="[
 				advance.selected ? 'border-gray-500' : '',
 				isReadOnly ? '' : 'cursor-pointer',

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -10,7 +10,7 @@
 			:key="advance.name"
 			class="flex flex-col bg-white border shadow-sm rounded-lg p-3.5"
 			:class="[
-				advance.selected ? 'border-blue-500' : '',
+				advance.selected ? 'border-gray-500' : '',
 				isReadOnly ? '' : 'cursor-pointer',
 			]"
 			@click="toggleAdvanceSelection(advance)"

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -59,7 +59,7 @@
 		</div>
 	</div>
 
-	<EmptyState message="No advances found" v-else />
+	<EmptyState v-else message="No advances found" :isTableField="true" />
 </template>
 
 <script setup>

--- a/frontend/src/components/ExpenseClaimItem.vue
+++ b/frontend/src/components/ExpenseClaimItem.vue
@@ -19,12 +19,17 @@
 				</div>
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
-				<span
-					class="text-gray-600 bg-gray-100 font-medium rounded-lg text-xs px-2"
-				>
-					{{ props.doc.status }}
-				</span>
-				<Badge :colorMap="colorMap" :label="approvalStatus" />
+				<Badge
+					variant="outline"
+					:theme="statusMap[props.doc.status]"
+					:label="props.doc.status"
+					size="sm"
+				/>
+				<Badge
+					:theme="approvalStatusMap[props.doc.approval_status]"
+					:label="approvalStatus"
+					size="sm"
+				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>
 		</div>
@@ -44,10 +49,10 @@
 import { FeatherIcon, Badge } from "frappe-ui"
 import { computed, inject } from "vue"
 
-import { getCompanyCurrencySymbol } from "@/data/currencies"
-
 import EmployeeAvatar from "@/components/EmployeeAvatar.vue"
 import ExpenseIcon from "@/components/icons/ExpenseIcon.vue"
+
+import { getCompanyCurrencySymbol } from "@/data/currencies"
 
 const dayjs = inject("$dayjs")
 const props = defineProps({
@@ -60,10 +65,19 @@ const props = defineProps({
 	},
 })
 
-const colorMap = {
+const statusMap = {
+	Draft: "gray",
+	Submitted: "blue",
+	Cancelled: "red",
+	Paid: "green",
+	Unpaid: "orange",
+	Rejected: "red",
+}
+
+const approvalStatusMap = {
 	Approved: "green",
 	Rejected: "red",
-	Pending: "yellow",
+	Draft: "orange",
 }
 
 const claimTitle = computed(() => {

--- a/frontend/src/components/ExpenseClaimItem.vue
+++ b/frontend/src/components/ExpenseClaimItem.vue
@@ -20,15 +20,10 @@
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
 				<Badge
-					variant="outline"
-					:theme="statusMap[props.doc.status]"
-					:label="props.doc.status"
-					size="sm"
-				/>
-				<Badge
-					:theme="approvalStatusMap[props.doc.approval_status]"
-					:label="approvalStatus"
-					size="sm"
+					variant="subtle"
+					:theme="statusMap[claimStatus]"
+					:label="claimStatus"
+					size="md"
 				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>
@@ -71,14 +66,23 @@ const statusMap = {
 	Cancelled: "red",
 	Paid: "green",
 	Unpaid: "orange",
+	"Approved & Draft": "gray",
+	"Approved & Unpaid": "orange",
+	"Approved & Submitted": "blue",
 	Rejected: "red",
 }
 
-const approvalStatusMap = {
-	Approved: "green",
-	Rejected: "red",
-	Draft: "orange",
-}
+const claimStatus = computed(() => {
+	if (
+		props.doc.approval_status === "Approved" &&
+		["Draft", "Unpaid", "Submitted"].includes(props.doc.status)
+	) {
+		return `${props.doc.approval_status} & ${props.doc.status}`
+	} else if (props.doc.approval_status === "Rejected") {
+		return "Rejected"
+	}
+	return props.doc.status
+})
 
 const claimTitle = computed(() => {
 	let title = props.doc.expense_type

--- a/frontend/src/components/ExpenseClaimItem.vue
+++ b/frontend/src/components/ExpenseClaimItem.vue
@@ -2,12 +2,12 @@
 	<div class="flex flex-col w-full justify-center gap-2.5">
 		<div class="flex flex-row items-center justify-between">
 			<div class="flex flex-row items-start gap-3 grow">
-				<ExpenseIcon class="h-5 w-5 mt-0.5 text-gray-500" />
-				<div class="flex flex-col items-start">
-					<div class="text-lg font-normal text-gray-800">
+				<ExpenseIcon class="h-5 w-5 text-gray-500" />
+				<div class="flex flex-col items-start gap-1.5">
+					<div class="text-base font-normal text-gray-800">
 						{{ claimTitle }}
 					</div>
-					<div class="text-sm font-normal text-gray-500">
+					<div class="text-xs font-normal text-gray-500">
 						<span>
 							{{ `${currency} ${props.doc.total_claimed_amount}` }}
 						</span>

--- a/frontend/src/components/ExpenseClaimItem.vue
+++ b/frontend/src/components/ExpenseClaimItem.vue
@@ -20,7 +20,7 @@
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
 				<Badge
-					variant="subtle"
+					variant="outline"
 					:theme="statusMap[claimStatus]"
 					:label="claimStatus"
 					size="md"

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -3,10 +3,10 @@
 		<div class="text-xl text-gray-800 font-bold">Expense Claim Summary</div>
 		<div class="flex flex-col gap-4 bg-white py-3 px-3.5 mt-3 rounded-xl">
 			<div class="flex flex-col gap-1.5">
-				<span class="text-gray-600 text-base font-medium leading-5"
-					>Total Expense Amount</span
-				>
-				<span class="text-gray-800 text-2xl font-bold leading-6">
+				<span class="text-gray-600 text-base font-medium leading-5">
+					Total Expense Amount
+				</span>
+				<span class="text-gray-800 text-xl font-bold leading-6">
 					{{ `${company_currency} ${total_claimed_amount}` }}
 				</span>
 			</div>
@@ -19,7 +19,7 @@
 						</span>
 						<FeatherIcon name="alert-circle" class="text-yellow-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-xl font-semibold leading-6">
+					<span class="text-gray-800 text-lg font-semibold leading-6">
 						{{ `${company_currency} ${summary.data?.total_pending_amount}` }}
 					</span>
 				</div>
@@ -30,7 +30,7 @@
 						</span>
 						<FeatherIcon name="check-circle" class="text-green-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-xl font-semibold leading-6">
+					<span class="text-gray-800 text-lg font-semibold leading-6">
 						{{ `${company_currency} ${summary.data?.total_approved_amount}` }}
 					</span>
 				</div>
@@ -42,7 +42,7 @@
 						</span>
 						<FeatherIcon name="x-circle" class="text-red-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-xl font-semibold leading-6">
+					<span class="text-gray-800 text-lg font-semibold leading-6">
 						{{
 							`${summary.data?.currency} ${summary.data?.total_rejected_amount}`
 						}}

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="flex flex-col w-full" v-if="summary.data">
+	<div class="flex flex-col w-full gap-5" v-if="summary.data">
 		<div class="text-lg text-gray-800 font-bold">Expense Claim Summary</div>
 		<div
-			class="flex flex-col gap-4 bg-white py-3 px-3.5 mt-3 rounded-lg border-none"
+			class="flex flex-col gap-4 bg-white py-3 px-3.5 rounded-lg border-none"
 		>
 			<div class="flex flex-col gap-1.5">
 				<span class="text-gray-600 text-base font-medium leading-5">

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -1,12 +1,12 @@
 <template>
 	<div class="flex flex-col w-full" v-if="summary.data">
-		<div class="text-xl text-gray-800 font-bold">Expense Claim Summary</div>
+		<div class="text-lg text-gray-800 font-bold">Expense Claim Summary</div>
 		<div class="flex flex-col gap-4 bg-white py-3 px-3.5 mt-3 rounded-xl">
 			<div class="flex flex-col gap-1.5">
 				<span class="text-gray-600 text-base font-medium leading-5">
 					Total Expense Amount
 				</span>
-				<span class="text-gray-800 text-xl font-bold leading-6">
+				<span class="text-gray-800 text-lg font-bold leading-6">
 					{{ `${company_currency} ${total_claimed_amount}` }}
 				</span>
 			</div>
@@ -19,7 +19,7 @@
 						</span>
 						<FeatherIcon name="alert-circle" class="text-yellow-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-lg font-semibold leading-6">
+					<span class="text-gray-800 text-base font-semibold leading-6">
 						{{ `${company_currency} ${summary.data?.total_pending_amount}` }}
 					</span>
 				</div>
@@ -30,7 +30,7 @@
 						</span>
 						<FeatherIcon name="check-circle" class="text-green-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-lg font-semibold leading-6">
+					<span class="text-gray-800 text-base font-semibold leading-6">
 						{{ `${company_currency} ${summary.data?.total_approved_amount}` }}
 					</span>
 				</div>
@@ -42,7 +42,7 @@
 						</span>
 						<FeatherIcon name="x-circle" class="text-red-500 h-3 w-3" />
 					</div>
-					<span class="text-gray-800 text-lg font-semibold leading-6">
+					<span class="text-gray-800 text-base font-semibold leading-6">
 						{{
 							`${summary.data?.currency} ${summary.data?.total_rejected_amount}`
 						}}

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -1,7 +1,9 @@
 <template>
 	<div class="flex flex-col w-full" v-if="summary.data">
 		<div class="text-lg text-gray-800 font-bold">Expense Claim Summary</div>
-		<div class="flex flex-col gap-4 bg-white py-3 px-3.5 mt-3 rounded-xl">
+		<div
+			class="flex flex-col gap-4 bg-white py-3 px-3.5 mt-3 rounded-lg border-none"
+		>
 			<div class="flex flex-col gap-1.5">
 				<span class="text-gray-600 text-base font-medium leading-5">
 					Total Expense Amount

--- a/frontend/src/components/ExpenseItems.vue
+++ b/frontend/src/components/ExpenseItems.vue
@@ -12,11 +12,11 @@
 			<div class="flex flex-col w-full justify-center gap-2.5">
 				<div class="flex flex-row items-center justify-between">
 					<div class="flex flex-row items-start gap-3 grow">
-						<div class="flex flex-col items-start">
-							<div class="text-lg font-normal text-gray-800">
+						<div class="flex flex-col items-start gap-1.5">
+							<div class="text-base font-normal text-gray-800">
 								{{ item.expense_type }}
 							</div>
-							<div class="text-sm font-normal text-gray-500">
+							<div class="text-xs font-normal text-gray-500">
 								<span>
 									{{ `Sanctioned: ${currency} ${item.sanctioned_amount || 0}` }}
 								</span>
@@ -27,7 +27,7 @@
 							</div>
 						</div>
 					</div>
-					<span class="text-gray-700 font-normal rounded-lg text-lg">
+					<span class="text-gray-700 font-normal rounded-lg text-base">
 						{{ `${currency} ${item.amount}` }}
 					</span>
 				</div>

--- a/frontend/src/components/ExpenseItems.vue
+++ b/frontend/src/components/ExpenseItems.vue
@@ -2,7 +2,7 @@
 	<!-- Table -->
 	<div
 		v-if="doc?.expenses"
-		class="flex flex-col bg-white mt-5 rounded-lg border overflow-auto"
+		class="flex flex-col bg-white mt-5 rounded border overflow-auto"
 	>
 		<div
 			class="flex flex-row p-3.5 items-center justify-between cursor-pointer"
@@ -27,7 +27,7 @@
 							</div>
 						</div>
 					</div>
-					<span class="text-gray-700 font-normal rounded-lg text-base">
+					<span class="text-gray-700 font-normal rounded text-base">
 						{{ `${currency} ${item.amount}` }}
 					</span>
 				</div>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -10,7 +10,7 @@
 					id="add-taxes-modal"
 					class="text-sm"
 					icon="plus"
-					appearance="secondary"
+					variant="subtle"
 					@click="openModal()"
 					:disabled="isReadOnly"
 				/>
@@ -100,13 +100,13 @@
 							v-if="editingIdx !== null"
 							class="py-3 px-12 border-red-600 text-red-600"
 							icon-left="trash"
-							appearance="white"
+							variant="outline"
 							@click="deleteExpenseTax()"
 						>
 							Delete
 						</Button>
 						<Button
-							appearance="primary"
+							variant="solid"
 							class="w-full py-3 px-12"
 							:icon-left="editingIdx === null ? 'plus' : 'check'"
 							@click="updateExpenseTax()"

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -110,7 +110,7 @@
 						</Button>
 						<Button
 							variant="solid"
-							class="w-full py-5 text-sm"
+							class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
 							@click="updateExpenseTax()"
 							:disabled="addButtonDisabled"
 						>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -30,11 +30,11 @@
 				<div class="flex flex-col w-full justify-center gap-2.5">
 					<div class="flex flex-row items-center justify-between">
 						<div class="flex flex-row items-start gap-3 grow">
-							<div class="flex flex-col items-start">
-								<div class="text-lg font-normal text-gray-800">
+							<div class="flex flex-col items-start gap-1.5">
+								<div class="text-base font-normal text-gray-800">
 									{{ item.account_head }}
 								</div>
-								<div class="text-sm font-normal text-gray-500">
+								<div class="text-xs font-normal text-gray-500">
 									<span>
 										{{ `Rate: ${currency} ${item.rate || 0}` }}
 									</span>
@@ -46,7 +46,7 @@
 							</div>
 						</div>
 						<div class="flex flex-row justify-end items-center gap-2">
-							<span class="text-gray-700 font-normal rounded-lg text-lg">
+							<span class="text-gray-700 font-normal rounded-lg text-base">
 								{{ `${currency} ${item.total}` }}
 							</span>
 							<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -7,12 +7,12 @@
 					{{ expenseClaim.total_taxes_and_charges || 0 }}
 				</span>
 				<Button
+					v-if="!isReadOnly"
 					id="add-taxes-modal"
 					class="text-sm"
 					icon="plus"
 					variant="subtle"
 					@click="openModal()"
-					:disabled="isReadOnly"
 				/>
 			</div>
 		</div>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -98,8 +98,9 @@
 					>
 						<Button
 							v-if="editingIdx !== null"
-							class="py-3 px-12 border-red-600 text-red-600"
+							class="border-red-600 text-red-600 py-5 text-sm"
 							variant="outline"
+							theme="red"
 							@click="deleteExpenseTax()"
 						>
 							<template #prefix>
@@ -109,7 +110,7 @@
 						</Button>
 						<Button
 							variant="solid"
-							class="w-full py-3 px-12"
+							class="w-full py-5 text-sm"
 							@click="updateExpenseTax()"
 							:disabled="addButtonDisabled"
 						>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -99,19 +99,26 @@
 						<Button
 							v-if="editingIdx !== null"
 							class="py-3 px-12 border-red-600 text-red-600"
-							icon-left="trash"
 							variant="outline"
 							@click="deleteExpenseTax()"
 						>
+							<template #prefix>
+								<FeatherIcon name="trash" class="w-4" />
+							</template>
 							Delete
 						</Button>
 						<Button
 							variant="solid"
 							class="w-full py-3 px-12"
-							:icon-left="editingIdx === null ? 'plus' : 'check'"
 							@click="updateExpenseTax()"
 							:disabled="addButtonDisabled"
 						>
+							<template #prefix>
+								<FeatherIcon
+									:name="editingIdx === null ? 'plus' : 'check'"
+									class="w-4"
+								/>
+							</template>
 							{{ editingIdx === null ? "Add Tax" : "Update Tax" }}
 						</Button>
 					</div>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -55,7 +55,7 @@
 				</div>
 			</div>
 		</div>
-		<EmptyState v-else message="No taxes added" />
+		<EmptyState v-else message="No taxes added" :isTableField="true" />
 
 		<ion-modal
 			ref="modal"

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -1,9 +1,9 @@
 <template>
 	<template v-if="expenseClaim.expenses">
 		<div class="flex flex-row justify-between items-center pt-4">
-			<h2 class="text-lg font-semibold text-gray-800">Taxes & Charges</h2>
+			<h2 class="text-base font-semibold text-gray-800">Taxes & Charges</h2>
 			<div class="flex flex-row gap-3 items-center">
-				<span class="text-lg font-semibold text-gray-800">
+				<span class="text-base font-semibold text-gray-800">
 					{{ expenseClaim.total_taxes_and_charges || 0 }}
 				</span>
 				<Button

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -19,7 +19,7 @@
 
 		<div
 			v-if="expenseClaim.taxes?.length"
-			class="flex flex-col bg-white mt-5 rounded-lg border overflow-auto"
+			class="flex flex-col bg-white mt-5 rounded border overflow-auto"
 		>
 			<div
 				class="flex flex-row p-3.5 items-center justify-between border-b cursor-pointer"
@@ -46,7 +46,7 @@
 							</div>
 						</div>
 						<div class="flex flex-row justify-end items-center gap-2">
-							<span class="text-gray-700 font-normal rounded-lg text-base">
+							<span class="text-gray-700 font-normal rounded text-base">
 								{{ `${currency} ${item.total}` }}
 							</span>
 							<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -108,7 +108,7 @@
 					</Button>
 					<Button
 						variant="solid"
-						class="w-full py-5 text-sm"
+						class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
 						@click="updateExpenseItem()"
 						:disabled="addButtonDisabled"
 					>

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -7,12 +7,12 @@
 				{{ expenseClaim.total_claimed_amount || 0 }}
 			</span>
 			<Button
+				v-if="!isReadOnly"
 				id="add-expense-modal"
 				class="text-sm"
 				icon="plus"
 				variant="subtle"
 				@click="openModal()"
-				:disabled="isReadOnly"
 			/>
 		</div>
 	</div>

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -10,7 +10,7 @@
 				id="add-expense-modal"
 				class="text-sm"
 				icon="plus"
-				appearance="secondary"
+				variant="subtle"
 				@click="openModal()"
 				:disabled="isReadOnly"
 			/>
@@ -98,13 +98,13 @@
 						v-if="editingIdx !== null"
 						class="py-3 px-12 border-red-600 text-red-600"
 						icon-left="trash"
-						appearance="white"
+						variant="outline"
 						@click="deleteExpenseItem()"
 					>
 						Delete
 					</Button>
 					<Button
-						appearance="primary"
+						variant="solid"
 						class="w-full py-3 px-12"
 						:icon-left="editingIdx === null ? 'plus' : 'check'"
 						@click="updateExpenseItem()"

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -31,11 +31,11 @@
 			<div class="flex flex-col w-full justify-center gap-2.5">
 				<div class="flex flex-row items-center justify-between">
 					<div class="flex flex-row items-start gap-3 grow">
-						<div class="flex flex-col items-start">
-							<div class="text-lg font-normal text-gray-800">
+						<div class="flex flex-col items-start gap-1.5">
+							<div class="text-base font-normal text-gray-800">
 								{{ item.expense_type }}
 							</div>
-							<div class="text-sm font-normal text-gray-500">
+							<div class="text-xs font-normal text-gray-500">
 								<span>
 									{{ `Sanctioned: ${currency} ${item.sanctioned_amount || 0}` }}
 								</span>
@@ -47,7 +47,7 @@
 						</div>
 					</div>
 					<div class="flex flex-row justify-end items-center gap-2">
-						<span class="text-gray-700 font-normal rounded-lg text-lg">
+						<span class="text-gray-700 font-normal rounded-lg text-base">
 							{{ `${currency} ${item.amount}` }}
 						</span>
 						<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -68,7 +68,7 @@
 		<!-- Add Expense Action Sheet -->
 		<div class="bg-white w-full flex flex-col items-center justify-center pb-5">
 			<div class="w-full pt-8 pb-5 border-b text-center">
-				<span class="text-gray-900 font-bold text-xl">
+				<span class="text-gray-900 font-bold text-lg">
 					{{ modalTitle }}
 				</span>
 			</div>

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -20,7 +20,7 @@
 	<!-- Table -->
 	<div
 		v-if="expenseClaim.expenses"
-		class="flex flex-col bg-white mt-5 rounded-lg border overflow-auto"
+		class="flex flex-col bg-white mt-5 rounded border overflow-auto"
 	>
 		<div
 			class="flex flex-row p-3.5 items-center justify-between border-b cursor-pointer"
@@ -47,7 +47,7 @@
 						</div>
 					</div>
 					<div class="flex flex-row justify-end items-center gap-2">
-						<span class="text-gray-700 font-normal rounded-lg text-base">
+						<span class="text-gray-700 font-normal rounded text-base">
 							{{ `${currency} ${item.amount}` }}
 						</span>
 						<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -1,9 +1,9 @@
 <template>
 	<!-- Header -->
-	<div class="flex flex-row justify-between items-center">
-		<h2 class="text-lg font-semibold text-gray-800">Expenses</h2>
+	<div class="flex flex-row justify-between items-center mt-2">
+		<h2 class="text-base font-semibold text-gray-800">Expenses</h2>
 		<div class="flex flex-row gap-3 items-center">
-			<span class="text-lg font-semibold text-gray-800">
+			<span class="text-base font-semibold text-gray-800">
 				{{ expenseClaim.total_claimed_amount || 0 }}
 			</span>
 			<Button

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -96,8 +96,9 @@
 				>
 					<Button
 						v-if="editingIdx !== null"
-						class="py-3 px-12 border-red-600 text-red-600"
+						class="border-red-600 text-red-600 py-5 text-sm"
 						variant="outline"
+						theme="red"
 						@click="deleteExpenseItem()"
 					>
 						<template #prefix>
@@ -107,7 +108,7 @@
 					</Button>
 					<Button
 						variant="solid"
-						class="w-full py-3 px-12"
+						class="w-full py-5 text-sm"
 						@click="updateExpenseItem()"
 						:disabled="addButtonDisabled"
 					>

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -97,19 +97,26 @@
 					<Button
 						v-if="editingIdx !== null"
 						class="py-3 px-12 border-red-600 text-red-600"
-						icon-left="trash"
 						variant="outline"
 						@click="deleteExpenseItem()"
 					>
+						<template #prefix>
+							<FeatherIcon name="trash" class="w-4" />
+						</template>
 						Delete
 					</Button>
 					<Button
 						variant="solid"
 						class="w-full py-3 px-12"
-						:icon-left="editingIdx === null ? 'plus' : 'check'"
 						@click="updateExpenseItem()"
 						:disabled="addButtonDisabled"
 					>
+						<template #prefix>
+							<FeatherIcon
+								:name="editingIdx === null ? 'plus' : 'check'"
+								class="w-4"
+							/>
+						</template>
 						{{ editingIdx === null ? "Add Expense" : "Update Expense" }}
 					</Button>
 				</div>

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -56,7 +56,7 @@
 			</div>
 		</div>
 	</div>
-	<EmptyState v-else message="No expenses added" />
+	<EmptyState v-else message="No expenses added" :isTableField="true" />
 
 	<ion-modal
 		ref="modal"

--- a/frontend/src/components/FileUploaderView.vue
+++ b/frontend/src/components/FileUploaderView.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex flex-col gap-3 py-4">
 		<label class="file-select">
-			<h2 class="text-lg font-semibold text-gray-800 pb-4">Attachments</h2>
+			<h2 class="text-base font-semibold text-gray-800 pb-4">Attachments</h2>
 			<div class="select-button cursor-pointer">
 				<div
 					class="flex flex-col w-full border shadow-sm items-center rounded-lg p-3 gap-2"

--- a/frontend/src/components/FileUploaderView.vue
+++ b/frontend/src/components/FileUploaderView.vue
@@ -4,7 +4,7 @@
 			<h2 class="text-base font-semibold text-gray-800 pb-4">Attachments</h2>
 			<div class="select-button cursor-pointer">
 				<div
-					class="flex flex-col w-full border shadow-sm items-center rounded-lg p-3 gap-2"
+					class="flex flex-col w-full border shadow-sm items-center rounded p-3 gap-2"
 				>
 					<FeatherIcon name="upload" class="h-6 w-6 text-gray-700" />
 					<span class="block text-sm font-normal leading-5 text-gray-700">
@@ -25,7 +25,7 @@
 		<div v-if="modelValue.length" class="w-full">
 			<ul class="w-full flex flex-col items-center gap-2">
 				<li
-					class="bg-gray-100 rounded-lg p-2 w-full"
+					class="bg-gray-100 rounded p-2 w-full"
 					v-for="(file, index) in modelValue"
 					:key="index"
 				>

--- a/frontend/src/components/FileUploaderView.vue
+++ b/frontend/src/components/FileUploaderView.vue
@@ -44,29 +44,37 @@
 				</li>
 			</ul>
 
-			<Dialog
-				:options="{
-					title: 'Delete Attachment',
-					message: `Are you sure you want to delete the attachment ${deleteAttachment.file_name}?`,
-					icon: {
-						name: 'trash',
-						appearance: 'danger',
-					},
-					size: 'xs',
-					actions: [
-						{
-							label: 'Delete',
-							appearance: 'danger',
-							handler: ({ close }) => {
-								emit('handle-file-delete', deleteAttachment)
-								close() // closes dialog
-							},
-						},
-						{ label: 'Cancel' },
-					],
-				}"
-				v-model="showDialog"
-			/>
+			<Dialog v-model="showDialog">
+				<template #body-title>
+					<h2 class="text-xl font-bold">Delete Attachment</h2>
+				</template>
+				<template #body-content>
+					<p>
+						Are you sure you want to delete the attachment
+						<span class="font-bold">{{ deleteAttachment.file_name }}</span>
+						?
+					</p>
+				</template>
+				<template #actions>
+					<div class="flex flex-row gap-4">
+						<Button
+							variant="outline"
+							class="py-5 w-full"
+							@click="showDialog = false"
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="solid"
+							theme="red"
+							@click="handleFileDelete"
+							class="py-5 w-full"
+						>
+							Delete
+						</Button>
+					</div>
+				</template>
+			</Dialog>
 		</div>
 	</div>
 </template>
@@ -89,5 +97,10 @@ const emit = defineEmits(["handle-file-select", "handle-file-delete"])
 function confirmDeleteAttachment(fileObj) {
 	deleteAttachment.value = fileObj
 	showDialog.value = true
+}
+
+function handleFileDelete() {
+	emit("handle-file-delete", deleteAttachment.value)
+	showDialog.value = false
 }
 </script>

--- a/frontend/src/components/FileUploaderView.vue
+++ b/frontend/src/components/FileUploaderView.vue
@@ -46,7 +46,7 @@
 
 			<Dialog v-model="showDialog">
 				<template #body-title>
-					<h2 class="text-xl font-bold">Delete Attachment</h2>
+					<h2 class="text-lg font-bold">Delete Attachment</h2>
 				</template>
 				<template #body-content>
 					<p>

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -39,6 +39,7 @@
 			@change="(v) => emit('change', v)"
 			v-bind="$attrs"
 			:disabled="isReadOnly"
+			class="h-15"
 		/>
 
 		<!-- Check -->

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -26,7 +26,7 @@
 		/>
 
 		<!-- Text -->
-		<Input
+		<FormControl
 			v-else-if="
 				['Text Editor', 'Small Text', 'Text', 'Long Text'].includes(
 					props.fieldtype
@@ -42,7 +42,7 @@
 		/>
 
 		<!-- Check -->
-		<Input
+		<FormControl
 			v-else-if="props.fieldtype === 'Check'"
 			type="checkbox"
 			:label="props.label"
@@ -54,7 +54,7 @@
 		/>
 
 		<!-- Data field -->
-		<Input
+		<FormControl
 			v-else-if="props.fieldtype === 'Data'"
 			type="text"
 			:value="modelValue"
@@ -65,7 +65,7 @@
 		/>
 
 		<!-- Read only currency field -->
-		<Input
+		<FormControl
 			v-else-if="props.fieldtype === 'Currency' && isReadOnly"
 			type="text"
 			:value="modelValue"
@@ -76,7 +76,7 @@
 		/>
 
 		<!-- Float/Int field -->
-		<Input
+		<FormControl
 			v-else-if="isNumberType"
 			type="number"
 			:value="modelValue"
@@ -99,7 +99,7 @@
 
 		<!-- Date -->
 		<!-- FIXME: default datepicker has poor UI -->
-		<Input
+		<FormControl
 			v-else-if="props.fieldtype === 'Date'"
 			type="date"
 			v-model="date"

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -26,7 +26,7 @@
 		/>
 
 		<!-- Text -->
-		<FormControl
+		<Input
 			v-else-if="
 				['Text Editor', 'Small Text', 'Text', 'Long Text'].includes(
 					props.fieldtype
@@ -42,7 +42,7 @@
 		/>
 
 		<!-- Check -->
-		<FormControl
+		<Input
 			v-else-if="props.fieldtype === 'Check'"
 			type="checkbox"
 			:label="props.label"
@@ -54,7 +54,7 @@
 		/>
 
 		<!-- Data field -->
-		<FormControl
+		<Input
 			v-else-if="props.fieldtype === 'Data'"
 			type="text"
 			:value="modelValue"
@@ -65,7 +65,7 @@
 		/>
 
 		<!-- Read only currency field -->
-		<FormControl
+		<Input
 			v-else-if="props.fieldtype === 'Currency' && isReadOnly"
 			type="text"
 			:value="modelValue"
@@ -76,7 +76,7 @@
 		/>
 
 		<!-- Float/Int field -->
-		<FormControl
+		<Input
 			v-else-if="isNumberType"
 			type="number"
 			:value="modelValue"
@@ -102,7 +102,7 @@
 
 		<!-- Date -->
 		<!-- FIXME: default datepicker has poor UI -->
-		<FormControl
+		<Input
 			v-else-if="props.fieldtype === 'Date'"
 			type="date"
 			v-model="date"

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="showField" class="flex flex-col gap-1">
+	<div v-if="showField" class="flex flex-col gap-1.5">
 		<!-- Label -->
 		<span
 			v-if="
@@ -8,7 +8,7 @@
 			:class="[
 				// mark field as mandatory
 				props.reqd ? `after:content-['_*'] after:text-red-400` : ``,
-				`block text-base leading-5 text-gray-700`,
+				`block text-sm leading-5 text-gray-700`,
 			]"
 		>
 			{{ props.label }}

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -52,6 +52,7 @@
 			@change="(v) => emit('change', v)"
 			v-bind="$attrs"
 			:disabled="isReadOnly"
+			class="rounded-sm text-gray-800"
 		/>
 
 		<!-- Data field -->

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -89,7 +89,7 @@
 		<!-- Section Break -->
 		<div
 			v-else-if="props.fieldtype === 'Section Break'"
-			:class="props.addSectionPadding ? 'mt-2': ''"
+			:class="props.addSectionPadding ? 'mt-2' : ''"
 		>
 			<h2
 				v-if="props.label"

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -87,10 +87,10 @@
 		/>
 
 		<!-- Section Break -->
-		<div v-else-if="props.fieldtype === 'Section Break'">
+		<div v-else-if="props.fieldtype === 'Section Break'" class="mt-2">
 			<h2
 				v-if="props.label"
-				class="text-lg font-semibold text-gray-800"
+				class="text-base font-semibold text-gray-800"
 				:class="props.addSectionPadding ? 'pt-4' : ''"
 			>
 				{{ props.label }}

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -87,7 +87,10 @@
 		/>
 
 		<!-- Section Break -->
-		<div v-else-if="props.fieldtype === 'Section Break'" class="mt-2">
+		<div
+			v-else-if="props.fieldtype === 'Section Break'"
+			:class="props.addSectionPadding ? 'mt-2': ''"
+		>
 			<h2
 				v-if="props.label"
 				class="text-base font-semibold text-gray-800"

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -7,7 +7,7 @@
 			"
 			:class="[
 				// mark field as mandatory
-				props.reqd ? `after:content-['_*'] after:text-red-400` : ``,
+				props.reqd ? `after:content-['_*'] after:text-red-600` : ``,
 				`block text-sm leading-5 text-gray-700`,
 			]"
 		>

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -65,7 +65,7 @@
 								class="inline-block p-4 border-b-2 border-transparent rounded-t-lg"
 								:class="[
 									activeTab === tab.name
-										? '!text-blue-600 !border-blue-600'
+										? '!text-gray-800 !border-gray-800'
 										: 'hover:text-gray-600 hover:border-gray-300',
 								]"
 							>

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -14,7 +14,7 @@
 					class="flex flex-row items-center gap-2 overflow-hidden grow"
 				>
 					<h2
-						class="text-2xl font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis"
+						class="text-xl font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis"
 					>
 						{{ doctype }}
 					</h2>
@@ -43,7 +43,7 @@
 						:button="{
 							label: 'Menu',
 							icon: 'more-horizontal',
-							appearance: 'minimal',
+							variant: 'ghost',
 						}"
 					/>
 				</div>

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -159,7 +159,7 @@
 				/>
 
 				<Button
-					class="w-full rounded-md py-2.5 px-3.5 mt-2"
+					class="w-full rounded-md mt-2 py-5 text-sm"
 					:class="formButton === 'Cancel' ? 'shadow' : ''"
 					@click="formButton === 'Save' ? saveForm() : submitOrCancelForm()"
 					:variant="formButton === 'Cancel' ? 'subtle' : 'solid'"

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -6,7 +6,7 @@
 			<header
 				class="flex flex-row gap-1 bg-white shadow-sm py-4 px-2 items-center border-b sticky top-0 z-[1000]"
 			>
-				<Button appearance="minimal" class="!px-0 !py-0" @click="router.back()">
+				<Button variant="ghost" class="!px-0 !py-0" @click="router.back()">
 					<FeatherIcon name="chevron-left" class="h-5 w-5" />
 				</Button>
 				<div
@@ -162,7 +162,7 @@
 					class="w-full rounded-md py-2.5 px-3.5 mt-2"
 					:class="formButton === 'Cancel' ? 'shadow' : ''"
 					@click="formButton === 'Save' ? saveForm() : submitOrCancelForm()"
-					:appearance="formButton === 'Cancel' ? 'secondary' : 'primary'"
+					:variant="formButton === 'Cancel' ? 'subtle' : 'solid'"
 					:disabled="saveButtonDisabled"
 					:loading="
 						docList.insert.loading || documentResource?.setValue?.loading

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -36,9 +36,9 @@
 							{
 								label: 'Delete',
 								condition: showDeleteButton,
-								handler: () => (showDeleteDialog = true),
+								onClick: () => (showDeleteDialog = true),
 							},
-							{ label: 'Reload', handler: () => handleDocReload() },
+							{ label: 'Reload', onClick: () => handleDocReload() },
 						]"
 						:button="{
 							label: 'Menu',
@@ -182,66 +182,99 @@
 	</div>
 
 	<!-- Confirmation Dialogs -->
-	<Dialog
-		:options="{
-			title: `Delete ${props.doctype}`,
-			message: `Are you sure you want to delete the ${props.doctype} ${formModel.name}?`,
-			icon: { name: 'trash', appearance: 'danger' },
-			size: 'xs',
-			actions: [
-				{
-					label: 'Delete',
-					appearance: 'danger',
-					handler: ({ close }) => {
-						handleDocDelete()
-						close() // closes dialog
-					},
-				},
-				{ label: 'Cancel' },
-			],
-		}"
-		v-model="showDeleteDialog"
-	/>
+	<Dialog v-model="showDeleteDialog">
+		<template #body-title>
+			<h2 class="text-xl font-bold">Delete {{ props.doctype }}</h2>
+		</template>
+		<template #body-content>
+			<p>
+				Are you sure you want to delete the {{ props.doctype }}
+				<span class="font-bold">{{ formModel.name }}</span>
+				?
+			</p>
+		</template>
+		<template #actions>
+			<div class="flex flex-row gap-4">
+				<Button
+					variant="outline"
+					class="py-5 w-full"
+					@click="showDeleteDialog = false"
+				>
+					Cancel
+				</Button>
+				<Button
+					variant="solid"
+					theme="red"
+					@click="handleDocDelete"
+					class="py-5 w-full"
+				>
+					Delete
+				</Button>
+			</div>
+		</template>
+	</Dialog>
 
-	<Dialog
-		:options="{
-			title: 'Confirm',
-			message: `Permanently submit ${props.doctype} ${formModel.name}?`,
-			size: 'xs',
-			actions: [
-				{
-					label: 'Yes',
-					appearance: 'primary',
-					handler: ({ close }) => {
-						handleDocUpdate('submit')
-						close() // closes dialog
-					},
-				},
-				{ label: 'No' },
-			],
-		}"
-		v-model="showSubmitDialog"
-	/>
+	<Dialog v-model="showSubmitDialog">
+		<template #body-title>
+			<h2 class="text-xl font-bold">Confirm</h2>
+		</template>
+		<template #body-content>
+			<p>
+				Permanently submit {{ props.doctype }}
+				<span class="font-bold">{{ formModel.name }}</span>
+				?
+			</p>
+		</template>
+		<template #actions>
+			<div class="flex flex-row gap-4">
+				<Button
+					variant="outline"
+					class="py-5 w-full"
+					@click="showSubmitDialog = false"
+				>
+					No
+				</Button>
+				<Button
+					variant="solid"
+					@click="handleDocUpdate('submit')"
+					class="py-5 w-full"
+				>
+					Yes
+				</Button>
+			</div>
+		</template>
+	</Dialog>
 
-	<Dialog
-		:options="{
-			title: 'Confirm',
-			message: `Permanently cancel ${props.doctype} ${formModel.name}?`,
-			size: 'xs',
-			actions: [
-				{
-					label: 'Yes',
-					appearance: 'primary',
-					handler: ({ close }) => {
-						handleDocUpdate('cancel')
-						close() // closes dialog
-					},
-				},
-				{ label: 'No' },
-			],
-		}"
-		v-model="showCancelDialog"
-	/>
+	<Dialog v-model="showCancelDialog">
+		<template #body-title>
+			<h2 class="text-xl font-bold">Confirm</h2>
+		</template>
+		<template #body-content>
+			<p>
+				Permanently cancel {{ props.doctype }}
+				<span class="font-bold">{{ formModel.name }}</span
+				>?
+			</p>
+		</template>
+		<template #actions>
+			<div class="flex flex-row gap-4">
+				<Button
+					variant="outline"
+					class="py-5 w-full"
+					@click="showCancelDialog = false"
+				>
+					No
+				</Button>
+				<Button
+					variant="solid"
+					@click="handleDocUpdate('cancel')"
+					class="py-5 w-full"
+				>
+					Yes
+				</Button>
+			</div>
+		</template>
+	</Dialog>
 </template>
 
 <script setup>
@@ -550,6 +583,9 @@ async function handleDocUpdate(action) {
 			isFormUpdated.value = true
 		})
 	}
+
+	if (action === "submit") showSubmitDialog.value = false
+	else if (action === "cancel") showCancelDialog.value = false
 }
 
 function saveForm() {
@@ -575,6 +611,7 @@ function submitOrCancelForm() {
 
 function handleDocDelete() {
 	documentResource.delete.submit()
+	showDeleteDialog.value = false
 }
 
 function handleDocReload() {

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -20,13 +20,13 @@
 					</h2>
 					<Badge
 						:label="id"
-						color="white"
 						class="whitespace-nowrap text-[8px]"
+						variant="outline"
 					/>
 					<Badge
 						v-if="formModel?.status"
 						:label="formModel?.status"
-						:color="statusColor"
+						:theme="statusColor"
 						class="whitespace-nowrap text-[8px]"
 					/>
 
@@ -294,7 +294,7 @@ import {
 import FormField from "@/components/FormField.vue"
 import FileUploaderView from "@/components/FileUploaderView.vue"
 
-import { FileAttachment, guessStatusColor } from "@/composables/index"
+import { FileAttachment, guessStatusColor } from "@/composables"
 import { getCompanyCurrency } from "@/data/currencies"
 import { formatCurrency } from "@/utils/formatters"
 

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -159,7 +159,7 @@
 				/>
 
 				<Button
-					class="w-full rounded mt-2 py-5 text-sm"
+					class="w-full rounded mt-2 py-5 text-base"
 					:class="formButton === 'Cancel' ? 'shadow' : ''"
 					@click="formButton === 'Save' ? saveForm() : submitOrCancelForm()"
 					:variant="formButton === 'Cancel' ? 'subtle' : 'solid'"

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -159,7 +159,7 @@
 				/>
 
 				<Button
-					class="w-full rounded mt-2 py-5 text-base"
+					class="w-full rounded mt-2 py-5 text-base disabled:bg-gray-700 disabled:text-white"
 					:class="formButton === 'Cancel' ? 'shadow' : ''"
 					@click="formButton === 'Save' ? saveForm() : submitOrCancelForm()"
 					:variant="formButton === 'Cancel' ? 'subtle' : 'solid'"

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -151,7 +151,7 @@
 			<!-- Bottom Save Button -->
 			<div
 				v-if="formButton"
-				class="px-4 pt-4 mt-2 sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-xl pb-10"
+				class="px-4 pt-4 mt-2 sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-lg pb-10"
 			>
 				<ErrorMessage
 					class="mb-2"
@@ -159,7 +159,7 @@
 				/>
 
 				<Button
-					class="w-full rounded-md mt-2 py-5 text-sm"
+					class="w-full rounded mt-2 py-5 text-sm"
 					:class="formButton === 'Cancel' ? 'shadow' : ''"
 					@click="formButton === 'Save' ? saveForm() : submitOrCancelForm()"
 					:variant="formButton === 'Cancel' ? 'subtle' : 'solid'"
@@ -174,7 +174,7 @@
 
 			<div
 				v-else
-				class="px-4 pt-4 mt-2 sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-xl pb-10"
+				class="px-4 pt-4 mt-2 sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-lg pb-10"
 			>
 				<slot name="formButton"></slot>
 			</div>

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -19,7 +19,7 @@
 
 	<div
 		v-else-if="['Small Text', 'Text', 'Long Text'].includes(props.fieldtype)"
-		class="text-gray-900 text-base bg-gray-200 rounded-lg py-2.5 pl-3 mt-1"
+		class="text-gray-900 text-base bg-gray-200 rounded py-2.5 pl-3 mt-1"
 	>
 		{{ props.value }}
 	</div>

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -20,7 +20,7 @@
 
 	<div
 		v-else-if="['Small Text', 'Text', 'Long Text'].includes(props.fieldtype)"
-		class="text-gray-900 text-base bg-gray-200 rounded py-2.5 pl-3 mt-1"
+		class="text-gray-900 text-base bg-gray-100 rounded py-3 pl-3 mt-2"
 	>
 		{{ props.value }}
 	</div>
@@ -36,7 +36,7 @@
 
 <script setup>
 import { inject } from "vue"
-import { Badge, Input } from "frappe-ui"
+import { Badge, FormControl, Input } from "frappe-ui"
 
 import EmployeeAvatar from "@/components/EmployeeAvatar.vue"
 

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -9,7 +9,7 @@
 		{{ dayjs(props.value).format("D MMM") }}
 	</div>
 
-	<FormControl
+	<Input
 		v-else-if="props.fieldtype === 'Check'"
 		type="checkbox"
 		label=""
@@ -35,7 +35,7 @@
 
 <script setup>
 import { inject } from "vue"
-import { Badge, FormControl, Input } from "frappe-ui"
+import { Badge, Input } from "frappe-ui"
 
 import EmployeeAvatar from "@/components/EmployeeAvatar.vue"
 

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -1,7 +1,7 @@
 <template>
 	<Badge
 		v-if="props.fieldtype === 'Select'"
-		:colorMap="colorMap"
+		:theme="colorMap[props.value]"
 		:label="props.value"
 	/>
 
@@ -50,6 +50,6 @@ const props = defineProps({
 const colorMap = {
 	Approved: "green",
 	Rejected: "red",
-	Open: "yellow",
+	Open: "orange",
 }
 </script>

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -1,6 +1,7 @@
 <template>
 	<Badge
 		v-if="props.fieldtype === 'Select'"
+		variant="outline"
 		:theme="colorMap[props.value]"
 		:label="props.value"
 		size="md"

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -16,6 +16,7 @@
 		label=""
 		v-model="props.value"
 		:disabled="true"
+		class="rounded-sm text-gray-800"
 	/>
 
 	<div

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -9,7 +9,7 @@
 		{{ dayjs(props.value).format("D MMM") }}
 	</div>
 
-	<Input
+	<FormControl
 		v-else-if="props.fieldtype === 'Check'"
 		type="checkbox"
 		label=""
@@ -35,7 +35,7 @@
 
 <script setup>
 import { inject } from "vue"
-import { Badge, Input } from "frappe-ui"
+import { Badge, FormControl, Input } from "frappe-ui"
 
 import EmployeeAvatar from "@/components/EmployeeAvatar.vue"
 

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -3,6 +3,7 @@
 		v-if="props.fieldtype === 'Select'"
 		:theme="colorMap[props.value]"
 		:label="props.value"
+		size="md"
 	/>
 
 	<div v-else-if="props.fieldtype === 'Date'" class="text-gray-900 text-base">

--- a/frontend/src/components/Holidays.vue
+++ b/frontend/src/components/Holidays.vue
@@ -5,7 +5,7 @@
 			<div
 				v-if="upcomingHolidays?.length"
 				id="open-holiday-list"
-				class="text-base text-blue-500 font-medium cursor-pointer"
+				class="text-sm text-gray-800 font-semibold cursor-pointer underline underline-offset-2"
 			>
 				View All
 			</div>

--- a/frontend/src/components/Holidays.vue
+++ b/frontend/src/components/Holidays.vue
@@ -11,10 +11,7 @@
 			</div>
 		</div>
 
-		<div
-			class="flex flex-col bg-white rounded-lg"
-			v-if="upcomingHolidays?.length"
-		>
+		<div class="flex flex-col bg-white rounded" v-if="upcomingHolidays?.length">
 			<div
 				class="flex flex-row flex-start p-4 items-center justify-between border-b"
 				v-for="holiday in upcomingHolidays"

--- a/frontend/src/components/Holidays.vue
+++ b/frontend/src/components/Holidays.vue
@@ -22,11 +22,11 @@
 			>
 				<div class="flex flex-row items-center gap-3 grow">
 					<FeatherIcon name="calendar" class="h-5 w-5 text-gray-500" />
-					<div class="text-lg font-normal text-gray-800">
+					<div class="text-base font-normal text-gray-800">
 						{{ holiday.description }}
 					</div>
 				</div>
-				<div class="text-lg font-bold text-gray-800">
+				<div class="text-base font-bold text-gray-800">
 					{{ holiday.formatted_holiday_date }}
 				</div>
 			</div>
@@ -54,11 +54,11 @@
 				>
 					<div class="flex flex-row items-center gap-3 grow">
 						<FeatherIcon name="calendar" class="h-5 w-5 text-gray-500" />
-						<div class="text-lg font-normal text-gray-800">
+						<div class="text-base font-normal text-gray-800">
 							{{ holiday.description }}
 						</div>
 					</div>
-					<div class="text-lg font-bold text-gray-800">
+					<div class="text-base font-bold text-gray-800">
 						{{ holiday.formatted_holiday_date }}
 					</div>
 				</div>

--- a/frontend/src/components/Holidays.vue
+++ b/frontend/src/components/Holidays.vue
@@ -1,11 +1,11 @@
 <template>
 	<div class="flex flex-col gap-5 w-full">
 		<div class="flex flex-row justify-between items-center">
-			<div class="text-xl text-gray-800 font-bold">Upcoming Holidays</div>
+			<div class="text-lg text-gray-800 font-bold">Upcoming Holidays</div>
 			<div
 				v-if="upcomingHolidays?.length"
 				id="open-holiday-list"
-				class="text-lg text-blue-500 font-medium cursor-pointer"
+				class="text-base text-blue-500 font-medium cursor-pointer"
 			>
 				View All
 			</div>
@@ -44,7 +44,7 @@
 	>
 		<div class="bg-white w-full flex flex-col items-center justify-center pb-5">
 			<div class="w-full pt-8 pb-5 border-b text-center">
-				<span class="text-gray-900 font-bold text-xl">Holiday List</span>
+				<span class="text-gray-900 font-bold text-lg">Holiday List</span>
 			</div>
 			<div class="w-full flex flex-col items-center justify-center gap-5 p-4">
 				<div

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -23,7 +23,7 @@
 	<Popover :show="iosInstallMessage" placement="bottom">
 		<template #body>
 			<div
-				class="mt-[calc(100vh-15rem)] flex flex-col gap-2 mx-2 rounded-xl py-5 bg-blue-50 shadow-xl"
+				class="mt-[calc(100vh-15rem)] flex flex-col gap-2 mx-2 rounded-lg py-5 bg-blue-50 shadow-xl"
 			>
 				<div
 					class="flex flex-row text-center items-center justify-between mb-1 px-3"

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -2,7 +2,7 @@
 	<!-- Install PWA dialog -->
 	<Dialog v-model="showDialog">
 		<template #body-title>
-			<h2 class="text-xl font-bold">Install Frappe HR</h2>
+			<h2 class="text-lg font-bold">Install Frappe HR</h2>
 		</template>
 		<template #body-content>
 			<p>Get the app on your device for easy access & a better experience!</p>

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -1,25 +1,23 @@
 <template>
 	<!-- Install PWA dialog -->
-	<Dialog
-		:options="{
-			title: 'Install Frappe HR',
-			message:
-				'Get the app on your device for easy access & a better experience!',
-			size: 'xs',
-			actions: [
-				{
-					label: 'Install',
-					appearance: 'primary',
-					'icon-left': 'download',
-					handler: ({ close }) => {
-						install()
-						close() // closes dialog
-					},
-				},
-			],
-		}"
-		v-model="showDialog"
-	/>
+	<Dialog v-model="showDialog">
+		<template #body-title>
+			<h2 class="text-xl font-bold">Install Frappe HR</h2>
+		</template>
+		<template #body-content>
+			<p>Get the app on your device for easy access & a better experience!</p>
+		</template>
+		<template #actions>
+			<Button
+				variant="solid"
+				@click="handleDocUpdate('submit')"
+				class="py-5 w-full"
+			>
+				<template #prefix><FeatherIcon name="download" class="w-4" /></template>
+				Install
+			</Button>
+		</template>
+	</Dialog>
 
 	<!-- iOS installation info message -->
 	<Popover :show="iosInstallMessage" placement="bottom">

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -33,7 +33,7 @@
 				<div class="text-gray-800 font-bold text-base">
 					{{ `${allocation.balance_leaves}/${allocation.allocated_leaves}` }}
 				</div>
-				<div class="text-gray-600 font-normal text-sm w-24">
+				<div class="text-gray-600 font-normal text-sm w-24 leading-4">
 					{{ `${leave_type} balance` }}
 				</div>
 			</div>

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -1,24 +1,19 @@
 <template>
 	<div class="flex flex-col w-full mt-7">
 		<div class="flex flex-row justify-between items-center px-4">
-			<div class="text-xl text-gray-800 font-bold">Leave Balance</div>
-			<div
-				class="text-lg text-blue-500 font-medium cursor-pointer"
+			<div class="text-lg text-gray-800 font-bold">Leave Balance</div>
+			<router-link
+				:to="{ name: 'LeaveApplicationListView' }"
+				v-slot="{ navigate }"
 				v-if="leaveBalance.data"
 			>
-				<router-link
-					:to="{ name: 'LeaveApplicationListView' }"
-					v-slot="{ navigate }"
-					v-if="leaveBalance.data"
+				<div
+					@click="navigate"
+					class="text-base text-blue-500 font-medium cursor-pointer"
 				>
-					<div
-						@click="navigate"
-						class="text-lg text-blue-500 font-medium cursor-pointer"
-					>
-						View Leave History
-					</div>
-				</router-link>
-			</div>
+					View Leave History
+				</div>
+			</router-link>
 		</div>
 
 		<!-- Leave Balance Dashboard -->

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -70,7 +70,8 @@ const leaveBalance = createResource({
 })
 
 const getChartColor = (index) => {
-	const chartColors = ["text-pink-500", "text-orange-500", "text-purple-500"]
+	// note: tw colors - rose-400, pink-400 & purple-500 of the old frappeui palette #918ef5
+	const chartColors = ["text-[#fb7185]", "text-[#f472b6]", "text-[#918ef5]"]
 	return chartColors[index % chartColors.length]
 }
 </script>

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -34,7 +34,7 @@
 					{{ `${allocation.balance_leaves}/${allocation.allocated_leaves}` }}
 				</div>
 				<div class="text-gray-600 font-normal text-sm w-24">
-					{{ leave_type }}
+					{{ `${leave_type} balance` }}
 				</div>
 			</div>
 		</div>

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -9,7 +9,7 @@
 			>
 				<div
 					@click="navigate"
-					class="text-base text-blue-500 font-medium cursor-pointer"
+					class="text-sm text-gray-800 font-semibold cursor-pointer underline underline-offset-2"
 				>
 					View Leave History
 				</div>

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex flex-col w-full mt-7">
+	<div class="flex flex-col w-full">
 		<div class="flex flex-row justify-between items-center px-4">
 			<div class="text-lg text-gray-800 font-bold">Leave Balance</div>
 			<router-link

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -24,7 +24,7 @@
 			<div
 				v-for="(allocation, leave_type, index) in leaveBalance.data"
 				:key="leave_type"
-				class="flex flex-col bg-white border-none rounded-xl drop-shadow-md gap-2 p-4 items-start first:ml-4"
+				class="flex flex-col bg-white border-none rounded-lg drop-shadow-md gap-2 p-4 items-start first:ml-4"
 			>
 				<SemicircleChart
 					:percentage="allocation.balance_percentage"

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -29,17 +29,17 @@
 			<div
 				v-for="(allocation, leave_type, index) in leaveBalance.data"
 				:key="leave_type"
-				class="flex flex-col bg-white rounded-xl shadow-md gap-2 p-4 items-start first:ml-4"
+				class="flex flex-col bg-white border-none rounded-xl drop-shadow-md gap-2 p-4 items-start first:ml-4"
 			>
 				<SemicircleChart
 					:percentage="allocation.balance_percentage"
 					:colorClass="getChartColor(index)"
 				/>
-				<div class="text-gray-800 font-bold text-lg">
+				<div class="text-gray-800 font-bold text-base">
 					{{ `${allocation.balance_leaves}/${allocation.allocated_leaves}` }}
 				</div>
-				<div class="text-gray-600 font-normal text-base w-24">
-					{{ `${leave_type} balance` }}
+				<div class="text-gray-600 font-normal text-sm w-24">
+					{{ leave_type }}
 				</div>
 			</div>
 		</div>
@@ -75,7 +75,7 @@ const leaveBalance = createResource({
 })
 
 const getChartColor = (index) => {
-	const chartColors = ["text-pink-500", "text-orange-400", "text-purple-500"]
+	const chartColors = ["text-pink-500", "text-orange-500", "text-purple-500"]
 	return chartColors[index % chartColors.length]
 }
 </script>

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -3,11 +3,11 @@
 		<div class="flex flex-row items-center justify-between">
 			<div class="flex flex-row items-start gap-3 grow">
 				<FeatherIcon name="calendar" class="h-5 w-5 text-gray-500" />
-				<div class="flex flex-col items-start">
-					<div class="text-lg font-normal text-gray-800">
+				<div class="flex flex-col items-start gap-1.5">
+					<div class="text-base font-normal text-gray-800">
 						{{ props.doc.leave_type }}
 					</div>
-					<div class="text-sm font-normal text-gray-500">
+					<div class="text-xs font-normal text-gray-500">
 						<span>{{ props.doc.leave_dates || getLeaveDates(props.doc) }}</span>
 						<span class="whitespace-pre"> &middot; </span>
 						<span class="whitespace-nowrap">{{

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -18,7 +18,7 @@
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
 				<Badge
-					variant="subtle"
+					variant="outline"
 					:theme="colorMap[props.doc.status]"
 					:label="props.doc.status"
 					size="md"

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -17,7 +17,12 @@
 				</div>
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
-				<Badge :colorMap="colorMap" :label="props.doc.status" />
+				<Badge
+					variant="subtle"
+					:theme="colorMap[props.doc.status]"
+					:label="props.doc.status"
+					size="sm"
+				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>
 		</div>
@@ -52,6 +57,6 @@ const props = defineProps({
 const colorMap = {
 	Approved: "green",
 	Rejected: "red",
-	Open: "yellow",
+	Open: "orange",
 }
 </script>

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -21,7 +21,7 @@
 					variant="subtle"
 					:theme="colorMap[props.doc.status]"
 					:label="props.doc.status"
-					size="sm"
+					size="md"
 				/>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</div>

--- a/frontend/src/components/ListFiltersActionSheet.vue
+++ b/frontend/src/components/ListFiltersActionSheet.vue
@@ -69,15 +69,15 @@
 		>
 			<Button
 				@click="emit('clear-filters')"
-				variant="subtle"
-				class="w-full py-3 px-12"
+				variant="outline"
+				class="w-full py-5 text-sm"
 			>
 				Clear All
 			</Button>
 			<Button
 				@click="emit('apply-filters')"
 				variant="solid"
-				class="w-full py-3 px-12"
+				class="w-full py-5 text-sm"
 			>
 				Apply Filters
 			</Button>

--- a/frontend/src/components/ListFiltersActionSheet.vue
+++ b/frontend/src/components/ListFiltersActionSheet.vue
@@ -25,7 +25,7 @@
 						<div class="flex flex-row gap-2 mt-2 flex-wrap">
 							<Button
 								v-for="option in filter.options"
-								appearance="white"
+								variant="outline"
 								@click="setStatusFilter(filter.fieldname, option)"
 								:class="[
 									option === filters[filter.fieldname].value
@@ -69,14 +69,14 @@
 		>
 			<Button
 				@click="emit('clear-filters')"
-				appearance="secondary"
+				variant="subtle"
 				class="w-full py-3 px-12"
 			>
 				Clear All
 			</Button>
 			<Button
 				@click="emit('apply-filters')"
-				appearance="primary"
+				variant="solid"
 				class="w-full py-3 px-12"
 			>
 				Apply Filters

--- a/frontend/src/components/ListFiltersActionSheet.vue
+++ b/frontend/src/components/ListFiltersActionSheet.vue
@@ -16,22 +16,22 @@
 				>
 					<!-- Status filter -->
 					<div
-						class="flex flex-col"
+						class="flex flex-col gap-1.5"
 						v-if="['status', 'approval_status'].includes(filter.fieldname)"
 					>
-						<div class="text-gray-800 font-semibold text-lg">
+						<div class="text-gray-800 font-semibold text-base">
 							{{ filter.label }}
 						</div>
 						<div class="flex flex-row gap-2 mt-2 flex-wrap">
 							<Button
 								v-for="option in filter.options"
-								variant="outline"
-								@click="setStatusFilter(filter.fieldname, option)"
-								:class="[
+								:variant="
 									option === filters[filter.fieldname].value
-										? '!border !border-blue-500 !text-blue-500'
-										: '',
-								]"
+										? 'solid'
+										: 'outline'
+								"
+								@click="setStatusFilter(filter.fieldname, option)"
+								class="text-sm"
 							>
 								{{ option }}
 							</Button>
@@ -40,7 +40,7 @@
 
 					<!-- Field filters -->
 					<div v-else class="flex flex-col gap-2">
-						<div class="text-gray-800 font-semibold text-lg">
+						<div class="text-gray-800 font-semibold text-base">
 							{{ filter.label }}
 						</div>
 						<div class="flex flex-row items-center gap-3">

--- a/frontend/src/components/ListFiltersActionSheet.vue
+++ b/frontend/src/components/ListFiltersActionSheet.vue
@@ -4,7 +4,7 @@
 		class="bg-white w-full flex flex-col items-center justify-center pb-5 max-h-[calc(100vh-5rem)]"
 	>
 		<div class="w-full pt-8 pb-5 border-b text-center sticky top-0 z-[100]">
-			<span class="text-gray-900 font-bold text-xl">Filters</span>
+			<span class="text-gray-900 font-bold text-lg">Filters</span>
 		</div>
 
 		<div class="w-full p-4 overflow-auto">

--- a/frontend/src/components/ListFiltersActionSheet.vue
+++ b/frontend/src/components/ListFiltersActionSheet.vue
@@ -25,13 +25,14 @@
 						<div class="flex flex-row gap-2 mt-2 flex-wrap">
 							<Button
 								v-for="option in filter.options"
-								:variant="
-									option === filters[filter.fieldname].value
-										? 'solid'
-										: 'outline'
-								"
+								variant="outline"
 								@click="setStatusFilter(filter.fieldname, option)"
-								class="text-sm"
+								class="text-sm text-gray-800"
+								:class="[
+									option === filters[filter.fieldname].value
+										? '!border !border-gray-800 !text-gray-900 !bg-gray-50 !font-medium'
+										: '!font-normal',
+								]"
 							>
 								{{ option }}
 							</Button>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -18,7 +18,7 @@
 						variant="subtle"
 						:class="[
 							areFiltersApplied
-								? '!border !border-gray-800 !bg-white !text-gray-800'
+								? '!border !border-gray-800 !bg-white !text-gray-900 !font-semibold'
 								: '',
 						]"
 					/>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -4,7 +4,7 @@
 			<header
 				class="flex flex-row bg-white shadow-sm py-4 px-2 items-center justify-between border-b sticky top-0 z-10"
 			>
-				<div class="flex flex-row gap-1">
+				<div class="flex flex-row gap-1 items-center">
 					<Button variant="ghost" class="!px-0 !py-0" @click="router.back()">
 						<FeatherIcon name="chevron-left" class="h-5 w-5" />
 					</Button>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -18,7 +18,7 @@
 						variant="subtle"
 						:class="[
 							areFiltersApplied
-								? '!border !border-blue-500 !bg-white !text-blue-500'
+								? '!border !border-gray-800 !bg-white !text-gray-800'
 								: '',
 						]"
 					/>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -71,7 +71,7 @@
 				v-if="documents.loading"
 				class="flex h-64 items-center justify-center"
 			>
-				<LoadingIndicator class="w-8 h-8 text-blue-500" />
+				<LoadingIndicator class="w-8 h-8 text-gray-800" />
 			</div>
 
 			<ion-modal

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -23,12 +23,10 @@
 						]"
 					/>
 					<router-link :to="{ name: formViewRoute }" v-slot="{ navigate }">
-						<Button
-							icon-left="plus"
-							variant="solid"
-							class="mr-2"
-							@click="navigate"
-						>
+						<Button variant="solid" class="mr-2" @click="navigate">
+							<template #prefix>
+								<FeatherIcon name="plus" class="w-4" />
+							</template>
 							New
 						</Button>
 					</router-link>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -5,11 +5,7 @@
 				class="flex flex-row bg-white shadow-sm py-4 px-2 items-center justify-between border-b sticky top-0 z-10"
 			>
 				<div class="flex flex-row gap-1">
-					<Button
-						appearance="minimal"
-						class="!px-0 !py-0"
-						@click="router.back()"
-					>
+					<Button variant="ghost" class="!px-0 !py-0" @click="router.back()">
 						<FeatherIcon name="chevron-left" class="h-5 w-5" />
 					</Button>
 					<h2 class="text-2xl font-semibold text-gray-900">{{ pageTitle }}</h2>
@@ -19,7 +15,7 @@
 					<Button
 						id="show-filter-modal"
 						icon="filter"
-						appearance="secondary"
+						variant="subtle"
 						:class="[
 							areFiltersApplied
 								? '!border !border-blue-500 !bg-white !text-blue-500'
@@ -29,7 +25,7 @@
 					<router-link :to="{ name: formViewRoute }" v-slot="{ navigate }">
 						<Button
 							icon-left="plus"
-							appearance="primary"
+							variant="solid"
 							class="mr-2"
 							@click="navigate"
 						>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -8,7 +8,7 @@
 					<Button variant="ghost" class="!px-0 !py-0" @click="router.back()">
 						<FeatherIcon name="chevron-left" class="h-5 w-5" />
 					</Button>
-					<h2 class="text-2xl font-semibold text-gray-900">{{ pageTitle }}</h2>
+					<h2 class="text-xl font-semibold text-gray-900">{{ pageTitle }}</h2>
 				</div>
 
 				<div class="flex flex-row gap-2">

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -41,7 +41,7 @@
 					/>
 
 					<div
-						class="flex flex-col bg-white rounded-lg mt-5 overflow-auto"
+						class="flex flex-col bg-white rounded mt-5 overflow-auto"
 						v-if="documents.data?.length"
 					>
 						<div

--- a/frontend/src/components/MenuLinks.vue
+++ b/frontend/src/components/MenuLinks.vue
@@ -13,7 +13,7 @@
 						item.current
 							? 'bg-gray-200 font-bold text-gray-800'
 							: 'text-gray-700 font-normal hover:bg-gray-100 hover:text-gray-900',
-						'flex flex-row rounded-lg gap-3 flex-start py-3 px-2 items-center text-base',
+						'flex flex-row rounded-lg gap-3 flex-start py-3 px-2 items-center text-sm',
 					]"
 				>
 					<FeatherIcon :name="item.icon" class="h-5 w-5" />

--- a/frontend/src/components/MenuLinks.vue
+++ b/frontend/src/components/MenuLinks.vue
@@ -13,7 +13,7 @@
 						item.current
 							? 'bg-gray-200 font-bold text-gray-800'
 							: 'text-gray-700 font-normal hover:bg-gray-100 hover:text-gray-900',
-						'flex flex-row rounded-lg gap-3 flex-start py-3 px-2 items-center text-sm',
+						'flex flex-row rounded gap-3 flex-start py-3 px-2 items-center text-sm',
 					]"
 				>
 					<FeatherIcon :name="item.icon" class="h-5 w-5" />

--- a/frontend/src/components/QuickLinks.vue
+++ b/frontend/src/components/QuickLinks.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex flex-col gap-5 my-4 w-full">
 		<div class="text-lg font-medium text-gray-900">{{ title }}</div>
-		<div class="flex flex-col bg-white rounded-lg">
+		<div class="flex flex-col bg-white rounded">
 			<router-link
 				class="flex flex-row flex-start p-4 items-center justify-between border-b"
 				v-for="link in props.items"

--- a/frontend/src/components/QuickLinks.vue
+++ b/frontend/src/components/QuickLinks.vue
@@ -10,7 +10,9 @@
 			>
 				<div class="flex flex-row items-center gap-3 grow">
 					<FeatherIcon :name="link.icon" class="h-5 w-5 text-gray-500" />
-					<div class="text-lg font-normal text-gray-800">{{ link.title }}</div>
+					<div class="text-base font-normal text-gray-800">
+						{{ link.title }}
+					</div>
 				</div>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
 			</router-link>

--- a/frontend/src/components/QuickLinks.vue
+++ b/frontend/src/components/QuickLinks.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col gap-5 my-4 w-full">
-		<div class="font-medium text-gray-900">{{ title }}</div>
+		<div class="text-lg font-medium text-gray-900">{{ title }}</div>
 		<div class="flex flex-col bg-white rounded-lg">
 			<router-link
 				class="flex flex-row flex-start p-4 items-center justify-between border-b"

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -78,14 +78,14 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ status: 'Rejected' })"
-				class="w-full py-3 px-12 bg-red-100 text-red-600"
+				class="w-full bg-red-100 text-red-600 py-5 text-sm"
 				icon-left="x"
 			>
 				Reject
 			</Button>
 			<Button
 				@click="updateDocumentStatus({ status: 'Approved' })"
-				class="w-full bg-green-600 text-white py-3 px-12"
+				class="w-full bg-green-600 text-white py-5 text-sm"
 				icon-left="check"
 			>
 				Approve
@@ -101,7 +101,7 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ docstatus: 1 })"
-				class="w-full py-3 px-12"
+				class="w-full py-5 text-sm"
 				variant="solid"
 			>
 				Submit
@@ -114,7 +114,7 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ docstatus: 2 })"
-				class="w-full py-3 px-12 bg-red-100 text-red-600"
+				class="w-full py-5 text-sm bg-red-100 text-red-600"
 				icon-left="x"
 			>
 				Cancel

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -54,7 +54,7 @@
 					<div class="text-gray-600 text-base">Attachments</div>
 					<ul class="w-full flex flex-col items-center gap-2">
 						<li
-							class="bg-gray-100 rounded-lg p-2 w-full"
+							class="bg-gray-100 rounded p-2 w-full"
 							v-for="(file, index) in attachedFiles.data"
 							:key="index"
 						>

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -79,15 +79,19 @@
 			<Button
 				@click="updateDocumentStatus({ status: 'Rejected' })"
 				class="w-full bg-red-100 text-red-600 py-5 text-sm"
-				icon-left="x"
 			>
+				<template #prefix>
+					<FeatherIcon name="x" class="w-4" />
+				</template>
 				Reject
 			</Button>
 			<Button
 				@click="updateDocumentStatus({ status: 'Approved' })"
 				class="w-full bg-green-600 text-white py-5 text-sm"
-				icon-left="check"
 			>
+				<template #prefix>
+					<FeatherIcon name="check" class="w-4" />
+				</template>
 				Approve
 			</Button>
 		</div>
@@ -115,8 +119,10 @@
 			<Button
 				@click="updateDocumentStatus({ docstatus: 2 })"
 				class="w-full py-5 text-sm bg-red-100 text-red-600"
-				icon-left="x"
 			>
+				<template #prefix>
+					<FeatherIcon name="x" class="w-4" />
+				</template>
 				Cancel
 			</Button>
 		</div>

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -78,16 +78,21 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ status: 'Rejected' })"
-				class="w-full bg-red-100 text-red-600 py-5 text-sm"
+				class="w-full py-5"
+				variant="subtle"
+				theme="red"
 			>
 				<template #prefix>
 					<FeatherIcon name="x" class="w-4" />
 				</template>
 				Reject
 			</Button>
+
 			<Button
 				@click="updateDocumentStatus({ status: 'Approved' })"
-				class="w-full bg-green-600 text-white py-5 text-sm"
+				class="w-full py-5"
+				variant="solid"
+				theme="green"
 			>
 				<template #prefix>
 					<FeatherIcon name="check" class="w-4" />
@@ -105,7 +110,7 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ docstatus: 1 })"
-				class="w-full py-5 text-sm"
+				class="w-full py-5"
 				variant="solid"
 			>
 				Submit
@@ -118,7 +123,9 @@
 		>
 			<Button
 				@click="updateDocumentStatus({ docstatus: 2 })"
-				class="w-full py-5 text-sm bg-red-100 text-red-600"
+				class="w-full py-5"
+				variant="subtle"
+				theme="red"
 			>
 				<template #prefix>
 					<FeatherIcon name="x" class="w-4" />

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -7,7 +7,7 @@
 		<div
 			class="w-full flex flex-row gap-2 pt-8 pb-5 border-b justify-center items-center sticky top-0 z-[100]"
 		>
-			<span class="text-gray-900 font-bold text-xl text-center">
+			<span class="text-gray-900 font-bold text-lg text-center">
 				{{ document?.doctype }}
 			</span>
 			<FeatherIcon

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -102,7 +102,7 @@
 			<Button
 				@click="updateDocumentStatus({ docstatus: 1 })"
 				class="w-full py-3 px-12"
-				appearance="primary"
+				variant="solid"
 			>
 				Submit
 			</Button>

--- a/frontend/src/components/RequestList.vue
+++ b/frontend/src/components/RequestList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="flex flex-col bg-white rounded-lg mt-5 overflow-auto"
+		class="flex flex-col bg-white rounded mt-5 overflow-auto"
 		v-if="props.items?.length"
 	>
 		<div

--- a/frontend/src/components/RequestList.vue
+++ b/frontend/src/components/RequestList.vue
@@ -22,8 +22,9 @@
 			v-slot="{ navigate }"
 		>
 			<Button
+				variant="ghost"
 				@click="navigate"
-				class="w-full !text-gray-600 py-4 mt-0 border-none bg-white hover:bg-white"
+				class="w-full !text-gray-600 py-6 text-sm border-none bg-white hover:bg-white"
 			>
 				View List
 			</Button>

--- a/frontend/src/components/SalaryDetailTable.vue
+++ b/frontend/src/components/SalaryDetailTable.vue
@@ -27,7 +27,7 @@
 			</span>
 		</div>
 	</div>
-	<EmptyState v-else message="No expenses added" />
+	<EmptyState v-else message="No expenses added" :isTableField="true" />
 </template>
 
 <script setup>

--- a/frontend/src/components/SalaryDetailTable.vue
+++ b/frontend/src/components/SalaryDetailTable.vue
@@ -1,8 +1,8 @@
 <template>
 	<!-- Header -->
 	<div class="flex flex-row justify-between items-center">
-		<h2 class="text-lg font-semibold text-gray-800">{{ type }}</h2>
-		<span class="text-lg font-semibold text-gray-800">
+		<h2 class="text-base font-semibold text-gray-800">{{ type }}</h2>
+		<span class="text-base font-semibold text-gray-800">
 			{{ total }}
 		</span>
 	</div>
@@ -18,11 +18,11 @@
 			:key="idx"
 		>
 			<div
-				class="text-lg font-normal whitespace-nowrap overflow-hidden text-ellipsis text-gray-800"
+				class="text-base font-normal whitespace-nowrap overflow-hidden text-ellipsis text-gray-800"
 			>
 				{{ item.salary_component }}
 			</div>
-			<span class="text-gray-700 font-normal rounded-lg text-lg">
+			<span class="text-gray-700 font-normal rounded-lg text-base">
 				{{ formatCurrency(item.amount, salarySlip.currency) }}
 			</span>
 		</div>

--- a/frontend/src/components/SalaryDetailTable.vue
+++ b/frontend/src/components/SalaryDetailTable.vue
@@ -10,7 +10,7 @@
 	<!-- Table -->
 	<div
 		v-if="items"
-		class="flex flex-col bg-white mt-5 rounded-lg border overflow-auto"
+		class="flex flex-col bg-white mt-5 rounded border overflow-auto"
 	>
 		<div
 			class="flex flex-row p-3.5 items-center justify-between border-b"
@@ -22,7 +22,7 @@
 			>
 				{{ item.salary_component }}
 			</div>
-			<span class="text-gray-700 font-normal rounded-lg text-base">
+			<span class="text-gray-700 font-normal rounded text-base">
 				{{ formatCurrency(item.amount, salarySlip.currency) }}
 			</span>
 		</div>

--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -16,7 +16,7 @@
 				</div>
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
-				<span class="text-gray-700 font-normal rounded-lg text-lg">
+				<span class="text-gray-700 font-normal rounded-lg text-base">
 					{{ formatCurrency(doc.net_pay, doc.currency) }}
 				</span>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -2,12 +2,12 @@
 	<div class="flex flex-col w-full justify-center gap-2.5">
 		<div class="flex flex-row items-center justify-between">
 			<div class="flex flex-row items-start gap-3 grow">
-				<SalaryIcon class="h-4 w-4 mt-0.5 text-gray-500" />
-				<div class="flex flex-col items-start">
-					<div class="text-lg font-normal text-gray-800">
+				<SalaryIcon class="h-4 w-4 text-gray-500" />
+				<div class="flex flex-col items-start gap-1.5">
+					<div class="text-base font-normal text-gray-800">
 						{{ title }}
 					</div>
-					<div class="text-sm font-normal text-gray-500">
+					<div class="text-xs font-normal text-gray-500">
 						<span>
 							{{ `Gross Pay: ${formatCurrency(doc.gross_pay, doc.currency)}` }}
 						</span>

--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -16,7 +16,7 @@
 				</div>
 			</div>
 			<div class="flex flex-row justify-end items-center gap-2">
-				<span class="text-gray-700 font-normal rounded-lg text-base">
+				<span class="text-gray-700 font-normal rounded text-base">
 					{{ formatCurrency(doc.net_pay, doc.currency) }}
 				</span>
 				<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/components/TabButtons.vue
+++ b/frontend/src/components/TabButtons.vue
@@ -1,12 +1,12 @@
 <template>
-	<div class="flex p-1 bg-gray-200 rounded-lg">
+	<div class="flex p-1 bg-gray-200 rounded">
 		<button
 			v-for="button in buttons"
 			:key="button.label"
-			class="px-8 py-2.5 transition-all rounded-md flex-auto font-medium text-base"
+			class="px-8 py-2.5 transition-all rounded-[7px] flex-auto font-medium text-sm"
 			:class="
 				modelValue === button.label
-					? 'bg-white shadow text-gray-900'
+					? 'bg-white drop-shadow text-gray-900'
 					: 'text-gray-600'
 			"
 			@click="$emit('update:modelValue', button.label)"

--- a/frontend/src/components/TabButtons.vue
+++ b/frontend/src/components/TabButtons.vue
@@ -3,7 +3,7 @@
 		<button
 			v-for="button in buttons"
 			:key="button.label"
-			class="px-8 py-2.5 transition-all rounded-[7px] flex-auto font-medium text-sm"
+			class="px-8 py-2.5 transition-all rounded-[7px] flex-auto font-medium text-base"
 			:class="
 				modelValue === button.label
 					? 'bg-white drop-shadow text-gray-900'

--- a/frontend/src/composables/index.js
+++ b/frontend/src/composables/index.js
@@ -57,6 +57,7 @@ export async function guessStatusColor(doctype, status) {
 	const stateMap = await statesResource.reload()
 
 	if (stateMap?.length) {
+		if (stateMap?.[status] === "yellow") return "orange"
 		return stateMap?.[status]
 	}
 
@@ -67,7 +68,7 @@ export async function guessStatusColor(doctype, status) {
 			status
 		)
 	) {
-		color = "yellow"
+		color = "orange"
 	} else if (
 		["Urgent", "High", "Failed", "Rejected", "Error"].includes(status)
 	) {

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -6,8 +6,9 @@ ion-modal {
 }
 
 input:disabled {
-	--webkit-text-fill-color: var(--text-color);
-	opacity: 1; /* required on iOS */
+	--webkit-text-fill-color: var(--tw-text-color);
+	opacity: 0.9; /* required on iOS */
+	color: var(--tw-text-color);
 }
 
 /* For Webkit-based browsers (Chrome, Safari and Opera) */

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,6 +9,7 @@ import {
 	setConfig,
 	frappeRequest,
 	resourcesPlugin,
+	FormControl,
 } from "frappe-ui"
 import EmptyState from "@/components/EmptyState.vue"
 
@@ -34,6 +35,7 @@ app.use(resourcesPlugin)
 
 app.component("Button", Button)
 app.component("Input", Input)
+app.component("FormControl", FormControl)
 app.component("EmptyState", EmptyState)
 
 app.use(router)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,6 +6,7 @@ import socket from "./socket"
 import {
 	Button,
 	Input,
+	FormControl,
 	setConfig,
 	frappeRequest,
 	resourcesPlugin,
@@ -34,6 +35,7 @@ app.use(resourcesPlugin)
 
 app.component("Button", Button)
 app.component("Input", Input)
+app.component("FormControl", FormControl)
 app.component("EmptyState", EmptyState)
 
 app.use(router)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,7 +6,6 @@ import socket from "./socket"
 import {
 	Button,
 	Input,
-	FormControl,
 	setConfig,
 	frappeRequest,
 	resourcesPlugin,
@@ -35,7 +34,6 @@ app.use(resourcesPlugin)
 
 app.component("Button", Button)
 app.component("Input", Input)
-app.component("FormControl", FormControl)
 app.component("EmptyState", EmptyState)
 
 app.use(router)

--- a/frontend/src/theme/variables.css
+++ b/frontend/src/theme/variables.css
@@ -5,7 +5,7 @@ http://ionicframework.com/docs/theming/ */
 
 :root {
 	--ion-background-color: #f4f5f6;
-	--ion-font-family: "Inter", sans-serif;
+	--ion-font-family: "InterVar", sans-serif;
 
 	/** primary **/
 	--ion-color-primary: #3880ff;

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,7 +4,7 @@
 		:showCheckInPanel="true"
 	>
 		<template #body>
-			<div class="flex flex-col items-center mt-5 p-4 gap-7">
+			<div class="flex flex-col items-center mt-3 p-4 gap-7">
 				<QuickLinks :items="quickLinks" title="Quick Links" />
 				<RequestPanel />
 			</div>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -7,13 +7,13 @@
 				</div>
 				<div class="mx-auto mt-6 w-full px-8 sm:w-96">
 					<form class="flex flex-col space-y-4" @submit.prevent="submit">
-						<Input
+						<FormControl
 							label="Email"
 							placeholder="johndoe@mail.com"
 							v-model="email"
 							:type="email !== 'Administrator' ? 'email' : 'text'"
 						/>
-						<Input
+						<FormControl
 							label="Password"
 							type="password"
 							placeholder="••••••"
@@ -32,7 +32,7 @@
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
 import { inject, ref } from "vue"
-import { Input, Button } from "frappe-ui"
+import { Button, FormControl } from "frappe-ui"
 
 const email = ref(null)
 const password = ref(null)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -19,7 +19,7 @@
 							placeholder="••••••"
 							v-model="password"
 						/>
-						<Button :loading="session.login.loading" appearance="primary">
+						<Button :loading="session.login.loading" variant="solid">
 							Login
 						</Button>
 					</form>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -7,13 +7,13 @@
 				</div>
 				<div class="mx-auto mt-6 w-full px-8 sm:w-96">
 					<form class="flex flex-col space-y-4" @submit.prevent="submit">
-						<FormControl
+						<Input
 							label="Email"
 							placeholder="johndoe@mail.com"
 							v-model="email"
 							:type="email !== 'Administrator' ? 'email' : 'text'"
 						/>
-						<FormControl
+						<Input
 							label="Password"
 							type="password"
 							placeholder="••••••"
@@ -32,7 +32,7 @@
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
 import { inject, ref } from "vue"
-import { Button, FormControl } from "frappe-ui"
+import { Input, Button } from "frappe-ui"
 
 const email = ref(null)
 const password = ref(null)

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -28,11 +28,13 @@
 							</div>
 							<Button
 								variant="outline"
-								icon-left="check-circle"
 								class="ml-auto"
 								@click="markAllAsRead.submit"
 								:loading="markAllAsRead.loading"
 							>
+								<template #prefix>
+									<FeatherIcon name="check-circle" class="w-4" />
+								</template>
 								Mark all as read
 							</Button>
 						</div>

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -14,9 +14,7 @@
 							>
 								<FeatherIcon name="chevron-left" class="h-5 w-5" />
 							</Button>
-							<h2 class="text-2xl font-semibold text-gray-900">
-								Notifications
-							</h2>
+							<h2 class="text-xl font-semibold text-gray-900">Notifications</h2>
 						</div>
 					</header>
 

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -6,7 +6,7 @@
 					<header
 						class="flex flex-row bg-white shadow-sm py-4 px-2 items-center justify-between border-b sticky top-0 z-10"
 					>
-						<div class="flex flex-row gap-1">
+						<div class="flex flex-row gap-1 items-center">
 							<Button
 								variant="ghost"
 								class="!px-0 !py-0"

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -54,11 +54,7 @@
 								:to="getItemRoute(item)"
 								@click="markAsRead(item.name)"
 							>
-								<EmployeeAvatar
-									:userID="item.from_user"
-									size="md"
-									class="mt-0.5"
-								/>
+								<EmployeeAvatar :userID="item.from_user" size="md" />
 								<div class="flex flex-col gap-0.5 grow ml-3">
 									<div
 										class="text-base font-normal text-gray-800"

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -40,7 +40,7 @@
 						</div>
 
 						<div
-							class="flex flex-col bg-white rounded-lg"
+							class="flex flex-col bg-white rounded"
 							v-if="notifications.data?.length"
 						>
 							<router-link

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -8,7 +8,7 @@
 					>
 						<div class="flex flex-row gap-1">
 							<Button
-								appearance="minimal"
+								variant="ghost"
 								class="!px-0 !py-0"
 								@click="router.back()"
 							>
@@ -29,7 +29,7 @@
 								{{ unreadNotificationsCount.data }} Unread
 							</div>
 							<Button
-								appearance="white"
+								variant="outline"
 								icon-left="check-circle"
 								class="ml-auto"
 								@click="markAllAsRead.submit"

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -45,7 +45,7 @@
 						>
 							<router-link
 								:class="[
-									'flex flex-row items-start p-4 justify-between border-b before:mt-4',
+									'flex flex-row items-start p-4 justify-between border-b before:mt-3',
 									`before:content-[''] before:mr-2 before:shrink-0 before:w-1.5 before:h-1.5 before:rounded-full`,
 									item.read ? 'bg-white-500' : 'before:bg-blue-500',
 								]"
@@ -54,13 +54,13 @@
 								:to="getItemRoute(item)"
 								@click="markAsRead(item.name)"
 							>
-								<EmployeeAvatar :userID="item.from_user" size="md" />
+								<EmployeeAvatar :userID="item.from_user" size="lg" />
 								<div class="flex flex-col gap-0.5 grow ml-3">
 									<div
-										class="text-base font-normal text-gray-800"
+										class="text-sm leading-5 font-normal text-gray-800"
 										v-html="item.message"
 									></div>
-									<div class="text-sm font-normal text-gray-500">
+									<div class="text-xs font-normal text-gray-500">
 										{{ dayjs(item.creation).fromNow() }}
 									</div>
 								</div>

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -8,7 +8,7 @@
 					:alt="user.data.first_name"
 				/>
 
-				<div class="flex flex-col gap-1 items-center mt-2 mb-5">
+				<div class="flex flex-col gap-1.5 items-center mt-2 mb-5">
 					<span v-if="employee" class="text-xl font-bold text-gray-900">{{
 						employee?.data?.employee_name
 					}}</span>
@@ -23,7 +23,8 @@
 				<Button
 					@click="logout"
 					variant="outline"
-					class="text-red-500 w-full shadow py-2 mt-5"
+					theme="red"
+					class="w-full shadow py-4 mt-5"
 					icon-left="log-out"
 				>
 					Log Out
@@ -40,6 +41,7 @@ import BaseLayout from "@/components/BaseLayout.vue"
 import { inject } from "vue"
 
 import { showErrorAlert } from "@/utils/dialogs"
+import { Avatar } from "frappe-ui"
 
 const session = inject("$session")
 const user = inject("$user")

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -25,8 +25,10 @@
 					variant="outline"
 					theme="red"
 					class="w-full shadow py-4 mt-5"
-					icon-left="log-out"
 				>
+					<template #prefix>
+						<FeatherIcon name="log-out" class="w-4" />
+					</template>
 					Log Out
 				</Button>
 			</div>
@@ -41,7 +43,7 @@ import BaseLayout from "@/components/BaseLayout.vue"
 import { inject } from "vue"
 
 import { showErrorAlert } from "@/utils/dialogs"
-import { Avatar } from "frappe-ui"
+import { FeatherIcon } from "frappe-ui"
 
 const session = inject("$session")
 const user = inject("$user")

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -9,7 +9,7 @@
 				/>
 
 				<div class="flex flex-col gap-1.5 items-center mt-2 mb-5">
-					<span v-if="employee" class="text-xl font-bold text-gray-900">{{
+					<span v-if="employee" class="text-lg font-bold text-gray-900">{{
 						employee?.data?.employee_name
 					}}</span>
 					<span v-if="employee" class="font-normal text-sm text-gray-500">{{

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -22,7 +22,7 @@
 
 				<Button
 					@click="logout"
-					appearance="white"
+					variant="outline"
 					class="text-red-500 w-full shadow py-2 mt-5"
 					icon-left="log-out"
 				>

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -16,7 +16,7 @@
 				</div>
 
 				<div>
-					<div class="text-xl text-gray-800 font-bold">Recent Expenses</div>
+					<div class="text-lg text-gray-800 font-bold">Recent Expenses</div>
 					<RequestList
 						:component="markRaw(ExpenseClaimItem)"
 						:items="myClaims.data"
@@ -27,7 +27,7 @@
 
 				<div>
 					<div class="flex flex-row justify-between items-center">
-						<div class="text-xl text-gray-800 font-bold">
+						<div class="text-lg text-gray-800 font-bold">
 							Employee Advance Balance
 						</div>
 						<router-link

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -12,7 +12,7 @@
 						<Button
 							@click="navigate"
 							variant="solid"
-							class="w-full py-5 text-sm"
+							class="w-full py-5 text-base"
 						>
 							Claim an Expense
 						</Button>

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -37,7 +37,7 @@
 						<router-link
 							v-if="advanceBalance?.data?.length"
 							:to="{ name: 'EmployeeAdvanceListView' }"
-							class="text-lg text-blue-500 font-medium cursor-pointer"
+							class="text-sm text-gray-800 font-semibold cursor-pointer underline underline-offset-2"
 						>
 							View List
 						</router-link>

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -9,7 +9,7 @@
 						:to="{ name: 'ExpenseClaimFormView' }"
 						v-slot="{ navigate }"
 					>
-						<Button @click="navigate" appearance="primary" class="py-2 w-full">
+						<Button @click="navigate" variant="solid" class="py-2 w-full">
 							Claim an Expense
 						</Button>
 					</router-link>

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
 	<BaseLayout pageTitle="Expense Claims">
 		<template #body>
-			<div class="flex flex-col mt-5 mb-7 p-4 gap-7">
+			<div class="flex flex-col mt-7 mb-7 p-4 gap-7">
 				<ExpenseClaimSummary />
 
 				<div class="w-full">

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -9,7 +9,11 @@
 						:to="{ name: 'ExpenseClaimFormView' }"
 						v-slot="{ navigate }"
 					>
-						<Button @click="navigate" variant="solid" class="py-2 w-full">
+						<Button
+							@click="navigate"
+							variant="solid"
+							class="w-full py-5 text-sm"
+						>
 							Claim an Expense
 						</Button>
 					</router-link>

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -12,7 +12,7 @@
 						<Button
 							@click="navigate"
 							variant="solid"
-							class="py-5 text-sm w-full"
+							class="py-5 text-base w-full"
 						>
 							Request a Leave
 						</Button>

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -1,10 +1,10 @@
 <template>
 	<BaseLayout pageTitle="Leaves &amp; Holidays">
 		<template #body>
-			<div class="flex flex-col items-center mt-5 mb-7">
+			<div class="flex flex-col items-center mt-7 mb-7 py-4">
 				<LeaveBalance />
 
-				<div class="flex flex-col gap-7 px-4 mt-4 w-full">
+				<div class="flex flex-col gap-7 mt-5 px-4 w-full">
 					<router-link
 						:to="{ name: 'LeaveApplicationFormView' }"
 						v-slot="{ navigate }"

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -9,7 +9,7 @@
 						:to="{ name: 'LeaveApplicationFormView' }"
 						v-slot="{ navigate }"
 					>
-						<Button @click="navigate" appearance="primary" class="py-2 w-full">
+						<Button @click="navigate" variant="solid" class="py-2 w-full">
 							Request a Leave
 						</Button>
 					</router-link>

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -9,7 +9,11 @@
 						:to="{ name: 'LeaveApplicationFormView' }"
 						v-slot="{ navigate }"
 					>
-						<Button @click="navigate" variant="solid" class="py-2 w-full">
+						<Button
+							@click="navigate"
+							variant="solid"
+							class="py-5 text-sm w-full"
+						>
 							Request a Leave
 						</Button>
 					</router-link>

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -14,7 +14,7 @@
 						</Button>
 					</router-link>
 					<div>
-						<div class="text-xl text-gray-800 font-bold">Recent Leaves</div>
+						<div class="text-lg text-gray-800 font-bold">Recent Leaves</div>
 						<RequestList
 							:component="markRaw(LeaveRequestItem)"
 							:items="myLeaves.data"

--- a/frontend/src/views/salary_slip/Dashboard.vue
+++ b/frontend/src/views/salary_slip/Dashboard.vue
@@ -2,7 +2,7 @@
 	<BaseLayout pageTitle="Salary Slips">
 		<template #body>
 			<div class="flex flex-col items-center my-7 p-4">
-				<div class="flex flex-col w-full bg-white rounded-lg py-5 px-3.5 gap-5">
+				<div class="flex flex-col w-full bg-white rounded py-5 px-3.5 gap-5">
 					<div v-if="lastSalarySlip" class="flex flex-col w-full gap-1.5">
 						<span class="text-gray-600 text-sm font-medium leading-5">
 							Year To Date
@@ -29,7 +29,7 @@
 				<div class="flex flex-col items-center mt-5 mb-7 w-full">
 					<div
 						v-if="documents.data?.length"
-						class="flex flex-col bg-white rounded-lg mt-5 overflow-auto w-full"
+						class="flex flex-col bg-white rounded mt-5 overflow-auto w-full"
 					>
 						<div
 							class="p-3.5 items-center justify-between border-b cursor-pointer"

--- a/frontend/src/views/salary_slip/Dashboard.vue
+++ b/frontend/src/views/salary_slip/Dashboard.vue
@@ -4,10 +4,10 @@
 			<div class="flex flex-col items-center my-7 p-4">
 				<div class="flex flex-col w-full bg-white rounded-lg py-5 px-3.5 gap-5">
 					<div v-if="lastSalarySlip" class="flex flex-col w-full gap-1.5">
-						<span class="text-gray-600 text-base font-medium leading-5">
+						<span class="text-gray-600 text-sm font-medium leading-5">
 							Year To Date
 						</span>
-						<span class="text-gray-800 text-2xl font-bold leading-6">
+						<span class="text-gray-800 text-xl font-bold leading-6">
 							{{
 								formatCurrency(
 									lastSalarySlip.year_to_date,

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -31,7 +31,7 @@
 				<template #formButton>
 					<ErrorMessage :message="downloadError" class="mt-2" />
 					<Button
-						class="w-full rounded-md py-2.5 px-3.5 mt-2"
+						class="w-full rounded-md py-5 text-sm px-3.5 mt-2"
 						@click="downloadPDF"
 						variant="solid"
 						:loading="loading"

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -31,7 +31,7 @@
 				<template #formButton>
 					<ErrorMessage :message="downloadError" class="mt-2" />
 					<Button
-						class="w-full rounded-md py-5 text-sm px-3.5 mt-2"
+						class="w-full rounded py-5 text-sm px-3.5 mt-2"
 						@click="downloadPDF"
 						variant="solid"
 						:loading="loading"

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -33,7 +33,7 @@
 					<Button
 						class="w-full rounded-md py-2.5 px-3.5 mt-2"
 						@click="downloadPDF"
-						appearance="primary"
+						variant="solid"
 						:loading="loading"
 					>
 						Download PDF

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -31,7 +31,7 @@
 				<template #formButton>
 					<ErrorMessage :message="downloadError" class="mt-2" />
 					<Button
-						class="w-full rounded py-5 text-sm px-3.5 mt-2"
+						class="w-full rounded py-5 text-base px-3.5 mt-2"
 						@click="downloadPDF"
 						variant="solid"
 						:loading="loading"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,11 +3,11 @@ import vue from "@vitejs/plugin-vue"
 import { VitePWA } from "vite-plugin-pwa"
 
 import path from "path"
-import { getProxyOptions } from "frappe-ui/src/utils/vite-dev-server"
-import { webserver_port } from "../../../sites/common_site_config.json"
+import frappeui from "frappe-ui/vite"
 
 export default defineConfig({
 	plugins: [
+		frappeui(),
 		vue(),
 		VitePWA({
 			registerType: "autoUpdate",
@@ -49,10 +49,6 @@ export default defineConfig({
 			},
 		}),
 	],
-	server: {
-		port: 8080,
-		proxy: getProxyOptions({ port: webserver_port }),
-	},
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -968,10 +968,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
   integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
 
-"@headlessui/vue@^1.5.0":
-  version "1.7.13"
-  resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.7.13.tgz#bf4c5e324c3a724f6f7911362e7f38989b754590"
-  integrity sha512-obG5TdPdBDfs+jiA1mY29LPFqyJl93Q90EL86ontfRe1B6XvbjPkx+x1aAC5DA18bXbb0Juni1ayDbXo0w1u0A==
+"@headlessui/vue@^1.7.14":
+  version "1.7.16"
+  resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.7.16.tgz#bdc9d32d329248910325539b99e6abfce0c69f89"
+  integrity sha512-nKT+nf/q6x198SsyK54mSszaQl/z+QxtASmgMEJtpxSX2Q0OPJX0upS/9daDyiECpeAsvjkoOrm2O/6PyBQ+Qg==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -1241,186 +1241,186 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@tiptap/core@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-2.0.3.tgz#dfd55124b3e7b0482e5ccb8be46eb9c3189167e2"
-  integrity sha512-jLyVIWAdjjlNzrsRhSE2lVL/7N8228/1R1QtaVU85UlMIwHFAcdzhD8FeiKkqxpTnGpaDVaTy7VNEtEgaYdCyA==
+"@tiptap/core@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-2.1.7.tgz#9823a3712d176849cfd281dd8229ad0719c9eb9e"
+  integrity sha512-1pqTwlTnwTKQSNQmmTWhs2lwdvd+hFFNFZnrRAfvZhQZA6qPmPmKMNTcYmK38Tn4axKth6mhBamzTJgMZFI7ng==
 
-"@tiptap/extension-blockquote@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-blockquote/-/extension-blockquote-2.0.3.tgz#3ee7aff66a2526501154ca69f3e91e153c58313c"
-  integrity sha512-rkUcFv2iL6f86DBBHoa4XdKNG2StvkJ7tfY9GoMpT46k3nxOaMTqak9/qZOo79TWxMLYtXzoxtKIkmWsbbcj4A==
+"@tiptap/extension-blockquote@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-blockquote/-/extension-blockquote-2.1.7.tgz#fe25ec1dedd1f7e3eb1a851a6ac8738ca4691a17"
+  integrity sha512-oAsUU1c0DDZKHwK7/uCtYpnTUQt0o3w+SsJSv4S2vlSHidiFl9gCQGozUQ/Alzc7GO1Y95rOscL28DJXgXESQg==
 
-"@tiptap/extension-bold@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-bold/-/extension-bold-2.0.3.tgz#2a28816195562a39c33f50e626796d14a800784f"
-  integrity sha512-OGT62fMRovSSayjehumygFWTg2Qn0IDbqyMpigg/RUAsnoOI2yBZFVrdM2gk1StyoSay7gTn2MLw97IUfr7FXg==
+"@tiptap/extension-bold@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-bold/-/extension-bold-2.1.7.tgz#c5d89284235d75c2e65745b50a5c0681be1cbab6"
+  integrity sha512-GZV2D91WENkWd1W29vM4kyGWObcxOKQrY8MuCvTdxni1kobEc/LPZzQ1XiQmiNTvXTMcBz5ckLpezdjASV1dNg==
 
-"@tiptap/extension-bubble-menu@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.0.3.tgz#44b3c4e35fd478c42467d8fb7dbc9532614e5b18"
-  integrity sha512-lPt1ELrYCuoQrQEUukqjp9xt38EwgPUwaKHI3wwt2Rbv+C6q1gmRsK1yeO/KqCNmFxNqF2p9ZF9srOnug/RZDQ==
+"@tiptap/extension-bubble-menu@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.1.7.tgz#62616c9ee456c8413ad6c120757978266052a1a0"
+  integrity sha512-VcwwUgiG17TEDZda1JBbyKCHLIBTu8B2OAzYrnd4ZqeRs5KTVAB279o/TVjsLVgEfC+c7IWwhhaPPMoXn/lJ3g==
   dependencies:
     tippy.js "^6.3.7"
 
-"@tiptap/extension-bullet-list@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-bullet-list/-/extension-bullet-list-2.0.3.tgz#43c4c0c161d5c065f3f87e4bf54d13bd6c55b4c3"
-  integrity sha512-RtaLiRvZbMTOje+FW5bn+mYogiIgNxOm065wmyLPypnTbLSeHeYkoqVSqzZeqUn+7GLnwgn1shirUe6csVE/BA==
+"@tiptap/extension-bullet-list@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-bullet-list/-/extension-bullet-list-2.1.7.tgz#3a7356824a931122314a6bd73b5f9d8a8a313791"
+  integrity sha512-BReix1wkGNH12DSWGnWPKNu4do92Avh98aLkRS1o1V1Y49/+YGMYtfBXB9obq40o0WqKvk4MoM+rhKbfEc44Gg==
 
-"@tiptap/extension-code-block@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-code-block/-/extension-code-block-2.0.3.tgz#4ce08b4f3c5af166d3cc00e91ba5b989f01fee63"
-  integrity sha512-F4xMy18EwgpyY9f5Te7UuF7UwxRLptOtCq1p2c2DfxBvHDWhAjQqVqcW/sq/I/WuED7FwCnPLyyAasPiVPkLPw==
+"@tiptap/extension-code-block@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-code-block/-/extension-code-block-2.1.7.tgz#c087c22c305f3c87645228ad32f32595dde7f2a2"
+  integrity sha512-uiasfWCIQuk34vGoIENqAJOHf9m3hAkcELnb9T6+uNxA3O7PUZQqBVN/27oEipj7j15pqua50D6C1jql9kFe0g==
 
-"@tiptap/extension-code@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-code/-/extension-code-2.0.3.tgz#74d88073faedd1fc52d6ed3de4eed8fde80ff4bf"
-  integrity sha512-LsVCKVxgBtkstAr1FjxN8T3OjlC76a2X8ouoZpELMp+aXbjqyanCKzt+sjjUhE4H0yLFd4v+5v6UFoCv4EILiw==
+"@tiptap/extension-code@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-code/-/extension-code-2.1.7.tgz#bad3b1aedc23123a2094f8810801edb0c13acbff"
+  integrity sha512-g0IA6Q6DFZE0AEOMXAV1mktl/XzIO3s1h/haPIKZ8GNes522qhBr9FYc5OUPQCCbgYjL7soTGzxA/W5Jk3f2AQ==
 
-"@tiptap/extension-color@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-color/-/extension-color-2.0.3.tgz#48cb4cd2a613678edbf5a8e2d5e00b19c26fe1e6"
-  integrity sha512-LYj3CWahhuJOy4/bwOur+cob8eky7xx7wyyBFIYELuzLcZt9hBmZwXxinQzD7BaQv4YdT+3oqr8BhChuPNj52w==
+"@tiptap/extension-color@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-color/-/extension-color-2.1.7.tgz#7f436aed2f41087d8de6af6a4dd4cb7d964354dd"
+  integrity sha512-NLspH5taSpZP60rXJjDKu8AP9VDd+dlqz4guxvijtuPEePw87Fzidxx9w6X0uYQfx1O0xdPFq3UodlDz591scA==
 
-"@tiptap/extension-document@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-document/-/extension-document-2.0.3.tgz#b58af5b4f71c0acea953a7ebe8b1d24341bfaf68"
-  integrity sha512-PsYeNQQBYIU9ayz1R11Kv/kKNPFNIV8tApJ9pxelXjzcAhkjncNUazPN/dyho60mzo+WpsmS3ceTj/gK3bCtWA==
+"@tiptap/extension-document@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-document/-/extension-document-2.1.7.tgz#5e1d56e899fdca8ebfad1b7cb358d5ace664b851"
+  integrity sha512-tZyoPPmvzti7PEnyulXomEtINd/Oi2S84uOt6gw7DTCnDq5bF5sn1IfN8Icqp9t4jDwyLXy2TL0Zg/sR0a2Ibg==
 
-"@tiptap/extension-dropcursor@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-dropcursor/-/extension-dropcursor-2.0.3.tgz#205d02c70b200810572d0b7e264bbdb718343ad0"
-  integrity sha512-McthMrfusn6PjcaynJLheZJcXto8TaIW5iVitYh8qQrDXr31MALC/5GvWuiswmQ8bAXiWPwlLDYE/OJfwtggaw==
+"@tiptap/extension-dropcursor@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-dropcursor/-/extension-dropcursor-2.1.7.tgz#a3f79b7453579f36f326852b16e421601e881a28"
+  integrity sha512-hNk2BuLnNSXlGOQphlzdpFKCKo7uHUFjWuBfzF1S9FMAQgcN7eTia+cCClmXABYfVLW4fT14PC1KiuGjxi9MuA==
 
-"@tiptap/extension-floating-menu@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-floating-menu/-/extension-floating-menu-2.0.3.tgz#8d9943246aa3247442c1993f235617094fe705b5"
-  integrity sha512-zN1vRGRvyK3pO2aHRmQSOTpl4UJraXYwKYM009n6WviYKUNm0LPGo+VD4OAtdzUhPXyccnlsTv2p6LIqFty6Bg==
+"@tiptap/extension-floating-menu@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-floating-menu/-/extension-floating-menu-2.1.7.tgz#fe2def740b3136d38101634ae60d2fec5468c57e"
+  integrity sha512-K0bO7JKHAvgLM5MkhNgoYcD6SB0Z2tNIFhZHs5SCTuhg7dwduMSM3pC6QBrJGUk99DGsKuMPYQn3c2oG7MLbyQ==
   dependencies:
     tippy.js "^6.3.7"
 
-"@tiptap/extension-gapcursor@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-gapcursor/-/extension-gapcursor-2.0.3.tgz#e098b78c4a169e1630dc6531d68b7f365de59c2f"
-  integrity sha512-6I9EzzsYOyyqDvDvxIK6Rv3EXB+fHKFj8ntHO8IXmeNJ6pkhOinuXVsW6Yo7TcDYoTj4D5I2MNFAW2rIkgassw==
+"@tiptap/extension-gapcursor@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-gapcursor/-/extension-gapcursor-2.1.7.tgz#5c0303ba37b4c066f3a3c5835fd0b298f0d3e919"
+  integrity sha512-7eoInzzk1sssoD3RMkwFC86U15Ja4ANve+8wIC+xhN4R3Oe3PY3lFbp1GQxCmaJj8b3rtjNKIQZ2zO0PH58afA==
 
-"@tiptap/extension-hard-break@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-hard-break/-/extension-hard-break-2.0.3.tgz#aa7805d825e5244bdccc508da18c781e231b2859"
-  integrity sha512-RCln6ARn16jvKTjhkcAD5KzYXYS0xRMc0/LrHeV8TKdCd4Yd0YYHe0PU4F9gAgAfPQn7Dgt4uTVJLN11ICl8sQ==
+"@tiptap/extension-hard-break@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-hard-break/-/extension-hard-break-2.1.7.tgz#1cd783adfe2788d41614f8851b8d7a52ec027cce"
+  integrity sha512-6gFXXlCGAdXjy27BW29q4yfCQPAEFd18k7zRTnbd4aE/zIWUtLqdiTfI3kotUMab9Tt9/z1BRmCbEUxRsf1Nww==
 
-"@tiptap/extension-heading@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-heading/-/extension-heading-2.0.3.tgz#5e9e779f33f366afcf729d9f68ef49721f825e11"
-  integrity sha512-f0IEv5ms6aCzL80WeZ1qLCXTkRVwbpRr1qAETjg3gG4eoJN18+lZNOJYpyZy3P92C5KwF2T3Av00eFyVLIbb8Q==
+"@tiptap/extension-heading@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-heading/-/extension-heading-2.1.7.tgz#26d16227eab95b1f381e977f7aa1685f493c6fb5"
+  integrity sha512-jMeTqtq3kbMFtMvUb3SeIt4FFM3W+b6TAw5H4Qd6z3gYsAU3GahRK67MtbJfPmznUkZfimrqW9VCaBezScfrsQ==
 
-"@tiptap/extension-highlight@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-highlight/-/extension-highlight-2.0.3.tgz#4a52de6666dfe4a80b018aa43805d2d220e90219"
-  integrity sha512-NrtibY8cZkIjZMQuHRrKd4php+plOvAoSo8g3uVFu275I/Ixt5HqJ53R4voCXs8W8BOBRs2HS2QX8Cjh79XhtA==
+"@tiptap/extension-highlight@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-highlight/-/extension-highlight-2.1.7.tgz#0f9434eedfdcb95a22ca5b6f601d13f4343a7e5c"
+  integrity sha512-3EXrnf1BQSdOe/iqzcTIr5Tf0NOhPQ+y1B9nMi/40v3MD8WzRBLaqj0lvpwO7xMAdgxm6IiL/XFYU41n9yFl/Q==
 
-"@tiptap/extension-history@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-history/-/extension-history-2.0.3.tgz#8936c15aa46f2ddeada1c3d9abe2888d58d08c30"
-  integrity sha512-00KHIcJ8kivn2ARI6NQYphv2LfllVCXViHGm0EhzDW6NQxCrriJKE3tKDcTFCu7LlC5doMpq9Z6KXdljc4oVeQ==
+"@tiptap/extension-history@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-history/-/extension-history-2.1.7.tgz#baa566875ef1278c5dd8821970362d85348b266c"
+  integrity sha512-8SIEKSImrIkqJThym1bPD13sC4/76UrG+piQ30xKQU4B7zUFCbutvrwYuQHSRvaEt8BPdTv2LWIK+wBkIgbWVA==
 
-"@tiptap/extension-horizontal-rule@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.0.3.tgz#5c67db2c0bf3bc14a8aab80df584bee5aa23fbeb"
-  integrity sha512-SZRUSh07b/M0kJHNKnfBwBMWrZBEm/E2LrK1NbluwT3DBhE+gvwiEdBxgB32zKHNxaDEXUJwUIPNC3JSbKvPUA==
+"@tiptap/extension-horizontal-rule@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.1.7.tgz#7c21bc4917e4ced9382e81626e0f0068b224bfbb"
+  integrity sha512-hJupsDxDVmjmKI/Ewl/gtiyUx52Y3wRUhT8dCXNOA5eldmPXN23E2Fa2BC8XB47dyc5pubyNcLuqaLeaZ5hedw==
 
-"@tiptap/extension-image@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-image/-/extension-image-2.0.3.tgz#048484b2e059d4bed78f97f08651bd57b41855a9"
-  integrity sha512-hS9ZJwz0md07EHsC+o4NuuJkhCZsZn7TuRz/2CvRSj2fWFIz+40CyNAHf/2J0qNugG9ommXaemetsADeEZP9ag==
+"@tiptap/extension-image@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-image/-/extension-image-2.1.7.tgz#597129fb072f6b0014c980892c367a283077f564"
+  integrity sha512-aWa/NPMc1U9Z6xuV0gk1O1nk4H7BAwQMwqXWdvUQCJhmW5+LJPdEiKvt3P6j+ClIN7sdyokZCgr6eGr817qTLA==
 
-"@tiptap/extension-italic@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-italic/-/extension-italic-2.0.3.tgz#2d9d5d8ccf3c38266f745029c2ec0646c075c1fc"
-  integrity sha512-cfS5sW0gu7qf4ihwnLtW/QMTBrBEXaT0sJl3RwkhjIBg/65ywJKE5Nz9ewnQHmDeT18hvMJJ1VIb4j4ze9jj9A==
+"@tiptap/extension-italic@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-italic/-/extension-italic-2.1.7.tgz#d077683597d4282ae272c48b313d768d71985b67"
+  integrity sha512-7e37f+OFqisdY19nWIthbSNHMJy4+4dec06rUICPrkiuFaADj5HjUQr0dyWpL/LkZh92Wf/rWgp4V/lEwon3jA==
 
-"@tiptap/extension-link@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-link/-/extension-link-2.0.3.tgz#4714a4c23d04032e75b5b8364a9c532f7a385aba"
-  integrity sha512-H72tXQ5rkVCkAhFaf08fbEU7EBUCK0uocsqOF+4th9sOlrhfgyJtc8Jv5EXPDpxNgG5jixSqWBo0zKXQm9s9eg==
+"@tiptap/extension-link@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-link/-/extension-link-2.1.7.tgz#2705c212d105ccf411d505e334ece4a723971ee4"
+  integrity sha512-NDfoMCkThng1B530pMg5y69+eWoghZXK2uCntrJH7Rs8jNeGMyt9wGIOd7N8ZYz0oJ2ZYKzZjS0RANdBDS17DA==
   dependencies:
     linkifyjs "^4.1.0"
 
-"@tiptap/extension-list-item@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-list-item/-/extension-list-item-2.0.3.tgz#2bca673b1ed83fdc00cb208f4d5c57d4d44ddb22"
-  integrity sha512-p7cUsk0LpM1PfdAuFE8wYBNJ3gvA0UhNGR08Lo++rt9UaCeFLSN1SXRxg97c0oa5+Ski7SrCjIJ5Ynhz0viTjQ==
+"@tiptap/extension-list-item@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-list-item/-/extension-list-item-2.1.7.tgz#dc24045e445d0f91baec9b113f711dc90c6682ac"
+  integrity sha512-hd/E4qQopBXWa6kdFY19qFVgqj4fzdPgAnzdXJ2XW7bC6O2CusmHphRRZ5FBsuspYTN/6/fv0i0jK9rSGlsEyA==
 
-"@tiptap/extension-mention@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-mention/-/extension-mention-2.0.3.tgz#7ef0968c31543b806e431982ca697161439410ce"
-  integrity sha512-mT+tMJyf15gN3kW7UfZrP+J0jlhlBnR50SHj0PnDWqGnJ70qKSZTxcHfohrxU6On6yaOFsd+5Omn5seGK4XFWA==
+"@tiptap/extension-mention@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-mention/-/extension-mention-2.1.7.tgz#09fa03af6f502a9c0343c2d39e2557b74c5ffcfd"
+  integrity sha512-GPVw8AiGwCozkY2TKLk/eMpo7IYfVuXnFB82yPlG3RQTGREpvf6L5Vv28HdXcgk7KMTo2IcEdH32EJDqjPYlEg==
 
-"@tiptap/extension-ordered-list@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-ordered-list/-/extension-ordered-list-2.0.3.tgz#d1e5d6fc240545dbba7f7e6666bebd658fc3b4ad"
-  integrity sha512-ZB3MpZh/GEy1zKgw7XDQF4FIwycZWNof1k9WbDZOI063Ch4qHZowhVttH2mTCELuyvTMM/o9a8CS7qMqQB48bw==
+"@tiptap/extension-ordered-list@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-ordered-list/-/extension-ordered-list-2.1.7.tgz#72d9ddc432ecf0fd19c8acd3c6b44f5358d8e0d0"
+  integrity sha512-3XIXqbZmYkNzF+8PQ2jcCOCj0lpC3y9HGM/+joPIunhiUiktrIgpbUDv2E1Gq5lJHYqthIeujniI2dB85tkwJQ==
 
-"@tiptap/extension-paragraph@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-paragraph/-/extension-paragraph-2.0.3.tgz#88d332158c70622d36849256f90e43ca4d226dfe"
-  integrity sha512-a+tKtmj4bU3GVCH1NE8VHWnhVexxX5boTVxsHIr4yGG3UoKo1c5AO7YMaeX2W5xB5iIA+BQqOPCDPEAx34dd2A==
+"@tiptap/extension-paragraph@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-paragraph/-/extension-paragraph-2.1.7.tgz#76408706f0037a510a384b86780bd50c6e8ffeea"
+  integrity sha512-cLqX27hNrXrwZCKrIW8OC3rW2+MT8hhS37+cdqOxZo5hUqQ9EF/puwS0w8uUZ7B3awX9Jm1QZDMjjERLkcmobw==
 
-"@tiptap/extension-placeholder@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-placeholder/-/extension-placeholder-2.0.3.tgz#69575353f09fc7524c9cdbfbf16c04f73c29d154"
-  integrity sha512-Z42jo0termRAf0S0L8oxrts94IWX5waU4isS2CUw8xCUigYyCFslkhQXkWATO1qRbjNFLKN2C9qvCgGf4UeBrw==
+"@tiptap/extension-placeholder@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-placeholder/-/extension-placeholder-2.1.7.tgz#8477cf5116c89f0f75e8e2e3b8528e146a7f0f24"
+  integrity sha512-IiBoItYYNS7hb/zmPitw3w6Cylmp9qX+zW+QKe3lDkCNPeKxyQr86AnVLcQYOuXg62cLV9dp+4azZzHoz9SOcg==
 
-"@tiptap/extension-strike@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-strike/-/extension-strike-2.0.3.tgz#4ec0001db5f51f86d06da22364114f20f073d4b3"
-  integrity sha512-RO4/EYe2iPD6ifDHORT8fF6O9tfdtnzxLGwZIKZXnEgtweH+MgoqevEzXYdS+54Wraq4TUQGNcsYhe49pv7Rlw==
+"@tiptap/extension-strike@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-strike/-/extension-strike-2.1.7.tgz#b7b7f49254f1de22416b1415ca88a2a20edd0627"
+  integrity sha512-ONLXYnuZGM2EoGcxkyvJSDMBeAp7K6l83UXkK9TSj+VpEEDdeV7m8mJs8/vACJjJxD5HMN61+EPgU7VTEukQCA==
 
-"@tiptap/extension-table-cell@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-cell/-/extension-table-cell-2.0.3.tgz#44369bafdad3bb5b4f96296a8e93701673079b3a"
-  integrity sha512-d0vpwQfRIOhqKJdoiOJybwWhjnug3QA4Mkgccp378moDRyOer3hPKavG1Ljgz087qHrN4WfdUlMGEvasYsWE7w==
+"@tiptap/extension-table-cell@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-cell/-/extension-table-cell-2.1.7.tgz#87841144b8368c9611ad46f2134b637e2c33c8bc"
+  integrity sha512-p3e4FNdbKVIjOLHDcXrRtlP6FYPoN6hBUFjq6QZbf5g4+ao2Uq4bQCL+eKbYMxUVERl8g/Qu9X+jG99fVsBDjA==
 
-"@tiptap/extension-table-header@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-header/-/extension-table-header-2.0.3.tgz#bb35953da353f757202efab6e0c0d5d390a70f51"
-  integrity sha512-SnGl1U6usRRS6LyAjSdhaCYLF6NWbGhjVFSmiPrjb0pOzsiVeDOiUNCyUAIYaDNnjAF2pfK6+H+uHzYPqTi+/w==
+"@tiptap/extension-table-header@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-header/-/extension-table-header-2.1.7.tgz#4757834655e2c4edffa65bc6f6807eb59401e0d8"
+  integrity sha512-rolSUQxFJf/CEj2XBJpeMsLiLHASKrVIzZ2A/AZ9pT6WpFqmECi8r9xyutpJpx21n2Hrk46Y+uGFOKhyvbZ5ug==
 
-"@tiptap/extension-table-row@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-row/-/extension-table-row-2.0.3.tgz#fb7fd381435b06942dfbc2ba475072c25bf0a478"
-  integrity sha512-tyqeXmQLNSBsYyiNsnQuJMxNbz6dYt+P5W58+h10mjbt+hERA5+alQQyP06O2DggsT3Z0LPt7QRAlNmOBe7cyQ==
+"@tiptap/extension-table-row@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-table-row/-/extension-table-row-2.1.7.tgz#f736a61035b271423ef18f65a25f8d1e240263a1"
+  integrity sha512-DBCaEMEuCCoOmr4fdDfp2jnmyWPt672rmCZ5WUuenJ47Cy4Ox2dV+qk5vBZ/yDQcq12WvzLMhdSnAo9pMMMa6Q==
 
-"@tiptap/extension-table@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-table/-/extension-table-2.0.3.tgz#780b946ca8526ac8a4044bdec4c9c720ad8ba89a"
-  integrity sha512-8swHqm8vRM1w9WzaAhLmY24gGoTozctz4KHKBjvFY/Ka0yXabT0+hoCCdkZLnXWi15H3pbHs2HnDBaTGL9bZTw==
+"@tiptap/extension-table@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-table/-/extension-table-2.1.7.tgz#c8a83744f60c76ae1e41438b04d5ac9e984afa66"
+  integrity sha512-nlKs35vTQOFW9lfw76S7kJvqVJAfHUlz1muQgWT0gNUlKJYINMXjUIg4Wcx8LTaITCCkp0lMGrLETGRNI+RyxA==
 
-"@tiptap/extension-text-align@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-text-align/-/extension-text-align-2.0.3.tgz#00a7ce067cb033aa54edb82e8c2a023c73d7ef3c"
-  integrity sha512-VlLgqncKdjMjVjbU60/ALYhFs0wUdjAyvjDXnH1OoM/HuzbILvufPMYz4DUieJIWVJOYUKHQgg4XwBWceAM2Tw==
+"@tiptap/extension-text-align@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-text-align/-/extension-text-align-2.1.7.tgz#4f8df8296a1cd7be16db99337cdceebdbdff4fd2"
+  integrity sha512-DiRvGzcFQfXotgU7CpQxgstxgu6ZUUmSVQ7pzAxg9CQHwNgKQ4uYeDabt/R/SLEeb3YfXoEScxFMbyO1ys8ZsQ==
 
-"@tiptap/extension-text-style@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-text-style/-/extension-text-style-2.0.3.tgz#34498d2ed92e0a6725db847a4c0cf35667844610"
-  integrity sha512-yHIYtZVewSwfBfI6TffnsDRiOuXzytppcCsaDlsZFm8OtLG8v9ioH0ItMoOstmZZBiWJOm8iOy2yWSc4rNQEJw==
+"@tiptap/extension-text-style@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-text-style/-/extension-text-style-2.1.7.tgz#57f5dc5b223a855e782f24e09dc7fc53d9bd4b00"
+  integrity sha512-0QhEMDiDqMpyBGRt6o4GvbN9cUibZe4LT9e0ujarT6ElSe2fbtwGPnXSXApUtgHDDwHw95M5ZVxX/H5cjyjw1g==
 
-"@tiptap/extension-text@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.0.3.tgz#12b6400a31ac6d35cbaf1822600f4c425457902f"
-  integrity sha512-LvzChcTCcPSMNLUjZe/A9SHXWGDHtvk73fR7CBqAeNU0MxhBPEBI03GFQ6RzW3xX0CmDmjpZoDxFMB+hDEtW1A==
+"@tiptap/extension-text@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.1.7.tgz#071053ab0a8804a3bce36d1488a603b7446dff4e"
+  integrity sha512-3xaMMMNydLgoS+o+yOvaZF04ui9spJwJZl8VyYgcJKVGGLGRlWHrireXN5/OqXG2jLb/jWqXVx5idppQjX+PMA==
 
-"@tiptap/extension-typography@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-typography/-/extension-typography-2.0.3.tgz#fc3e9a5e15cfd9fa041315437a46681c3b0b5d51"
-  integrity sha512-5U91O2dffYOvwenWG+zT1N/pnt+RppSlocxs1KaNWFLlI2fgzDTyUyjzygIHGmskStqay2MuvmPnfVABoC+1Gw==
+"@tiptap/extension-typography@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-typography/-/extension-typography-2.1.7.tgz#fbfe0202fadf6413e1383d6c5fd274a70b3907b5"
+  integrity sha512-/K07CeIxwJ2t0amjIrxpQkfPJqTlRoA8YIVd6O1iqriINZVS0EK2IJAaE/PNVQNnUYhyU+0Z2/Xie3SlCP7PVQ==
 
-"@tiptap/pm@^2.0.0-beta.220":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/pm/-/pm-2.0.3.tgz#e8bb47df765fc1b7acd52f2800c52d7ff945c5ec"
-  integrity sha512-I9dsInD89Agdm1QjFRO9dmJtU1ldVSILNPW0pEhv9wYqYVvl4HUj/JMtYNqu2jWrCHNXQcaX/WkdSdvGJtmg5g==
+"@tiptap/pm@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/pm/-/pm-2.1.7.tgz#91e1b87d4ddbddca3cfe46e3c052b0072e4e1d97"
+  integrity sha512-RBVb/k9OjmClwdVl7fpekFgUsLAm1U+5I4w1qA2tj7L/hSPOuPzaEHwCqDYe0b2PR5dd8h0nylS9qXuXVlfwfQ==
   dependencies:
     prosemirror-changeset "^2.2.0"
     prosemirror-collab "^1.3.0"
@@ -1441,48 +1441,43 @@
     prosemirror-transform "^1.7.0"
     prosemirror-view "^1.28.2"
 
-"@tiptap/prosemirror-tables@^1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@tiptap/prosemirror-tables/-/prosemirror-tables-1.1.4.tgz#e123978f13c9b5f980066ba660ec5df857755916"
-  integrity sha512-O2XnDhZV7xTHSFxMMl8Ei3UVeCxuMlbGYZ+J2QG8CzkK8mxDpBa66kFr5DdyAhvdi1ptpcH9u7/GMwItQpN4sA==
-
-"@tiptap/starter-kit@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/starter-kit/-/starter-kit-2.0.3.tgz#e9a7e26f981ee5295762d796f02e1794c247d417"
-  integrity sha512-t4WG4w93zTpL2VxhVyJJvl3kdLF001ZrhpOuEiZqEMBMUMbM56Uiigv1CnUQpTFrjDAh3IM8hkqzAh20TYw2iQ==
+"@tiptap/starter-kit@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/starter-kit/-/starter-kit-2.1.7.tgz#a33a7928b7051ac9cd89d1798745f9855b7b72d9"
+  integrity sha512-z2cmJRSC7ImaTGWrHv+xws9y1wIG0OCPosBYpmpwlEfA3JG3axWFmVRJlWnsQV4eSMi3QY3vaPgBAnrR4IxRhQ==
   dependencies:
-    "@tiptap/core" "^2.0.3"
-    "@tiptap/extension-blockquote" "^2.0.3"
-    "@tiptap/extension-bold" "^2.0.3"
-    "@tiptap/extension-bullet-list" "^2.0.3"
-    "@tiptap/extension-code" "^2.0.3"
-    "@tiptap/extension-code-block" "^2.0.3"
-    "@tiptap/extension-document" "^2.0.3"
-    "@tiptap/extension-dropcursor" "^2.0.3"
-    "@tiptap/extension-gapcursor" "^2.0.3"
-    "@tiptap/extension-hard-break" "^2.0.3"
-    "@tiptap/extension-heading" "^2.0.3"
-    "@tiptap/extension-history" "^2.0.3"
-    "@tiptap/extension-horizontal-rule" "^2.0.3"
-    "@tiptap/extension-italic" "^2.0.3"
-    "@tiptap/extension-list-item" "^2.0.3"
-    "@tiptap/extension-ordered-list" "^2.0.3"
-    "@tiptap/extension-paragraph" "^2.0.3"
-    "@tiptap/extension-strike" "^2.0.3"
-    "@tiptap/extension-text" "^2.0.3"
+    "@tiptap/core" "^2.1.7"
+    "@tiptap/extension-blockquote" "^2.1.7"
+    "@tiptap/extension-bold" "^2.1.7"
+    "@tiptap/extension-bullet-list" "^2.1.7"
+    "@tiptap/extension-code" "^2.1.7"
+    "@tiptap/extension-code-block" "^2.1.7"
+    "@tiptap/extension-document" "^2.1.7"
+    "@tiptap/extension-dropcursor" "^2.1.7"
+    "@tiptap/extension-gapcursor" "^2.1.7"
+    "@tiptap/extension-hard-break" "^2.1.7"
+    "@tiptap/extension-heading" "^2.1.7"
+    "@tiptap/extension-history" "^2.1.7"
+    "@tiptap/extension-horizontal-rule" "^2.1.7"
+    "@tiptap/extension-italic" "^2.1.7"
+    "@tiptap/extension-list-item" "^2.1.7"
+    "@tiptap/extension-ordered-list" "^2.1.7"
+    "@tiptap/extension-paragraph" "^2.1.7"
+    "@tiptap/extension-strike" "^2.1.7"
+    "@tiptap/extension-text" "^2.1.7"
 
-"@tiptap/suggestion@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/suggestion/-/suggestion-2.0.3.tgz#3f25e20f50de6748f2b65a88e264d9b5887ca16a"
-  integrity sha512-1y3palQStGZq13UtHjouZ50k4sotM+N56cIlFeygIv3gqdai2zGPaPQtqV9FOVVQizXpUbQMTlPSDC5Ej4SPnQ==
+"@tiptap/suggestion@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/suggestion/-/suggestion-2.1.7.tgz#ac88deef2ade8d836ca9084c276cc9d64c6e604a"
+  integrity sha512-FKlXFMWf9rCnNJQsUfeX6WpS2VUs2O98ENkyhfV8ehCB7X5+57mkkxJxl/88SMbjZL+FbWPBKLaiOvsXfIUoww==
 
-"@tiptap/vue-3@^2.0.0-beta.205":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@tiptap/vue-3/-/vue-3-2.0.3.tgz#a2f1fd7f55bee1815dfb905e03f788099748938e"
-  integrity sha512-2CtNUzt+e7sgvIjxPOyBwoiRcuCHNeJzW+XGxNK2uCWlAKp/Yw3boJ51d51UuIbj9RitGHJ5GpCdLJoL7SDiQA==
+"@tiptap/vue-3@^2.0.3":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@tiptap/vue-3/-/vue-3-2.1.7.tgz#9614045dab75fe6ca7a1ae33a98df6bc09f4fa6d"
+  integrity sha512-JJRXWKLJ8mopb0uZV4JXyOW6vKQnarYoCj0hsy9ZT2LhSuLlPXY0D40NAbFVMMbQssewUtgPUFgVZ/TusMEysQ==
   dependencies:
-    "@tiptap/extension-bubble-menu" "^2.0.3"
-    "@tiptap/extension-floating-menu" "^2.0.3"
+    "@tiptap/extension-bubble-menu" "^2.1.7"
+    "@tiptap/extension-floating-menu" "^2.1.7"
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -2477,40 +2472,36 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-frappe-ui@^0.0.112:
-  version "0.0.112"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.0.112.tgz#2246c8739ffdb913eb92cba4a7290a997d3c7b8c"
-  integrity sha512-6hu7GwXQh1W4O6wKOjwSgl0RwszGsIgh+IM9/hOOsYHLOsb58pQkSnWNb8F2A70qGbE9u07zqX0knFtzI381kQ==
+frappe-ui@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.1.tgz#aa878105d7b11209efa05f1c3965c91f0dcb220b"
+  integrity sha512-FlAxNzJmAf8B5NGrQYyDdznoF5MRB9bTaHacrmpgaXWuoVSknLeW02eHIoyYMBd1Q3Fwp7GvEhz6kk1ZRzUsIQ==
   dependencies:
-    "@headlessui/vue" "^1.5.0"
+    "@headlessui/vue" "^1.7.14"
     "@popperjs/core" "^2.11.2"
     "@tailwindcss/forms" "^0.5.3"
     "@tailwindcss/typography" "^0.5.0"
-    "@tiptap/extension-color" "^2.0.0-beta.205"
-    "@tiptap/extension-highlight" "^2.0.0-beta.205"
-    "@tiptap/extension-image" "^2.0.0-beta.205"
-    "@tiptap/extension-link" "^2.0.0-beta.205"
-    "@tiptap/extension-mention" "^2.0.0-beta.205"
-    "@tiptap/extension-placeholder" "^2.0.0-beta.205"
-    "@tiptap/extension-table" "^2.0.0-beta.205"
-    "@tiptap/extension-table-cell" "^2.0.0-beta.205"
-    "@tiptap/extension-table-header" "^2.0.0-beta.205"
-    "@tiptap/extension-table-row" "^2.0.0-beta.205"
-    "@tiptap/extension-text-align" "^2.0.0-beta.205"
-    "@tiptap/extension-text-style" "^2.0.0-beta.205"
-    "@tiptap/extension-typography" "^2.0.0-beta.205"
-    "@tiptap/pm" "^2.0.0-beta.220"
-    "@tiptap/prosemirror-tables" "^1.1.3"
-    "@tiptap/starter-kit" "^2.0.0-beta.205"
-    "@tiptap/suggestion" "^2.0.0-beta.205"
-    "@tiptap/vue-3" "^2.0.0-beta.205"
-    autoprefixer "^10.4.2"
+    "@tiptap/extension-color" "^2.0.3"
+    "@tiptap/extension-highlight" "^2.0.3"
+    "@tiptap/extension-image" "^2.0.3"
+    "@tiptap/extension-link" "^2.0.3"
+    "@tiptap/extension-mention" "^2.0.3"
+    "@tiptap/extension-placeholder" "^2.0.3"
+    "@tiptap/extension-table" "^2.0.3"
+    "@tiptap/extension-table-cell" "^2.0.3"
+    "@tiptap/extension-table-header" "^2.0.3"
+    "@tiptap/extension-table-row" "^2.0.3"
+    "@tiptap/extension-text-align" "^2.0.3"
+    "@tiptap/extension-text-style" "^2.0.3"
+    "@tiptap/extension-typography" "^2.0.3"
+    "@tiptap/pm" "^2.0.3"
+    "@tiptap/starter-kit" "^2.0.3"
+    "@tiptap/suggestion" "^2.0.3"
+    "@tiptap/vue-3" "^2.0.3"
     feather-icons "^4.28.0"
     idb-keyval "^6.2.0"
-    postcss "^8.4.5"
     showdown "^2.1.0"
     socket.io-client "^4.5.1"
-    tailwindcss "^3.0.12"
     tippy.js "^6.3.7"
 
 fs-extra@^9.0.1:
@@ -3938,7 +3929,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tailwindcss@^3.0.12, tailwindcss@^3.0.15:
+tailwindcss@^3.0.15:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"
   integrity sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==


### PR DESCRIPTION
Styling fixes after upgrading to espresso

- [x] Vite config 
- [x] Button
	- [x] appearance -> variant + theme
	- [x] Increase padding
	- [x] Action sheet buttons - filter, request approval/rejection
	- [x] Action sheet - child table edit/delete buttons
	- [x] inline icon-left refactor
    - [x] Can still look better
    - [x] Disabled state should be darker
- [x] Fonts
- [x] Dialog
    - [x] Handler
    - [x] Use dialog with slots. The default one looks too huge on a mobile
    - [x] Buttons in dialogs
- [x] Badges
	- [x] colors
	- [x] Badge: sm -> md
	- [x] Expense claim - unified status field
- [ ] Charts
	- [x] colors
	- [x] fonts & shadow
	- [ ] More color shades should be available - frappe-ui (pink-400 & 500 have a lot of difference - add 450?)
    - [ ] Can still improve
- [ ] Tap area
    - [ ] Icons
    - [ ] Actions
    - [ ] Increase form field height
- [x] Form controls 
    - [x] Change Input > Form control wherever reqd
    - [x] Fix Input textarea height
    ~- [ ] use variant outline~
    - [x] Input type=number fields not working in espresso. Affects values watchers, etc. Not changing for now
- [x] Replace blue elements
	- [x] Links
	- [x] Filter pill selection
	- [x] Action selection - (employee advances)
	- [x] Applied filters indicator
	- [x] Tab color
- [x] Rounded corners
	- [x] rounded-lg -> rounded
	- [x] Attachment div looks completely round
- [x] Child table empty state design
- [x] Checkbox colour
- [ ] Autocomplete disabled not working
- [x] Disabled field opacity
- [x] Reqd field indicator not visible
- [x] Uniform Spacing - Dashboard 

## Other changes

- [ ] Holiday List - show old holidays in gray
- [ ] Saved form view - header -> card (?)
- [ ] Action sheet - view doc icon change - looks like an external link
- ~[ ] Request List -> Move view list button beside the section title~