### PR TITLE
fix: journals as invoice throwing validation error

### DIFF
--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -42,7 +42,7 @@ class EmployeePaymentEntry(PaymentEntry):
 				)
 
 				for field, value in ref_details.items():
-					if d.exchange_gain_loss:
+					if d.exchange_gain_loss is not None:
 						# for cases where gain/loss is booked into invoice
 						# exchange_gain_loss is calculated from invoice & populated
 						# and row.exchange_rate is already set to payment entry's exchange rate


### PR DESCRIPTION
With the same exchange rate on Journal Entry and Payment Entry, reconcilition should not post exc gain/loss journal and should not throw validation error.

Continues: https://github.com/frappe/erpnext/pull/38766