### PR TITLE
fix: error while selecting an employee when `salary_slip_based_on_timesheet` is unchecked

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1367,7 +1367,8 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
 		]
 		filters.pop("start_date")
 		filters.pop("end_date")
-		filters.pop("salary_slip_based_on_timesheet")
+		if filters.get("salary_slip_based_on_timesheet"):
+			filters.pop("salary_slip_based_on_timesheet")
 		filters.pop("payroll_frequency")
 		filters.pop("payroll_payable_account")
 		filters.pop("currency")


### PR DESCRIPTION
@ruchamahabal 
![Screenshot 2023-10-04 150712](https://github.com/frappe/hrms/assets/141210323/9b7a2f97-caf4-4019-9926-ad505eb30524)

as per mention is image i have updating an api by if condition

https://github.com/frappe/hrms/issues/939