### PR TITLE
fix: Employee-wise loan repayment processing

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -14,3 +14,4 @@ hrms.patches.v14_0.create_vehicle_service_item
 hrms.patches.v15_0.notify_about_loan_app_separation
 hrms.patches.v15_0.rename_enable_late_entry_early_exit_grace_period
 hrms.patches.v14_0.update_repay_from_salary_and_payroll_payable_account_fields
+hrms.patches.v14_0.create_custom_field_in_loan

--- a/hrms/patches/v14_0/create_custom_field_in_loan.py
+++ b/hrms/patches/v14_0/create_custom_field_in_loan.py
@@ -1,6 +1,9 @@
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
+from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
 
+
+@if_lending_app_installed
 def execute():
 	create_custom_field(
 		"Loan Repayment",

--- a/hrms/patches/v14_0/create_custom_field_in_loan.py
+++ b/hrms/patches/v14_0/create_custom_field_in_loan.py
@@ -1,5 +1,6 @@
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
+
 def execute():
 	create_custom_field(
 		"Loan Repayment",

--- a/hrms/patches/v14_0/create_custom_field_in_loan.py
+++ b/hrms/patches/v14_0/create_custom_field_in_loan.py
@@ -1,0 +1,15 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+def execute():
+	create_custom_field(
+		"Loan Repayment",
+		{
+			"default": "0",
+			"depends_on": 'eval:doc.applicant_type=="Employee"',
+			"fieldname": "process_payroll_accounting_entry_based_on_employee",
+			"hidden": 1,
+			"fieldtype": "Check",
+			"label": "Process Payroll Accounting Entry based on Employee",
+			"insert_after": "repay_from_salary",
+		},
+	)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -197,10 +197,10 @@ class TestPayrollEntry(FrappeTestCase):
 	@if_lending_app_installed
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
 	def test_loan_with_settings_enabled(self):
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 			process_loan_interest_accrual_for_term_loans,
 		)
-		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 
 		frappe.db.delete("Loan")
 
@@ -245,10 +245,10 @@ class TestPayrollEntry(FrappeTestCase):
 	@if_lending_app_installed
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
 	def test_loan_with_settings_disabled(self):
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 			process_loan_interest_accrual_for_term_loans,
 		)
-		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 
 		frappe.db.delete("Loan")
 
@@ -749,11 +749,9 @@ def create_assignments_with_cost_centers(employee1, employee2):
 	)
 	ssa_doc.save()
 
+
 def setup_lending():
-	from lending.loan_management.doctype.loan.test_loan import (
-		create_loan_accounts,
-		create_loan_type,
-	)
+	from lending.loan_management.doctype.loan.test_loan import create_loan_accounts, create_loan_type
 
 	company = "_Test Company"
 	branch = "Test Employee Branch"
@@ -788,7 +786,13 @@ def setup_lending():
 			repayment_schedule_type="Monthly as per repayment start date",
 		)
 
-	return applicant, branch, company_doc.default_currency, company_doc.default_payroll_payable_account
+	return (
+		applicant,
+		branch,
+		company_doc.default_currency,
+		company_doc.default_payroll_payable_account,
+	)
+
 
 def create_loan_for_employee(applicant):
 	from lending.loan_management.doctype.loan.test_loan import create_loan
@@ -806,17 +810,16 @@ def create_loan_for_employee(applicant):
 
 	return loan
 
-def get_repayment_party_type(loan):
-	loan_repayment_entry, payroll_payable_account = frappe.db.get_value("Loan Repayment", 
-		{"against_loan": loan}, ["name", "payroll_payable_account"])
 
-	party_type, party = frappe.db.get_value("GL Entry", 
-		{
-			"voucher_no": loan_repayment_entry,
-			"account": payroll_payable_account,
-			"is_cancelled": 0
-		}, 
-		["party_type", "party"]
+def get_repayment_party_type(loan):
+	loan_repayment_entry, payroll_payable_account = frappe.db.get_value(
+		"Loan Repayment", {"against_loan": loan}, ["name", "payroll_payable_account"]
+	)
+
+	party_type, party = frappe.db.get_value(
+		"GL Entry",
+		{"voucher_no": loan_repayment_entry, "account": payroll_payable_account, "is_cancelled": 0},
+		["party_type", "party"],
 	)
 
 	return party_type, party

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 import frappe
 from frappe.tests.utils import FrappeTestCase, change_settings
-from frappe.utils import add_days, add_months
+from frappe.utils import add_days, add_months, cstr
 
 import erpnext
 from erpnext.accounts.utils import get_fiscal_year, getdate, nowdate
@@ -195,62 +195,17 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertEqual(get_end_date("2017-02-15", "daily"), {"end_date": "2017-02-15"})
 
 	@if_lending_app_installed
-	def test_loan(self):
-		from lending.loan_management.doctype.loan.test_loan import (
-			create_loan,
-			create_loan_accounts,
-			create_loan_type,
-			make_loan_disbursement_entry,
-		)
+	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	def test_loan_with_settings_enabled(self):
 		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 			process_loan_interest_accrual_for_term_loans,
 		)
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 
 		frappe.db.delete("Loan")
 
