### PR TITLE
fix: Employee Dashboard must accomodate Document Links

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -5,13 +5,8 @@ from frappe import _
 
 
 def get_dashboard_for_employee(data):
-	return {
-		"heatmap": True,
-		"heatmap_message": _("This is based on the attendance of this Employee"),
-		"fieldname": "employee",
-		"non_standard_fieldnames": {"Bank Account": "party", "Employee Grievance": "raised_by"},
-		"method": "hrms.overrides.employee_master.get_timeline_data",
-		"transactions": [
+	data["transactions"].extend(
+		[
 			{"label": _("Attendance"), "items": ["Attendance", "Attendance Request", "Employee Checkin"]},
 			{
 				"label": _("Leave"),
@@ -50,8 +45,21 @@ def get_dashboard_for_employee(data):
 				"items": ["Training Event", "Training Result", "Training Feedback", "Employee Skill Map"],
 			},
 			{"label": _("Evaluation"), "items": ["Appraisal"]},
-		],
-	}
+		]
+	)
+
+	data["non_standard_fieldnames"].update(
+		{"Bank Account": "party", "Employee Grievance": "raised_by"}
+	)
+	data.update(
+		{
+			"heatmap": True,
+			"heatmap_message": _("This is based on the attendance of this Employee"),
+			"fieldname": "employee",
+			"method": "hrms.overrides.employee_master.get_timeline_data",
+		}
+	)
+	return data
 
 
 def get_dashboard_for_holiday_list(data):


### PR DESCRIPTION
- Document Links added via Customize Form/Doctype aren't added to the Employee dashboard
   <img width="500" alt="Screenshot 2023-11-24 at 4 28 07 PM" src="https://github.com/frappe/hrms/assets/25857446/62138200-004a-4903-abb9-57ebe6a2f27c">
     <img width="700" alt="Screenshot 2023-11-24 at 4 32 24 PM" src="https://github.com/frappe/hrms/assets/25857446/8af7cbec-3d4c-4faf-9345-db0f23301d64">


## Fix
- Extend `data` in the dashboard override, don't invalidate `data`
   <img width="600" alt="Screenshot 2023-11-24 at 4 31 04 PM" src="https://github.com/frappe/hrms/assets/25857446/1750a5cf-c785-4348-bb43-de209c7f6bb5">
