### PR TITLE
fix(Salary Slip): data evaluation

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -145,7 +145,7 @@ class SalarySlip(TransactionBase):
 		else:
 			self.get_working_days_details(lwp=self.leave_without_pay)
 
-		self.set_salary_structure_assignement()
+		self.set_salary_structure_assignment()
 		self.calculate_net_pay()
 		self.compute_year_to_date()
 		self.compute_month_to_date()
@@ -710,7 +710,7 @@ class SalarySlip(TransactionBase):
 			}
 			doc.append("earnings", wages_row)
 
-	def set_salary_structure_assignement(self):
+	def set_salary_structure_assignment(self):
 		self._salary_structure_assignment = frappe.db.get_value(
 			"Salary Structure Assignment",
 			{
@@ -1111,11 +1111,11 @@ class SalarySlip(TransactionBase):
 		employee = frappe.get_cached_doc("Employee", self.employee).as_dict()
 
 		if not hasattr(self, "_salary_structure_assignment"):
-			self.set_salary_structure_assignement()
+			self.set_salary_structure_assignment()
 
 		data.update(self._salary_structure_assignment)
-		data.update(employee)
 		data.update(self.as_dict())
+		data.update(employee)
 
 		data.update(self.get_component_abbr_map())
 


### PR DESCRIPTION
Closes: https://github.com/frappe/hrms/issues/1203

This issue does not arise due to the usage of string fields, but rather due to the data evaluation logic employed in Salary Slip.

Previously, the Employee data fields pulled for evaluation (such as Branch, Department, etc.) were being overwritten by the fields of the same name of the Salary Slip document. Since these fields were being fetched from Employee, they weren't updated in the unsaved document. The Employee fields were added to the dict (against which conditions/formulae are evaluated) before the Salary Slip fields. As a result, these fields became overwritten as None making them unusable for evaluation. 

Adding the Employee fields after the Salary Slip fields seems to fix the issue for now as all relevant fields of the same name (namely employee, employee_name, company, department, designation, branch, grade, ctc, and bank_name) are from Employee making it okay for them to be overwritten. However, if fields with the same name but storing different data were to be introduced, a better fix would be required.

`no-docs`