### PR TITLE
feat(Payroll): Option to use Email Template when send Salary Slip email

### DIFF
--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -20,7 +20,7 @@ from hrms.hr.doctype.interview.interview import (
 	update_job_applicant_status,
 )
 from hrms.hr.doctype.job_applicant.job_applicant import get_interview_details
-from hrms.tests.test_utils import create_job_applicant
+from hrms.tests.test_utils import create_job_applicant, get_email_by_subject
 
 
 class TestInterview(FrappeTestCase):
@@ -317,7 +317,3 @@ def setup_reminder_settings():
 	hr_settings.interview_reminder_template = _("Interview Reminder")
 	hr_settings.feedback_reminder_notification_template = _("Interview Feedback Reminder")
 	hr_settings.save()
-
-
-def get_email_by_subject(subject: str) -> bool:
-	return frappe.db.exists("Email Queue", {"message": ("like", f"%{subject}%")})

--- a/hrms/payroll/doctype/payroll_settings/payroll_settings.json
+++ b/hrms/payroll/doctype/payroll_settings/payroll_settings.json
@@ -22,6 +22,7 @@
   "email_salary_slip_to_employee",
   "sender",
   "sender_email",
+  "email_template",
   "column_break_iewr",
   "encrypt_salary_slips_in_emails",
   "password_policy",
@@ -172,13 +173,20 @@
    "fieldtype": "Data",
    "label": "Sender Email",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.email_salary_slip_to_employee",
+   "fieldname": "email_template",
+   "fieldtype": "Link",
+   "label": "Email Template",
+   "options": "Email Template"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-01 13:51:04.225492",
+ "modified": "2024-01-23 17:42:52.958013",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Settings",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1794,21 +1794,23 @@ class SalarySlip(TransactionBase):
 	def email_salary_slip(self):
 		receiver = frappe.db.get_value("Employee", self.employee, "prefered_email", cache=True)
 		payroll_settings = frappe.get_single("Payroll Settings")
+
 		subject = "Salary Slip - from {0} to {1}".format(self.start_date, self.end_date)
 		message = _("Please see attachment")
 		if payroll_settings.email_template:
 			email_template = frappe.get_doc("Email Template", payroll_settings.email_template)
-			doc = frappe.get_doc("Salary Slip", self.name)
-			context = doc.as_dict()
+			context = self.as_dict()
 			subject = frappe.render_template(email_template.subject, context)
-			message = frappe.render_template(email_template.response_, context)
+			message = frappe.render_template(email_template.response, context)
+
 		password = None
 		if payroll_settings.encrypt_salary_slips_in_emails:
 			password = generate_password_for_pdf(payroll_settings.password_policy, self.employee)
 			if not payroll_settings.email_template:
-				message += _("""<br>Note: Your salary slip is password protected,
-					the password to unlock the PDF is of the format {0}. """.format(
-					payroll_settings.password_policy)
+				message += "<br>" + _(
+					"Note: Your salary slip is password protected, the password to unlock the PDF is of the format {0}.".format(
+						payroll_settings.password_policy
+					)
 				)
 
 		if receiver:

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1808,10 +1808,8 @@ class SalarySlip(TransactionBase):
 			password = generate_password_for_pdf(payroll_settings.password_policy, self.employee)
 			if not payroll_settings.email_template:
 				message += "<br>" + _(
-					"Note: Your salary slip is password protected, the password to unlock the PDF is of the format {0}.".format(
-						payroll_settings.password_policy
-					)
-				)
+					"Note: Your salary slip is password protected, the password to unlock the PDF is of the format {0}."
+				).format(payroll_settings.password_policy)
 
 		if receiver:
 			email_args = {

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -45,7 +45,7 @@ from hrms.payroll.doctype.salary_slip.salary_slip import (
 )
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
-from hrms.tests.test_utils import get_first_sunday
+from hrms.tests.test_utils import get_email_by_subject, get_first_sunday
 
 
 class TestSalarySlip(FrappeTestCase):
@@ -605,12 +605,10 @@ class TestSalarySlip(FrappeTestCase):
 		ss.save()
 		ss.submit()
 
-		email_queue = frappe.db.a_row_exists("Email Queue")
-		self.assertTrue(email_queue)
+		self.assertIsNotNone(get_email_by_subject("Salary Slip - from"))
 
 	@change_settings(
-		"Payroll Settings",
-		{"email_salary_slip_to_employee": 1, "email_template": "Salary Slip"}
+		"Payroll Settings", {"email_salary_slip_to_employee": 1, "email_template": "Salary Slip"}
 	)
 	def test_email_salary_slip_with_email_template(self):
 		frappe.db.delete("Email Queue")
@@ -621,8 +619,7 @@ class TestSalarySlip(FrappeTestCase):
 		ss.save()
 		ss.submit()
 
-		email_queue = frappe.db.a_row_exists("Email Queue")
-		self.assertTrue(email_queue)
+		self.assertIsNotNone(get_email_by_subject("Test Salary Slip Email Template"))
 
 	@if_lending_app_installed
 	def test_loan_repayment_salary_slip(self):
@@ -2415,7 +2412,7 @@ def create_ss_email_template():
 				"doctype": "Email Template",
 				"name": "Salary Slip",
 				"response": "Test Salary Slip",
-				"subject": "Test Subject",
+				"subject": "Test Salary Slip Email Template",
 				"owner": frappe.session.user,
 			}
 		)

--- a/hrms/tests/test_utils.py
+++ b/hrms/tests/test_utils.py
@@ -130,3 +130,7 @@ def create_job_applicant(**args):
 	job_applicant.update(filters)
 	job_applicant.save()
 	return job_applicant
+
+
+def get_email_by_subject(subject: str) -> str | None:
+	return frappe.db.exists("Email Queue", {"message": ("like", f"%{subject}%")})


### PR DESCRIPTION
Because the standard message "Please see attachment" on email salary slip is too raw. It is better to use email template.
![image](https://github.com/frappe/hrms/assets/1973598/c49d270f-4382-4b9f-9841-9ac52e5cff49)

Docs added here: https://frappehr.com/docs/v14/en/salary-slip#3-4-bulk-email-salary-slips