### PR TITLE
fix(Leave Application): Resolved leave type missing for accurate payroll processing

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -289,8 +289,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if attendance_name:
 			# update existing attendance, change absent to on leave
 			doc = frappe.get_doc("Attendance", attendance_name)
-			if doc.status != status:
-				doc.db_set({"status": status, "leave_type": self.leave_type, "leave_application": self.name})
+			doc.db_set({"status": status, "leave_type": self.leave_type, "leave_application": self.name})
 		else:
 			# make new attendance and submit it
 			doc = frappe.new_doc("Attendance")


### PR DESCRIPTION
In the leave application process, attendance is currently updated only when the attendance and leave application statuses differ. However, if attendance was initially created through an employee check-in and a leave application for half-day is later submitted, the leave type is not added. As a result, during payroll processing, the employee may incur a loss of pay for that day. 