### PR TITLE
fix(Employee Advance): Return amount cannot be greater than unclaim…

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -122,7 +122,9 @@ class EmployeeAdvance(Document):
 				EmployeeAdvanceOverPayment,
 			)
 
-		if flt(return_amount) > 0 and flt(return_amount) > (self.paid_amount - self.claimed_amount):
+		if flt(return_amount) > 0 and flt(return_amount) > round(
+			(self.paid_amount - self.claimed_amount), 2
+		):
 			frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
 
 		self.db_set("paid_amount", paid_amount)


### PR DESCRIPTION
fix: (Employee Advance ) Return amount cannot be greater than unclaimed amount

get error massage if claimed_amount have fractions as desribed below :

flt(return_amount) > (self.paid_amount - self.claimed_amount)
619.35 > (2000.0 - 1380.65 )
619.35 > 619.3499999999999
After add round round(self.paid_amount - self.claimed_amount),2)
619.35 > 619.35