### PR TITLE
fix: incorrect leave balance for backdated earned leaves

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -495,17 +495,19 @@ class TestLeaveAllocation(FrappeTestCase):
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
 		self.assertEqual(leaves_allocated, 3)
 
-		# 1 more leave allocated in the next 2 months, balance = 5
+		# 2 more leave allocated in the next 2 months, balance = 5
 		allocate_earned_leaves_for_months(2)
 
+		# reset current date
+		frappe.flags.current_date = None
+
 		# 4 leaves consumed, current balance = 1
-		first_sunday = get_first_sunday(self.holiday_list, for_date=frappe.flags.current_date)
+		first_sunday = get_first_sunday(self.holiday_list)
 		leave_date = add_days(first_sunday, 1)
 		make_leave_application(self.employee.name, leave_date, add_days(leave_date, 3), self.leave_type)
 
 		# backdated leave application to consume 2 leaves - insufficient balance
-		frappe.flags.current_date = add_months(year_start, 1)
-		first_sunday = get_first_sunday(self.holiday_list, for_date=frappe.flags.current_date)
+		first_sunday = get_first_sunday(self.holiday_list, for_date=add_months(year_start, 1))
 		leave_from_date = add_days(first_sunday, 1)
 		leave_to_date = add_days(leave_from_date, 1)
 		with self.assertRaises(InsufficientLeaveBalanceError):

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1186,7 +1186,7 @@ class TestLeaveApplication(FrappeTestCase):
 def create_carry_forwarded_allocation(employee, leave_type, date=None):
 	date = date or nowdate()
 
-	# initial leave allocation
+	# initial leave allocation = 15 days
 	leave_allocation = create_leave_allocation(
 		leave_type="_Test_CF_leave_expiry",
 		employee=employee.name,
@@ -1197,7 +1197,7 @@ def create_carry_forwarded_allocation(employee, leave_type, date=None):
 	)
 	leave_allocation.submit()
 
-	# carry forward leave allocation
+	# carry forward leave allocation = 15 days
 	leave_allocation = create_leave_allocation(
 		leave_type="_Test_CF_leave_expiry",
 		employee=employee.name,


### PR DESCRIPTION
## Problem:

Eg:
Earned Leave configured to allocate 1 leave per month
Oct 2023: balance = 8/8

Dec 2023: balance = 1/10 (9 leaves applied in Dec, so balance is 1)

Try creating a backdated leave application in dec for oct for 1 leave
Balance = (8-9) = -1. This leads to insufficient leave balance error
Ideally, 1 leave consumption should be allowed, >1 should not be.

## Solution

While applying for a backdated leave - check the balance for the complete period to make sure this leave balance wasn't consumed later although no leaves were taken in Oct.

Ex: In the above case, when someone tries to apply for a leave in Dec for Oct adjust the leave balance:

`Adjusted Balance for Oct = min(Leave balance for Oct, Total allocation in full period - Total leaves taken in full period)
`
- [ ] Fix carry-forwarding edge cases