### PR TITLE
test: remove assertion for amount in consider marked attendance on holidays test

### DIFF
--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -512,9 +512,6 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(ss.total_working_days, no_of_days[0])
 		# deduct 1 day for absent on holiday
 		self.assertEqual(ss.payment_days, no_of_days[0] - 1)
-		self.assertEqual(ss.earnings[0].amount, 48333.33)
-		self.assertEqual(ss.earnings[1].amount, 2900)
-		self.assertEqual(ss.gross_pay, 75399.99)
 
 		# disable consider marked attendance on holidays
 		frappe.db.set_single_value("Payroll Settings", "consider_marked_attendance_on_holidays", 0)


### PR DESCRIPTION
amount based on payment days gets tested in other tests. This will change every month based on number of days.
<img width="991" alt="image" src="https://github.com/frappe/hrms/assets/24353136/7012ae25-9718-4e74-909e-db3883078599">

Not asserting it here with calculated gross to complicate the test. Removing the assertion as the main aim of this feature is to show the payment days precisely