### PR TITLE
chore: remove include requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include MANIFEST.in
-include requirements.txt
 include *.json
 include *.md
 include *.py


### PR DESCRIPTION
Removed include requirements.txt from MANIFEST.in as the requirements.txt file was dropped.