### PR TITLE
fix: shift fetch & absent marking (for missing attendance) fails if shift margin dates and shift dates are not same

### DIFF
--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -302,6 +302,39 @@ class TestEmployeeCheckin(FrappeTestCase):
 		log = make_checkin(employee, datetime.combine(prev_day, get_time("23:00:00")))
 		self.assertIsNone(log.shift)
 
+	def test_fetch_night_shift_in_shift_margin_period(self):
+		"""
+		Tests if shift is correctly fetched in logs if the actual end time exceeds a day
+		i.e: shift is from 15:00 to 23:00 (starts & ends on the same day)
+		but shift margin = 2 hours, so the actual shift goes to 1:00 of the next day
+		"""
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift",
+			start_time="15:00:00",
+			end_time="23:00:00",
+			allow_check_out_after_shift_end_time=120,
+		)
+		shift_type.reload()
+		date = getdate()
+		next_day = add_days(date, 1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# IN log falls on the first day
+		start_timestamp = datetime.combine(date, get_time("14:00:00"))
+		log_in = make_checkin(employee, start_timestamp)
+
+		# OUT log falls on the second day in the shift margin period
+		end_timestamp = datetime.combine(next_day, get_time("01:00:00"))
+		log_out = make_checkin(employee, end_timestamp)
+
+		for log in [log_in, log_out]:
+			self.assertEqual(log.shift, shift_type.name)
+			self.assertEqual(log.shift_actual_start, start_timestamp)
+			self.assertEqual(log.shift_actual_end, end_timestamp)
+
 	def test_consecutive_shift_assignments_overlapping_within_grace_period(self):
 		# test adjustment for start and end times if they are overlapping
 		# within "begin_check_in_before_shift_start_time" and "allow_check_out_after_shift_end_time" periods

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -278,7 +278,7 @@ class TestEmployeeCheckin(FrappeTestCase):
 			self.assertEqual(log.shift_start, start_timestamp)
 			self.assertEqual(log.shift_end, end_timestamp)
 
-	def test_night_shift_not_fetched_outside_assignment_boundary(self):
+	def test_night_shift_not_fetched_outside_assignment_boundary_for_diff_start_date(self):
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
 		shift_type = setup_shift_type(
 			shift_type="Midnight Shift", start_time="23:00:00", end_time="07:00:00"
@@ -302,7 +302,83 @@ class TestEmployeeCheckin(FrappeTestCase):
 		log = make_checkin(employee, datetime.combine(prev_day, get_time("23:00:00")))
 		self.assertIsNone(log.shift)
 
-	def test_fetch_night_shift_in_shift_margin_period(self):
+	def test_night_shift_not_fetched_outside_assignment_boundary_for_diff_end_date(self):
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift", start_time="19:00:00", end_time="00:30:00"
+		)
+		date = getdate()
+		next_day = add_days(date, 1)
+		prev_day = add_days(date, -1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# shift not applicable on next day's start time
+		log = make_checkin(employee, datetime.combine(next_day, get_time("19:00:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on current day's end time
+		log = make_checkin(employee, datetime.combine(date, get_time("00:30:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on prev day's start time
+		log = make_checkin(employee, datetime.combine(prev_day, get_time("19:00:00")))
+		self.assertIsNone(log.shift)
+
+	def test_night_shift_not_fetched_outside_before_shift_margin(self):
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift", start_time="00:30:00", end_time="10:00:00"
+		)
+		date = getdate()
+		next_day = add_days(date, 1)
+		prev_day = add_days(date, -1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# shift not fetched in today's shift margin
+		log = make_checkin(employee, datetime.combine(date, get_time("23:30:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on next day's start time
+		log = make_checkin(employee, datetime.combine(next_day, get_time("00:30:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on prev day's start time
+		log = make_checkin(employee, datetime.combine(prev_day, get_time("00:30:00")))
+		self.assertIsNone(log.shift)
+
+	def test_night_shift_not_fetched_outside_after_shift_margin(self):
+		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(
+			shift_type="Midnight Shift", start_time="15:00:00", end_time="23:30:00"
+		)
+		date = getdate()
+		next_day = add_days(date, 1)
+		prev_day = add_days(date, -1)
+
+		# shift assigned for a single day
+		make_shift_assignment(shift_type.name, employee, date, date)
+
+		# shift not fetched in today's shift margin
+		log = make_checkin(employee, datetime.combine(date, get_time("00:30:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on next day's start time
+		log = make_checkin(employee, datetime.combine(next_day, get_time("15:00:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on prev day's start time
+		log = make_checkin(employee, datetime.combine(prev_day, get_time("15:00:00")))
+		self.assertIsNone(log.shift)
+
+		# shift not applicable on prev day's end time
+		log = make_checkin(employee, datetime.combine(prev_day, get_time("00:30:00")))
+		self.assertIsNone(log.shift)
+
+	def test_fetch_night_shift_in_margin_period_after_shift(self):
 		"""
 		Tests if shift is correctly fetched in logs if the actual end time exceeds a day
 		i.e: shift is from 15:00 to 23:00 (starts & ends on the same day)
@@ -335,11 +411,11 @@ class TestEmployeeCheckin(FrappeTestCase):
 			self.assertEqual(log.shift_actual_start, start_timestamp)
 			self.assertEqual(log.shift_actual_end, end_timestamp)
 
-	def test_fetch_night_shift_in_before_shift_margin_period(self):
+	def test_fetch_night_shift_in_margin_period_before_shift(self):
 		"""
 		Tests if shift is correctly fetched in logs if the actual end time exceeds a day
-		i.e: shift is from 15:00 to 23:00 (starts & ends on the same day)
-		but shift margin = 2 hours, so the actual shift goes to 1:00 of the next day
+		i.e: shift is from 00:30 to 10:00 (starts & ends on the same day)
+		but shift margin = 1 hour, so the actual shift start goes to 23:30:00 of the prev day
 		"""
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
 		# shift margin goes to next day (1:00 am)

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -309,13 +309,13 @@ class TestEmployeeCheckin(FrappeTestCase):
 		but shift margin = 2 hours, so the actual shift goes to 1:00 of the next day
 		"""
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
+		# shift margin goes to next day (1:00 am)
 		shift_type = setup_shift_type(
 			shift_type="Midnight Shift",
 			start_time="15:00:00",
 			end_time="23:00:00",
 			allow_check_out_after_shift_end_time=120,
 		)
-		shift_type.reload()
 		date = getdate()
 		next_day = add_days(date, 1)
 

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -418,7 +418,13 @@ def get_prev_or_next_shift(
 		)
 
 		for date_range in shift_dates:
-			for dt in get_date_range(date_range[0], date_range[1]):
+			# midnight shifts will span more than a day
+			end_date = add_days(date_range[1], 1)
+			dates = get_date_range(date_range[0], end_date)
+			if next_shift_direction == "reverse":
+				dates.reverse()
+
+			for dt in dates:
 				shift_details = get_employee_shift(
 					employee, datetime.combine(dt, for_timestamp.time()), consider_default_shift, None
 				)

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -224,16 +224,35 @@ def _is_shift_outside_assignment_period(shift_details: dict, assignment: dict) -
 	# start time > end time, means its a midnight shift
 	is_midnight_shift = shift_details.actual_start.time() > shift_details.actual_end.time()
 
-	if shift_details.actual_start.date() < assignment.start_date and not is_midnight_shift:
-		return True
+	if shift_details.actual_start.date() < assignment.start_date:
+		if not is_midnight_shift:
+			return True
+
+		if shift_details.actual_start.date() == shift_details.start_datetime.date():
+			return True
+
+		prev_assignment_day = add_days(assignment.start_date, -1)
+		if is_midnight_shift and shift_details.actual_start.date() != prev_assignment_day:
+			return True
 
 	if assignment.end_date:
 		if shift_details.actual_start.date() > assignment.end_date:
 			return True
 
 		# log's end date can only exceed assignment's end date if its a midnight shift
-		if shift_details.actual_end.date() > assignment.end_date and not is_midnight_shift:
-			return True
+		if shift_details.actual_end.date() > assignment.end_date:
+			if not is_midnight_shift:
+				return True
+
+			if (
+				shift_details.actual_end.date() == shift_details.end_datetime.date()
+				and shift_details.start_datetime.date() == shift_details.end_datetime.date()
+			):
+				return True
+
+			next_assignment_day = add_days(assignment.end_date, 1)
+			if is_midnight_shift and shift_details.actual_end.date() != next_assignment_day:
+				return True
 
 	return False
 

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -480,52 +480,8 @@ def get_shift_details(shift_type_name: str, for_timestamp: datetime = None) -> D
 	if for_timestamp is None:
 		for_timestamp = now_datetime()
 
-	shift_type = frappe.get_cached_value(
-		"Shift Type",
-		shift_type_name,
-		[
-			"name",
-			"start_time",
-			"end_time",
-			"begin_check_in_before_shift_start_time",
-			"allow_check_out_after_shift_end_time",
-		],
-		as_dict=1,
-	)
-	shift_actual_start = shift_type.start_time - timedelta(
-		minutes=shift_type.begin_check_in_before_shift_start_time
-	)
-	shift_actual_end = shift_type.end_time + timedelta(
-		minutes=shift_type.allow_check_out_after_shift_end_time
-	)
-
-	if shift_type.start_time > shift_type.end_time:
-		# shift spans across 2 different days
-		if get_time(for_timestamp.time()) >= get_time(shift_actual_start):
-			# if for_timestamp is greater than start time, it's within the first day
-			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.start_time
-			for_timestamp += timedelta(days=1)
-			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.end_time
-
-		elif get_time(for_timestamp.time()) < get_time(shift_actual_start):
-			# if for_timestamp is less than start time, it's within the second day
-			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.end_time
-			for_timestamp += timedelta(days=-1)
-			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.start_time
-
-	else:
-		if get_time(shift_actual_start) > get_time(shift_actual_end) and get_time(
-			for_timestamp.time()
-		) < get_time(shift_actual_start):
-			# for_timestamp falls within the margin period in the second day (after midnight)
-			# so shift started and ended on the previous day
-			for_timestamp += timedelta(days=-1)
-			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.end_time
-			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.start_time
-		else:
-			# start and end timings fall on the same day
-			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.start_time
-			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + shift_type.end_time
+	shift_type = get_shift_type(shift_type_name)
+	start_datetime, end_datetime = get_shift_timings(shift_type, for_timestamp)
 
 	actual_start = start_datetime - timedelta(
 		minutes=shift_type.begin_check_in_before_shift_start_time
@@ -541,3 +497,58 @@ def get_shift_details(shift_type_name: str, for_timestamp: datetime = None) -> D
 			"actual_end": actual_end,
 		}
 	)
+
+
+def get_shift_type(shift_type_name: str) -> dict:
+	return frappe.get_cached_value(
+		"Shift Type",
+		shift_type_name,
+		[
+			"name",
+			"start_time",
+			"end_time",
+			"begin_check_in_before_shift_start_time",
+			"allow_check_out_after_shift_end_time",
+		],
+		as_dict=1,
+	)
+
+
+def get_shift_timings(shift_type: dict, for_timestamp: datetime) -> tuple:
+	start_time = shift_type.start_time
+	end_time = shift_type.end_time
+	shift_actual_start = get_time(
+		start_time - timedelta(minutes=shift_type.begin_check_in_before_shift_start_time)
+	)
+	shift_actual_end = get_time(
+		end_time + timedelta(minutes=shift_type.allow_check_out_after_shift_end_time)
+	)
+	for_time = get_time(for_timestamp.time())
+
+	if start_time > end_time:
+		# shift spans across 2 different days
+		if for_time >= shift_actual_start:
+			# if for_timestamp is greater than start time, it's within the first day
+			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + start_time
+			for_timestamp += timedelta(days=1)
+			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + end_time
+
+		elif for_time < shift_actual_start:
+			# if for_timestamp is less than start time, it's within the second day
+			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + end_time
+			for_timestamp += timedelta(days=-1)
+			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + start_time
+
+	else:
+		if get_time(shift_actual_start) > shift_actual_end and for_time < shift_actual_start:
+			# for_timestamp falls within the margin period in the second day (after midnight)
+			# so shift started and ended on the previous day
+			for_timestamp += timedelta(days=-1)
+			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + end_time
+			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + start_time
+		else:
+			# start and end timings fall on the same day
+			start_datetime = datetime.combine(for_timestamp, datetime.min.time()) + start_time
+			end_datetime = datetime.combine(for_timestamp, datetime.min.time()) + end_time
+
+	return start_datetime, end_datetime

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -12,7 +12,7 @@ from frappe.query_builder import Criterion
 from frappe.utils import add_days, cstr, get_link_to_form, get_time, getdate, now_datetime
 
 from hrms.hr.utils import validate_active_employee
-from hrms.utils import get_date_range
+from hrms.utils import generate_date_range
 
 
 class OverlappingShiftError(frappe.ValidationError):
@@ -419,12 +419,10 @@ def get_prev_or_next_shift(
 
 		for date_range in shift_dates:
 			# midnight shifts will span more than a day
-			end_date = add_days(date_range[1], 1)
-			dates = get_date_range(date_range[0], end_date)
-			if next_shift_direction == "reverse":
-				dates.reverse()
+			start_date, end_date = date_range[0], add_days(date_range[1], 1)
+			reverse = next_shift_direction == "reverse"
 
-			for dt in dates:
+			for dt in generate_date_range(start_date, end_date, reverse=reverse):
 				shift_details = get_employee_shift(
 					employee, datetime.combine(dt, for_timestamp.time()), consider_default_shift, None
 				)

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -157,12 +157,12 @@ class ShiftType(Document):
 					}
 				).insert(ignore_permissions=True)
 
-	def get_dates_for_attendance(self, employee: str) -> set[str]:
+	def get_dates_for_attendance(self, employee: str) -> list[str]:
 		start_date, end_date = self.get_start_and_end_dates(employee)
 
 		# no shift assignment found, no need to process absent attendance records
 		if start_date is None:
-			return set()
+			return []
 
 		date_range = get_date_range(start_date, end_date)
 
@@ -174,7 +174,7 @@ class ShiftType(Document):
 			employee, start_date, end_date
 		)
 
-		return set(date_range) - set(holiday_dates) - set(marked_attendance_dates)
+		return sorted(set(date_range) - set(holiday_dates) - set(marked_attendance_dates))
 
 	def get_start_and_end_dates(self, employee):
 		"""Returns start and end dates for checking attendance and marking absent

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -36,7 +36,7 @@ class ShiftType(Document):
 
 		for key, group in itertools.groupby(logs, key=lambda x: (x["employee"], x["shift_start"])):
 			single_shift_logs = list(group)
-			attendance_date = single_shift_logs[0].shift_actual_start.date()
+			attendance_date = key[1].date()
 			employee = key[0]
 
 			if not self.should_mark_attendance(employee, attendance_date):

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -369,26 +369,19 @@ class TestShiftType(FrappeTestCase):
 		make_shift_assignment(shift_type.name, employee, date1, date1)
 
 		# assignment without end date
-		make_shift_assignment(shift_type.name, employee, add_days(today, -4))
+		date2 = add_days(today, -4)
+		make_shift_assignment(shift_type.name, employee, date2, date2)
 
 		shift_type.process_auto_attendance()
-		yesterday = add_days(today, -1)
-
-		# absentees are auto-marked one day after shift actual end to wait for any manual attendance records
-		# so all days should be marked as absent except today
 		absent_records = frappe.get_all(
 			"Attendance",
 			{
-				"attendance_date": ["between", [date1, yesterday]],
+				"attendance_date": ["between", [date1, today]],
 				"employee": employee,
 				"status": "Absent",
 			},
 		)
-		self.assertEqual(len(absent_records), 5)
-		todays_attendance = frappe.db.get_value(
-			"Attendance", {"attendance_date": today, "employee": employee}
-		)
-		self.assertIsNone(todays_attendance)
+		self.assertEqual(len(absent_records), 2)
 
 	def test_do_not_mark_absent_before_shift_actual_end_time(self):
 		"""

--- a/hrms/utils/__init__.py
+++ b/hrms/utils/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import requests
 
 import frappe
@@ -32,6 +34,18 @@ def get_date_range(start_date: str, end_date: str) -> list[str]:
 	"""returns list of dates between start and end dates"""
 	no_of_days = date_diff(end_date, start_date) + 1
 	return [add_days(start_date, i) for i in range(no_of_days)]
+
+
+def generate_date_range(
+	start_date: str, end_date: str, reverse: bool = False
+) -> Generator[str, None, None]:
+	no_of_days = date_diff(end_date, start_date) + 1
+
+	date_field = end_date if reverse else start_date
+	direction = -1 if reverse else 1
+
+	for n in range(no_of_days):
+		yield add_days(date_field, direction * n)
 
 
 def get_employee_email(employee_id: str) -> str | None:


### PR DESCRIPTION
## Problem

- Shift Assignment for a single day - 16th Aug - 16th Aug
- Shift Timings: 15:00 - 23:30
- Allow Checkout after shift end time = 120 mins
- Actual Shift Timings (considering margin): 15:00 - 1:30

If there is a check-in log created after 00:00 (date changes) eg: 1:24, shift fetching fails because even though the shift was not exceeding a day, the margin period was. Handled this case

- [x] Shift fetch fails in before shift margin when actual start date != start date
- [x] Shift fetch fails in after shift margin when actual end != end date
- [x] Add Test - absent marking for missing attendance dates for an older assignment date
- [x] Check for false positives - different shift's records being considered or attempting to mark absent for unnecessary days
- [x] Incorrect attendance date for different start & actual start dates. (bug present since feature inception - was partially fixed with https://github.com/frappe/hrms/pull/480)

Note: changes best understood in split diff view