### PR TITLE
perf: enqueue payroll entry cancellation

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -7,6 +7,8 @@ frappe.provide("erpnext.accounts.dimensions");
 
 frappe.ui.form.on('Payroll Entry', {
 	onload: function (frm) {
+		frm.ignore_doctypes_on_cancel_all = ["Salary Slip", "Journal Entry"];
+
 		if (!frm.doc.posting_date) {
 			frm.doc.posting_date = frappe.datetime.nowdate();
 		}

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -92,20 +92,56 @@ class PayrollEntry(Document):
 			)
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = "GL Entry"
+		self.ignore_linked_doctypes = ("GL Entry", "Salary Slip", "Journal Entry")
 
-		frappe.delete_doc(
-			"Salary Slip",
-			frappe.db.sql_list(
-				"""select name from `tabSalary Slip`
-			where payroll_entry=%s """,
-				(self.name),
-			),
-		)
+		self.delete_linked_salary_slips()
+		self.cancel_linked_journal_entries()
+
+		# reset flags & update status
 		self.db_set("salary_slips_created", 0)
 		self.db_set("salary_slips_submitted", 0)
 		self.set_status(update=True, status="Cancelled")
 		self.db_set("error_message", "")
+
+	def cancel(self):
+		if len(self.get_linked_salary_slips()) > 50:
+			msg = _("Payroll Entry cancellation is queued. It may take a few minutes")
+			msg += "<br>"
+			msg += _(
+				"In case of any error during this background process, the system will add a comment about the error on this Payroll Entry and revert to the Submitted status"
+			)
+			frappe.msgprint(
+				msg,
+				indicator="blue",
+				title=_("Cancellation Queued"),
+			)
+			self.queue_action("cancel", timeout=3000)
+		else:
+			self._cancel()
+
+	def delete_linked_salary_slips(self):
+		salary_slips = self.get_linked_salary_slips()
+
+		# cancel & delete salary slips
+		for salary_slip in salary_slips:
+			if salary_slip.docstatus == 1:
+				frappe.get_doc("Salary Slip", salary_slip.name).cancel()
+			frappe.delete_doc("Salary Slip", salary_slip.name)
+
+	def cancel_linked_journal_entries(self):
+		journal_entries = frappe.get_all(
+			"Journal Entry Account",
+			{"reference_type": self.doctype, "reference_name": self.name, "docstatus": 1},
+			pluck="parent",
+			distinct=True,
+		)
+
+		# cancel Journal Entries
+		for je in journal_entries:
+			frappe.get_doc("Journal Entry", je).cancel()
+
+	def get_linked_salary_slips(self):
+		return frappe.get_all("Salary Slip", {"payroll_entry": self.name}, ["name", "docstatus"])
 
 	def make_filters(self):
 		filters = frappe._dict(

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1391,7 +1391,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 
 	finally:
 		frappe.db.commit()  # nosemgrep
-		frappe.publish_realtime("completed_salary_slip_creation")
+		frappe.publish_realtime("completed_salary_slip_creation", user=frappe.session.user)
 
 
 def show_payroll_submission_status(submitted, unsubmitted, payroll_entry):
@@ -1468,7 +1468,7 @@ def submit_salary_slips_for_employees(payroll_entry, salary_slips, publish_progr
 
 	finally:
 		frappe.db.commit()  # nosemgrep
-		frappe.publish_realtime("completed_salary_slip_submission")
+		frappe.publish_realtime("completed_salary_slip_submission", user=frappe.session.user)
 
 	frappe.flags.via_payroll_entry = False
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -358,13 +358,48 @@ class TestPayrollEntry(FrappeTestCase):
 		self.assertEqual(payroll_entry.status, "Submitted")
 		self.assertEqual(payroll_entry.error_message, "")
 
-	def test_payroll_entry_status(self):
-		company = "_Test Company"
-		company_doc = frappe.get_doc("Company", company)
-		employee = make_employee("test_employee@payroll.com", company=company)
+	def test_payroll_entry_cancellation(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		employee = make_employee("test_employee@payroll.com", company=company_doc.name)
 
 		setup_salary_structure(employee, company_doc)
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = make_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company=company_doc.name,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+		)
+		payroll_entry.make_bank_entry()
+		submit_bank_entry(payroll_entry.name)
 
+		salary_slip = frappe.db.get_value("Salary Slip", {"payroll_entry": payroll_entry.name}, "name")
+		self.assertIsNotNone(salary_slip)
+
+		# 2 submitted JVs
+		journal_entries = get_linked_journal_entries(payroll_entry.name, docstatus=1)
+		self.assertEqual(len(journal_entries), 2)
+
+		frappe.flags.enqueue_payroll_entry = True
+		payroll_entry.cancel()
+		frappe.flags.enqueue_payroll_entry = False
+		self.assertEqual(payroll_entry.status, "Cancelled")
+
+		salary_slip = frappe.db.get_value("Salary Slip", {"payroll_entry": payroll_entry.name}, "name")
+		self.assertIsNone(salary_slip)
+
+		# 2 cancelled JVs
+		journal_entries = get_linked_journal_entries(payroll_entry.name, docstatus=2)
+		self.assertEqual(len(journal_entries), 2)
+
+	def test_payroll_entry_status(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		employee = make_employee("test_employee@payroll.com", company=company_doc.name)
+
+		setup_salary_structure(employee, company_doc)
 		dates = get_start_end_dates("Monthly", nowdate())
 		payroll_entry = get_payroll_entry(
 			start_date=dates.start_date,
@@ -395,41 +430,21 @@ class TestPayrollEntry(FrappeTestCase):
 			cost_center="Main - _TC",
 			payment_account="Cash - _TC",
 		)
-		payroll_entry.reload()
+
 		payroll_entry.make_bank_entry()
-
-		# submit the bank entry journal voucher
-		jv = frappe.db.get_value(
-			"Journal Entry Account",
-			{"reference_type": "Payroll Entry", "reference_name": payroll_entry.name, "docstatus": 0},
-			"parent",
-		)
-
-		jv_doc = frappe.get_doc("Journal Entry", jv)
-		self.assertEqual(jv_doc.accounts[0].cost_center, payroll_entry.cost_center)
-
-		jv_doc.cheque_no = "123456"
-		jv_doc.cheque_date = nowdate()
-		jv_doc.submit()
+		submit_bank_entry(payroll_entry.name)
 
 		# cancel the salary slip
 		salary_slip = frappe.db.get_value("Salary Slip", {"payroll_entry": payroll_entry.name}, "name")
 		salary_slip = frappe.get_doc("Salary Slip", salary_slip)
 		salary_slip.cancel()
 
-		# cancel the payroll entry
-		jvs = frappe.db.get_values(
-			"Journal Entry Account",
-			{
-				"reference_type": "Payroll Entry",
-				"reference_name": payroll_entry.name,
-			},
-			"parent",
-			as_dict=True,
-		)
+		# cancel the journal entries
+		jvs = get_linked_journal_entries(payroll_entry.name)
 
 		for jv in jvs:
 			jv_doc = frappe.get_doc("Journal Entry", jv.parent)
+			self.assertEqual(jv_doc.accounts[0].cost_center, payroll_entry.cost_center)
 			jv_doc.cancel()
 
 		payroll_entry.cancel()
@@ -828,3 +843,26 @@ def get_repayment_party_type(loan):
 	)
 
 	return party_type, party
+
+
+def submit_bank_entry(payroll_entry_id):
+	# submit the bank entry journal voucher
+	jv = get_linked_journal_entries(payroll_entry_id, docstatus=0)[0].parent
+
+	jv_doc = frappe.get_doc("Journal Entry", jv)
+	jv_doc.cheque_no = "123456"
+	jv_doc.cheque_date = nowdate()
+	jv_doc.submit()
+
+
+def get_linked_journal_entries(payroll_entry_id, docstatus=None):
+	filters = {"reference_type": "Payroll Entry", "reference_name": payroll_entry_id}
+	if docstatus is not None:
+		filters["docstatus"] = docstatus
+
+	return frappe.get_all(
+		"Journal Entry Account",
+		filters,
+		"parent",
+		distinct=True,
+	)

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -346,7 +346,7 @@ def get_employees(salary_structure):
 	employees = frappe.get_list(
 		"Salary Structure Assignment",
 		filters={"salary_structure": salary_structure, "docstatus": 1},
-		fields=["employee"],
+		pluck="employee",
 	)
 
 	if not employees:
@@ -356,7 +356,7 @@ def get_employees(salary_structure):
 			).format(salary_structure, salary_structure)
 		)
 
-	return list(set([d.employee for d in employees]))
+	return list(set(employees))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Problem**:

Payroll entry submission is queued for > 30 employees but cancellation isn't resulting in timeout:

<img width="1440" alt="Pasted Graphic 4" src="https://github.com/frappe/hrms/assets/24353136/a4362478-1034-4e58-ad0e-e5cc6f6831d3">

**Fix**:

Enqueue payroll cancellation for salary slips > 50
Also small server-side perf improvement for https://github.com/frappe/hrms/issues/929