### PR TITLE
ENH: allow using Email Template for Salary Slip

### DIFF
--- a/hrms/payroll/doctype/payroll_settings/payroll_settings.json
+++ b/hrms/payroll/doctype/payroll_settings/payroll_settings.json
@@ -22,6 +22,7 @@
   "email_salary_slip_to_employee",
   "sender",
   "sender_email",
+  "email_template",
   "column_break_iewr",
   "encrypt_salary_slips_in_emails",
   "password_policy",
@@ -172,13 +173,20 @@
    "fieldtype": "Data",
    "label": "Sender Email",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.email_salary_slip_to_employee",
+   "fieldname": "email_template",
+   "fieldtype": "Link",
+   "label": "Email Template",
+   "options": "Email Template"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-01 13:51:04.225492",
+ "modified": "2024-01-23 17:42:52.958013",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Settings",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1794,21 +1794,32 @@ class SalarySlip(TransactionBase):
 	def email_salary_slip(self):
 		receiver = frappe.db.get_value("Employee", self.employee, "prefered_email", cache=True)
 		payroll_settings = frappe.get_single("Payroll Settings")
-		message = "Please see attachment"
+
+		subject = "Salary Slip - from {0} to {1}".format(self.start_date, self.end_date)
+		message = _("Please see attachment")
+
+		if payroll_settings.email_template:
+			email_template = frappe.get_doc("Email Template", payroll_settings.email_template)
+			doc = frappe.get_doc("Salary Slip", self.name)
+			context = doc.as_dict()
+			subject = frappe.render_template(email_template.subject, context)
+			message = frappe.render_template(email_template.response_, context)
+
 		password = None
 		if payroll_settings.encrypt_salary_slips_in_emails:
 			password = generate_password_for_pdf(payroll_settings.password_policy, self.employee)
-			message += """<br>Note: Your salary slip is password protected,
-				the password to unlock the PDF is of the format {0}. """.format(
-				payroll_settings.password_policy
-			)
+			if not payroll_settings.email_template:
+				message += _("""<br>Note: Your salary slip is password protected,
+					the password to unlock the PDF is of the format {0}. """.format(
+					payroll_settings.password_policy)
+				)
 
 		if receiver:
 			email_args = {
 				"sender": payroll_settings.sender_email,
 				"recipients": [receiver],
-				"message": _(message),
-				"subject": "Salary Slip - from {0} to {1}".format(self.start_date, self.end_date),
+				"message": message,
+				"subject": subject,
 				"attachments": [
 					frappe.attach_print(self.doctype, self.name, file_name=self.name, password=password)
 				],


### PR DESCRIPTION
This enhancement add option to use Email Template in Payroll Setting when sending salary slip.

![image](https://github.com/frappe/hrms/assets/1973598/288ad873-9f07-436b-9ad0-89ba0089fe3a)
