### PR TITLE
fix: Duplicate Overwritten Salary error for other employee

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -123,8 +123,8 @@ class AdditionalSalary(Document):
 				"salary_component": self.salary_component,
 				"payroll_date": self.payroll_date,
 				"overwrite_salary_structure_amount": 1,
-				"employee" :  self.employee,
-				"docstatus" :  1,
+				"employee": self.employee,
+				"docstatus": 1,
 			},
 		)
 

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -123,6 +123,8 @@ class AdditionalSalary(Document):
 				"salary_component": self.salary_component,
 				"payroll_date": self.payroll_date,
 				"overwrite_salary_structure_amount": 1,
+				"employee" :  self.employee,
+				"docstatus" :  1,
 			},
 		)
 


### PR DESCRIPTION
The current ِadditional salary  employee was not added to the validation condition , which led to an error appearing to  get error for other employees additional salary 

Regression: https://github.com/frappe/hrms/pull/1108