### PR TITLE
fix: incorrect calculation for expiring carry forwarded leaves in leave ledger entry scheduled job

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -17,6 +17,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Leave Period")
 		frappe.db.delete("Leave Allocation")
+		frappe.db.delete("Leave Application")
 		frappe.db.delete("Leave Ledger Entry")
 
 		emp_id = make_employee("test_leave_allocation@salary.com", company="_Test Company")
@@ -323,6 +324,107 @@ class TestLeaveAllocation(FrappeTestCase):
 		leave_allocation_1.submit()
 
 		self.assertEqual(leave_allocation_1.unused_leaves, leave_allocation.new_leaves_allocated)
+
+	def test_carry_forward_leaves_expiry_after_partially_used_leaves(self):
+		from hrms.payroll.doctype.salary_slip.test_salary_slip import make_leave_application
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=90,
+		)
+
+		# initial leave allocation = 5
+		leave_allocation = create_leave_allocation(
+			employee=self.employee.name,
+			leave_type="_Test_CF_leave_expiry",
+			from_date=add_months(nowdate(), -24),
+			to_date=add_months(nowdate(), -12),
+			new_leaves_allocated=5,
+			carry_forward=0,
+		)
+		leave_allocation.submit()
+
+		# carry-forward 5 leaves + 15 new leaves
+		leave_allocation = create_leave_allocation(
+			employee=self.employee.name,
+			leave_type="_Test_CF_leave_expiry",
+			from_date=add_days(nowdate(), -90),
+			to_date=add_days(nowdate(), 100),
+			carry_forward=1,
+		)
+		leave_allocation.submit()
+
+		# leave application for 3 days
+		make_leave_application(
+			self.employee.name,
+			leave_allocation.from_date,
+			add_days(leave_allocation.from_date, 2),
+			leave_type.name,
+		)
+
+		# only unused carry-forwarded leaves should expire
+		process_expired_allocation()
+		expired_leaves = frappe.db.get_value(
+			"Leave Ledger Entry",
+			dict(
+				transaction_name=leave_allocation.name,
+				is_expired=1,
+				is_carry_forward=1,
+			),
+			"leaves",
+		)
+		self.assertEqual(expired_leaves, -2)
+
+	def test_carry_forward_leaves_expiry_after_completely_used_leaves(self):
+		from hrms.payroll.doctype.salary_slip.test_salary_slip import make_leave_application
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test_CF_leave_expiry",
+			is_carry_forward=1,
+			expire_carry_forwarded_leaves_after_days=90,
+		)
+
+		# initial leave allocation = 5
+		leave_allocation = create_leave_allocation(
+			employee=self.employee.name,
+			leave_type="_Test_CF_leave_expiry",
+			from_date=add_months(nowdate(), -24),
+			to_date=add_months(nowdate(), -12),
+			new_leaves_allocated=5,
+			carry_forward=0,
+		)
+		leave_allocation.submit()
+
+		# carry-forward 5 leaves + 15 new leaves
+		leave_allocation = create_leave_allocation(
+			employee=self.employee.name,
+			leave_type="_Test_CF_leave_expiry",
+			from_date=add_days(nowdate(), -90),
+			to_date=add_days(nowdate(), 100),
+			carry_forward=1,
+		)
+		leave_allocation.submit()
+
+		# leave application for 6 days, all cf leaves used
+		make_leave_application(
+			self.employee.name,
+			leave_allocation.from_date,
+			add_days(leave_allocation.from_date, 5),
+			leave_type.name,
+		)
+
+		# 0 leaves should expire
+		process_expired_allocation()
+		expired_leaves = frappe.db.exists(
+			"Leave Ledger Entry",
+			dict(
+				transaction_name=leave_allocation.name,
+				is_expired=1,
+				is_carry_forward=1,
+			),
+		)
+		self.assertIsNone(expired_leaves)
 
 	def test_creation_of_leave_ledger_entry_on_submit(self):
 		leave_allocation = create_leave_allocation(

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -130,7 +130,7 @@ def process_expired_allocation():
 	expire_allocation = frappe.db.sql(
 		"""
 		SELECT
-			leaves, to_date, employee, leave_type,
+			leaves, to_date, from_date, employee, leave_type,
 			is_carry_forward, transaction_name as name, transaction_type
 		FROM `tabLeave Ledger Entry` l
 		WHERE (NOT EXISTS
@@ -218,7 +218,7 @@ def expire_carried_forward_allocation(allocation):
 		args = frappe._dict(
 			transaction_name=allocation.name,
 			transaction_type="Leave Allocation",
-			leaves=allocation.leaves * -1,
+			leaves=leaves * -1,
 			is_carry_forward=allocation.is_carry_forward,
 			is_expired=1,
 			from_date=allocation.to_date,

--- a/hrms/hr/doctype/leave_type/test_leave_type.py
+++ b/hrms/hr/doctype/leave_type/test_leave_type.py
@@ -9,7 +9,7 @@ test_records = frappe.get_test_records("Leave Type")
 def create_leave_type(**args):
 	args = frappe._dict(args)
 	if frappe.db.exists("Leave Type", args.leave_type_name):
-		frappe.delete_doc("Leave Type", args.leave_type_name)
+		frappe.delete_doc("Leave Type", args.leave_type_name, force=True)
 
 	leave_type = frappe.get_doc(
 		{


### PR DESCRIPTION
The `hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation` scheduled job is use to expire any unused carry forwarded leaves for employee. For current Implementation the calculation for expired carry forwarded leave is incorrect as it will expired all carry forwarded leaves in Leave Allocation instead of only expiring unused carry forwarded leaves.

## Versions
The issue affects version-13 ERPNext, version-14, and version-15 HRMS

### Changes Made
Updated the logic to expire only unused carry forwarded leaves.

### Test Cases
Employee have 10 carry forwarded leaves and the carry forwarded leaves will be expired in 31st March, and 20 new leaves are allocated for this year. Total leaves is 10 CF leaves and 20 new leaves = 30 Leaves.
| Leaves Taken before 31st March | Expected Expired Carry Forwarded Laves | Result |
|--------|--------|--------|
| 0 | 10 | ✅ |
| 8 | 2 | ✅ |
| 10 | 0 | ✅ |
| 12 | 0 | ✅ | 


This fix addresses the issue across version-13 ERPNext, version-14, and version-15 HRMS. Please review and merge the pull request to ensure the correct functionality of the scheduled job in these versions.