### PR TITLE
refactor: split auto attendance jobs - checkin-based attendance & absent marking

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -209,6 +209,7 @@ scheduler_events = {
 	],
 	"hourly_long": [
 		"hrms.hr.doctype.shift_type.shift_type.process_auto_attendance_for_all_shifts",
+		"hrms.hr.doctype.shift_type.shift_type.mark_absent_for_missing_attendance_for_all_shifts",
 	],
 	"daily": [
 		"hrms.controllers.employee_reminders.send_birthday_reminders",

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -25,6 +25,10 @@ from hrms.utils.holiday_list import get_holiday_dates_between
 class ShiftType(Document):
 	@frappe.whitelist()
 	def process_auto_attendance(self):
+		self.process_attendance_based_on_checkins()
+		self.mark_absent_for_missing_attendance()
+
+	def process_attendance_based_on_checkins(self):
 		if (
 			not cint(self.enable_auto_attendance)
 			or not self.process_attendance_after
@@ -63,6 +67,7 @@ class ShiftType(Document):
 				self.name,
 			)
 
+	def mark_absent_for_missing_attendance(self):
 		for employee in self.get_assigned_employees(self.process_attendance_after, True):
 			self.mark_absent_for_dates_with_no_attendance(employee)
 
@@ -282,4 +287,11 @@ def process_auto_attendance_for_all_shifts():
 	shift_list = frappe.get_all("Shift Type", filters={"enable_auto_attendance": "1"}, pluck="name")
 	for shift in shift_list:
 		doc = frappe.get_cached_doc("Shift Type", shift)
-		doc.process_auto_attendance()
+		doc.process_attendance_based_on_checkins()
+
+
+def mark_absent_for_missing_attendance_for_all_shifts():
+	shift_list = frappe.get_all("Shift Type", filters={"enable_auto_attendance": "1"}, pluck="name")
+	for shift in shift_list:
+		doc = frappe.get_cached_doc("Shift Type", shift)
+		doc.mark_absent_for_missing_attendance()


### PR DESCRIPTION
## Before

Currently, auto-attendance marking has 2 main parts:
- Generate attendance records (Present/Absent/Half Day) based on employee checkins
- Mark employees with no attendance records/check-in records as Absent

## After

Split these 2 tasks into 2 separate jobs

- absent marking for missing attendance goes on for a long time as it tries to generate absent records for all the records from Process Attendance After -> Last sync of check-in for missing attendance

- When shift types are created for the first time, missing attendance records could be generated for all employees for many months which can cause the job to timeout

- split these jobs so that basic attendance marking based on check-ins gets done & absent marking can happen parallelly (if there are more workers)