-		company = "_Test Company"
-		branch = "Test Employee Branch"
-
-		if not frappe.db.exists("Branch", branch):
-			frappe.get_doc({"doctype": "Branch", "branch": branch}).insert()
-
-		applicant = make_employee("test_employee@loan.com", company="_Test Company", branch=branch)
-		company_doc = frappe.get_doc("Company", company)
-
-		make_salary_structure(
-			"Test Salary Structure for Loan",
-			"Monthly",
-			employee=applicant,
-			company="_Test Company",
-			currency=company_doc.default_currency,
-		)
-
-		if not frappe.db.exists("Loan Type", "Car Loan"):
-			create_loan_accounts()
-			create_loan_type(
-				"Car Loan",
-				500000,
-				8.4,
-				is_term_loan=1,
-				mode_of_payment="Cash",
-				disbursement_account="Disbursement Account - _TC",
-				payment_account="Payment Account - _TC",
-				loan_account="Loan Account - _TC",
-				interest_income_account="Interest Income Account - _TC",
-				penalty_income_account="Penalty Income Account - _TC",
-				repayment_schedule_type="Monthly as per repayment start date",
-			)
-
-		loan = create_loan(
-			applicant,
-			"Car Loan",
-			280000,
-			"Repay Over Number of Periods",
-			20,
-			posting_date=add_months(nowdate(), -1),
-		)
-		loan.repay_from_salary = 1
-		loan.submit()
+		[applicant, branch, currency, payroll_payable_account] = setup_lending()
+		loan = create_loan_for_employee(applicant)
 
 		make_loan_disbursement_entry(
 			loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1)
@@ -261,8 +216,8 @@ class TestPayrollEntry(FrappeTestCase):
 		make_payroll_entry(
 			company="_Test Company",
 			start_date=dates.start_date,
-			payable_account=company_doc.default_payroll_payable_account,
-			currency=company_doc.default_currency,
+			payable_account=payroll_payable_account,
+			currency=currency,
 			end_date=dates.end_date,
 			branch=branch,
 			cost_center="Main - _TC",
@@ -281,6 +236,46 @@ class TestPayrollEntry(FrappeTestCase):
 				self.assertEqual(row.interest_amount, interest_amount)
 				self.assertEqual(row.principal_amount, principal_amount)
 				self.assertEqual(row.total_payment, interest_amount + principal_amount)
+
+		[party_type, party] = get_repayment_party_type(loan.name)
+
+		self.assertEqual(party_type, "Employee")
+		self.assertEqual(party, applicant)
+
+	@if_lending_app_installed
+	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	def test_loan_with_settings_disabled(self):
+		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+			process_loan_interest_accrual_for_term_loans,
+		)
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
+
+		frappe.db.delete("Loan")
+
+		[applicant, branch, currency, payroll_payable_account] = setup_lending()
+		loan = create_loan_for_employee(applicant)
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1)
+		)
+		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		make_payroll_entry(
+			company="_Test Company",
+			start_date=dates.start_date,
+			payable_account=payroll_payable_account,
+			currency=currency,
+			end_date=dates.end_date,
+			branch=branch,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+		)
+
+		[party_type, party] = get_repayment_party_type(loan.name)
+
+		self.assertEqual(cstr(party_type), "")
+		self.assertEqual(cstr(party), "")
 
 	def test_salary_slip_operation_queueing(self):
 		company = "_Test Company"
@@ -753,3 +748,75 @@ def create_assignments_with_cost_centers(employee1, employee2):
 		"payroll_cost_centers", {"cost_center": "_Test Cost Center 2 - _TC", "percentage": 40}
 	)
 	ssa_doc.save()
