### PR TITLE
fix(Expense Claim): description not saved

### DIFF
--- a/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -59,6 +59,7 @@
   },
   {
    "fetch_from": "expense_type.description",
+   "fetch_if_empty": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "in_list_view": 1,
@@ -128,7 +129,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-08-07 14:07:19.298844",
+ "modified": "2024-01-08 11:47:28.315381",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Detail",


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/1256

Expense Description was being fetched from Expense Claim Type. It is now fetched only if the field is left empty.

`no-docs`