### PR TITLE
fix: comp leave request fails on leave period boundary dates

### DIFF
--- a/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_days, cint, date_diff, format_date, getdate
+from frappe.utils import add_days, cint, date_diff, format_date, get_url_to_list, getdate
 
 from hrms.hr.utils import (
 	create_additional_leave_ledger_entry,
@@ -75,7 +75,9 @@ class CompensatoryLeaveRequest(Document):
 		date_difference = date_diff(self.work_end_date, self.work_from_date) + 1
 		if self.half_day:
 			date_difference -= 0.5
-		leave_period = get_leave_period(self.work_from_date, self.work_end_date, company)
+
+		comp_leave_valid_from = add_days(self.work_end_date, 1)
+		leave_period = get_leave_period(comp_leave_valid_from, comp_leave_valid_from, company)
 		if leave_period:
 			leave_allocation = self.get_existing_allocation_for_period(leave_period)
 			if leave_allocation:
@@ -85,19 +87,22 @@ class CompensatoryLeaveRequest(Document):
 				leave_allocation.db_set("total_leaves_allocated", leave_allocation.total_leaves_allocated)
 
 				# generate additional ledger entry for the new compensatory leaves off
-				create_additional_leave_ledger_entry(
-					leave_allocation, date_difference, add_days(self.work_end_date, 1)
-				)
+				create_additional_leave_ledger_entry(leave_allocation, date_difference, comp_leave_valid_from)
 
 			else:
 				leave_allocation = self.create_leave_allocation(leave_period, date_difference)
 			self.db_set("leave_allocation", leave_allocation.name)
 		else:
-			frappe.throw(
-				_("There is no leave period in between {0} and {1}").format(
-					format_date(self.work_from_date), format_date(self.work_end_date)
-				)
+			comp_leave_valid_from = frappe.bold(format_date(comp_leave_valid_from))
+			msg = _("This compensatory leave will be applicable from {0}.").format(comp_leave_valid_from)
+			msg += " " + _(
+				"Currently, there is no {0} leave period for this date to create/update leave allocation."
+			).format(frappe.bold(_("active")))
+			msg += "<br><br>" + _("Please create a new {0} for the date {1} first.").format(
+				f"""<a href='{get_url_to_list("Leave Period")}'>Leave Period</a>""",
+				comp_leave_valid_from,
 			)
+			frappe.throw(msg, title=_("No Leave Period Found"))
 
 	def on_cancel(self):
 		if self.leave_allocation:

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -11,6 +11,7 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 
 from hrms.hr.doctype.leave_application.test_leave_application import get_first_sunday
 from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
+from hrms.tests.test_utils import add_date_to_holiday_list
 
 
 class TestShiftType(FrappeTestCase):
@@ -648,18 +649,3 @@ def make_shift_assignment(shift_type, employee, start_date, end_date=None, do_no
 		shift_assignment.submit()
 
 	return shift_assignment
-
-
-def add_date_to_holiday_list(date: str, holiday_list: str) -> None:
-	if frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": date}):
-		return
-
-	holiday_list = frappe.get_doc("Holiday List", holiday_list)
-	holiday_list.append(
-		"holidays",
-		{
-			"holiday_date": date,
-			"description": "test",
-		},
-	)
-	holiday_list.save()

--- a/hrms/tests/test_utils.py
+++ b/hrms/tests/test_utils.py
@@ -69,6 +69,21 @@ def get_first_day_for_prev_month():
 	return prev_month_first
 
 
+def add_date_to_holiday_list(date: str, holiday_list: str) -> None:
+	if frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": date}):
+		return
+
+	holiday_list = frappe.get_doc("Holiday List", holiday_list)
+	holiday_list.append(
+		"holidays",
+		{
+			"holiday_date": date,
+			"description": "test",
+		},
+	)
+	holiday_list.save()
+
+
 def create_company(name: str = "_Test Company"):
 	if frappe.db.exists("Company", name):
 		return frappe.get_doc("Company", name)


### PR DESCRIPTION
**Steps to replicate**:
1. Leave Period - 1/1/2023 - 31/12/2023
2. Present Attendance on 31/12/2023
3. Try creating a compensatory leave request for 31/12/2023. Errors out with this message:

<img width="1409" alt="image" src="https://github.com/frappe/hrms/assets/24353136/7363845d-112f-4b53-ab2f-056abe61b861">


**Fix**:

This is because compensatory leave request is applicable 1 day after work end date. In this case its 1/1/2024. So it should find the relevant allocation from that date but instead it finds allocation for work from & to dates (previous leave period) and tries to create a leave ledger entry from 01-01-2024 (applicable date)- 31-12-2023 (fetched allocation end date) (different leave periods).

Since comp off is applicable from the next date, find relevant leave period & allocation from that day onwards. Also improve error message when relevant leave period is missing instead of "There is no leave period in between {0} and {1}". User won't understand what the system is trying to do behind the scenes.

<img width="1344" alt="image" src="https://github.com/frappe/hrms/assets/24353136/72acfd6e-1ee7-459b-a524-b1a6add6a824">
