### PR TITLE
fix(PWA): double back-swipe animation on ios

### DIFF
--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -1,5 +1,5 @@
 <template>
-	<ion-menu side="start" content-id="main-content">
+	<ion-menu side="start" content-id="main-content" :swipe-gesture="false">
 		<ion-content class="ion-padding">
 			<div class="bg-white h-full">
 				<div

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -18,7 +18,9 @@ import { IonicVue } from "@ionic/vue"
 import { session } from "@/data/session"
 import { userResource } from "@/data/user"
 import { employeeResource } from "@/data/employee"
+
 import dayjs from "@/utils/dayjs"
+import getIonicConfig from "@/utils/ionicConfig"
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/vue/css/core.css"
@@ -39,7 +41,7 @@ app.component("FormControl", FormControl)
 app.component("EmptyState", EmptyState)
 
 app.use(router)
-app.use(IonicVue)
+app.use(IonicVue, getIonicConfig())
 
 if (session?.isLoggedIn && !employeeResource?.data) {
 	employeeResource.reload()

--- a/frontend/src/utils/ionicConfig.js
+++ b/frontend/src/utils/ionicConfig.js
@@ -1,0 +1,32 @@
+import { isPlatform } from "@ionic/vue"
+import { createAnimation, iosTransitionAnimation } from "@ionic/core"
+/**
+ * on iOS, the back swipe gesture triggers the animation twice:
+ * the safari's default back swipe animation & ionic's animation
+ * The config here takes care of the same
+ */
+
+export const animationBuilder = (baseEl, opts) => {
+	if (opts.direction === "back") {
+		/**
+		 * Even after disabling swipeBackEnabled, when the swipe is completed & we're back on the first screen
+		 * the "pop" animation is triggered, resulting in a double animation
+		 * HACK: return empty animation for back swipe in ios
+		 **/
+		return createAnimation()
+	}
+
+	return iosTransitionAnimation(baseEl, opts)
+}
+
+const getIonicConfig = () => {
+	return isPlatform("iphone")
+		? {
+				// disable ionic's swipe back gesture on ios
+				swipeBackEnabled: false,
+				navAnimation: animationBuilder,
+		  }
+		: {}
+}
+
+export default getIonicConfig

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -19,7 +19,7 @@
 							placeholder="••••••"
 							v-model="password"
 						/>
-						<Button :loading="session.login.loading" variant="solid">
+						<Button :loading="session.login.loading" variant="solid" class="disabled:bg-gray-700 disabled:text-white">
 							Login
 						</Button>
 					</form>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -19,7 +19,11 @@
 							placeholder="••••••"
 							v-model="password"
 						/>
-						<Button :loading="session.login.loading" variant="solid" class="disabled:bg-gray-700 disabled:text-white">
+						<Button
+							:loading="session.login.loading"
+							variant="solid"
+							class="disabled:bg-gray-700 disabled:text-white"
+						>
 							Login
 						</Button>
 					</form>


### PR DESCRIPTION
## Problem

on iOS, the back swipe gesture triggers the animation twice: safari's default back swipe animation and Ionic's animation

- set `swipeBackEnabled: false` in config
- Even after disabling swipeBackEnabled, when the swipe is completed & we're back on the first screen, the "pop" animation is triggered, resulting in a double animation. **HACK**: return empty animation for back swipe in ios'
- Even disabling the menu toggle on swiping back

## Before

https://github.com/frappe/hrms/assets/24353136/63108fe5-0d6b-4584-9ea9-2007f3b2bac9




## After

https://github.com/frappe/hrms/assets/24353136/71f80743-8eea-4327-96b3-243ed39b8035


Got this temporary fix from this thread: https://github.com/ionic-team/ionic-framework/issues/20904#issuecomment-950227078
