### PR TITLE
fix: fetch logic for repay_from_salary in loan_repayment [v14]

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -11,3 +11,4 @@ execute:frappe.db.set_default("date_format", frappe.db.get_single_value("System 
 hrms.patches.v14_0.create_vehicle_service_item
 hrms.patches.v14_0.update_repay_from_salary_and_payroll_payable_account_fields
 hrms.patches.v14_0.create_custom_field_in_loan
+hrms.patches.v14_0.update_loan_repayment_repay_from_salary

--- a/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
+++ b/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
+		frappe.db.set_value(
+			"Custom Field", {"name": "Loan Repayment-repay_from_salary"}, { "fetch_from": None, "fetch_if_empty": 0 }
+		)

--- a/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
+++ b/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
@@ -2,9 +2,9 @@ import frappe
 
 
 def execute():
-	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
+	if frappe.db.exists("Custom Field", "Loan Repayment-repay_from_salary"):
 		frappe.db.set_value(
 			"Custom Field",
-			{"name": "Loan Repayment-repay_from_salary"},
+			"Loan Repayment-repay_from_salary",
 			{"fetch_from": None, "fetch_if_empty": 0},
 		)

--- a/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
+++ b/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
@@ -4,5 +4,7 @@ import frappe
 def execute():
 	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
 		frappe.db.set_value(
-			"Custom Field", {"name": "Loan Repayment-repay_from_salary"}, { "fetch_from": None, "fetch_if_empty": 0 }
+			"Custom Field",
+			{"name": "Loan Repayment-repay_from_salary"},
+			{"fetch_from": None, "fetch_if_empty": 0},
 		)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -304,8 +304,6 @@ def get_custom_fields():
 		"Loan Repayment": [
 			{
 				"default": "0",
-				"fetch_from": "against_loan.repay_from_salary",
-				"fetch_if_empty": 1,
 				"fieldname": "repay_from_salary",
 				"fieldtype": "Check",
 				"label": "Repay From Salary",


### PR DESCRIPTION
Depends on https://github.com/frappe/erpnext/pull/37135.

Currently checkboxes with `fetch_from` and `fetch_if_empty` set (like `repay_from_salary` check in `loan_repayment` doctype) don't work in the framework. We [tried](https://github.com/frappe/frappe/pull/22442) to fix it in the framework but we haven't come up with a solution which won't break lots of custom code. This PR fixes the issue until we come up with a long-term fix.