### PR TITLE
fix: handle null & empty shift ('') values in Monthly Attendance Sheet

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -223,6 +223,9 @@ def get_attendance_map(filters: Filters) -> Dict:
 			leave_map.setdefault(d.employee, []).append(d.day_of_month)
 			continue
 
+		if d.shift is None:
+			d.shift = ""
+
 		attendance_map.setdefault(d.employee, {}).setdefault(d.shift, {})
 		attendance_map[d.employee][d.shift][d.day_of_month] = d.status
 

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -92,7 +92,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(day_shift_row[1], "A")  # absent on the 1st day of the month
 		self.assertEqual(day_shift_row[2], "P")  # present on the 2nd day
 
-		self.assertEqual(row_without_shift["shift"], None)
+		self.assertEqual(row_without_shift["shift"], "")
 		self.assertEqual(row_without_shift[4], "P")  # present on the 4th day
 
 		# leave should be shown against every shift
@@ -236,7 +236,7 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		self.assertEqual(day_shift_row[1], "A")  # absent on the 1st day of the month
 		self.assertEqual(day_shift_row[2], "P")  # present on the 2nd day
 
-		self.assertEqual(row_without_shift["shift"], None)
+		self.assertEqual(row_without_shift["shift"], "")
 		self.assertEqual(row_without_shift[3], "L")  # on leave on the 3rd day
 		self.assertEqual(row_without_shift[4], "P")  # present on the 4th day
 


### PR DESCRIPTION
Before:

null and empty shift ("") being treated as 2 different shifts in attendance sheet

<img width="1440" alt="shifts-null-empty" src="https://github.com/frappe/hrms/assets/24353136/8c787e1c-5d55-48dc-875e-babceecfda85">


After:

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/c23777ae-c16b-4d28-bbd4-df093c523fc2">

