### PR TITLE
feat: Earned Leave UX Enhancement

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -1,138 +1,253 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch('employee', 'employee_name', 'employee_name');
+cur_frm.add_fetch("employee", "employee_name", "employee_name");
 
 frappe.ui.form.on("Leave Allocation", {
-	onload: function(frm) {
+	onload: function (frm) {
 		// Ignore cancellation of doctype on cancel all.
 		frm.ignore_doctypes_on_cancel_all = ["Leave Ledger Entry"];
 
-		if (!frm.doc.from_date) frm.set_value("from_date", frappe.datetime.get_today());
+		if (!frm.doc.from_date)
+			frm.set_value("from_date", frappe.datetime.get_today());
 
-		frm.set_query("employee", function() {
+		frm.set_query("employee", function () {
 			return {
-				query: "erpnext.controllers.queries.employee_query"
+				query: "erpnext.controllers.queries.employee_query",
 			};
 		});
-		frm.set_query("leave_type", function() {
+		frm.set_query("leave_type", function () {
 			return {
 				filters: {
-					is_lwp: 0
-				}
+					is_lwp: 0,
+				},
 			};
 		});
 	},
 
-	refresh: function(frm) {
+	make_dashboard: async function (frm) {
+		response = await frappe.db.get_value("Leave Type", frm.doc.leave_type, [
+			"is_earned_leave",
+			"earned_leave_frequency",
+		]);
+		leave_type = response.message;
+		if (
+			!leave_type.is_earned_leave ||
+			leave_type.earned_leave_frequency != "Monthly"
+		)
+			return;
+		$("div").remove(".form-dashboard-section.custom");
+
+		frm.dashboard.add_section(
+			frappe.render_template("leave_allocation_dashboard", {
+				data: leave_details,
+			}),
+			__("Allocated Leaves")
+		);
+		frm.dashboard.show();
+	},
+
+	refresh: function (frm) {
 		if (frm.doc.docstatus === 1 && frm.doc.expired) {
-			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(frm.doc.from_date, frm.doc.to_date);
+			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(
+				frm.doc.from_date,
+				frm.doc.to_date
+			);
 			if (valid_expiry) {
 				// expire current allocation
-				frm.add_custom_button(__('Expire Allocation'), function() {
+				frm.add_custom_button(__("Expire Allocation"), function () {
 					frm.trigger("expire_allocation");
 				});
 			}
 		}
 
 		if (!frm.doc.__islocal && frm.doc.leave_policy_assignment) {
-			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
-				if (cint(r?.is_earned_leave))
+			frappe.db.get_value(
+				"Leave Type",
+				frm.doc.leave_type,
+				["is_earned_leave", "earned_leave_frequency", "rounding"],
+				(r) => {
+					if (!cint(r?.is_earned_leave)) return;
 					frm.set_df_property("new_leaves_allocated", "read_only", 1);
-			});
+					frm.frequency = r?.earned_leave_frequency;
+					frm.rounding = r?.rounding;
+
+					frm.add_custom_button(__("Allocate Leaves Manually"), function () {
+						const dialog = new frappe.ui.Dialog({
+							title: "Enter details",
+							fields: [
+								{
+									label: "New Leaves Allocated",
+									fieldname: "new_leaves_allocated",
+									fieldtype: "Data",
+								},
+							],
+							primary_action_label: "Allocate",
+							primary_action() {
+								dialog.hide();
+							},
+						});
+						dialog.show();
+					});
+				}
+			);
 		}
 	},
 
-	expire_allocation: function(frm) {
+	expire_allocation: function (frm) {
 		frappe.call({
-			method: 'hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.expire_allocation',
+			method:
+				"hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.expire_allocation",
 			args: {
-				'allocation': frm.doc,
-				'expiry_date': frappe.datetime.get_today()
+				allocation: frm.doc,
+				expiry_date: frappe.datetime.get_today(),
 			},
 			freeze: true,
-			callback: function(r) {
+			callback: function (r) {
 				if (!r.exc) {
 					frappe.msgprint(__("Allocation Expired!"));
 				}
 				frm.refresh();
-			}
+			},
 		});
 	},
 
-	employee: function(frm) {
+	employee: function (frm) {
 		frm.trigger("calculate_total_leaves_allocated");
 	},
 
-	leave_type: function(frm) {
+	leave_type: function (frm) {
 		frm.trigger("leave_policy");
 		frm.trigger("calculate_total_leaves_allocated");
+		frm.trigger("make_dashboard");
 	},
 
-	carry_forward: function(frm) {
+	carry_forward: function (frm) {
 		frm.trigger("calculate_total_leaves_allocated");
 	},
 
-	unused_leaves: function(frm) {
-		frm.set_value("total_leaves_allocated",
-			flt(frm.doc.unused_leaves) + flt(frm.doc.new_leaves_allocated));
+	unused_leaves: function (frm) {
+		frm.set_value(
+			"total_leaves_allocated",
+			flt(frm.doc.unused_leaves) + flt(frm.doc.new_leaves_allocated)
+		);
 	},
 
-	new_leaves_allocated: function(frm) {
-		frm.set_value("total_leaves_allocated",
-			flt(frm.doc.unused_leaves) + flt(frm.doc.new_leaves_allocated));
+	new_leaves_allocated: function (frm) {
+		frm.set_value(
+			"total_leaves_allocated",
+			flt(frm.doc.unused_leaves) + flt(frm.doc.new_leaves_allocated)
+		);
 	},
 
-	leave_policy: function(frm) {
+	leave_policy: function (frm) {
 		if (frm.doc.leave_policy && frm.doc.leave_type) {
-			frappe.db.get_value("Leave Policy Detail", {
-				'parent': frm.doc.leave_policy,
-				'leave_type': frm.doc.leave_type
-			}, 'annual_allocation', (r) => {
-				if (r && !r.exc) frm.set_value("new_leaves_allocated", flt(r.annual_allocation));
-			}, "Leave Policy");
+			frappe.db.get_value(
+				"Leave Policy Detail",
+				{
+					parent: frm.doc.leave_policy,
+					leave_type: frm.doc.leave_type,
+				},
+				"annual_allocation",
+				(r) => {
+					if (r && !r.exc)
+						frm.set_value("new_leaves_allocated", flt(r.annual_allocation));
+				},
+				"Leave Policy"
+			);
 		}
 	},
-	calculate_total_leaves_allocated: function(frm) {
-		if (cint(frm.doc.carry_forward) == 1 && frm.doc.leave_type && frm.doc.employee) {
+	calculate_total_leaves_allocated: function (frm) {
+		if (
+			cint(frm.doc.carry_forward) == 1 &&
+			frm.doc.leave_type &&
+			frm.doc.employee
+		) {
 			return frappe.call({
 				method: "set_total_leaves_allocated",
 				doc: frm.doc,
-				callback: function() {
+				callback: function () {
 					frm.refresh_fields();
-				}
+				},
 			});
 		} else if (cint(frm.doc.carry_forward) == 0) {
 			frm.set_value("unused_leaves", 0);
-			frm.set_value("total_leaves_allocated", flt(frm.doc.new_leaves_allocated));
+			frm.set_value(
+				"total_leaves_allocated",
+				flt(frm.doc.new_leaves_allocated)
+			);
 		}
-	}
+	},
+	get_monthly_earned_leave: async function (frm) {
+		await frappe.run_serially([
+			() =>
+				frappe.db
+					.get_value("Employee", frm.doc.employee, "date_of_joining")
+					.then((r) => (frm.doj = r.message.date_of_joining)),
+			() =>
+				frappe.db.get_value(
+					"Leave Policy Detail",
+					{
+						parent: frm.doc.leave_policy,
+						leave_type: frm.doc.leave_type,
+					},
+					"annual_allocation",
+					(r) => {
+						frm.annual_leaves = r.annual_allocation;
+					},
+					"Leave Policy"
+				),
+			() =>
+				frappe.call({
+					method: "hrms.hr.utils.get_monthly_earned_leave",
+					args: {
+						date_of_joining: frm.doj,
+						annual_leaves: frm.annual_leaves,
+						frequency: frm.frequency,
+						rounding: frm.rounding,
+					},
+					callback: function (r) {
+						frm.monthly_earned_leave = r.message;
+					},
+				}),
+		]);
+	},
 });
 
 frappe.tour["Leave Allocation"] = [
 	{
 		fieldname: "employee",
 		title: "Employee",
-		description: __("Select the Employee for which you want to allocate leaves.")
+		description: __(
+			"Select the Employee for which you want to allocate leaves."
+		),
 	},
 	{
 		fieldname: "leave_type",
 		title: "Leave Type",
-		description: __("Select the Leave Type like Sick leave, Privilege Leave, Casual Leave, etc.")
+		description: __(
+			"Select the Leave Type like Sick leave, Privilege Leave, Casual Leave, etc."
+		),
 	},
 	{
 		fieldname: "from_date",
 		title: "From Date",
-		description: __("Select the date from which this Leave Allocation will be valid.")
+		description: __(
+			"Select the date from which this Leave Allocation will be valid."
+		),
 	},
 	{
 		fieldname: "to_date",
 		title: "To Date",
-		description: __("Select the date after which this Leave Allocation will expire.")
+		description: __(
+			"Select the date after which this Leave Allocation will expire."
+		),
 	},
 	{
 		fieldname: "new_leaves_allocated",
 		title: "New Leaves Allocated",
-		description: __("Enter the number of leaves you want to allocate for the period.")
-	}
+		description: __(
+			"Enter the number of leaves you want to allocate for the period."
+		),
+	},
 ];

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -71,14 +71,15 @@ frappe.ui.form.on("Leave Allocation", {
 					frm.set_df_property("new_leaves_allocated", "read_only", 1);
 					frm.frequency = r?.earned_leave_frequency;
 					frm.rounding = r?.rounding;
+					frm.trigger("get_monthly_earned_leave");
 
 					frm.add_custom_button(__("Allocate Leaves Manually"), function () {
 						const dialog = new frappe.ui.Dialog({
 							title: "Enter details",
 							fields: [
 								{
-									label: "New Leaves Allocated",
-									fieldname: "new_leaves_allocated",
+									label: "New Leaves to be Allocated",
+									fieldname: "new_leaves",
 									fieldtype: "Data",
 								},
 							],
@@ -87,6 +88,7 @@ frappe.ui.form.on("Leave Allocation", {
 								dialog.hide();
 							},
 						});
+						dialog.fields_dict.new_leaves.set_value(frm.monthly_earned_leave);
 						dialog.show();
 					});
 				}

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -195,7 +195,7 @@ frappe.ui.form.on("Leave Allocation", {
 						rounding: frm.rounding,
 					},
 					callback: function (r) {
-						frm.monthly_leaves = r.message;
+						frm.monthly_earned_leave = r.message;
 						frm.new_leaves = r.message;
 						frm.trigger("make_dashboard");
 					},
@@ -230,18 +230,19 @@ frappe.ui.form.on("Leave Allocation", {
 		$("div").remove(".form-dashboard-section.custom");
 
 		frappe.call({
-			method: "hrms.hr.utils.get_monthly_allocations",
+			method: "hrms.hr.utils.get_monthly_allocation_dates",
 			args: {
-				employee: frm.doc.employee,
 				leave_type: frm.doc.leave_type,
 				from_date: frm.doc.from_date,
 				to_date: frm.doc.to_date,
 				leave_policy: frm.doc.leave_policy,
+				monthly_earned_leave: frm.monthly_earned_leave,
 			},
 			callback: function (r) {
 				frm.dashboard.add_section(
 					frappe.render_template("leave_allocation_dashboard", {
-						allocations: r.message
+						allocation_dates: r.message,
+						monthly_earned_leave: frm.monthly_earned_leave,
 					}),
 					__("Leaves Allocated")
 				);

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -211,7 +211,7 @@ frappe.ui.form.on("Leave Allocation", {
 				new_leaves: frm.new_leaves,
 			},
 			callback: function () {
-				frm.refresh();
+				frm.reload_doc();
 			},
 		});
 	},

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -250,7 +250,7 @@ frappe.ui.form.on("Leave Allocation", {
 						allocation_dates: r.message,
 						monthly_earned_leave: frm.monthly_earned_leave,
 					}),
-					__("Leaves Allocated")
+					__("Leave Allocation Schedule")
 				);
 				frm.dashboard.show();
 			},

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -224,7 +224,13 @@ frappe.ui.form.on("Leave Allocation", {
 		leave_type = response.message;
 		if (
 			!leave_type.is_earned_leave ||
-			leave_type.earned_leave_frequency != "Monthly"
+			leave_type.earned_leave_frequency != "Monthly" ||
+			!(
+				frm.doc.from_date &&
+				frm.doc.to_date &&
+				frm.doc.leave_policy &&
+				frm.monthly_earned_leave
+			)
 		)
 			return;
 		$("div").remove(".form-dashboard-section.custom");

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch("employee", "employee_name", "employee_name");
+frm.add_fetch("employee", "employee_name", "employee_name");
 
 frappe.ui.form.on("Leave Allocation", {
 	onload: function (frm) {

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -81,14 +81,18 @@ frappe.ui.form.on("Leave Allocation", {
 									label: "New Leaves to be Allocated",
 									fieldname: "new_leaves",
 									fieldtype: "Data",
+									onchange: function () {
+										frm.new_leaves = this.value;
+									},
 								},
 							],
 							primary_action_label: "Allocate",
 							primary_action() {
+								frm.trigger("allocate_leaves_manually");
 								dialog.hide();
 							},
 						});
-						dialog.fields_dict.new_leaves.set_value(frm.monthly_earned_leave);
+						dialog.fields_dict.new_leaves.set_value(frm.new_leaves);
 						dialog.show();
 					});
 				}
@@ -209,10 +213,23 @@ frappe.ui.form.on("Leave Allocation", {
 						rounding: frm.rounding,
 					},
 					callback: function (r) {
-						frm.monthly_earned_leave = r.message;
+						frm.new_leaves = r.message;
 					},
 				}),
 		]);
+	},
+
+	allocate_leaves_manually: function (frm) {
+		frappe.call({
+			method: "hrms.hr.utils.allocate_leaves_manually",
+			args: {
+				allocation_name: frm.doc.name,
+				new_leaves: frm.new_leaves,
+			},
+			callback: function () {
+				frm.refresh();
+			},
+		});
 	},
 });
 

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
@@ -1,0 +1,30 @@
+
+{% if not jQuery.isEmptyObject(data) %}
+<table class="table table-bordered small">
+	<thead>
+		<tr>
+			<th style="width: 16%">{{ __("Leave Type") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Total Allocated Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Expired Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Used Leaves") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Leaves Pending Approval") }}</th>
+			<th style="width: 16%" class="text-right">{{ __("Available Leaves") }}</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for(const [key, value] of Object.entries(data)) { %}
+			{% let color = cint(value["remaining_leaves"]) > 0 ? "green" : "red" %}
+			<tr>
+				<td> {%= key %} </td>
+				<td class="text-right"> {%= value["total_leaves"] %} </td>
+				<td class="text-right"> {%= value["expired_leaves"] %} </td>
+				<td class="text-right"> {%= value["leaves_taken"] %} </td>
+				<td class="text-right"> {%= value["leaves_pending_approval"] %} </td>
+				<td class="text-right" style="color: {{ color }}"> {%= value["remaining_leaves"] %} </td>
+			</tr>
+		{% } %}
+	</tbody>
+</table>
+{% else %}
+<p style="margin-top: 30px;"> No Leave has been allocated. </p>
+{% endif %}

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
@@ -1,4 +1,4 @@
-{% if allocations.length %}
+{% if allocation_dates.length %}
 <table class="table table-bordered small">
 	<thead>
 		<tr>
@@ -7,10 +7,10 @@
 		</tr>
 	</thead>
 	<tbody>
-		{% for(const i of allocations) { %} {% %}
+		{% for(const date of allocation_dates) { %} {% %}
 		<tr>
-			<td>{%= i.date %}</td>
-			<td>{%= i.leaves %}</td>
+			<td>{%= date %}</td>
+			<td>{%= monthly_earned_leave %}</td>
 		</tr>
 		{% } %}
 	</tbody>

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
@@ -1,30 +1,20 @@
-
-{% if not jQuery.isEmptyObject(data) %}
+{% if monthly_leaves %}
 <table class="table table-bordered small">
 	<thead>
 		<tr>
-			<th style="width: 16%">{{ __("Leave Type") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Total Allocated Leaves") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Expired Leaves") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Used Leaves") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Leaves Pending Approval") }}</th>
-			<th style="width: 16%" class="text-right">{{ __("Available Leaves") }}</th>
+			<th style="width: 50%">{{ __("Month") }}</th>
+			<th style="width: 50%">{{ __("No. of Leaves") }}</th>
 		</tr>
 	</thead>
 	<tbody>
-		{% for(const [key, value] of Object.entries(data)) { %}
-			{% let color = cint(value["remaining_leaves"]) > 0 ? "green" : "red" %}
-			<tr>
-				<td> {%= key %} </td>
-				<td class="text-right"> {%= value["total_leaves"] %} </td>
-				<td class="text-right"> {%= value["expired_leaves"] %} </td>
-				<td class="text-right"> {%= value["leaves_taken"] %} </td>
-				<td class="text-right"> {%= value["leaves_pending_approval"] %} </td>
-				<td class="text-right" style="color: {{ color }}"> {%= value["remaining_leaves"] %} </td>
-			</tr>
+		{% for(const value of months) { %} {% %}
+		<tr>
+			<td>{%= value %}</td>
+			<td>{%= monthly_leaves %}</td>
+		</tr>
 		{% } %}
 	</tbody>
 </table>
 {% else %}
-<p style="margin-top: 30px;"> No Leave has been allocated. </p>
+<p style="margin-top: 30px">No Leave has been allocated.</p>
 {% endif %}

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.html
@@ -1,16 +1,16 @@
-{% if monthly_leaves %}
+{% if allocations.length %}
 <table class="table table-bordered small">
 	<thead>
 		<tr>
-			<th style="width: 50%">{{ __("Month") }}</th>
+			<th style="width: 50%">{{ __("Date") }}</th>
 			<th style="width: 50%">{{ __("No. of Leaves") }}</th>
 		</tr>
 	</thead>
 	<tbody>
-		{% for(const value of months) { %} {% %}
+		{% for(const i of allocations) { %} {% %}
 		<tr>
-			<td>{%= value %}</td>
-			<td>{%= monthly_leaves %}</td>
+			<td>{%= i.date %}</td>
+			<td>{%= i.leaves %}</td>
 		</tr>
 		{% } %}
 	</tbody>

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -435,6 +435,7 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 		allocation.add_comment(comment_type="Info", text=text)
 
 
+@frappe.whitelist()
 def get_monthly_earned_leave(
 	date_of_joining,
 	annual_leaves,

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -505,6 +505,18 @@ def get_earned_leaves():
 	)
 
 
+@frappe.whitelist()
+def allocate_leaves_manually(allocation_name, new_leaves):
+	allocation = frappe.get_doc("Leave Allocation", allocation_name)
+	today_date = frappe.flags.current_date or getdate()
+
+	create_additional_leave_ledger_entry(allocation, new_leaves, today_date)
+	text = _("{0} leaves were manually allocated by {1} on {2}").format(
+		frappe.bold(new_leaves), frappe.session.user, frappe.bold(formatdate(today_date))
+	)
+	allocation.add_comment(comment_type="Info", text=text)
+
+
 def create_additional_leave_ledger_entry(allocation, leaves, date):
 	"""Create leave ledger entry for leave types"""
 	allocation.new_leaves_allocated = leaves


### PR DESCRIPTION
### Issue

Closes: https://github.com/frappe/hrms/issues/1104

### Changes

#### Monthly leave allocation schedule

Shows the date and the number of leaves to be allocated each month in the Leave Allocation form dashboard. This table is only rendered for Earned Leaves with 'Monthly' frequency.

![image](https://github.com/frappe/hrms/assets/61287991/dde60956-dfa0-4b29-8e2b-25922bb78994)

#### Notification of auto-allocation failure

In case of failure of auto-allocation of Earned Leaves, an email is sent to the users with the 'HR Manager' role, notifying them of said failure.

#### Manual allocation of leaves

"Allocate Leaves Manually" button to circumvent missed Leave Allocations due to failed background jobs. Number of leaves is defaulted to the monthly number of leaves to be allocated.

<img width="637" alt="image" src="https://github.com/frappe/hrms/assets/61287991/0bd164f5-315c-435e-b7e2-8964a943b52d">

### Documentation

https://frappehr.com/docs/v14/en/configuring-earned-leave