### PR TITLE
Enable Allow Import (via Data Import Tool) for DocTypes Job Applicant and Job Opening

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.json
+++ b/hrms/hr/doctype/job_applicant/job_applicant.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "allow_rename": 1,
  "autoname": "HR-APP-.YYYY.-.#####",
  "creation": "2013-01-29 19:25:37",

--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "autoname": "field:route",
  "creation": "2013-01-15 16:13:36",
  "description": "Description of a Job Opening",


### PR DESCRIPTION
Enable Allow Import (via Data Import Tool) for DocTypes `Job Applicant` and `Job Opening` as per issue #880

**Output:**

<img width="1395" alt="Screenshot 2023-09-14 at 3 53 11 PM" src="https://github.com/frappe/hrms/assets/69882648/5b2dec86-b411-4632-a519-871d20ed2cf5">
