### PR TITLE
feat: add Amount Based on Formula to list view & fix UX

### DIFF
--- a/hrms/payroll/doctype/salary_detail/salary_detail.json
+++ b/hrms/payroll/doctype/salary_detail/salary_detail.json
@@ -36,6 +36,7 @@
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "salary_component",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -65,7 +66,6 @@
    "fetch_from": "salary_component.statistical_component",
    "fieldname": "statistical_component",
    "fieldtype": "Check",
-   "in_list_view": 1,
    "label": "Statistical Component"
   },
   {
@@ -255,7 +255,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-04-24 11:17:11.397523",
+ "modified": "2023-12-12 13:52:30.726505",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",

--- a/hrms/payroll/doctype/salary_detail/salary_detail.json
+++ b/hrms/payroll/doctype/salary_detail/salary_detail.json
@@ -138,6 +138,7 @@
    "depends_on": "eval:doc.parenttype=='Salary Structure'",
    "fieldname": "amount_based_on_formula",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Amount based on formula"
   },
   {

--- a/hrms/payroll/doctype/salary_structure/salary_structure.js
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.js
@@ -13,6 +13,7 @@ cur_frm.cscript.onload = function(doc, dt, dn){
 
 frappe.ui.form.on('Salary Structure', {
 	onload: function(frm) {
+		frm.alerted_rows = []
 
 		let help_button = $(`<a class = 'control-label'>
 			${__("Condition and Formula Help")}
@@ -311,6 +312,13 @@ frappe.ui.form.on('Salary Detail', {
 		calculate_totals(frm.doc);
 	},
 
+	formula: function(frm, cdt, cdn) {
+		if (!locals[cdt][cdn].amount_based_on_formula && !frm.alerted_rows.includes(cdn)) {
+			frappe.msgprint(__("Warning: 'Amount Based on Formula' has been disabled for this row."));
+			frm.alerted_rows.push(cdn)
+		}
+	},
+
 	salary_component: function(frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 		if(child.salary_component){
@@ -349,6 +357,8 @@ frappe.ui.form.on('Salary Detail', {
 		var child = locals[cdt][cdn];
 		if(child.amount_based_on_formula == 1){
 			frappe.model.set_value(cdt, cdn, 'amount', null);
+			const index = frm.alerted_rows.indexOf(cdn);
+			if (index > -1) frm.alerted_rows.splice(index, 1);
 		}
 		else{
 			frappe.model.set_value(cdt, cdn, 'formula', null);

--- a/hrms/payroll/doctype/salary_structure/salary_structure.js
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.js
@@ -313,8 +313,12 @@ frappe.ui.form.on('Salary Detail', {
 	},
 
 	formula: function(frm, cdt, cdn) {
-		if (!locals[cdt][cdn].amount_based_on_formula && !frm.alerted_rows.includes(cdn)) {
-			frappe.msgprint(__("Warning: 'Amount Based on Formula' has been disabled for this row."));
+		const row = locals[cdt][cdn];
+		if (row.formula && !row?.amount_based_on_formula && !frm.alerted_rows.includes(cdn)) {
+			frappe.msgprint(
+				__("Row #{0}: {1} needs to be enabled for the formula to be considered.",
+				[row.idx, __("Amount based on formula").bold()])
+			);
 			frm.alerted_rows.push(cdn)
 		}
 	},
@@ -355,12 +359,11 @@ frappe.ui.form.on('Salary Detail', {
 
 	amount_based_on_formula: function(frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
-		if(child.amount_based_on_formula == 1){
+		if (child.amount_based_on_formula == 1) {
 			frappe.model.set_value(cdt, cdn, 'amount', null);
 			const index = frm.alerted_rows.indexOf(cdn);
 			if (index > -1) frm.alerted_rows.splice(index, 1);
-		}
-		else{
+		} else {
 			frappe.model.set_value(cdt, cdn, 'formula', null);
 		}
 	}

--- a/hrms/payroll/doctype/salary_structure/salary_structure.js
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.js
@@ -1,17 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch('company', 'default_letter_head', 'letter_head');
-
-
-cur_frm.cscript.onload = function(doc, dt, dn){
-	var e_tbl = doc.earnings || [];
-	var d_tbl = doc.deductions || [];
-	if (e_tbl.length == 0 && d_tbl.length == 0)
-		return function(r, rt) { refresh_many(['earnings', 'deductions']);};
-}
-
-frappe.ui.form.on('Salary Structure', {
+frappe.ui.form.on("Salary Structure", {
 	onload: function(frm) {
 		frm.alerted_rows = []
 

--- a/hrms/payroll/doctype/salary_structure/salary_structure.js
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.js
@@ -305,10 +305,12 @@ frappe.ui.form.on('Salary Detail', {
 	formula: function(frm, cdt, cdn) {
 		const row = locals[cdt][cdn];
 		if (row.formula && !row?.amount_based_on_formula && !frm.alerted_rows.includes(cdn)) {
-			frappe.msgprint(
-				__("Row #{0}: {1} needs to be enabled for the formula to be considered.",
-				[row.idx, __("Amount based on formula").bold()])
-			);
+			frappe.msgprint({
+				message: __("{0} Row #{1}: {2} needs to be enabled for the formula to be considered.",
+					[toTitle(row.parentfield), row.idx, __("Amount based on formula").bold()]),
+				title: __("Warning"),
+				indicator: "orange",
+			});
 			frm.alerted_rows.push(cdn)
 		}
 	},

--- a/hrms/payroll/doctype/salary_structure/salary_structure.json
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.json
@@ -48,6 +48,7 @@
    "search_index": 1
   },
   {
+   "fetch_from": "company.default_letter_head",
    "fieldname": "letter_head",
    "fieldtype": "Link",
    "label": "Letter Head",
@@ -239,7 +240,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-26 14:57:07.030623",
+ "modified": "2023-12-12 14:11:22.774017",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure",

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -23,21 +23,14 @@ class SalaryStructure(Document):
 		self.validate_timesheet_component()
 
 	def before_save(self):
-		for detail in self.earnings:
-			if not detail.amount_based_on_formula and detail.formula:
-				frappe.msgprint(
-					_(
-						"Earning Row #{0}: Formula entered for Salary Component {1} even though 'Amount Based on Formula' has been disabled"
-					).format(detail.idx, detail.salary_component)
-				)
-
-		for detail in self.deductions:
-			if not detail.amount_based_on_formula and detail.formula:
-				frappe.msgprint(
-					_(
-						"Deduction Row #{0}: Formula entered for Salary Component {1} even though 'Amount Based on Formula' has been disabled"
-					).format(detail.idx, detail.salary_component)
-				)
+		for table in ["earnings", "deductions"]:
+			for detail in self.get(table):
+				if not detail.amount_based_on_formula and detail.formula:
+					frappe.msgprint(
+						_(
+							"{0} Row #{1}: Formula entered for Salary Component {2} even though 'Amount Based on Formula' has been disabled"
+						).format(table[:-1].capitalize(), detail.idx, detail.salary_component)
+					)
 
 	def set_missing_values(self):
 		overwritten_fields = [

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -21,20 +21,21 @@ class SalaryStructure(Document):
 		self.validate_component_based_on_tax_slab()
 		self.validate_payment_days_based_dependent_component()
 		self.validate_timesheet_component()
+		self.validate_formula_setup()
 
-	def before_save(self):
+	def validate_formula_setup(self):
 		for table in ["earnings", "deductions"]:
-			for detail in self.get(table):
-				if not detail.amount_based_on_formula and detail.formula:
+			for row in self.get(table):
+				if not row.amount_based_on_formula and row.formula:
 					frappe.msgprint(
-						_(
-							"{0} Row #{1}: Formula entered for Salary Component {2} even though {3} has been disabled."
-						).format(
-							table[:-1].capitalize(),
-							detail.idx,
-							detail.salary_component,
-							frappe.bold("Amount Based on Formula"),
-						)
+						_("{0} Row #{1}: Formula is set but {2} is disabled for the Salary Component {3}.").format(
+							table.capitalize(),
+							row.idx,
+							frappe.bold(_("Amount Based on Formula")),
+							frappe.bold(row.salary_component),
+						),
+						title=_("Warning"),
+						indicator="orange",
 					)
 
 	def set_missing_values(self):

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -28,8 +28,13 @@ class SalaryStructure(Document):
 				if not detail.amount_based_on_formula and detail.formula:
 					frappe.msgprint(
 						_(
-							"{0} Row #{1}: Formula entered for Salary Component {2} even though 'Amount Based on Formula' has been disabled"
-						).format(table[:-1].capitalize(), detail.idx, detail.salary_component)
+							"{0} Row #{1}: Formula entered for Salary Component {2} even though {3} has been disabled."
+						).format(
+							table[:-1].capitalize(),
+							detail.idx,
+							detail.salary_component,
+							frappe.bold("Amount Based on Formula"),
+						)
 					)
 
 	def set_missing_values(self):

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -22,6 +22,23 @@ class SalaryStructure(Document):
 		self.validate_payment_days_based_dependent_component()
 		self.validate_timesheet_component()
 
+	def before_save(self):
+		for detail in self.earnings:
+			if not detail.amount_based_on_formula and detail.formula:
+				frappe.msgprint(
+					_(
+						"Earning Row #{0}: Formula entered for Salary Component {1} even though 'Amount Based on Formula' has been disabled"
+					).format(detail.idx, detail.salary_component)
+				)
+
+		for detail in self.deductions:
+			if not detail.amount_based_on_formula and detail.formula:
+				frappe.msgprint(
+					_(
+						"Deduction Row #{0}: Formula entered for Salary Component {1} even though 'Amount Based on Formula' has been disabled"
+					).format(detail.idx, detail.salary_component)
+				)
+
 	def set_missing_values(self):
 		overwritten_fields = [
 			"depends_on_payment_days",


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/899

This PR causes a warning to be issued to the user if they enter a Formula, under the Earnings or Deductions table of the Salary Structure DocType, for those rows wherein **Amount Based on Formula** has been disabled.

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/e71117b9-1f11-46fa-835a-c9b30970cfa7">

server-side warning

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/1f87f136-6dd8-46e5-a334-4d9daa247ab3">

`no-docs`