### PR TITLE
feat(minor): Show leave allocation table in Leave Application on refresh hook

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -105,7 +105,7 @@ frappe.ui.form.on("Leave Application", {
 		}
 
 		frm.trigger("set_employee");
-		if (frm.doc.employee) {
+		if (frm.doc.docstatus === 0) {
 			frm.trigger("make_dashboard");
 		}
 	},

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -105,6 +105,9 @@ frappe.ui.form.on("Leave Application", {
 		}
 
 		frm.trigger("set_employee");
+		if (frm.doc.employee) {
+			frm.trigger("make_dashboard");
+		}
 	},
 
 	async set_employee(frm) {


### PR DESCRIPTION
## What's changed:
- Show leave allocation dashboard on `refresh` hook.  This will allow managers to view the leaves allocated all the time.

`no-docs`

Closes: #1360