### PR TITLE
fix: update repay_from_salary and payroll_payable_account fields

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -13,3 +13,4 @@ execute:frappe.db.set_default("date_format", frappe.db.get_single_value("System 
 hrms.patches.v14_0.create_vehicle_service_item
 hrms.patches.v15_0.notify_about_loan_app_separation
 hrms.patches.v15_0.rename_enable_late_entry_early_exit_grace_period
+hrms.patches.v14_0.update_repay_from_salary_and_payroll_payable_account_fields

--- a/hrms/patches/v14_0/update_repay_from_salary_and_payroll_payable_account_fields.py
+++ b/hrms/patches/v14_0/update_repay_from_salary_and_payroll_payable_account_fields.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
+		frappe.db.set_value(
+			"Custom Field", {"name": "Loan Repayment-repay_from_salary"}, "fetch_if_empty", 1
+		)
+
+	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-payroll_payable_account"}):
+		frappe.db.set_value(
+			"Custom Field",
+			{"name": "Loan Repayment-payroll_payable_account"},
+			"insert_after",
+			"payment_account",
+		)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -785,6 +785,7 @@ SALARY_SLIP_LOAN_FIELDS = {
 		{
 			"default": "0",
 			"fetch_from": "against_loan.repay_from_salary",
+			"fetch_if_empty": 1,
 			"fieldname": "repay_from_salary",
 			"fieldtype": "Check",
 			"label": "Repay From Salary",
@@ -797,7 +798,7 @@ SALARY_SLIP_LOAN_FIELDS = {
 			"label": "Payroll Payable Account",
 			"mandatory_depends_on": "eval:doc.repay_from_salary",
 			"options": "Account",
-			"insert_after": "rate_of_interest",
+			"insert_after": "payment_account",
 		},
 	],
 }


### PR DESCRIPTION
- Making `Loan Repayment`'s `repay_from_salary` editable
- Moving `Loan Repayment`'s `Payroll Payable Account` to a better position (among other accounts)