### PR TITLE
feat: 'Email Salary Slips' bulk action in salary slip list view

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2250,3 +2250,25 @@ def _check_attributes(code: str) -> None:
 			and node.attr in UNSAFE_ATTRIBUTES
 		):
 			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{node.attr}"')
+
+
+@frappe.whitelist()
+def enqueue_email_salary_slips(names) -> None:
+	"""enqueue bulk emailing salary slips"""
+	import json
+
+	if isinstance(names, str):
+		names = json.loads(names)
+
+	frappe.enqueue("hrms.payroll.doctype.salary_slip.salary_slip.email_salary_slips", names=names)
+	frappe.msgprint(
+		_("Salary slip emails have been enqueued for sending. Check {0} for status.").format(
+			f"""<a href='{frappe.utils.get_url_to_list("Email Queue")}' target='blank'>Email Queue</a>"""
+		)
+	)
+
+
+def email_salary_slips(names) -> None:
+	for name in names:
+		salary_slip = frappe.get_doc("Salary Slip", name)
+		salary_slip.email_salary_slip()

--- a/hrms/payroll/doctype/salary_slip/salary_slip_list.js
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_list.js
@@ -1,3 +1,16 @@
-frappe.listview_settings['Salary Slip'] = {
-	add_fields: ["employee", "employee_name"],
-};
+frappe.listview_settings["Salary Slip"] = {
+	onload: function(listview) {
+		if (!has_common(frappe.user_roles, ["Administrator", "System Manager", "HR Manager", "HR User"])) return;
+
+		listview.page.add_menu_item(__("Email Salary Slips"), () => {
+			if (!listview.get_checked_items().length) {
+				frappe.msgprint(__("Please select the salary slips to email"));
+				return;
+			}
+
+			frappe.confirm(__("Are you sure you want to email the selected salary slips?"), () => {
+				listview.call_for_selected_items("hrms.payroll.doctype.salary_slip.salary_slip.enqueue_email_salary_slips");
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Problem

Payroll Entry sends salary slip emails to all the employees on salary slip submission but if there are a few employees who don't have an email account set or the setup is incorrect during this action, there is no way to retrigger sending emails to such employees

## Solution

Added list view action to send salary slip emails in bulk. This will enqueue sending emails for the selected salary slips.

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/05091787-853b-4f7a-90a6-a360793c7801">

Docs: https://frappehr.com/docs/v14/en/salary-slip#3-4-bulk-email-salary-slips
