### PR TITLE
fix(UX): make performance feedback dialog minimizable

### DIFF
--- a/hrms/public/js/performance/performance_feedback.js
+++ b/hrms/public/js/performance/performance_feedback.js
@@ -119,7 +119,9 @@ hrms.PerformanceFeedback = class PerformanceFeedback {
 					}
 				});
 			},
-			primary_action_label: __("Submit")
+			primary_action_label: __("Submit"),
+			minimizable: true,
+			size: "large",
 		});
 
 		dialog.show();


### PR DESCRIPTION
While adding big feedback, reviewers might want to interact with elements in the background and get back to it. Make the dialog minimizable to improve the UX

<img width="1334" alt="minimizable" src="https://github.com/frappe/hrms/assets/24353136/f2fd7f3f-b10f-401c-a796-1cc413f024ee">

P.S. Interview feedback dialog is already minimizable
