### PR TITLE
fix: consider previous Leave Applications while enforcing Maximum Consecutive Leaves Allowed

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -22,7 +22,6 @@ from frappe.utils import (
 
 from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import daterange
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
-from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
 
 from hrms.hr.doctype.leave_block_list.leave_block_list import get_applicable_block_dates
 from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import create_leave_ledger_entry
@@ -501,8 +500,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 	def get_consecutive_leave_details(self) -> dict:
 		leave_applications = set()
-		raise_exception = False if frappe.flags.in_patch else True
-		holiday_list = get_holiday_list_for_employee(self.employee, raise_exception=raise_exception)
 
 		def _get_first_from_date(reference_date):
 			"""gets `from_date` of first leave application from previous consecutive leave applications"""
@@ -516,9 +513,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			if application:
 				leave_applications.add(application.name)
 				return _get_first_from_date(application.from_date)
-			elif is_holiday(holiday_list, prev_date):
-				return _get_first_from_date(prev_date)
-
 			return reference_date
 
 		def _get_last_to_date(reference_date):
@@ -533,9 +527,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			if application:
 				leave_applications.add(application.name)
 				return _get_last_to_date(application.to_date)
-			elif is_holiday(holiday_list, next_date):
-				return _get_last_to_date(next_date)
-
 			return reference_date
 
 		first_from_date = _get_first_from_date(self.from_date)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -521,6 +521,10 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self.employee, self.leave_type, first_from_date, last_to_date
 		)
 		if total_consecutive_leaves > cint(max_days):
