### PR TITLE
fix(Payroll Entry): show Create Salary Slips button only after saving

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -65,7 +65,7 @@ frappe.ui.form.on('Payroll Entry', {
 			&& !cint(frm.doc.salary_slips_created)
 			&& (frm.doc.docstatus != 2)
 		) {
-			if (frm.doc.docstatus == 0) {
+			if (frm.doc.docstatus == 0 && !frm.is_new()) {
 				frm.page.clear_primary_action();
 				frm.page.set_primary_action(__("Create Salary Slips"), () => {
 					frm.save("Submit").then(() => {


### PR DESCRIPTION
**Problem**:

On amending a payroll entry, it directly starts creating salary slips. If employees > 30, its queued without a document ID and fails.

**Fix**:

Show **Create Salary Slips** button only after saving the payroll entry