### PR TITLE
fix(PWA): validate mandatory fields in form view on client-side

### DIFF
--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -194,7 +194,11 @@
 			>
 				<ErrorMessage
 					class="mb-2"
-					:message="docList.insert.error || documentResource?.setValue?.error"
+					:message="
+						formErrorMessage ||
+						docList?.insert?.error ||
+						documentResource?.setValue?.error
+					"
 				/>
 
 				<Button
@@ -379,6 +383,7 @@ const router = useRouter()
 let activeTab = ref(props.tabs?.[0].name)
 let fileAttachments = ref([])
 let statusColor = ref("")
+let formErrorMessage = ref("")
 let isFormDirty = ref(false)
 let isFormUpdated = ref(false)
 let showDeleteDialog = ref(false)
@@ -609,12 +614,35 @@ function hasPermission(action) {
 }
 
 function handleDocInsert() {
+	if (!validateMandatoryFields()) return
 	docList.insert.submit(formModel.value)
+}
+
+function validateMandatoryFields() {
+	const errorFields = props.fields
+		.filter(
+			(field) =>
+				field.reqd && !field.hidden && !formModel.value[field.fieldname]
+		)
+		.map((field) => field.label)
+
+	if (errorFields.length) {
+		formErrorMessage.value = `${errorFields.join(", ")} ${
+			errorFields.length > 1 ? "fields are mandatory" : "field is mandatory"
+		}`
+		return false
+	} else {
+		formErrorMessage.value = ""
+		return true
+	}
 }
 
 async function handleDocUpdate(action) {
 	if (documentResource.doc) {
 		let params = { ...formModel.value }
+
+		if (!validateMandatoryFields()) return
+
 		if (action == "submit") {
 			params.docstatus = 1
 		} else if (action == "cancel") {


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/1174

server-side runs doc validations before checking for mandatory fields & form.js (desk) explicitly checks for mandatory fields before sending a save request. Validating mandatory fields on form insert/update on client-side now

<img width="383" alt="image" src="https://github.com/frappe/hrms/assets/24353136/b2ec1e85-57cd-4a25-bd8e-44598dd79111">