### PR TITLE
fix(Leave Application): misleading draft state indicator

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application_list.js
+++ b/hrms/hr/doctype/leave_application/leave_application_list.js
@@ -13,7 +13,7 @@ frappe.listview_settings["Leave Application"] = {
 			Approved: "green",
 			Rejected: "red",
 			Open: "orange",
-			Draft: "orange",
+			Draft: "red",
 			Cancelled: "red",
 			Submitted: "blue",
 		};

--- a/hrms/hr/doctype/leave_application/leave_application_list.js
+++ b/hrms/hr/doctype/leave_application/leave_application_list.js
@@ -1,14 +1,26 @@
 frappe.listview_settings["Leave Application"] = {
-	add_fields: ["leave_type", "employee", "employee_name", "total_leave_days", "from_date", "to_date"],
+	add_fields: [
+		"leave_type",
+		"employee",
+		"employee_name",
+		"total_leave_days",
+		"from_date",
+		"to_date",
+	],
 	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
-		let status_color = {
-			"Approved": "green",
-			"Rejected": "red",
-			"Open": "orange",
-			"Cancelled": "red",
-			"Submitted": "blue"
+		const status_color = {
+			Approved: "green",
+			Rejected: "red",
+			Open: "orange",
+			Draft: "orange",
+			Cancelled: "red",
+			Submitted: "blue",
 		};
-		return [__(doc.status), status_color[doc.status], "status,=," + doc.status];
-	}
+		const status =
+			!doc.docstatus && ["Approved", "Rejected"].includes(doc.status)
+				? "Draft"
+				: doc.status;
+		return [__(status), status_color[status], "status,=," + doc.status];
+	},
 };


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/1073

Unsubmitted Approved/Rejected Leave Applications is now indicated as "Draft"

`no-docs`