### PR TITLE
fix: amended Expense Claims' resetting of sanctioned amounts

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -66,23 +66,6 @@ cur_frm.add_fetch('employee', 'company', 'company');
 cur_frm.add_fetch('employee','employee_name','employee_name');
 cur_frm.add_fetch('expense_type','description','description');
 
-cur_frm.cscript.onload = function(doc) {
-	if (doc.__islocal) {
-		cur_frm.set_value("posting_date", frappe.datetime.get_today());
-		// cur_frm.cscript.clear_sanctioned(doc);
-	}
-};
-
-cur_frm.cscript.clear_sanctioned = function(doc) {
-	var val = doc.expenses || [];
-	for(var i = 0; i<val.length; i++){
-		val[i].sanctioned_amount ='';
-	}
-
-	doc.total_sanctioned_amount = '';
-	refresh_many(['sanctioned_amount', 'total_sanctioned_amount']);
-};
-
 cur_frm.cscript.refresh = function(doc) {
 	cur_frm.cscript.set_help(doc);
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -69,7 +69,7 @@ cur_frm.add_fetch('expense_type','description','description');
 cur_frm.cscript.onload = function(doc) {
 	if (doc.__islocal) {
 		cur_frm.set_value("posting_date", frappe.datetime.get_today());
-		cur_frm.cscript.clear_sanctioned(doc);
+		// cur_frm.cscript.clear_sanctioned(doc);
 	}
 };
 


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/140

Issue seems to occur because of resetting of sanctioned amounts for unsaved docs on load. Not sure if the method causing this is being used for any other purpose, so only commenting it out for now.

`no-docs`