### PR TITLE
fix(Payroll Entry): permissibility of Queued status doc cancellation

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -52,6 +52,8 @@ frappe.ui.form.on('Payroll Entry', {
 	},
 
 	refresh: function (frm) {
+		if (frm.doc.status === "Queued") frm.page.btn_secondary.hide()
+
 		if (frm.doc.docstatus === 0 && !frm.is_new()) {
 			frm.page.clear_primary_action();
 			frm.add_custom_button(__("Get Employees"),


### PR DESCRIPTION
Creation of a Payroll Entry is followed by the creation of its associated Salary Slips. Cancellation/Deletion of said Payroll Entry while its Salary Slips are still being created could result in stale Slips that would otherwise have been deleted with the Entry.

This PR, therefore, hides the Cancel button for Payroll Entries till all Slips have been created.

`no-docs`