+
+def setup_lending():
+	from lending.loan_management.doctype.loan.test_loan import (
+		create_loan_accounts,
+		create_loan_type,
+	)
+
+	company = "_Test Company"
+	branch = "Test Employee Branch"
+
+	if not frappe.db.exists("Branch", branch):
+		frappe.get_doc({"doctype": "Branch", "branch": branch}).insert()
+
+	applicant = make_employee("test_employee@loan.com", company="_Test Company", branch=branch)
+	company_doc = frappe.get_doc("Company", company)
+
+	make_salary_structure(
+		"Test Salary Structure for Loan",
+		"Monthly",
+		employee=applicant,
+		company="_Test Company",
+		currency=company_doc.default_currency,
+	)
+
+	if not frappe.db.exists("Loan Type", "Car Loan"):
+		create_loan_accounts()
+		create_loan_type(
+			"Car Loan",
+			500000,
+			8.4,
+			is_term_loan=1,
+			mode_of_payment="Cash",
+			disbursement_account="Disbursement Account - _TC",
+			payment_account="Payment Account - _TC",
+			loan_account="Loan Account - _TC",
+			interest_income_account="Interest Income Account - _TC",
+			penalty_income_account="Penalty Income Account - _TC",
+			repayment_schedule_type="Monthly as per repayment start date",
+		)
+
+	return applicant, branch, company_doc.default_currency, company_doc.default_payroll_payable_account
+
+def create_loan_for_employee(applicant):
+	from lending.loan_management.doctype.loan.test_loan import create_loan
+
+	loan = create_loan(
+		applicant,
+		"Car Loan",
+		280000,
+		"Repay Over Number of Periods",
+		20,
+		posting_date=add_months(nowdate(), -1),
+	)
+	loan.repay_from_salary = 1
+	loan.submit()
+
+	return loan
+
+def get_repayment_party_type(loan):
+	loan_repayment_entry, payroll_payable_account = frappe.db.get_value("Loan Repayment", 
+		{"against_loan": loan}, ["name", "payroll_payable_account"])
+
+	party_type, party = frappe.db.get_value("GL Entry", 
+		{
+			"voucher_no": loan_repayment_entry,
+			"account": payroll_payable_account,
+			"is_cancelled": 0
+		}, 
+		["party_type", "party"]
+	)
+
+	return party_type, party

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -97,6 +97,8 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import create_repayment_entry
 
 	payroll_payable_account = get_payroll_payable_account(doc.company, doc.payroll_entry)
+	process_payroll_accounting_entry_based_on_employee = frappe.db.get_single_value("Payroll Settings", "process_payroll_accounting_entry_based_on_employee")
+
 	for loan in doc.loans:
 		if not loan.total_payment:
 			continue
@@ -112,6 +114,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 			loan.principal_amount,
 			loan.total_payment,
 			payroll_payable_account=payroll_payable_account,
+			process_payroll_accounting_entry_based_on_employee=process_payroll_accounting_entry_based_on_employee
 		)
 
 		repayment_entry.save()

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -97,7 +97,9 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import create_repayment_entry
 
 	payroll_payable_account = get_payroll_payable_account(doc.company, doc.payroll_entry)
-	process_payroll_accounting_entry_based_on_employee = frappe.db.get_single_value("Payroll Settings", "process_payroll_accounting_entry_based_on_employee")
+	process_payroll_accounting_entry_based_on_employee = frappe.db.get_single_value(
+		"Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
+	)
 
 	for loan in doc.loans:
 		if not loan.total_payment:
@@ -114,7 +116,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 			loan.principal_amount,
 			loan.total_payment,
 			payroll_payable_account=payroll_payable_account,
-			process_payroll_accounting_entry_based_on_employee=process_payroll_accounting_entry_based_on_employee
+			process_payroll_accounting_entry_based_on_employee=process_payroll_accounting_entry_based_on_employee,
 		)
 
 		repayment_entry.save()

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -800,5 +800,14 @@ SALARY_SLIP_LOAN_FIELDS = {
 			"options": "Account",
 			"insert_after": "payment_account",
 		},
+		{
+			"default": "0",
+			"depends_on": 'eval:doc.applicant_type=="Employee"',
+			"fieldname": "process_payroll_accounting_entry_based_on_employee",
+			"hidden": 1,
+			"fieldtype": "Check",
+			"label": "Process Payroll Accounting Entry based on Employee",
+			"insert_after": "repay_from_salary",
+		},
 	],
 }


### PR DESCRIPTION
Party Type (Employee) and Party against the Payroll Payable Account were removed during loan repayment via https://github.com/frappe/erpnext/pull/31077

This was done because employee-wise payroll processing was not allowed and adding employees against this GL Entry led to an incorrect balance while viewing the balance for employees

Now this has been introduced as a configuration in payroll settings and employee-wise payroll processing is allowed. So even the party and party type against payroll payable account should be dependent on this

Related PRs: https://github.com/frappe/erpnext/pull/36983, https://github.com/frappe/lending/pull/7