### PR TITLE
fix: expired leave balance is -ve when leaves taken > carry forwarded expired leaves

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -201,7 +201,10 @@ def get_allocated_and_expired_leaves(
 			# leave allocations ending before to_date, reduce leaves taken within that period
 			# since they are already used, they won't expire
 			expired_leaves += record.leaves
-			expired_leaves += get_leaves_for_period(employee, leave_type, record.from_date, record.to_date)
+			leaves_for_period = get_leaves_for_period(
+				employee, leave_type, record.from_date, record.to_date
+			)
+			expired_leaves -= min(abs(leaves_for_period), record.leaves)
 
 		if record.from_date >= getdate(from_date):
 			if record.is_carry_forward:


### PR DESCRIPTION
**Before:**

CF leaves = 11
Leaves taken = 12

In this case, all CF leaves are used and 1 leave is used from the new allocation but expired leaves show up as -1. 
<img width="1302" alt="expired" src="https://github.com/frappe/hrms/assets/24353136/7a67f96e-8cc6-4ae7-a3f6-2be7ab0f724c">

**After:**
<img width="1302" alt="image" src="https://github.com/frappe/hrms/assets/24353136/7f165031-9b81-41d4-980e-d3dd03fc8c8a">