+			msg = _("Leave of type {0} cannot be longer than {1}.").format(
+				get_link_to_form("Leave Type", self.leave_type), max_days
+			)
+
 			leave_applications = frappe.get_all(
 				"Leave Application",
 				filters={
@@ -535,16 +539,9 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				leave_applications = ", ".join(
 					[get_link_to_form("Leave Application", x) for x in leave_applications]
 				)
-				frappe.throw(
-					_("Cannot have more that {0} consecutive leaves of type {1}. Reference: {2}").format(
-						max_days, get_link_to_form("Leave Type", self.leave_type), leave_applications
-					)
-				)
-			frappe.throw(
-				_("Cannot have more that {0} consecutive leaves of type {1}").format(
-					max_days, get_link_to_form("Leave Type", self.leave_type)
-				)
-			)
+				msg += _(" Reference: {0}".format(leave_applications))
+
+			frappe.throw(msg)
 
 	def validate_attendance(self):
 		attendance = frappe.db.sql(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -491,8 +491,8 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if from_date:
 			return self.get_first_from_date(add_to_date(from_date, days=-1), holiday_list)
 		elif frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": to_date}):
-			return self.get_first_from_date(add_to_date(to_date, days=-1), holiday_list)
-		return add_to_date(to_date, days=1)
+			return self.get_first_from_date(add_to_date(to_date, days=-1), holiday_list)  # ignore holiday
+		return add_to_date(to_date, days=1)  # to_date is actually from_date
 
 	# gets to_date of last leave application from following consecutive leave applications
 	def get_last_to_date(self, from_date, holiday_list):
@@ -504,8 +504,8 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if to_date:
 			return self.get_last_to_date(add_to_date(to_date, days=1), holiday_list)
 		elif frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": from_date}):
-			return self.get_last_to_date(add_to_date(from_date, days=1), holiday_list)
-		return add_to_date(from_date, days=-1)
+			return self.get_last_to_date(add_to_date(from_date, days=1), holiday_list)  # ignore holiday
+		return add_to_date(from_date, days=-1)  # from_date is actually to_date
 
 	def validate_max_days(self):
 		max_days = frappe.db.get_value("Leave Type", self.leave_type, "max_continuous_days_allowed")
@@ -521,9 +521,28 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self.employee, self.leave_type, first_from_date, last_to_date
 		)
 		if total_consecutive_leaves > cint(max_days):
+			leave_applications = frappe.get_list(
+				"Leave Application",
+				filters={
+					"employee": self.employee,
+					"leave_type": self.leave_type,
+					"from_date": [">=", first_from_date],
+					"to_date": ["<=", last_to_date],
+				},
+				pluck="name",
+			)
+			if len(leave_applications) > 0:
+				leave_applications = ", ".join(
+					list(map(lambda x: get_link_to_form("Leave Application", x), leave_applications))
+				)
+				frappe.throw(
+					_("Cannot have more that {0} consecutive leaves of type {1}. Reference: {2}").format(
+						max_days, get_link_to_form("Leave Type", self.leave_type), leave_applications
+					)
+				)
 			frappe.throw(
-				_("Cannot have more that {0} consecutive leaves of Leave Type <b>{1}</b>").format(
-					max_days, self.leave_type, max_days
+				_("Cannot have more that {0} consecutive leaves of type {1}").format(
+					max_days, get_link_to_form("Leave Type", self.leave_type)
 				)
 			)
 

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.query_builder.functions import Max, Min, Sum
 from frappe.utils import (
 	add_days,
+	add_to_date,
 	cint,
 	cstr,
 	date_diff,
@@ -480,10 +481,51 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 		return leave_count_on_half_day_date * 0.5
 
+	# gets from_date of first leave application from previous consecutive leave applications
+	def get_first_from_date(self, to_date, holiday_list):
+		from_date = frappe.db.get_value(
+			"Leave Application",
+			{"employee": self.employee, "leave_type": self.leave_type, "to_date": to_date},
+			"from_date",
+		)
+		if from_date:
+			return self.get_first_from_date(add_to_date(from_date, days=-1), holiday_list)
+		elif frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": to_date}):
+			return self.get_first_from_date(add_to_date(to_date, days=-1), holiday_list)
+		return add_to_date(to_date, days=1)
+
+	# gets to_date of last leave application from following consecutive leave applications
+	def get_last_to_date(self, from_date, holiday_list):
+		to_date = frappe.db.get_value(
+			"Leave Application",
+			{"employee": self.employee, "leave_type": self.leave_type, "from_date": from_date},
+			"to_date",
+		)
+		if to_date:
+			return self.get_last_to_date(add_to_date(to_date, days=1), holiday_list)
+		elif frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": from_date}):
+			return self.get_last_to_date(add_to_date(from_date, days=1), holiday_list)
+		return add_to_date(from_date, days=-1)
+
 	def validate_max_days(self):
 		max_days = frappe.db.get_value("Leave Type", self.leave_type, "max_continuous_days_allowed")
-		if max_days and self.total_leave_days > cint(max_days):
-			frappe.throw(_("Leave of type {0} cannot be longer than {1}").format(self.leave_type, max_days))
+		if not max_days:
+			return
+
+		raise_exception = False if frappe.flags.in_patch else True
+		holiday_list = get_holiday_list_for_employee(self.employee, raise_exception=raise_exception)
+		first_from_date = self.get_first_from_date(add_to_date(self.from_date, days=-1), holiday_list)
+		last_to_date = self.get_last_to_date(add_to_date(self.to_date, days=1), holiday_list)
+
+		total_consecutive_leaves = get_number_of_leave_days(
+			self.employee, self.leave_type, first_from_date, last_to_date
+		)
+		if total_consecutive_leaves > cint(max_days):
+			frappe.throw(
+				_("Cannot have more that {0} consecutive leaves of Leave Type <b>{1}</b>").format(
+					max_days, self.leave_type, max_days
+				)
+			)
 
 	def validate_attendance(self):
 		attendance = frappe.db.sql(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -531,7 +531,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				},
 				pluck="name",
 			)
-			if len(leave_applications) > 0:
+			if leave_applications:
 				leave_applications = ", ".join(
 					[get_link_to_form("Leave Application", x) for x in leave_applications]
 				)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -533,7 +533,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			)
 			if len(leave_applications) > 0:
 				leave_applications = ", ".join(
-					list(map(lambda x: get_link_to_form("Leave Application", x), leave_applications))
+					[get_link_to_form("Leave Application", x) for x in leave_applications]
 				)
 				frappe.throw(
 					_("Cannot have more that {0} consecutive leaves of type {1}. Reference: {2}").format(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -539,7 +539,9 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				leave_applications = ", ".join(
 					[get_link_to_form("Leave Application", x) for x in leave_applications]
 				)
-				msg += _(" Reference: {0}".format(leave_applications))
+				msg = _("Leave of type {0} cannot be longer than {1}. Reference: {2}").format(
+					get_link_to_form("Leave Type", self.leave_type), max_days, leave_applications
+				)
 
 			frappe.throw(msg)
 

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -521,7 +521,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self.employee, self.leave_type, first_from_date, last_to_date
 		)
 		if total_consecutive_leaves > cint(max_days):
-			leave_applications = frappe.get_list(
+			leave_applications = frappe.get_all(
 				"Leave Application",
 				filters={
 					"employee": self.employee,

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -125,6 +125,81 @@ class TestLeaveApplication(FrappeTestCase):
 		application.to_date = "2013-01-05"
 		return application
 
+	@set_holiday_list("_Test Holiday List", "_Test Company")
+	def test_first_from_last_to_date(self):
+		employee = get_employee()
+		leave_type = frappe.get_doc(
+			dict(
+				leave_type_name="Test Consecutive Leave Type",
+				doctype="Leave Type",
+				max_continuous_days_allowed=10,
+			)
+		).insert()
+		make_allocation_record(
+			employee=employee.name, leave_type=leave_type.name, from_date="2013-01-01", to_date="2013-12-31"
+		)
+
+		# before
+
+		frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-01-30",
+				to_date="2013-01-31",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		# 2013-02-01 is a holiday
+
+		frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-02-02",
+				to_date="2013-02-03",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		# after
+
+		frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-02-06",
+				to_date="2013-02-08",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		# current
+
+		leave_application = frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-02-04",
+				to_date="2013-02-05",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		first_from_date = leave_application.get_first_from_date("2013-02-03", "_Test Holiday List")
+		last_to_date = leave_application.get_last_to_date("2013-02-06", "_Test Holiday List")
+		self.assertEqual(first_from_date, getdate("2013-01-30"))
+		self.assertEqual(last_to_date, getdate("2013-02-08"))
+
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validate_application_across_allocations(self):
 		# Test validation for application dates when negative balance is disabled

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -140,7 +140,6 @@ class TestLeaveApplication(FrappeTestCase):
 		)
 
 		# before
-
 		frappe.get_doc(
 			dict(
 				doctype="Leave Application",
@@ -154,7 +153,6 @@ class TestLeaveApplication(FrappeTestCase):
 		).insert()
 
 		# 2013-02-01 is a holiday
-
 		frappe.get_doc(
 			dict(
 				doctype="Leave Application",
@@ -168,37 +166,35 @@ class TestLeaveApplication(FrappeTestCase):
 		).insert()
 
 		# after
-
 		frappe.get_doc(
 			dict(
 				doctype="Leave Application",
 				employee=employee.name,
 				leave_type=leave_type.name,
 				from_date="2013-02-06",
-				to_date="2013-02-08",
+				to_date="2013-02-10",
 				company="_Test Company",
 				status="Approved",
 			)
 		).insert()
 
 		# current
-
+		from_date = getdate("2013-02-04")
+		to_date = getdate("2013-02-05")
 		leave_application = frappe.get_doc(
 			dict(
 				doctype="Leave Application",
 				employee=employee.name,
 				leave_type=leave_type.name,
-				from_date="2013-02-04",
-				to_date="2013-02-05",
+				from_date=from_date,
+				to_date=to_date,
 				company="_Test Company",
 				status="Approved",
 			)
-		).insert()
+		)
 
-		first_from_date = leave_application.get_first_from_date("2013-02-03", "_Test Holiday List")
-		last_to_date = leave_application.get_last_to_date("2013-02-06", "_Test Holiday List")
-		self.assertEqual(first_from_date, getdate("2013-01-30"))
-		self.assertEqual(last_to_date, getdate("2013-02-08"))
+		# 11 consecutive leaves
+		self.assertRaises(frappe.ValidationError, leave_application.insert)
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validate_application_across_allocations(self):

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -125,77 +125,6 @@ class TestLeaveApplication(FrappeTestCase):
 		application.to_date = "2013-01-05"
 		return application
 
-	@set_holiday_list("_Test Holiday List", "_Test Company")
-	def test_first_from_last_to_date(self):
-		employee = get_employee()
-		leave_type = frappe.get_doc(
-			dict(
-				leave_type_name="Test Consecutive Leave Type",
-				doctype="Leave Type",
-				max_continuous_days_allowed=10,
-			)
-		).insert()
-		make_allocation_record(
-			employee=employee.name, leave_type=leave_type.name, from_date="2013-01-01", to_date="2013-12-31"
-		)
-
-		# before
-		frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type=leave_type.name,
-				from_date="2013-01-30",
-				to_date="2013-01-31",
-				company="_Test Company",
-				status="Approved",
-			)
-		).insert()
-
-		# 2013-02-01 is a holiday
-		frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type=leave_type.name,
-				from_date="2013-02-02",
-				to_date="2013-02-03",
-				company="_Test Company",
-				status="Approved",
-			)
-		).insert()
-
-		# after
-		frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type=leave_type.name,
-				from_date="2013-02-06",
-				to_date="2013-02-10",
-				company="_Test Company",
-				status="Approved",
-			)
-		).insert()
-
-		# current
-		from_date = getdate("2013-02-04")
-		to_date = getdate("2013-02-05")
-		leave_application = frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type=leave_type.name,
-				from_date=from_date,
-				to_date=to_date,
-				company="_Test Company",
-				status="Approved",
-			)
-		)
-
-		# 11 consecutive leaves
-		self.assertRaises(frappe.ValidationError, leave_application.insert)
-
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validate_application_across_allocations(self):
 		# Test validation for application dates when negative balance is disabled
