### PR TITLE
fix(Org Chart): check if company is set before loading children

### DIFF
--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -219,8 +219,8 @@ hrms.HierarchyChart = class {
 			}
 		}).then(r => {
 			if (r.message.length) {
-				let expand_node = undefined;
-				let node = undefined;
+				let expand_node;
+				let node;
 
 				$.each(r.message, (_i, data) => {
 					if ($(`[id="${data.id}"]`).length)
@@ -229,7 +229,7 @@ hrms.HierarchyChart = class {
 					node = new me.Node({
 						id: data.id,
 						parent: $('<li class="child-node"></li>').appendTo(me.$hierarchy.find('.node-children')),
-						parent_id: undefined,
+						parent_id: '',
 						image: data.image,
 						name: data.name,
 						title: data.title,
@@ -371,8 +371,8 @@ hrms.HierarchyChart = class {
 	}
 
 	render_children_of_all_nodes(data_list) {
-		let entry = undefined;
-		let node = undefined;
+		let entry;
+		let node;
 
 		while (data_list.length) {
 			// to avoid overlapping connectors
@@ -427,7 +427,7 @@ hrms.HierarchyChart = class {
 			title: data.title,
 			expandable: data.expandable,
 			connections: data.connections,
-			children: undefined
+			children: null,
 		});
 	}
 
@@ -523,7 +523,7 @@ hrms.HierarchyChart = class {
 	collapse_previous_level_nodes(node) {
 		let node_parent = $(`[id="${node.parent_id}"]`);
 		let previous_level_nodes = node_parent.parent().parent().children('li');
-		let node_card = undefined;
+		let node_card;
 
 		previous_level_nodes.each(function() {
 			node_card = $(this).find('.node-card');
@@ -586,12 +586,12 @@ hrms.HierarchyChart = class {
 		level.nextAll('li').remove();
 
 		let nodes = level.find('.node-card');
-		let node_object = undefined;
+		let node_object;
 
 		$.each(nodes, (_i, element) => {
 			node_object = this.nodes[element.id];
 			node_object.expanded = 0;
-			node_object.$children = undefined;
+			node_object.$children = null;
 		});
 
 		nodes.removeClass('collapsed active-path');

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -80,7 +80,7 @@ hrms.HierarchyChart = class {
 			only_select: true,
 			reqd: 1,
 			change: () => {
-				me.company = undefined;
+				me.company = '';
 				$('#hierarchy-chart-wrapper').remove();
 
 				if (company.get_value()) {
@@ -286,6 +286,10 @@ hrms.HierarchyChart = class {
 	}
 
 	load_children(node, deep=false) {
+		if (!this.company) {
+			frappe.throw(__('Please select a company first.'));
+		}
+
 		if (!deep) {
 			frappe.run_serially([
 				() => this.get_child_nodes(node.id),

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -68,7 +68,7 @@ hrms.HierarchyChart = class {
 
 	show() {
 		this.setup_actions();
-		if ($(`[data-fieldname="company"]`).length) return;
+		if (this.page.main.find('[data-fieldname="company"]').length) return;
 		let me = this;
 
 		let company = this.page.add_field({

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -71,7 +71,7 @@ hrms.HierarchyChartMobile = class {
 			only_select: true,
 			reqd: 1,
 			change: () => {
-				me.company = undefined;
+				me.company = '';
 
 				if (company.get_value() && me.company != company.get_value()) {
 					me.company = company.get_value();
@@ -154,7 +154,7 @@ hrms.HierarchyChartMobile = class {
 					return new me.Node({
 						id: data.id,
 						parent: root_level,
-						parent_id: undefined,
+						parent_id: '',
 						image: data.image,
 						name: data.name,
 						title: data.title,
@@ -174,7 +174,7 @@ hrms.HierarchyChartMobile = class {
 
 		if (this.$sibling_group) {
 			const sibling_parent = this.$sibling_group.find('.node-group').attr('data-parent');
-			if (node.parent_id !== undefined && node.parent_id != sibling_parent)
+			if (node.parent_id != '' && node.parent_id != sibling_parent)
 				this.$sibling_group.empty();
 		}
 
@@ -281,7 +281,7 @@ hrms.HierarchyChartMobile = class {
 			title: data.title,
 			expandable: data.expandable,
 			connections: data.connections,
-			children: undefined
+			children: null
 		});
 	}
 
@@ -291,7 +291,7 @@ hrms.HierarchyChartMobile = class {
 
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
-		let connector = undefined;
+		let connector = null;
 
 		if ($(`[id="${parent_id}"]`).hasClass('active')) {
 			connector = this.get_connector_for_active_node(parent_node, child_node);
@@ -377,7 +377,7 @@ hrms.HierarchyChartMobile = class {
 		let node_element = $(`[id="${node.id}"]`);
 
 		node_element.click(function() {
-			let el = undefined;
+			let el = null;
 
 			if (node.is_root) {
 				el = $(this).detach();
@@ -411,7 +411,7 @@ hrms.HierarchyChartMobile = class {
 
 		$('.node-group').on('click', function() {
 			let parent = $(this).attr('data-parent');
-			if (parent === 'undefined') {
+			if (parent == '') {
 				me.setup_hierarchy();
 				me.render_root_nodes();
 			} else {
@@ -427,7 +427,7 @@ hrms.HierarchyChartMobile = class {
 
 		let node_object = this.nodes[node.id];
 		node_object.expanded = 0;
-		node_object.$children = undefined;
+		node_object.$children = null;
 		this.nodes[node.id] = node_object;
 	}
 
@@ -484,7 +484,7 @@ hrms.HierarchyChartMobile = class {
 
 		node.removeClass('active-child active-path');
 		node_object.expanded = 0;
-		node_object.$children = undefined;
+		node_object.$children = null;
 		this.nodes[node.id] = node_object;
 
 		// show parent's siblings and expand parent node
@@ -523,7 +523,7 @@ hrms.HierarchyChartMobile = class {
 		current_node.removeClass('active-child active-path');
 
 		node_object.expanded = 0;
-		node_object.$children = undefined;
+		node_object.$children = null;
 
 		level.empty().append(current_node);
 	}

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -225,6 +225,10 @@ hrms.HierarchyChartMobile = class {
 	}
 
 	load_children(node) {
+		if (!this.company) {
+			frappe.throw(__('Please select a company first'));
+		}
+
 		frappe.run_serially([
 			() => this.get_child_nodes(node.id),
 			(child_nodes) => this.render_child_nodes(node, child_nodes)

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -59,8 +59,8 @@ hrms.HierarchyChartMobile = class {
 	}
 
 	show() {
+		if (this.page.main.find('[data-fieldname="company"]').length) return;
 		let me = this;
-		if ($(`[data-fieldname="company"]`).length) return;
 
 		let company = this.page.add_field({
 			fieldtype: 'Link',


### PR DESCRIPTION
If someone goes to the employee master (or any route) and comes back to the chart & if the company field value is reset - on clicking "Expand All", the request is made without the company value.
`get_all_nodes() missing 1 required positional argument: 'company'`

Explicitly check for company value before loading children

**Other fixes:**
The company field doesn't get re-rendered on coming back to the org chart from the employee master. The check for the company field is truthy from the employee doctype, so it does not render the company field again if this transition is quick. Explicitly check for the company field on the same page. This results in a blank view