### PR TITLE
fix(Payroll): accrual entry creation fails if any employee has no earnings

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -680,7 +680,7 @@ class PayrollEntry(Document):
 			}
 			"""
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-				payable_amount = employee_details.get("earnings") - (employee_details.get("deductions") or 0)
+				payable_amount = employee_details.get("earnings", 0) - employee_details.get("deductions", 0)
 
 				payable_amount = self.get_accounting_entries_and_payable_amount(
 					payroll_payable_account,
@@ -926,8 +926,8 @@ class PayrollEntry(Document):
 
 		if self.employee_based_payroll_payable_entries:
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-				je_payment_amount = employee_details.get("earnings") - (
-					employee_details.get("deductions") or 0
+				je_payment_amount = employee_details.get("earnings", 0) - (
+					employee_details.get("deductions", 0)
 				)
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(
 					self.payment_account, je_payment_amount, company_currency, currencies


### PR DESCRIPTION
<details>
<summary>Traceback</summary>


```python
Traceback with variables (most recent call last):
  File "apps/hrms/hrms/payroll/doctype/payroll_entry/payroll_entry.py", line 1463, in submit_salary_slips_for_employees
    payroll_entry.make_accrual_jv_entry(submitted)
      payroll_entry = <PayrollEntry: HR-PRUN-2023-00062 docstatus=1>
      salary_slips = (('Sal Slip/HR-EMP-00008/00004', 'Test'),)
      publish_progress = False
      submitted = [<SalarySlip: Sal Slip/HR-EMP-00008/00004 docstatus=1>]
      unsubmitted = []
      count = 1
      entry = ('Sal Slip/HR-EMP-00008/00004', 'Test')
      salary_slip = <SalarySlip: Sal Slip/HR-EMP-00008/00004 docstatus=1>
      e = TypeError("unsupported operand type(s) for -: 'NoneType' and 'float'")
  File "apps/hrms/hrms/payroll/doctype/payroll_entry/payroll_entry.py", line 549, in make_accrual_jv_entry
    self.set_payable_amount_against_payroll_payable_account(
      self = <PayrollEntry: HR-PRUN-2023-00062 docstatus=1>
      submitted_salary_slips = [<SalarySlip: Sal Slip/HR-EMP-00008/00004 docstatus=1>]
      employee_wise_accounting_enabled = 1
      earnings = {}
      deductions = {('Cash - F', 'Main - F'): 0.0}
      precision = 2
      accounts = []
      currencies = ['INR']
      payable_amount = 0.0
      accounting_dimensions = []
      company_currency = 'INR'
  File "apps/hrms/hrms/payroll/doctype/payroll_entry/payroll_entry.py", line 683, in set_payable_amount_against_payroll_payable_account
    payable_amount = employee_details.get("earnings") - employee_details.get("deductions", 0)
      self = <PayrollEntry: HR-PRUN-2023-00062 docstatus=1>
      accounts = []
      currencies = ['INR']
      company_currency = 'INR'
      accounting_dimensions = []
      precision = 2
      payable_amount = 0.0
      payroll_payable_account = 'Payroll Payable - F'
      employee_wise_accounting_enabled = 1
      employee = 'HR-EMP-00008'
      employee_details = {'deductions': 0.0}
builtins.TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```
</details>