### PR TITLE
fix(payroll): incorrect absent days if relieving date is set for a latter month

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -535,7 +535,7 @@ class SalarySlip(TransactionBase):
 		absent = 0
 
 		end_date = self.end_date
-		if relieving_date:
+		if relieving_date and getdate(self.start_date) <= relieving_date < getdate(self.end_date):
 			end_date = relieving_date
 
 		payroll_settings = frappe.get_cached_value(


### PR DESCRIPTION
while processing payroll for previous months for an employee whose relieving date is set, if there is an absent record in the latter months, it gets counted in absent days

There are only 5 absent records in the payroll month & 1 in the latter month
<img width="1321" alt="image" src="https://github.com/frappe/hrms/assets/24353136/345914c7-b579-4ee3-836a-2c2624fe9de3">

Absent days are shown as 6:
<img width="1321" alt="image" src="https://github.com/frappe/hrms/assets/24353136/8a766925-177d-467a-be4a-bab0d4a4d8d0">

**Fix**:

Explicitly check whether the relieving date is set for the employee
<img width="1321" alt="image" src="https://github.com/frappe/hrms/assets/24353136/a0e30c3c-23bc-465a-adf8-8ea19f82ab20">