### PR TITLE
fix(Payroll): fetching error message from message log

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1344,7 +1344,10 @@ def log_payroll_failure(process, payroll_entry, error):
 	message_log = frappe.message_log.pop() if frappe.message_log else str(error)
 
 	try:
-		error_message = json.loads(message_log).get("message")
+		if isinstance(message_log, str):
+			error_message = json.loads(message_log).get("message")
+		else:
+			error_message = message_log.get("message")
 	except Exception:
 		error_message = message_log
 


### PR DESCRIPTION
error message response structure changed in the Framework during API v2

<img width="957" alt="image" src="https://github.com/frappe/hrms/assets/24353136/002302c0-8385-4fe6-ab97-77862a421541">

Still retaining `json.loads` to be compatible with version discrepancies between HR & Framework
