### PR TITLE
fix: compensatory leave request for Half Day & WFH

### DIFF
--- a/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
@@ -35,18 +35,27 @@ class CompensatoryLeaveRequest(Document):
 			frappe.throw(_("Leave Type is madatory"))
 
 	def validate_attendance(self):
-		attendance = frappe.get_all(
+		attendance_records = frappe.get_all(
 			"Attendance",
 			filters={
 				"attendance_date": ["between", (self.work_from_date, self.work_end_date)],
-				"status": "Present",
+				"status": ("in", ["Present", "Work From Home", "Half Day"]),
 				"docstatus": 1,
 				"employee": self.employee,
 			},
 			fields=["attendance_date", "status"],
 		)
 
-		if len(attendance) < date_diff(self.work_end_date, self.work_from_date) + 1:
+		half_days = [entry.attendance_date for entry in attendance_records if entry.status == "Half Day"]
+
+		if half_days and (not self.half_day or getdate(self.half_day_date) not in half_days):
+			frappe.throw(
+				_(
+					"You were only present for Half Day on {}. Cannot apply for a full day compensatory leave"
+				).format(", ".join([frappe.bold(format_date(half_day)) for half_day in half_days]))
+			)
+
+		if len(attendance_records) < date_diff(self.work_end_date, self.work_from_date) + 1:
 			frappe.throw(_("You are not present all day(s) between compensatory leave request days"))
 
 	def validate_holidays(self):


### PR DESCRIPTION
Compensatory Leave Request does not work for a half day. It only checks for attendance records with "Present" status.
Employee worked for half day on 15th so this is a valid comp off

<img width="1334" alt="image" src="https://github.com/frappe/hrms/assets/24353136/914dbe32-6cab-4ee5-ab3a-f95e31e5c360">

