### PR TITLE
fix: company fetching & filter in Salary Structure Assignment

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -6,6 +6,7 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		frm.set_query("employee", function() {
 			return {
 				query: "erpnext.controllers.queries.employee_query",
+				filters: { company: frm.doc.company },
 			}
 		});
 		frm.set_query("salary_structure", function() {

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -91,11 +91,11 @@
    "reqd": 1
   },
   {
+   "fetch_from": "employee.company",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -209,7 +209,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-10 12:00:57.942233",
+ "modified": "2023-09-12 20:54:02.758373",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -22,6 +22,7 @@ class SalaryStructureAssignment(Document):
 
 	def validate(self):
 		self.validate_dates()
+		self.validate_company()
 		self.validate_income_tax_slab()
 		self.set_payroll_payable_account()
 
@@ -74,6 +75,17 @@ class SalaryStructureAssignment(Document):
 						self.from_date, relieving_date
 					)
 				)
+
+	def validate_company(self):
+		salary_structure_company = frappe.db.get_value(
+			"Salary Structure", self.salary_structure, "company", cache=True
+		)
+		if self.company != salary_structure_company:
+			frappe.throw(
+				_("Salary Structure {0} does not belong to company {1}").format(
+					frappe.bold(self.salary_structure), frappe.bold(self.company)
+				)
+			)
 
 	def validate_income_tax_slab(self):
 		if not self.income_tax_slab:


### PR DESCRIPTION
Better fix for https://github.com/frappe/hrms/pull/617

- Fetch company from employee
- If Assignment is created from Salary Structure, structure & company are auto-set. Company filter is applied on employee
- Server-side validation if structure's company does not match selected company