### PR TITLE
fix(Expense Claim): Pass company to properly pick currency for each record

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim_list.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim_list.js
@@ -1,0 +1,3 @@
+frappe.listview_settings["Expense Claim"] = {
+	add_fields: ["company"]
+}


### PR DESCRIPTION
We need to load company of each record in the list so that currency gets picked up properly in case of multi-currency setup.

**Before:**
<img width="1290" alt="Screenshot 2024-01-19 at 4 39 11 PM" src="https://github.com/frappe/hrms/assets/13928957/db4a2f9f-c6b0-4010-98f3-dfb97b192c60">
Here Donna raised expense claim in **USD** but it shows **INR** in list view cause the system was picking currency from global defaults. (or in some case from `doc` in `cur_frm` variable)

**After:**
<img width="1295" alt="Screenshot 2024-01-19 at 4 38 29 PM" src="https://github.com/frappe/hrms/assets/13928957/9ed6f688-1cb6-4636-9ec5-cbf0e0ca2673">

> resolves: 8673

