### PR TITLE
perf: batch and commit auto attendance processing

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -21,7 +21,7 @@ from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift
 from hrms.utils import get_date_range
 from hrms.utils.holiday_list import get_holiday_dates_between
 
-EMPLOYEE_CHUNK_SIZE = 20
+EMPLOYEE_CHUNK_SIZE = 50
 
 
 class ShiftType(Document):
@@ -69,10 +69,10 @@ class ShiftType(Document):
 		frappe.db.commit()  # nosemgrep
 
 		assigned_employees = self.get_assigned_employees(self.process_attendance_after, True)
+
+		# mark absent in batches & commit to avoid losing progress since this tries to process remaining attendance
+		# right from "Process Attendance After" to "Last Sync of Checkin"
 		for batch in create_batch(assigned_employees, EMPLOYEE_CHUNK_SIZE):
-			# mark absent in batches & commit to avoid losing progress
-			# since this tries to process remaining attendance
-			# right from "Process Attendance After" to "Last Sync of Checkin"
 			for employee in batch:
 				self.mark_absent_for_dates_with_no_attendance(employee)
 

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import cint, get_datetime, get_time, getdate
+from frappe.utils import cint, create_batch, get_datetime, get_time, getdate
 
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
@@ -20,6 +20,8 @@ from hrms.hr.doctype.employee_checkin.employee_checkin import (
 from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift, get_shift_details
 from hrms.utils import get_date_range
 from hrms.utils.holiday_list import get_holiday_dates_between
+
+EMPLOYEE_CHUNK_SIZE = 20
 
 
 class ShiftType(Document):
@@ -63,8 +65,18 @@ class ShiftType(Document):
 				self.name,
 			)
 
-		for employee in self.get_assigned_employees(self.process_attendance_after, True):
-			self.mark_absent_for_dates_with_no_attendance(employee)
+		# commit after processing checkin logs to avoid losing progress
+		frappe.db.commit()  # nosemgrep
+
+		assigned_employees = self.get_assigned_employees(self.process_attendance_after, True)
+		for batch in create_batch(assigned_employees, EMPLOYEE_CHUNK_SIZE):
+			# mark absent in batches & commit to avoid losing progress
+			# since this tries to process remaining attendance
+			# right from "Process Attendance After" to "Last Sync of Checkin"
+			for employee in batch:
+				self.mark_absent_for_dates_with_no_attendance(employee)
+
+			frappe.db.commit()  # nosemgrep
 
 	def get_employee_checkins(self) -> list[dict]:
 		return frappe.get_all(
@@ -225,7 +237,7 @@ class ShiftType(Document):
 			)
 		).run(pluck=True)
 
-	def get_assigned_employees(self, from_date=None, consider_default_shift=False):
+	def get_assigned_employees(self, from_date=None, consider_default_shift=False) -> list[str]:
 		filters = {"shift_type": self.name, "docstatus": "1", "status": "Active"}
 		if from_date:
 			filters["start_date"] = (">=", from_date)
@@ -239,7 +251,7 @@ class ShiftType(Document):
 		# exclude inactive employees
 		inactive_employees = frappe.db.get_all("Employee", {"status": "Inactive"}, pluck="name")
 
-		return set(assigned_employees) - set(inactive_employees)
+		return list(set(assigned_employees) - set(inactive_employees))
 
 	def get_employees_with_default_shift(self, filters: dict) -> list:
 		default_shift_employees = frappe.get_all(

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -461,7 +461,9 @@ class TestShiftType(FrappeTestCase):
 
 		default_shift = setup_shift_type()
 		employee = make_employee(
-			"test_employee_checkin@example.com", company="_Test Company", default_shift=default_shift.name
+			"test_employee_checkin_default@example.com",
+			company="_Test Company",
+			default_shift=default_shift.name,
 		)
 
 		assigned_shift = setup_shift_type(shift_type="Test Absent with no Attendance")

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -9,6 +9,7 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
+from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
 from hrms.hr.report.monthly_attendance_sheet.monthly_attendance_sheet import execute
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
@@ -16,14 +17,15 @@ from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 )
 from hrms.tests.test_utils import get_first_day_for_prev_month
 
-test_dependencies = ["Shift Type"]
-
 
 class TestMonthlyAttendanceSheet(FrappeTestCase):
 	def setUp(self):
 		self.company = "_Test Company"
 		self.employee = make_employee("test_employee@example.com", company=self.company)
 		frappe.db.delete("Attendance")
+
+		if not frappe.db.exists("Shift Type", "Day Shift"):
+			setup_shift_type(shift_type="Day Shift")
 
 		date = getdate()
 		from_date = get_year_start(date)


### PR DESCRIPTION
## Problem

Auto-attendance processing has 2 main parts:

- Generate attendance records (Present/Absent/Half Day) based on employee check-ins
- Mark employees with no attendance records/check-in records as Absent

The first one completes fast enough but absent marking for missing attendance goes on for a long time as it tries to generate absent records for all the records from Process Attendance After -> Last sync of check-in for missing attendance

When shift types are created for the first time, missing attendance records could be generated for all employees for several months in backlog which causes the job to timeout, and all the progress is lost

## Solution

- Commit after processing attendance based on check-ins for a shift type
- Process absent marking for missing attendance in batches and commit after each batch

This will ensure at least some progress gets saved with every job running even if the check-in count is high or the employees don't have any backdated attendance records

- [x] Test inner transaction - whether commit & rollback for a single attendance record works fine after this update and does not implicitly commit unnecessary changes