@@ -765,6 +694,64 @@ class TestLeaveApplication(FrappeTestCase):
 			)
 		)
 
+		self.assertRaises(frappe.ValidationError, leave_application.insert)
+
+	@set_holiday_list("_Test Holiday List", "_Test Company")
+	def test_max_consecutive_leaves_across_leave_applications(self):
+		employee = get_employee()
+		leave_type = frappe.get_doc(
+			dict(
+				leave_type_name="Test Consecutive Leave Type",
+				doctype="Leave Type",
+				max_continuous_days_allowed=10,
+			)
+		).insert()
+		make_allocation_record(
+			employee=employee.name, leave_type=leave_type.name, from_date="2013-01-01", to_date="2013-12-31"
+		)
+
+		# before
+		frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-01-30",
+				to_date="2013-02-03",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		# after
+		frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-02-06",
+				to_date="2013-02-10",
+				company="_Test Company",
+				status="Approved",
+			)
+		).insert()
+
+		# current
+		from_date = getdate("2013-02-04")
+		to_date = getdate("2013-02-05")
+		leave_application = frappe.get_doc(
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=from_date,
+				to_date=to_date,
+				company="_Test Company",
+				status="Approved",
+			)
+		)
+
+		# 11 consecutive leaves
 		self.assertRaises(frappe.ValidationError, leave_application.insert)
 
 	def test_leave_balance_near_allocaton_expiry(self):


### PR DESCRIPTION
### Issue

Closes: https://github.com/frappe/hrms/issues/1002

Currently, separate consecutive Leave Applications are not checked by the **Maximum Consecutive Leaves Allowed** limit entered in the Leave Type DocType. This PR fixes that.

### Example

- **Maximum Consecutive Leaves Allowed** set to 4

![image](https://github.com/frappe/hrms/assets/61287991/67bc2062-4fe6-43e6-a4f5-06684b09d850)

- Two Leave Applications created spanning 4 days

![image](https://github.com/frappe/hrms/assets/61287991/30e3dfd8-7932-453f-a555-10cceacb99a5)

- Details filled in for a third Leave Application that would constitute the fifth consecutive leave of this Leave Type

![image](https://github.com/frappe/hrms/assets/61287991/b7924c68-9cf5-49e4-a64d-29bc216d3fa6)

- Action is forbidden as this violates the **Maximum Consecutive Leaves Allowed** limit that has been set

![image](https://github.com/frappe/hrms/assets/61287991/033c1ef1-cfb7-4b16-bdc8-de9693288acf)


`no-docs`