### PR TITLE
fix: rewrite attendance query in qb & add test for half-day attendance overwritten by leave application

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -145,18 +145,24 @@ class Attendance(Document):
 			frappe.throw(_("Cannot mark attendance for an Inactive employee {0}").format(self.employee))
 
 	def check_leave_record(self):
-		leave_record = frappe.db.sql(
-			"""
-			select leave_type, half_day, half_day_date, name
-			from `tabLeave Application`
-			where employee = %s
-				and %s between from_date and to_date
-				and status = 'Approved'
-				and docstatus = 1
-		""",
-			(self.employee, self.attendance_date),
-			as_dict=True,
-		)
+		LeaveApplication = frappe.qb.DocType("Leave Application")
+		leave_record = (
+			frappe.qb.from_(LeaveApplication)
+			.select(
+				LeaveApplication.leave_type,
+				LeaveApplication.half_day,
+				LeaveApplication.half_day_date,
+				LeaveApplication.name,
+			)
+			.where(
+				(LeaveApplication.employee == self.employee)
+				& (self.attendance_date >= LeaveApplication.from_date)
+				& (self.attendance_date <= LeaveApplication.to_date)
+				& (LeaveApplication.status == "Approved")
+				& (LeaveApplication.docstatus == 1)
+			)
+		).run(as_dict=True)
+
 		if leave_record:
 			for d in leave_record:
 				self.leave_type = d.leave_type

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -18,6 +18,7 @@ from frappe.utils import (
 from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_list
 
+from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.leave_allocation.test_leave_allocation import create_leave_allocation
 from hrms.hr.doctype.leave_application.leave_application import (
 	InsufficientLeaveBalanceError,
@@ -305,6 +306,29 @@ class TestLeaveApplication(FrappeTestCase):
 		dates = [d.attendance_date for d in attendance]
 		for d in ("2018-01-01", "2018-01-02", "2018-01-03"):
 			self.assertTrue(getdate(d) in dates)
+
+	def test_overwrite_half_day_attendance(self):
+		mark_attendance("_T-Employee-00001", "2023-01-02", "Absent")
+
+		make_allocation_record(from_date="2023-01-01", to_date="2023-12-31")
+		application = self.get_application(_test_records[0])
+		application.status = "Approved"
+		application.from_date = "2023-01-02"
+		application.to_date = "2023-01-02"
+		application.half_day = 1
+		application.half_day_date = "2023-01-02"
+		application.submit()
+
+		attendance = frappe.db.get_value(
+			"Attendance",
+			{"attendance_date": "2023-01-02"},
+			["status", "leave_type", "leave_application"],
+			as_dict=True,
+		)
+
+		self.assertEqual(attendance.status, "Half Day")
+		self.assertEqual(attendance.leave_type, "_Test Leave Type")
+		self.assertEqual(attendance.leave_application, application.name)
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_attendance_for_include_holidays(self):


### PR DESCRIPTION
Fixed linter issue with https://github.com/frappe/hrms/pull/1147 by converting query to QB
Added test for half-day attendance overwritten by leave application that was fixed here: https://github.com/frappe/hrms/pull/1148