### PR TITLE
fix(PWA): add custom `ion-modal` to fix the focus trap issue

### DIFF
--- a/frontend/src/components/CustomIonModal.vue
+++ b/frontend/src/components/CustomIonModal.vue
@@ -1,0 +1,45 @@
+<template>
+	<ion-modal
+		ref="modal"
+		:trigger="trigger"
+		:initial-breakpoint="1"
+		:breakpoints="[0, 1]"
+		:backdrop-breakpoint="1"
+		:is-open="isOpen"
+		@willPresent="showModalBackdrop = true"
+		@willDismiss="showModalBackdrop = false"
+		@didDismiss="() => emit('did-dismiss')"
+	>
+		<slot name="actionSheet"></slot>
+	</ion-modal>
+
+	<!-- backdrop -->
+	<div
+		v-if="showModalBackdrop"
+		class="opacity-25 fixed inset-0 z-40 bg-black"
+		@click="() => modalController.dismiss()"
+	></div>
+</template>
+
+<script setup>
+/**
+ * Problem: ion-modal traps focus inside the modal making controls like autocomplete unusable inside it
+ * @see https://github.com/ionic-team/ionic-framework/issues/24646
+ * This custom ion-modal disables backdrop using backdrop-breakpoint=1 and we add a custom backdrop
+ */
+import { ref } from "vue"
+import { IonModal, modalController } from "@ionic/vue"
+
+const props = defineProps({
+	trigger: {
+		type: String,
+		required: false,
+	},
+	isOpen: {
+		type: Boolean,
+		required: false,
+	},
+})
+const emit = defineEmits(["did-dismiss"])
+const showModalBackdrop = ref(false)
+</script>

--- a/frontend/src/components/CustomIonModal.vue
+++ b/frontend/src/components/CustomIonModal.vue
@@ -16,7 +16,7 @@
 	<!-- backdrop -->
 	<div
 		v-if="showModalBackdrop"
-		class="opacity-25 fixed inset-0 z-40 bg-black"
+		class="fixed inset-0 z-[10000] !mt-0 bg-black opacity-30 cursor-pointer"
 		@click="() => modalController.dismiss()"
 	></div>
 </template>

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -57,85 +57,83 @@
 		</div>
 		<EmptyState v-else message="No taxes added" :isTableField="true" />
 
-		<ion-modal
-			ref="modal"
-			:is-open="isModalOpen"
-			@didDismiss="resetSelectedItem()"
-			:initial-breakpoint="1"
-			:breakpoints="[0, 1]"
-		>
-			<!-- Add Expense Tax Action Sheet -->
-			<div
-				class="bg-white w-full flex flex-col items-center justify-center pb-5"
-			>
-				<div class="w-full pt-8 pb-5 border-b text-center">
-					<span class="text-gray-900 font-bold text-xl">
-						{{ modalTitle }}
-					</span>
-				</div>
-				<div class="w-full flex flex-col items-center justify-center gap-5 p-4">
-					<div class="flex flex-col w-full space-y-4">
-						<FormField
-							v-for="field in taxesTableFields.data"
-							:key="field.fieldname"
-							class="w-full"
-							:label="field.label"
-							:fieldtype="field.fieldtype"
-							:fieldname="field.fieldname"
-							:options="field.options"
-							:linkFilters="field.linkFilters"
-							:hidden="field.hidden"
-							:reqd="field.reqd"
-							:readOnly="field.read_only || isReadOnly"
-							:default="field.default"
-							v-model="expenseTax[field.fieldname]"
-						/>
+		<CustomIonModal :isOpen="isModalOpen" @didDismiss="resetSelectedItem()">
+			<template #actionSheet>
+				<!-- Add Expense Tax Action Sheet -->
+				<div
+					class="bg-white w-full flex flex-col items-center justify-center pb-5"
+				>
+					<div class="w-full pt-8 pb-5 border-b text-center">
+						<span class="text-gray-900 font-bold text-xl">
+							{{ modalTitle }}
+						</span>
 					</div>
-
 					<div
-						v-if="!isReadOnly"
-						class="flex w-full flex-row items-center justify-between gap-3"
+						class="w-full flex flex-col items-center justify-center gap-5 p-4"
 					>
-						<Button
-							v-if="editingIdx !== null"
-							class="border-red-600 text-red-600 py-5 text-sm"
-							variant="outline"
-							theme="red"
-							@click="deleteExpenseTax()"
+						<div class="flex flex-col w-full space-y-4">
+							<FormField
+								v-for="field in taxesTableFields.data"
+								:key="field.fieldname"
+								class="w-full"
+								:label="field.label"
+								:fieldtype="field.fieldtype"
+								:fieldname="field.fieldname"
+								:options="field.options"
+								:linkFilters="field.linkFilters"
+								:hidden="field.hidden"
+								:reqd="field.reqd"
+								:readOnly="field.read_only || isReadOnly"
+								:default="field.default"
+								v-model="expenseTax[field.fieldname]"
+							/>
+						</div>
+
+						<div
+							v-if="!isReadOnly"
+							class="flex w-full flex-row items-center justify-between gap-3"
 						>
