### PR TITLE
feat(Employee Onboarding): add Mark as Completed button for Pending/In Process onboardings

### DIFF
--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.js
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.js
@@ -44,6 +44,11 @@ frappe.ui.form.on('Employee Onboarding', {
 			}, __('Create'));
 			frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
+		if (frm.doc.docstatus === 1 && (frm.doc.boarding_status== "Pending" || frm.doc.boarding_status == "In Process")) {
+			frm.add_custom_button(__('Mark as Completed'), function () {
+				frm.trigger("mark_as_completed");
+			});
+		}
 	},
 
 	employee_onboarding_template: function(frm) {
@@ -79,5 +84,18 @@ frappe.ui.form.on('Employee Onboarding', {
 		} else {
 			frm.set_value('employee', '');
 		}
-	}
+	},
+
+	mark_as_completed(frm) {
+		frm
+			.call({
+				method: "mark_onboarding_as_completed",
+				doc: frm.doc,
+				freeze: true,
+				freeze_message: __("Completing onboarding"),
+			})
+			.then((r) => {
+				frm.refresh();
+			});
+	},
 });

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.js
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.js
@@ -44,8 +44,8 @@ frappe.ui.form.on('Employee Onboarding', {
 			}, __('Create'));
 			frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
-		if (frm.doc.docstatus === 1 && (frm.doc.boarding_status== "Pending" || frm.doc.boarding_status == "In Process")) {
-			frm.add_custom_button(__('Mark as Completed'), function () {
+		if (frm.doc.docstatus === 1 && (frm.doc.boarding_status === "Pending" || frm.doc.boarding_status === "In Process")) {
+			frm.add_custom_button(__("Mark as Completed"), function() {
 				frm.trigger("mark_as_completed");
 			});
 		}

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
@@ -58,6 +58,13 @@ class EmployeeOnboarding(EmployeeBoardingController):
 	def on_cancel(self):
 		super(EmployeeOnboarding, self).on_cancel()
 
+	@frappe.whitelist()
+	def mark_onboarding_as_completed(self):
+		for activity in self.activities:
+			frappe.db.set_value("Task", activity.task, "status", "Completed")
+		frappe.db.set_value("Project", self.project, "status", "Completed")
+		self.boarding_status = "Completed"
+
 
 @frappe.whitelist()
 def make_employee(source_name, target_doc=None):

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
@@ -64,6 +64,7 @@ class EmployeeOnboarding(EmployeeBoardingController):
 			frappe.db.set_value("Task", activity.task, "status", "Completed")
 		frappe.db.set_value("Project", self.project, "status", "Completed")
 		self.boarding_status = "Completed"
+		self.save()
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
@@ -79,20 +79,18 @@ class TestEmployeeOnboarding(FrappeTestCase):
 		self.assertEqual(onboarding.boarding_status, "Pending")
 		project = frappe.get_doc("Project", onboarding.project)
 		self.assertEqual(project.status, "Open")
-		for task in frappe.get_all("Task", dict(project=project.name), pluck="name"):
-			task = frappe.get_doc("Task", task)
-			self.assertEqual(task.status, "Open")
+		for task_status in frappe.get_all("Task", dict(project=project.name), pluck="status"):
+			self.assertEqual(task_status, "Open")
 
 		onboarding.reload()
 		onboarding.mark_onboarding_as_completed()
 
 		# after marking as completed
 		self.assertEqual(onboarding.boarding_status, "Completed")
-		project = frappe.get_doc("Project", onboarding.project)
+		project.reload()
 		self.assertEqual(project.status, "Completed")
-		for task in frappe.get_all("Task", dict(project=project.name), pluck="name"):
-			task = frappe.get_doc("Task", task)
-			self.assertEqual(task.status, "Completed")
+		for task_status in frappe.get_all("Task", dict(project=project.name), pluck="status"):
+			self.assertEqual(task_status, "Completed")
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
@@ -11,15 +11,17 @@ from hrms.hr.doctype.employee_onboarding.employee_onboarding import (
 )
 from hrms.hr.doctype.job_offer.test_job_offer import create_job_offer
 from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
+from hrms.tests.test_utils import create_company
 
 
 class TestEmployeeOnboarding(FrappeTestCase):
 	def setUp(self):
+		create_company()
 		if frappe.db.exists("Employee Onboarding", {"employee_name": "Test Researcher"}):
-			frappe.delete_doc("Employee Onboarding", {"employee_name": "Test Researcher"})
+			frappe.db.sql("delete from `tabEmployee Onboarding` where employee_name=%s", "Test Researcher")
 
 		project = "Employee Onboarding : test@researcher.com"
-		frappe.db.sql("delete from tabProject where name=%s", project)
+		frappe.db.sql("delete from tabProject where project_name=%s", project)
 		frappe.db.sql("delete from tabTask where project=%s", project)
 
 	def test_employee_onboarding_incomplete_task(self):
@@ -69,6 +71,28 @@ class TestEmployeeOnboarding(FrappeTestCase):
 		employee.gender = "Female"
 		employee.insert()
 		self.assertEqual(employee.employee_name, "Test Researcher")
+
+	def test_mark_onboarding_as_completed(self):
+		onboarding = create_employee_onboarding()
+
+		# before marking as completed
+		self.assertEqual(onboarding.boarding_status, "Pending")
+		project = frappe.get_doc("Project", onboarding.project)
+		self.assertEqual(project.status, "Open")
+		for task in frappe.get_all("Task", dict(project=project.name), pluck="name"):
+			task = frappe.get_doc("Task", task)
+			self.assertEqual(task.status, "Open")
+
+		onboarding.reload()
+		onboarding.mark_onboarding_as_completed()
+
+		# after marking as completed
+		self.assertEqual(onboarding.boarding_status, "Completed")
+		project = frappe.get_doc("Project", onboarding.project)
+		self.assertEqual(project.status, "Completed")
+		for task in frappe.get_all("Task", dict(project=project.name), pluck="name"):
+			task = frappe.get_doc("Task", task)
+			self.assertEqual(task.status, "Completed")
 
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
Clicking on this button marks the linked Tasks, Project, and the Employee Onboarding itself as "Completed".

`no-docs`