### PR TITLE
fix(FnF): inform user where to set the Relieving Date & add desc for Assets Allocated table

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
@@ -103,8 +103,7 @@
    "fieldname": "relieving_date",
    "fieldtype": "Date",
    "label": "Relieving Date ",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fetch_from": "employee.date_of_joining",
@@ -114,6 +113,7 @@
    "read_only": 1
   },
   {
+   "description": "Automatically fetches all assets allocated to the employee, if any",
    "fieldname": "section_break_15",
    "fieldtype": "Section Break",
    "label": "Assets Allocated"
@@ -181,10 +181,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-11-05 00:05:09.892560",
+ "modified": "2024-01-11 18:06:22.669089",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Full and Final Statement",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -221,12 +222,13 @@
    "report": 1,
    "role": "HR Manager",
    "share": 1,
-   "submit": 1, 
+   "submit": 1,
    "write": 1
   }
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "employee_name",
  "track_changes": 1
 }

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -12,11 +12,22 @@ class FullandFinalStatement(Document):
 		self.get_outstanding_statements()
 
 	def validate(self):
+		self.validate_relieving_date()
 		self.get_assets_statements()
 		if self.docstatus == 1:
 			self.validate_settlement("payables")
 			self.validate_settlement("receivables")
 			self.validate_asset()
+
+	def validate_relieving_date(self):
+		if not self.relieving_date:
+			frappe.throw(
+				_("Please set {0} for Employee {1}").format(
+					frappe.bold(_("Relieving Date")),
+					get_link_to_form("Employee", self.employee),
+				),
+				title=_("Missing Relieving Date"),
+			)
 
 	def validate_settlement(self, component_type):
 		for data in self.get(component_type, []):


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/131

**Before**:

Relieving Date field is mandatory and read-only as it's fetched from the Employee. So if the relieving date is not set in Employee, the message prompts for missing mandatory fields but empty read-only fields are hidden so it's confusing for the user.

**After**:

Explicitly inform the user where to set the relieving date
<img width="1294" alt="image" src="https://github.com/frappe/hrms/assets/24353136/1f7f9b56-84db-4124-a19b-46197f24c840">

The assets Allocated table is auto-filled if there are any existing assets and is not supposed to be manually entered. Add description for explanation
