### PR TITLE
feat: Enable Allow Import (via Data Import Tool) for DocTypes Job Applicant and Job Opening

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.json
+++ b/hrms/hr/doctype/job_applicant/job_applicant.json
@@ -193,7 +193,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-01-25 17:39:20.694439",
+ "modified": "2023-09-14 16:50:39.316079",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Applicant",

--- a/hrms/hr/doctype/job_applicant/job_applicant.json
+++ b/hrms/hr/doctype/job_applicant/job_applicant.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "allow_rename": 1,
  "autoname": "HR-APP-.YYYY.-.#####",
  "creation": "2013-01-29 19:25:37",

--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "autoname": "field:route",
  "creation": "2013-01-15 16:13:36",
  "description": "Description of a Job Opening",

--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -186,7 +186,7 @@
  "icon": "fa fa-bookmark",
  "idx": 1,
  "links": [],
- "modified": "2023-01-09 13:34:47.274465",
+ "modified": "2023-09-14 16:50:39.316079",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Opening",


### PR DESCRIPTION
`no-docs`

Enable Allow Import (via Data Import Tool) for DocTypes `Job Applicant` and `Job Opening`
Closes #880

**Output:**

<img width="1395" alt="Screenshot 2023-09-14 at 3 53 11 PM" src="https://github.com/frappe/hrms/assets/69882648/5b2dec86-b411-4632-a519-871d20ed2cf5">