### PR TITLE
refactor(PWA): realtime updates, caching & invalidation

### DIFF
--- a/frontend/src/components/BaseLayout.vue
+++ b/frontend/src/components/BaseLayout.vue
@@ -50,7 +50,6 @@
 
 <script setup>
 import { IonHeader, IonContent, IonPage } from "@ionic/vue"
-import { onMounted } from "vue"
 import { FeatherIcon, Avatar } from "frappe-ui"
 
 import { unreadNotificationsCount } from "@/data/notifications"
@@ -58,7 +57,6 @@ import { unreadNotificationsCount } from "@/data/notifications"
 import { inject } from "vue"
 
 const user = inject("$user")
-const socket = inject("$socket")
 
 const props = defineProps({
 	pageTitle: {
@@ -66,11 +64,5 @@ const props = defineProps({
 		required: false,
 		default: "Frappe HR",
 	},
-})
-
-onMounted(() => {
-	socket.on("hrms:update_notifications", () => {
-		unreadNotificationsCount.reload()
-	})
 })
 </script>

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -70,20 +70,11 @@
 
 <script setup>
 import { FeatherIcon, createResource } from "frappe-ui"
-import { computed, inject, onMounted, onBeforeUnmount } from "vue"
+import { computed } from "vue"
+
+import { expenseClaimSummary as summary } from "@/data/claims"
 
 import { formatCurrency } from "@/utils/formatters"
-
-const employee = inject("$employee")
-const socket = inject("$socket")
-
-const summary = createResource({
-	url: "hrms.api.get_expense_claim_summary",
-	params: {
-		employee: employee.data.name,
-	},
-	auto: true,
-})
 
 const total_claimed_amount = computed(() => {
 	return (
@@ -94,16 +85,4 @@ const total_claimed_amount = computed(() => {
 })
 
 const company_currency = computed(() => summary.data?.currency)
-
-onMounted(() => {
-	socket.on("hrms:update_expense_claims", (data) => {
-		if (data.employee === employee.data.name) {
-			summary.reload()
-		}
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.off("hrms:update_expense_claims")
-})
 </script>

--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script setup>
-import { FeatherIcon, createResource } from "frappe-ui"
+import { FeatherIcon } from "frappe-ui"
 import { computed } from "vue"
 
 import { expenseClaimSummary as summary } from "@/data/claims"

--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -44,47 +44,13 @@
 </template>
 
 <script setup>
-import { inject, onMounted, onBeforeUnmount } from "vue"
-import { createResource } from "frappe-ui"
-
 import SemicircleChart from "@/components/SemicircleChart.vue"
 
-const employee = inject("$employee")
-const socket = inject("$socket")
-
-const leaveBalance = createResource({
-	url: "hrms.api.get_leave_balance_map",
-	params: {
-		employee: employee.data.name,
-	},
-	auto: true,
-	transform: (data) => {
-		// Calculate balance percentage for each leave type
-		return Object.fromEntries(
-			Object.entries(data).map(([leave_type, allocation]) => {
-				allocation.balance_percentage =
-					(allocation.balance_leaves / allocation.allocated_leaves) * 100
-				return [leave_type, allocation]
-			})
-		)
-	},
-})
+import { leaveBalance } from "@/data/leaves"
 
 const getChartColor = (index) => {
 	// note: tw colors - rose-400, pink-400 & purple-500 of the old frappeui palette #918ef5
 	const chartColors = ["text-[#fb7185]", "text-[#f472b6]", "text-[#918ef5]"]
 	return chartColors[index % chartColors.length]
 }
-
-onMounted(() => {
-	socket.on("hrms:update_leaves", (data) => {
-		if (data.employee === employee.data.name) {
-			leaveBalance.reload()
-		}
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.off("hrms:update_leaves")
-})
 </script>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -117,7 +117,6 @@ import {
 	computed,
 	reactive,
 	onMounted,
-	onBeforeUnmount,
 } from "vue"
 import {
 	modalController,
@@ -142,6 +141,7 @@ import ListFiltersActionSheet from "@/components/ListFiltersActionSheet.vue"
 import CustomIonModal from "@/components/CustomIonModal.vue"
 
 import useWorkflow from "@/composables/workflow"
+import { useListUpdate } from "@/composables/realtime"
 
 const props = defineProps({
 	doctype: {
@@ -352,17 +352,8 @@ onMounted(async () => {
 	const workflow = useWorkflow(props.doctype)
 	await workflow.workflowDoc.promise
 	workflowStateField.value = workflow.getWorkflowStateField()
-
 	fetchDocumentList()
 
-	socket.emit("doctype_subscribe", props.doctype)
-	socket.on("list_update", (data) => {
-		if (data?.doctype !== props.doctype) return
-		fetchDocumentList()
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.off("list_update")
+	useListUpdate(socket, props.doctype, () => fetchDocumentList())
 })
 </script>

--- a/frontend/src/components/RequestPanel.vue
+++ b/frontend/src/components/RequestPanel.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-import { ref, inject, onMounted, computed, markRaw, onBeforeUnmount } from "vue"
+import { ref, inject, onMounted, computed, markRaw } from "vue"
 
 import TabButtons from "@/components/TabButtons.vue"
 import RequestList from "@/components/RequestList.vue"
@@ -24,6 +24,8 @@ import { myClaims, teamClaims } from "@/data/claims"
 
 import LeaveRequestItem from "@/components/LeaveRequestItem.vue"
 import ExpenseClaimItem from "@/components/ExpenseClaimItem.vue"
+
+import { useListUpdate } from "@/composables/realtime"
 
 const activeTab = ref("My Requests")
 
@@ -57,22 +59,7 @@ const teamRequests = computed(() => {
 })
 
 onMounted(() => {
-	socket.emit("doctype_subscribe", "Leave Application")
-	socket.emit("doctype_subscribe", "Expense Claim")
-	socket.on("list_update", (data) => {
-		if (data.doctype === "Leave Application") {
-			myLeaves.reload()
-			teamLeaves.reload()
-		} else if (data.doctype === "Expense Claim") {
-			myClaims.reload()
-			teamClaims.reload()
-		}
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.emit("doctype_unsubscribe", "Leave Application")
-	socket.emit("doctype_unsubscribe", "Expense Claim")
-	socket.off("list_update")
+	useListUpdate(socket, "Leave Application", () => teamLeaves.reload())
+	useListUpdate(socket, "Expense Claim", () => teamClaims.reload())
 })
 </script>

--- a/frontend/src/composables/realtime.js
+++ b/frontend/src/composables/realtime.js
@@ -1,0 +1,19 @@
+import { reactive } from "vue"
+
+const subscribed = reactive({})
+
+export function useListUpdate(socket, doctype, callback) {
+	subscribe(socket, doctype)
+	socket.on("list_update", (data) => {
+		if (data.doctype == doctype) {
+			callback(data.name)
+		}
+	})
+}
+
+function subscribe(socket, doctype) {
+	if (subscribed[doctype]) return
+
+	socket.emit("doctype_subscribe", doctype)
+	subscribed[doctype] = true
+}

--- a/frontend/src/composables/workflow.js
+++ b/frontend/src/composables/workflow.js
@@ -6,7 +6,7 @@ export default function useWorkflow(doctype) {
 	const workflowDoc = createResource({
 		url: "hrms.api.get_workflow",
 		params: { doctype: doctype },
-		cache: `Workflow:${doctype}`,
+		cache: ["hrms:workflow", doctype],
 		onSuccess: (data) => {
 			console.log("Workflow loaded successfully ✅", data)
 		},

--- a/frontend/src/data/advances.js
+++ b/frontend/src/data/advances.js
@@ -14,6 +14,7 @@ export const advanceBalance = createResource({
 		employee: employeeResource.data.name,
 	},
 	auto: true,
+	cache: "hrms:employee_advance_balance",
 	transform(data) {
 		return transformAdvanceData(data)
 	},

--- a/frontend/src/data/claims.js
+++ b/frontend/src/data/claims.js
@@ -2,6 +2,15 @@ import { createResource } from "frappe-ui"
 import { employeeResource } from "./employee"
 import { reactive } from "vue"
 
+export const expenseClaimSummary = createResource({
+	url: "hrms.api.get_expense_claim_summary",
+	params: {
+		employee: employeeResource.data.name,
+	},
+	auto: true,
+	cache: "hrms:expense_claim_summary",
+})
+
 const transformClaimData = (data) => {
 	return data.map((claim) => {
 		claim.doctype = "Expense Claim"
@@ -16,8 +25,12 @@ export const myClaims = createResource({
 		limit: 5,
 	},
 	auto: true,
+	cache: "hrms:my_claims",
 	transform(data) {
 		return transformClaimData(data)
+	},
+	onSuccess() {
+		expenseClaimSummary.reload()
 	},
 })
 
@@ -30,6 +43,7 @@ export const teamClaims = createResource({
 		limit: 5,
 	},
 	auto: true,
+	cache: "hrms:team_claims",
 	transform(data) {
 		return transformClaimData(data)
 	},

--- a/frontend/src/data/employee.js
+++ b/frontend/src/data/employee.js
@@ -3,7 +3,7 @@ import { createResource } from "frappe-ui"
 
 export const employeeResource = createResource({
 	url: "hrms.api.get_current_employee_info",
-	cache: "Employee",
+	cache: "hrms:employee",
 	onError(error) {
 		if (error && error.exc_type === "AuthenticationError") {
 			router.push("/login")

--- a/frontend/src/data/leaves.js
+++ b/frontend/src/data/leaves.js
@@ -27,8 +27,12 @@ export const myLeaves = createResource({
 		limit: 5,
 	},
 	auto: true,
+	cache: "hrms:my_leaves",
 	transform(data) {
 		return transformLeaveData(data)
+	},
+	onSuccess() {
+		leaveBalance.reload()
 	},
 })
 
@@ -41,7 +45,27 @@ export const teamLeaves = createResource({
 		limit: 5,
 	},
 	auto: true,
+	cache: "hrms:team_leaves",
 	transform(data) {
 		return transformLeaveData(data)
+	},
+})
+
+export const leaveBalance = createResource({
+	url: "hrms.api.get_leave_balance_map",
+	params: {
+		employee: employeeResource.data.name,
+	},
+	auto: true,
+	cache: "hrms:leave_balance",
+	transform: (data) => {
+		// Calculate balance percentage for each leave type
+		return Object.fromEntries(
+			Object.entries(data).map(([leave_type, allocation]) => {
+				allocation.balance_percentage =
+					(allocation.balance_leaves / allocation.allocated_leaves) * 100
+				return [leave_type, allocation]
+			})
+		)
 	},
 })

--- a/frontend/src/data/notifications.js
+++ b/frontend/src/data/notifications.js
@@ -1,8 +1,29 @@
-import { createResource } from "frappe-ui"
+import { createResource, createListResource } from "frappe-ui"
+import { userResource } from "./user"
 
 export const unreadNotificationsCount = createResource({
 	url: "hrms.api.get_unread_notifications_count",
-	cache: "Unread Notifications Count",
+	cache: "hrms:unread_notifications_count",
 	initialData: 0,
 	auto: true,
+})
+
+export const notifications = createListResource({
+	doctype: "PWA Notification",
+	filters: { to_user: userResource.data.name },
+	fields: [
+		"name",
+		"from_user",
+		"message",
+		"read",
+		"creation",
+		"reference_document_type",
+		"reference_document_name",
+	],
+	auto: true,
+	cache: "hrms:notifications",
+	orderBy: "creation desc",
+	onSuccess() {
+		unreadNotificationsCount.reload()
+	},
 })

--- a/frontend/src/data/user.js
+++ b/frontend/src/data/user.js
@@ -3,7 +3,7 @@ import { createResource } from "frappe-ui"
 
 export const userResource = createResource({
 	url: "hrms.api.get_current_user_info",
-	cache: "User",
+	cache: "hrms:user",
 	onError(error) {
 		if (error && error.exc_type === "AuthenticationError") {
 			router.push({ name: "Login" })

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import { createApp } from "vue"
 import App from "./App.vue"
 import router from "./router"
-import socket from "./socket"
+import { initSocket } from "./socket"
 
 import {
 	Button,
@@ -31,6 +31,7 @@ import "./theme/variables.css"
 import "./main.css"
 
 const app = createApp(App)
+const socket = initSocket()
 
 setConfig("resourceFetcher", frappeRequest)
 app.use(resourcesPlugin)

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,7 +1,10 @@
 import { io } from "socket.io-client"
 import { socketio_port } from "../../../../sites/common_site_config.json"
 
-function initSocket() {
+import { getCachedListResource } from "frappe-ui/src/resources/listResource"
+import { getCachedResource } from "frappe-ui/src/resources/resources"
+
+export function initSocket() {
 	let host = window.location.hostname
 	let port = window.location.port ? `:${socketio_port}` : ""
 	let protocol = port ? "http" : "https"
@@ -10,8 +13,18 @@ function initSocket() {
 		withCredentials: true,
 		reconnectionAttempts: 5,
 	})
+
+	socket.on("hrms:refetch_resource", (data) => {
+		if (data.cache_key) {
+			let resource =
+				getCachedResource(data.cache_key) ||
+				getCachedListResource(data.cache_key)
+
+			if (resource) {
+				resource.reload()
+			}
+		}
+	})
+
 	return socket
 }
-
-const socket = initSocket()
-export default socket

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -78,37 +78,17 @@
 <script setup>
 import { IonContent, IonPage } from "@ionic/vue"
 import { useRouter } from "vue-router"
-import { createListResource, createResource, FeatherIcon } from "frappe-ui"
+import { createResource, FeatherIcon } from "frappe-ui"
 
-import { inject, onMounted } from "vue"
+import { inject } from "vue"
 import EmployeeAvatar from "@/components/EmployeeAvatar.vue"
 
-import { unreadNotificationsCount } from "@/data/notifications"
+import { unreadNotificationsCount, notifications } from "@/data/notifications"
 import EmptyState from "@/components/EmptyState.vue"
 
 const user = inject("$user")
 const dayjs = inject("$dayjs")
-const socket = inject("$socket")
 const router = useRouter()
-
-const notifications = createListResource({
-	doctype: "PWA Notification",
-	filters: { to_user: user.data.name },
-	fields: [
-		"name",
-		"from_user",
-		"message",
-		"read",
-		"creation",
-		"reference_document_type",
-		"reference_document_name",
-	],
-	auto: true,
-	orderBy: "creation desc",
-	onSuccess() {
-		unreadNotificationsCount.reload()
-	},
-})
 
 const markAllAsRead = createResource({
 	url: "hrms.api.mark_all_notifications_as_read",
@@ -134,10 +114,4 @@ function getItemRoute(item) {
 		params: { id: item.reference_document_name },
 	}
 }
-
-onMounted(() => {
-	socket.on("hrms:update_notifications", () => {
-		notifications.reload()
-	})
-})
 </script>

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -105,13 +105,15 @@ const notifications = createListResource({
 	],
 	auto: true,
 	orderBy: "creation desc",
+	onSuccess() {
+		unreadNotificationsCount.reload()
+	},
 })
 
 const markAllAsRead = createResource({
 	url: "hrms.api.mark_all_notifications_as_read",
 	onSuccess() {
 		notifications.reload()
-		unreadNotificationsCount.reload()
 	},
 })
 

--- a/frontend/src/views/employee_advance/List.vue
+++ b/frontend/src/views/employee_advance/List.vue
@@ -1,14 +1,17 @@
 <template>
-	<ListView
-		doctype="Employee Advance"
-		pageTitle="Employee Advances"
-		:tabButtons="TAB_BUTTONS"
-		:fields="EMPLOYEE_ADVANCE_FIELDS"
-		:filterConfig="FILTER_CONFIG"
-	/>
+	<ion-page>
+		<ListView
+			doctype="Employee Advance"
+			pageTitle="Employee Advances"
+			:tabButtons="TAB_BUTTONS"
+			:fields="EMPLOYEE_ADVANCE_FIELDS"
+			:filterConfig="FILTER_CONFIG"
+		/>
+	</ion-page>
 </template>
 
 <script setup>
+import { IonPage } from "@ionic/vue"
 import ListView from "@/components/ListView.vue"
 
 const TAB_BUTTONS = ["My Advances", "Team Advances"]

--- a/frontend/src/views/expense_claim/Dashboard.vue
+++ b/frontend/src/views/expense_claim/Dashboard.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup>
-import { markRaw, inject, onBeforeUnmount, onMounted } from "vue"
+import { markRaw } from "vue"
 
 import BaseLayout from "@/components/BaseLayout.vue"
 import ExpenseClaimSummary from "@/components/ExpenseClaimSummary.vue"
@@ -60,26 +60,4 @@ import EmployeeAdvanceBalance from "@/components/EmployeeAdvanceBalance.vue"
 
 import { myClaims } from "@/data/claims"
 import { advanceBalance } from "@/data/advances"
-
-const socket = inject("$socket")
-const employee = inject("$employee")
-
-onMounted(() => {
-	socket.on("hrms:update_expense_claims", (data) => {
-		if (data.employee === employee.data.name) {
-			myClaims.reload()
-		}
-	})
-
-	socket.on("hrms:update_employee_advances", (data) => {
-		if (data.employee === employee.data.name) {
-			advanceBalance.reload()
-		}
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.off("hrms:update_expense_claims")
-	socket.off("hrms:update_employee_advances")
-})
 </script>

--- a/frontend/src/views/expense_claim/List.vue
+++ b/frontend/src/views/expense_claim/List.vue
@@ -1,15 +1,18 @@
 <template>
-	<ListView
-		doctype="Expense Claim"
-		pageTitle="Claim History"
-		:tabButtons="TAB_BUTTONS"
-		:fields="EXPENSE_CLAIM_FIELDS"
-		groupBy="`tabExpense Claim`.name"
-		:filterConfig="FILTER_CONFIG"
-	/>
+	<ion-page>
+		<ListView
+			doctype="Expense Claim"
+			pageTitle="Claim History"
+			:tabButtons="TAB_BUTTONS"
+			:fields="EXPENSE_CLAIM_FIELDS"
+			groupBy="`tabExpense Claim`.name"
+			:filterConfig="FILTER_CONFIG"
+		/>
+	</ion-page>
 </template>
 
 <script setup>
+import { IonPage } from "@ionic/vue"
 import ListView from "@/components/ListView.vue"
 
 const TAB_BUTTONS = ["My Claims", "Team Claims"]

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup>
-import { inject, onMounted, onBeforeUnmount, markRaw } from "vue"
+import { markRaw } from "vue"
 
 import BaseLayout from "@/components/BaseLayout.vue"
 import LeaveBalance from "@/components/LeaveBalance.vue"
@@ -43,19 +43,4 @@ import LeaveRequestItem from "@/components/LeaveRequestItem.vue"
 import Holidays from "@/components/Holidays.vue"
 
 import { myLeaves } from "@/data/leaves"
-
-const socket = inject("$socket")
-const employee = inject("$employee")
-
-onMounted(() => {
-	socket.on("hrms:update_leaves", (data) => {
-		if (data.employee === employee.data.name) {
-			myLeaves.reload()
-		}
-	})
-})
-
-onBeforeUnmount(() => {
-	socket.off("hrms:update_leaves")
-})
 </script>

--- a/frontend/src/views/leave/List.vue
+++ b/frontend/src/views/leave/List.vue
@@ -1,14 +1,17 @@
 <template>
-	<ListView
-		doctype="Leave Application"
-		pageTitle="Leave History"
-		:tabButtons="TAB_BUTTONS"
-		:fields="LEAVE_FIELDS"
-		:filterConfig="FILTER_CONFIG"
-	/>
+	<ion-page>
+		<ListView
+			doctype="Leave Application"
+			pageTitle="Leave History"
+			:tabButtons="TAB_BUTTONS"
+			:fields="LEAVE_FIELDS"
+			:filterConfig="FILTER_CONFIG"
+		/>
+	</ion-page>
 </template>
 
 <script setup>
+import { IonPage } from "@ionic/vue"
 import ListView from "@/components/ListView.vue"
 
 const TAB_BUTTONS = ["My Leaves", "Team Leaves"]

--- a/hrms/__init__.py
+++ b/hrms/__init__.py
@@ -1,1 +1,12 @@
+import frappe
+
 __version__ = "16.0.0-dev"
+
+
+def refetch_resource(cache_key: str | list, user=None):
+	frappe.publish_realtime(
+		"hrms:refetch_resource",
+		{"cache_key": cache_key},
+		user=user or frappe.session.user,
+		after_commit=True,
+	)

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -186,9 +186,13 @@ doc_events = {
 	"Loan": {"validate": "hrms.hr.utils.validate_loan_repay_from_salary"},
 	"Employee": {
 		"validate": "hrms.overrides.employee_master.validate_onboarding_process",
-		"on_update": "hrms.overrides.employee_master.update_approver_role",
+		"on_update": [
+			"hrms.overrides.employee_master.update_approver_role",
+			"hrms.overrides.employee_master.publish_update",
+		],
 		"after_insert": "hrms.overrides.employee_master.update_job_applicant_and_offer",
 		"on_trash": "hrms.overrides.employee_master.update_employee_transfer",
+		"after_delete": "hrms.overrides.employee_master.publish_update",
 	},
 	"Project": {
 		"validate": "hrms.controllers.employee_boarding_controller.update_employee_boarding_status"

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -11,6 +11,7 @@ from frappe.utils import flt, nowdate
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
 
+import hrms
 from hrms.hr.utils import validate_active_employee
 
 
@@ -40,12 +41,7 @@ class EmployeeAdvance(Document):
 
 	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
-		frappe.publish_realtime(
-			event="hrms:update_employee_advances",
-			message={"employee": self.employee},
-			user=employee_user,
-			after_commit=True,
-		)
+		hrms.refetch_resource("hrms:employee_advance_balance", employee_user)
 
 	def set_status(self, update=False):
 		precision = self.precision("paid_amount")

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -13,6 +13,7 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_a
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
 
+import hrms
 from hrms.hr.utils import set_employee_name, share_doc_with_approver, validate_active_employee
 from hrms.mixins.pwa_notifications import PWANotificationsMixin
 
@@ -100,12 +101,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
-		frappe.publish_realtime(
-			event="hrms:update_expense_claims",
-			message={"employee": self.employee},
-			user=employee_user,
-			after_commit=True,
-		)
+		hrms.refetch_resource("hrms:my_claims", employee_user)
 
 	def set_payable_account(self):
 		if not self.payable_account and not self.is_paid:

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -23,6 +23,7 @@ from frappe.utils import (
 from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import daterange
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 
+import hrms
 from hrms.hr.doctype.leave_block_list.leave_block_list import get_applicable_block_dates
 from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import create_leave_ledger_entry
 from hrms.hr.utils import (
@@ -129,12 +130,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
-		frappe.publish_realtime(
-			event="hrms:update_leaves",
-			message={"employee": self.employee},
-			user=employee_user,
-			after_commit=True,
-		)
+		hrms.refetch_resource("hrms:my_leaves", employee_user)
 
 	def validate_applicable_after(self):
 		if self.leave_type:

--- a/hrms/hr/doctype/pwa_notification/pwa_notification.py
+++ b/hrms/hr/doctype/pwa_notification/pwa_notification.py
@@ -1,16 +1,10 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-import frappe
 from frappe.model.document import Document
+
+import hrms
 
 
 class PWANotification(Document):
 	def on_update(self):
-		self.publish_update()
-
-	def publish_update(self):
-		frappe.publish_realtime(
-			event="hrms:update_notifications",
-			user=self.to_user,
-			after_commit=True,
-		)
+		hrms.refetch_resource("hrms:notifications", self.to_user)

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -45,6 +45,12 @@ def validate_onboarding_process(doc, method=None):
 		onboarding.db_set("employee", doc.name)
 
 
+def publish_update(doc, method=None):
+	import hrms
+
+	hrms.refetch_resource("hrms:employee", doc.user_id)
+
+
 def update_job_applicant_and_offer(doc, method=None):
 	"""Updates Job Applicant and Job Offer status as 'Accepted' and submits them"""
 	if not doc.job_applicant:

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -222,13 +222,12 @@ class SalarySlip(TransactionBase):
 
 	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
-		if frappe.session.user == employee_user:
-			frappe.publish_realtime(
-				event="hrms:update_salary_slips",
-				message={"employee": self.employee},
-				user=frappe.session.user,
-				after_commit=True,
-			)
+		frappe.publish_realtime(
+			event="hrms:update_salary_slips",
+			message={"employee": self.employee},
+			user=employee_user,
+			after_commit=True,
+		)
 
 	def on_trash(self):
 		from frappe.model.naming import revert_series_if_last


### PR DESCRIPTION
## Problem

realtime updates sometimes fail in views

Ionic Vue follows a separate component lifecycle: https://ionicframework.com/docs/vue/lifecycle

> When an app is wrapped in `<ion-router-outlet>`, Ionic Framework treats navigation a bit differently. When you navigate to a new page, Ionic Framework will keep the old page in the existing DOM, but hide it from your view and transition to the new page. All the lifecycle methods in Vue (mounted, beforeUnmount, etc..) are available for you to use as well. However, since Ionic Vue manages the lifetime of a page, certain events might not fire when you expect them to. For instance, mounted fires the first time a page is displayed, but if you navigate away from the page Ionic Framework might keep the page around in the DOM, and a subsequent visit to the page might not call mounted again.

In the case of List Views & Request Lists, if both of them subscribe to the same doctype and one of them unmounts, it unsubscribes from doctype updates. The socket listener is not added every time we open a page since ionic doesn't unmount the component (it's just hidden). So it's unpredictable as to when the socket listeners would be active/added leaving the data in at least 1 of the views to be outdated.

## Solution

- Earlier ListView (child component) was wrapped in `<ion-page>`  instead of the individual parent lists. Swap this to avoid unusual behavior.
- Re-fetch resources using cache keys and remove redundant socket listeners.
- cache all important resources
- Keep all the data together under the data folder and reuse everywhere