### PR TITLE
fix: get current leave period for leave balance report

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -58,14 +58,15 @@ frappe.query_reports["Employee Leave Balance"] = {
 			depends_on: "eval: !doc.employee",
 		}
 	],
-
 	onload: () => {
+		const today = frappe.datetime.now_date();
+
 		frappe.call({
 			type: "GET",
 			method: "hrms.hr.utils.get_leave_period",
 			args: {
-				"from_date": frappe.defaults.get_default("year_start_date"),
-				"to_date": frappe.defaults.get_default("year_end_date"),
+				"from_date": today,
+				"to_date": today,
 				"company": frappe.defaults.get_user_default("Company")
 			},
 			freeze: true,


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/1096

If the fiscal year is absent or defaults aren't set getting leave period fails. Get leave period based on current date like other reports