### PR TITLE
fix: fetch logic for repay_from_salary in loan_repayment [dev]

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -15,3 +15,4 @@ hrms.patches.v15_0.notify_about_loan_app_separation
 hrms.patches.v15_0.rename_enable_late_entry_early_exit_grace_period
 hrms.patches.v14_0.update_repay_from_salary_and_payroll_payable_account_fields
 hrms.patches.v14_0.create_custom_field_in_loan
+hrms.patches.v14_0.update_loan_repayment_repay_from_salary

--- a/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
+++ b/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
@@ -2,9 +2,9 @@ import frappe
 
 
 def execute():
-	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
+	if frappe.db.exists("Custom Field", "Loan Repayment-repay_from_salary"):
 		frappe.db.set_value(
 			"Custom Field",
-			{"name": "Loan Repayment-repay_from_salary"},
+			"Loan Repayment-repay_from_salary",
 			{"fetch_from": None, "fetch_if_empty": 0},
 		)

--- a/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
+++ b/hrms/patches/v14_0/update_loan_repayment_repay_from_salary.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Custom Field", {"name": "Loan Repayment-repay_from_salary"}):
+		frappe.db.set_value(
+			"Custom Field",
+			{"name": "Loan Repayment-repay_from_salary"},
+			{"fetch_from": None, "fetch_if_empty": 0},
+		)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -784,8 +784,6 @@ SALARY_SLIP_LOAN_FIELDS = {
 	"Loan Repayment": [
 		{
 			"default": "0",
-			"fetch_from": "against_loan.repay_from_salary",
-			"fetch_if_empty": 1,
 			"fieldname": "repay_from_salary",
 			"fieldtype": "Check",
 			"label": "Repay From Salary",


### PR DESCRIPTION
Depends on https://github.com/frappe/lending/pull/32

Currently checkboxes with `fetch_from` and `fetch_if_empty` set (like `repay_from_salary` check in `loan_repayment` doctype) don't work in the framework. We [tried](https://github.com/frappe/frappe/pull/22442) to fix it in the framework but we haven't come up with a solution which won't break lots of custom code. This PR fixes the issue until we come up with a long-term fix.