-							<template #prefix>
-								<FeatherIcon name="trash" class="w-4" />
-							</template>
-							Delete
-						</Button>
-						<Button
-							variant="solid"
-							class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
-							@click="updateExpenseTax()"
-							:disabled="addButtonDisabled"
-						>
-							<template #prefix>
-								<FeatherIcon
-									:name="editingIdx === null ? 'plus' : 'check'"
-									class="w-4"
-								/>
-							</template>
-							{{ editingIdx === null ? "Add Tax" : "Update Tax" }}
-						</Button>
+							<Button
+								v-if="editingIdx !== null"
+								class="border-red-600 text-red-600 py-5 text-sm"
+								variant="outline"
+								theme="red"
+								@click="deleteExpenseTax()"
+							>
+								<template #prefix>
+									<FeatherIcon name="trash" class="w-4" />
+								</template>
+								Delete
+							</Button>
+							<Button
+								variant="solid"
+								class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
+								@click="updateExpenseTax()"
+								:disabled="addButtonDisabled"
+							>
+								<template #prefix>
+									<FeatherIcon
+										:name="editingIdx === null ? 'plus' : 'check'"
+										class="w-4"
+									/>
+								</template>
+								{{ editingIdx === null ? "Add Tax" : "Update Tax" }}
+							</Button>
+						</div>
 					</div>
 				</div>
-			</div>
-		</ion-modal>
+			</template>
+		</CustomIonModal>
 	</template>
 </template>
 
 <script setup>
-import { IonModal } from "@ionic/vue"
 import { FeatherIcon, createResource } from "frappe-ui"
 import { computed, ref, watch } from "vue"
 
 import FormField from "@/components/FormField.vue"
 import EmptyState from "@/components/EmptyState.vue"
