### PR TITLE
test: add product_code in create_loan_product

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -778,6 +778,7 @@ def setup_lending():
 		create_loan_accounts()
 		create_loan_product(
 			"Car Loan",
+			"Car Loan",
 			500000,
 			8.4,
 			is_term_loan=1,

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -627,6 +627,7 @@ class TestSalarySlip(FrappeTestCase):
 
 		create_loan_product(
 			"Car Loan",
+			"Car Loan",
 			500000,
 			8.4,
 			is_term_loan=1,


### PR DESCRIPTION
`product_code` was added in the `create_loan_product` function, hence this change.

Depends on https://github.com/frappe/lending/pull/80