### PR TITLE
feat(Payroll Settings): Consider Marked Attendance on Holidays

### DIFF
--- a/hrms/payroll/doctype/additional_salary/test_additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/test_additional_salary.py
@@ -30,9 +30,7 @@ class TestAdditionalSalary(FrappeTestCase):
 		)
 		add_sal = get_additional_salary(emp_id)
 
-		ss = make_employee_salary_slip(
-			"test_additional@salary.com", "Monthly", salary_structure=salary_structure.name
-		)
+		ss = make_employee_salary_slip(emp_id, "Monthly", salary_structure=salary_structure.name)
 		for earning in ss.earnings:
 			if earning.salary_component == "Recurring Salary Component":
 				amount = earning.amount
@@ -49,9 +47,7 @@ class TestAdditionalSalary(FrappeTestCase):
 			"Test Salary Structure Additional Salary", "Monthly", employee=emp_id
 		)
 		add_sal = get_additional_salary(emp_id)
-		ss = make_employee_salary_slip(
-			"test_additional@salary.com", "Monthly", salary_structure=salary_structure.name
-		)
+		ss = make_employee_salary_slip(emp_id, "Monthly", salary_structure=salary_structure.name)
 		salary_componets = [earning.salary_component for earning in ss.earnings]
 		self.assertIn("Recurring Salary Component", salary_componets)
 
@@ -76,9 +72,7 @@ class TestAdditionalSalary(FrappeTestCase):
 		)
 		add_sal = get_additional_salary(emp_id, recurring=False, payroll_date=date)
 
-		ss = make_employee_salary_slip(
-			"test_additional@salary.com", "Monthly", salary_structure=salary_structure.name
-		)
+		ss = make_employee_salary_slip(emp_id, "Monthly", salary_structure=salary_structure.name)
 
 		amount, salary_component = None, None
 		for earning in ss.earnings:

--- a/hrms/payroll/doctype/gratuity/test_gratuity.py
+++ b/hrms/payroll/doctype/gratuity/test_gratuity.py
@@ -55,7 +55,7 @@ class TestGratuity(FrappeTestCase):
 			date_of_joining=doj,
 			relieving_date=relieving_date,
 		)
-		sal_slip = create_salary_slip("test_employee_gratuity@salary.com")
+		sal_slip = create_salary_slip(employee)
 
 		rule = get_gratuity_rule("Rule Under Unlimited Contract on termination (UAE)")
 		gratuity = create_gratuity(pay_via_salary_slip=1, employee=employee, rule=rule.name)
@@ -112,7 +112,7 @@ class TestGratuity(FrappeTestCase):
 			relieving_date=relieving_date,
 		)
 
-		sal_slip = create_salary_slip("test_employee_gratuity@salary.com")
+		sal_slip = create_salary_slip(employee)
 		rule = get_gratuity_rule("Rule Under Limited Contract (UAE)")
 		set_mode_of_payment_account()
 

--- a/hrms/payroll/doctype/payroll_settings/payroll_settings.json
+++ b/hrms/payroll/doctype/payroll_settings/payroll_settings.json
@@ -10,6 +10,7 @@
   "payroll_based_on",
   "consider_unmarked_attendance_as",
   "include_holidays_in_total_working_days",
+  "consider_marked_attendance_on_holidays",
   "column_break_6",
   "max_working_hours_against_timesheet",
   "daily_wages_fraction_for_half_day",
