### PR TITLE
fix: change hook name for advance payment doctypes

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -228,7 +228,7 @@ scheduler_events = {
 	"monthly": ["hrms.controllers.employee_reminders.send_reminders_in_advance_monthly"],
 }
 
-advance_payment_doctypes = ["Gratuity", "Employee Advance"]
+advance_payment_payable_doctypes = ["Gratuity", "Employee Advance"]
 
 invoice_doctypes = ["Expense Claim"]
 


### PR DESCRIPTION
Employee advance & gratuity settlement failing due to changed hook name in https://github.com/frappe/erpnext/pull/38560
Depends on: https://github.com/frappe/erpnext/pull/39535

Only applicable for `develop`. Breaking change in ERPNext

<img width="1058" alt="image" src="https://github.com/frappe/hrms/assets/24353136/383230e1-306c-41aa-bb61-b7362eaf9745">