+import CustomIonModal from "@/components/CustomIonModal.vue"
 
 const props = defineProps({
 	expenseClaim: {

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -58,81 +58,79 @@
 	</div>
 	<EmptyState v-else message="No expenses added" :isTableField="true" />
 
-	<ion-modal
-		ref="modal"
-		:is-open="isModalOpen"
-		@didDismiss="resetSelectedItem()"
-		:initial-breakpoint="1"
-		:breakpoints="[0, 1]"
-	>
-		<!-- Add Expense Action Sheet -->
-		<div class="bg-white w-full flex flex-col items-center justify-center pb-5">
-			<div class="w-full pt-8 pb-5 border-b text-center">
-				<span class="text-gray-900 font-bold text-lg">
-					{{ modalTitle }}
-				</span>
-			</div>
-			<div class="w-full flex flex-col items-center justify-center gap-5 p-4">
-				<div class="flex flex-col w-full space-y-4">
-					<FormField
-						v-for="field in expensesTableFields.data"
-						:key="field.fieldname"
-						class="w-full"
-						:label="field.label"
-						:fieldtype="field.fieldtype"
-						:fieldname="field.fieldname"
-						:options="field.options"
-						:hidden="field.hidden"
-						:reqd="field.reqd"
-						:default="field.default"
-						:readOnly="field.read_only || isReadOnly"
-						v-model="expenseItem[field.fieldname]"
-					/>
+	<CustomIonModal :isOpen="isModalOpen" @didDismiss="resetSelectedItem()">
+		<template #actionSheet>
+			<!-- Add Expense Action Sheet -->
+			<div
+				class="bg-white w-full flex flex-col items-center justify-center pb-5"
+			>
+				<div class="w-full pt-8 pb-5 border-b text-center">
+					<span class="text-gray-900 font-bold text-lg">
+						{{ modalTitle }}
+					</span>
 				</div>
+				<div class="w-full flex flex-col items-center justify-center gap-5 p-4">
+					<div class="flex flex-col w-full space-y-4">
+						<FormField
+							v-for="field in expensesTableFields.data"
+							:key="field.fieldname"
+							class="w-full"
+							:label="field.label"
+							:fieldtype="field.fieldtype"
+							:fieldname="field.fieldname"
+							:options="field.options"
+							:hidden="field.hidden"
+							:reqd="field.reqd"
+							:default="field.default"
+							:readOnly="field.read_only || isReadOnly"
+							v-model="expenseItem[field.fieldname]"
+						/>
+					</div>
 
-				<div
-					v-if="!isReadOnly"
-					class="flex w-full flex-row items-center justify-between gap-3"
-				>
-					<Button
-						v-if="editingIdx !== null"
-						class="border-red-600 text-red-600 py-5 text-sm"
-						variant="outline"
-						theme="red"
-						@click="deleteExpenseItem()"
+					<div
+						v-if="!isReadOnly"
+						class="flex w-full flex-row items-center justify-between gap-3"
 					>
-						<template #prefix>
-							<FeatherIcon name="trash" class="w-4" />
-						</template>
-						Delete
-					</Button>
-					<Button
-						variant="solid"
-						class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
-						@click="updateExpenseItem()"
-						:disabled="addButtonDisabled"
-					>
-						<template #prefix>
-							<FeatherIcon
-								:name="editingIdx === null ? 'plus' : 'check'"
-								class="w-4"
-							/>
-						</template>
-						{{ editingIdx === null ? "Add Expense" : "Update Expense" }}
-					</Button>
+						<Button
+							v-if="editingIdx !== null"
+							class="border-red-600 text-red-600 py-5 text-sm"
+							variant="outline"
+							theme="red"
+							@click="deleteExpenseItem()"
+						>
+							<template #prefix>
+								<FeatherIcon name="trash" class="w-4" />
+							</template>
+							Delete
+						</Button>
+						<Button
+							variant="solid"
+							class="w-full py-5 text-sm disabled:bg-gray-700 disabled:text-white"
+							@click="updateExpenseItem()"
+							:disabled="addButtonDisabled"
+						>
+							<template #prefix>
+								<FeatherIcon
+									:name="editingIdx === null ? 'plus' : 'check'"
+									class="w-4"
+								/>
+							</template>
+							{{ editingIdx === null ? "Add Expense" : "Update Expense" }}
+						</Button>
+					</div>
 				</div>
 			</div>
-		</div>
-	</ion-modal>
+		</template>
+	</CustomIonModal>
 </template>
 
 <script setup>
-import { IonModal } from "@ionic/vue"
 import { FeatherIcon, createResource } from "frappe-ui"
 import { computed, ref, watch, inject } from "vue"
 
 import FormField from "@/components/FormField.vue"
 import EmptyState from "@/components/EmptyState.vue"
+import CustomIonModal from "@/components/CustomIonModal.vue"
 
 import { claimTypesByID } from "@/data/claims"
 

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -153,8 +153,6 @@ const activeTab = ref(props.tabButtons[0])
 const areFiltersApplied = ref(false)
 const appliedFilters = ref([])
 
-const showModalBackdrop = ref(false)
-
 // computed properties
 const isTeamRequest = computed(() => {
 	return activeTab.value === props.tabButtons[1]

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -73,23 +73,20 @@
 			>
 				<LoadingIndicator class="w-8 h-8 text-gray-800" />
 			</div>
-
-			<ion-modal
-				ref="modal"
-				trigger="show-filter-modal"
-				:initial-breakpoint="1"
-				:breakpoints="[0, 1]"
-			>
-				<!-- Filter Action Sheet -->
-				<ListFiltersActionSheet
-					:filterConfig="filterConfig"
-					@applyFilters="applyFilters"
-					@clearFilters="clearFilters"
-					v-model:filters="filterMap"
-				/>
-			</ion-modal>
 		</div>
 	</div>
+
+	<CustomIonModal trigger="show-filter-modal">
+		<!-- Filter Action Sheet -->
+		<template #actionSheet>
+			<ListFiltersActionSheet
+				:filterConfig="filterConfig"
+				@applyFilters="applyFilters"
+				@clearFilters="clearFilters"
+				v-model:filters="filterMap"
+			/>
+		</template>
+	</CustomIonModal>
 </template>
 
 <script setup>
@@ -104,7 +101,7 @@ import {
 	onMounted,
 	onBeforeUnmount,
 } from "vue"
-import { IonModal, modalController } from "@ionic/vue"
+import { modalController } from "@ionic/vue"
 
 import { FeatherIcon, createResource, LoadingIndicator } from "frappe-ui"
 
@@ -113,6 +110,7 @@ import LeaveRequestItem from "@/components/LeaveRequestItem.vue"
 import ExpenseClaimItem from "@/components/ExpenseClaimItem.vue"
 import EmployeeAdvanceItem from "@/components/EmployeeAdvanceItem.vue"
 import ListFiltersActionSheet from "@/components/ListFiltersActionSheet.vue"
+import CustomIonModal from "@/components/CustomIonModal.vue"
 
 const props = defineProps({
 	doctype: {
@@ -154,6 +152,8 @@ const filterMap = reactive({})
 const activeTab = ref(props.tabButtons[0])
 const areFiltersApplied = ref(false)
 const appliedFilters = ref([])
+
+const showModalBackdrop = ref(false)
 
 // computed properties
 const isTeamRequest = computed(() => {


### PR DESCRIPTION
`ion-modal` traps focus inside the modal making controls like autocomplete unusable. Tried adding `ion-disable-focus-trap` class but ionic forcefully removes this if backdrop-breakpoint >= the current breakpoint (via js)

Also don't want to make it a fullscreen modal because the content is less.
So adding this CustomIonModal component that disables the backdrop using `backdrop-breakpoint=1` and we add a custom backdrop that dismisses the modal on clicking outside.

## Before:

Not able to focus on the autocomplete. Also, after selecting an option, the focus automatically shifts to the field below the autocomplete popover, skipping the fields in between

https://github.com/frappe/hrms/assets/24353136/54f0e520-a35b-40d4-b5e9-2d3579c0f4d5

## After:

https://github.com/frappe/hrms/assets/24353136/28f59479-11bc-4ccd-8384-d82351324ce5