@@ -42,7 +43,7 @@
   },
   {
    "default": "0",
-   "description": "If checked, Total no. of Working Days will include holidays, and this will reduce the value of Salary Per Day",
+   "description": "If enabled, total no. of working days will include holidays, and this will reduce the value of Salary Per Day",
    "fieldname": "include_holidays_in_total_working_days",
    "fieldtype": "Check",
    "label": "Include holidays in Total no. of Working Days"
@@ -146,13 +147,21 @@
   {
    "fieldname": "column_break_iewr",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "include_holidays_in_total_working_days",
+   "description": "If enabled, deducts payment days for absent attendance on holidays. By default, holidays are considered as paid",
+   "fieldname": "consider_marked_attendance_on_holidays",
+   "fieldtype": "Check",
+   "label": "Consider Marked Attendance on Holidays"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-02-23 14:56:15.335250",
+ "modified": "2023-09-25 14:03:59.215240",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Settings",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -41,6 +41,8 @@
   "column_break_geio",
   "absent_days",
   "payment_days",
+  "help_section",
+  "payment_days_calculation_help",
   "earnings_and_deductions_tab",
   "timesheets_section",
   "timesheets",
@@ -708,13 +710,22 @@
    "depends_on": "eval:doc.salary_slip_based_on_timesheet",
    "fieldname": "timesheets_section",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "help_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "payment_days_calculation_help",
+   "fieldtype": "HTML",
+   "label": "Payment Days Calculation Help"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-18 12:51:14.969424",
+ "modified": "2023-09-25 19:31:53.460393",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -287,12 +287,6 @@ class SalarySlip(TransactionBase):
 				)
 				self.set_time_sheet()
 				self.pull_sal_struct()
-				payroll_settings = frappe.get_cached_value(
-					"Payroll Settings",
-					None,
-					("payroll_based_on", "consider_unmarked_attendance_as"),
-				)
-				return payroll_settings
 
 	def set_time_sheet(self):
 		if self.salary_slip_based_on_timesheet:

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -129,7 +129,7 @@ class TestSalarySlip(FrappeTestCase):
 		)  # invalid lwp
 
 		ss = make_employee_salary_slip(
-			"test_payment_days_based_on_attendance@salary.com",
+			emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -176,7 +176,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 
 		new_ss = make_employee_salary_slip(
-			"test_payment_days_based_on_joining_date@salary.com",
+			new_emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -191,7 +191,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		frappe.delete_doc("Salary Slip", new_ss.name, force=True)
 		new_ss = make_employee_salary_slip(
-			"test_payment_days_based_on_joining_date@salary.com",
+			new_emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -206,7 +206,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		frappe.delete_doc("Salary Slip", new_ss.name, force=True)
 		new_ss = make_employee_salary_slip(
-			"test_payment_days_based_on_joining_date@salary.com",
+			new_emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -247,7 +247,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 
 		new_ss = make_employee_salary_slip(
-			"test_payment_days_based_on_joining_date@salary.com",
+			new_emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -287,7 +287,7 @@ class TestSalarySlip(FrappeTestCase):
 				holidays += 1
 
 		new_ss = make_employee_salary_slip(
-			"test_payment_days_based_on_joining_date@salary.com",
+			new_emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -332,7 +332,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 
 		ss = make_employee_salary_slip(
-			"test_payment_days_based_on_leave_application@salary.com",
+			emp_id,
 			"Monthly",
 			"Test Payment Based On Leave Application",
 		)
@@ -442,25 +442,14 @@ class TestSalarySlip(FrappeTestCase):
 	@change_settings("Payroll Settings", {"include_holidays_in_total_working_days": 1})
 	def test_salary_slip_with_holidays_included(self):
 		no_of_days = get_no_of_days()
-		make_employee("test_salary_slip_with_holidays_included@salary.com")
-		frappe.db.set_value(
-			"Employee",
-			frappe.get_value(
-				"Employee", {"employee_name": "test_salary_slip_with_holidays_included@salary.com"}, "name"
-			),
-			"relieving_date",
-			None,
-		)
-		frappe.db.set_value(
-			"Employee",
-			frappe.get_value(
-				"Employee", {"employee_name": "test_salary_slip_with_holidays_included@salary.com"}, "name"
-			),
-			"status",
-			"Active",
-		)
-		ss = make_employee_salary_slip(
+		emp_id = make_employee(
 			"test_salary_slip_with_holidays_included@salary.com",
+			relieving_date=None,
+			status="Active",
+		)
+
+		ss = make_employee_salary_slip(
+			emp_id,
 			"Monthly",
 			"Test Salary Slip With Holidays Included",
 		)
@@ -474,25 +463,14 @@ class TestSalarySlip(FrappeTestCase):
 	@change_settings("Payroll Settings", {"include_holidays_in_total_working_days": 0})
 	def test_salary_slip_with_holidays_excluded(self):
 		no_of_days = get_no_of_days()
-		make_employee("test_salary_slip_with_holidays_excluded@salary.com")
-		frappe.db.set_value(
-			"Employee",
-			frappe.get_value(
-				"Employee", {"employee_name": "test_salary_slip_with_holidays_excluded@salary.com"}, "name"
-			),
-			"relieving_date",
-			None,
-		)
-		frappe.db.set_value(
-			"Employee",
-			frappe.get_value(
-				"Employee", {"employee_name": "test_salary_slip_with_holidays_excluded@salary.com"}, "name"
-			),
-			"status",
-			"Active",
-		)
-		ss = make_employee_salary_slip(
+		emp_id = make_employee(
 			"test_salary_slip_with_holidays_excluded@salary.com",
+			relieving_date=None,
+			status="Active",
+		)
+
+		ss = make_employee_salary_slip(
+			emp_id,
 			"Monthly",
 			"Test Salary Slip With Holidays Excluded",
 		)
@@ -513,7 +491,7 @@ class TestSalarySlip(FrappeTestCase):
 		no_of_days = get_no_of_days()
 
 		# set joinng date in the same month
-		employee = make_employee("test_payment_days@salary.com")
+		emp_id = make_employee("test_payment_days@salary.com")
 		if getdate(nowdate()).day >= 15:
 			relieving_date = getdate(add_days(nowdate(), -10))
 			date_of_joining = getdate(add_days(nowdate(), -10))
@@ -529,12 +507,12 @@ class TestSalarySlip(FrappeTestCase):
 
 		frappe.db.set_value(
 			"Employee",
-			employee,
+			emp_id,
 			{"date_of_joining": date_of_joining, "relieving_date": None, "status": "Active"},
 		)
 
 		salary_structure = "Test Payment Days"
-		ss = make_employee_salary_slip("test_payment_days@salary.com", "Monthly", salary_structure)
+		ss = make_employee_salary_slip(emp_id, "Monthly", salary_structure)
 
 		self.assertEqual(ss.total_working_days, no_of_days[0])
 		self.assertEqual(ss.payment_days, (no_of_days[0] - getdate(date_of_joining).day + 1))
@@ -542,7 +520,7 @@ class TestSalarySlip(FrappeTestCase):
 		# set relieving date in the same month
 		frappe.db.set_value(
 			"Employee",
-			employee,
+			emp_id,
 			{
 				"date_of_joining": add_days(nowdate(), -60),
 				"relieving_date": relieving_date,
@@ -553,7 +531,7 @@ class TestSalarySlip(FrappeTestCase):
 		if date_of_joining.day > 1:
 			self.assertRaises(frappe.ValidationError, ss.save)
 
-		create_salary_structure_assignment(employee, salary_structure)
+		create_salary_structure_assignment(emp_id, salary_structure)
 		ss.reload()
 		ss.save()
 
@@ -562,22 +540,18 @@ class TestSalarySlip(FrappeTestCase):
 
 		frappe.db.set_value(
 			"Employee",
-			frappe.get_value("Employee", {"employee_name": "test_payment_days@salary.com"}, "name"),
-			"relieving_date",
-			None,
-		)
-		frappe.db.set_value(
-			"Employee",
-			frappe.get_value("Employee", {"employee_name": "test_payment_days@salary.com"}, "name"),
-			"status",
-			"Active",
+			emp_id,
+			{
+				"relieving_date": None,
+				"status": "Active",
+			},
 		)
 
 	def test_employee_salary_slip_read_permission(self):
-		make_employee("test_employee_salary_slip_read_permission@salary.com")
+		emp_id = make_employee("test_employee_salary_slip_read_permission@salary.com")
 
 		salary_slip_test_employee = make_employee_salary_slip(
-			"test_employee_salary_slip_read_permission@salary.com",
+			emp_id,
 			"Monthly",
 			"Test Employee Salary Slip Read Permission",
 		)
@@ -588,10 +562,8 @@ class TestSalarySlip(FrappeTestCase):
 	def test_email_salary_slip(self):
 		frappe.db.delete("Email Queue")
 
-		user_id = "test_email_salary_slip@salary.com"
-
-		make_employee(user_id, company="_Test Company")
-		ss = make_employee_salary_slip(user_id, "Monthly", "Test Salary Slip Email")
+		emp_id = make_employee("test_email_salary_slip@salary.com", company="_Test Company")
+		ss = make_employee_salary_slip(emp_id, "Monthly", "Test Salary Slip Email")
 		ss.company = "_Test Company"
 		ss.save()
 		ss.submit()
@@ -661,9 +633,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
 
-		ss = make_employee_salary_slip(
-			"test_loan_repayment_salary_slip@salary.com", "Monthly", "Test Loan Repayment Salary Structure"
-		)
+		ss = make_employee_salary_slip(applicant, "Monthly", "Test Loan Repayment Salary Structure")
 		ss.submit()
 
 		self.assertEqual(ss.total_loan_repayment, 592)
@@ -677,9 +647,9 @@ class TestSalarySlip(FrappeTestCase):
 		m = get_month_details(fiscal_year, month)
 
 		for payroll_frequency in ["Monthly", "Bimonthly", "Fortnightly", "Weekly", "Daily"]:
-			make_employee(payroll_frequency + "_test_employee@salary.com")
+			emp_id = make_employee(payroll_frequency + "_test_employee@salary.com")
 			ss = make_employee_salary_slip(
-				payroll_frequency + "_test_employee@salary.com",
+				emp_id,
 				payroll_frequency,
 				payroll_frequency + "_Test Payroll Frequency",
 			)
@@ -1039,9 +1009,9 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(timesheet.status, "Submitted")
 
 	def test_do_not_show_statistical_component_in_slip(self):
-		make_employee("test_statistical_component@salary.com")
+		emp_id = make_employee("test_statistical_component@salary.com")
 		new_ss = make_employee_salary_slip(
-			"test_statistical_component@salary.com",
+			emp_id,
 			"Monthly",
 			"Test Payment Based On Attendence",
 		)
@@ -1261,7 +1231,7 @@ class TestSalarySlip(FrappeTestCase):
 		frappe.db.set_value("Employee", emp_id, {"relieving_date": relieving_date, "status": "Left"})
 
 		ss = make_employee_salary_slip(
-			"test_lwp_based_on_relieving_date@salary.com",
+			emp_id,
 			"Monthly",
 			"Test Payment Based On Leave Application",
 		)
@@ -1474,14 +1444,14 @@ def get_no_of_days():
 	return [no_of_days_in_month[1], no_of_holidays_in_month]
 
 
-def make_employee_salary_slip(user, payroll_frequency, salary_structure=None, posting_date=None):
+def make_employee_salary_slip(emp_id, payroll_frequency, salary_structure=None, posting_date=None):
 	from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 	if not salary_structure:
 		salary_structure = payroll_frequency + " Salary Structure Test for Salary Slip"
 
 	employee = frappe.db.get_value(
-		"Employee", {"user_id": user}, ["name", "company", "employee_name"], as_dict=True
+		"Employee", emp_id, ["name", "company", "employee_name"], as_dict=True
 	)
 
 	salary_structure_doc = make_salary_structure(
@@ -1491,9 +1461,7 @@ def make_employee_salary_slip(user, payroll_frequency, salary_structure=None, po
 		company=employee.company,
 		from_date=posting_date,
 	)
-	salary_slip_name = frappe.db.get_value(
-		"Salary Slip", {"employee": frappe.db.get_value("Employee", {"user_id": user})}
-	)
+	salary_slip_name = frappe.db.get_value("Salary Slip", {"employee": emp_id})
 
 	if not salary_slip_name:
 		salary_slip = make_salary_slip(salary_structure_doc.name, employee=employee.name)

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -77,18 +77,18 @@ class TestSalaryStructure(FrappeTestCase):
 
 	def test_amount_totals(self):
 		frappe.db.set_single_value("Payroll Settings", "include_holidays_in_total_working_days", 0)
-		sal_slip = frappe.get_value("Salary Slip", {"employee_name": "test_employee_2@salary.com"})
-		if not sal_slip:
-			sal_slip = make_employee_salary_slip(
-				"test_employee_2@salary.com", "Monthly", "Salary Structure Sample"
-			)
-			self.assertEqual(sal_slip.get("salary_structure"), "Salary Structure Sample")
-			self.assertEqual(sal_slip.get("earnings")[0].amount, 50000)
-			self.assertEqual(sal_slip.get("earnings")[1].amount, 3000)
-			self.assertEqual(sal_slip.get("earnings")[2].amount, 25000)
-			self.assertEqual(sal_slip.get("gross_pay"), 78000)
-			self.assertEqual(sal_slip.get("deductions")[0].amount, 200)
-			self.assertEqual(sal_slip.get("net_pay"), 78000 - sal_slip.get("total_deduction"))
+		emp_id = make_employee("test_employee_2@salary.com")
+		salary_slip = frappe.get_value("Salary Slip", {"employee": emp_id})
+
+		if not salary_slip:
+			salary_slip = make_employee_salary_slip(emp_id, "Monthly", "Salary Structure Sample")
+			self.assertEqual(salary_slip.get("salary_structure"), "Salary Structure Sample")
+			self.assertEqual(salary_slip.get("earnings")[0].amount, 50000)
+			self.assertEqual(salary_slip.get("earnings")[1].amount, 3000)
+			self.assertEqual(salary_slip.get("earnings")[2].amount, 25000)
+			self.assertEqual(salary_slip.get("gross_pay"), 78000)
+			self.assertEqual(salary_slip.get("deductions")[0].amount, 200)
+			self.assertEqual(salary_slip.get("net_pay"), 78000 - salary_slip.get("total_deduction"))
 
 	def test_whitespaces_in_formula_conditions_fields(self):
 		salary_structure = make_salary_structure("Salary Structure Sample", "Monthly", dont_submit=True)

--- a/hrms/payroll/utils.py
+++ b/hrms/payroll/utils.py
@@ -1,4 +1,4 @@
-# import frappe
+import frappe
 
 
 def sanitize_expression(string: str | None = None) -> str | None:
@@ -24,3 +24,18 @@ def sanitize_expression(string: str | None = None) -> str | None:
 	string = " ".join(parts)
 
 	return string
+
+
+@frappe.whitelist()
+def get_payroll_settings_for_payment_days() -> dict:
+	return frappe.get_cached_value(
+		"Payroll Settings",
+		None,
+		[
+			"payroll_based_on",
+			"consider_unmarked_attendance_as",
+			"include_holidays_in_total_working_days",
+			"consider_marked_attendance_on_holidays",
+		],
+		as_dict=True,
+	)


### PR DESCRIPTION
By default, holidays are considered as paid days even if an employee is marked absent on that day. But consider a scenario where a daily wage worker only works for 5 days a month (other days are marked as absent). They should not be paid for weekends and holidays.

Added a setting to allow overriding holidays with attendance status (disabled by default to continue current behavior). After enabling this, on a holiday:
- If attendance is marked, that attendance status will be considered
- Else, it will be considered as a paid holiday (like it does right now)

<img width="1334" alt="image" src="https://github.com/frappe/hrms/assets/24353136/bebb915d-3934-4224-9655-34f1830346da"><br>

Added payroll settings desc in draft salary slips for context to improve feature flag discoverability and context

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/0ac3548d-0439-4a64-be34-909d684ce650">

Docs: https://frappehr.com/docs/v14/en/payroll-settings#1-4-consider-marked-attendance-on-holidays
