### PR TITLE
fix: separate tab for HR and Payroll in company

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -20,3 +20,4 @@ hrms.patches.v14_0.update_loan_repayment_repay_from_salary
 hrms.patches.v15_0.migrate_loan_type_to_loan_product
 hrms.patches.v15_0.rename_and_update_leave_encashment_fields
 hrms.patches.v14_0.update_title_in_employee_onboarding_and_separation_templates
+hrms.patches.v15_0.make_hr_settings_tab_in_company_master

--- a/hrms/patches/v15_0/make_hr_settings_tab_in_company_master.py
+++ b/hrms/patches/v15_0/make_hr_settings_tab_in_company_master.py
@@ -1,0 +1,22 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	custom_fields = {
+		"Company": [
+			{
+				"fieldname": "hr_and_payroll_tab",
+				"fieldtype": "Tab Break",
+				"label": "HR & Payroll",
+				"insert_after": "credit_limit",
+			},
+			{
+				"fieldname": "hr_settings_section",
+				"fieldtype": "Section Break",
+				"label": "HR & Payroll Settings",
+				"insert_after": "hr_and_payroll_tab",
+			},
+		],
+	}
+
+	create_custom_fields(custom_fields)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -133,10 +133,16 @@ def get_custom_fields():
 		],
 		"Company": [
 			{
+				"fieldname": "hr_and_payroll_tab",
+				"fieldtype": "Tab Break",
+				"label": "HR & Payroll",
+				"insert_after": "credit_limit",
+			},
+			{
 				"fieldname": "hr_settings_section",
 				"fieldtype": "Section Break",
 				"label": "HR & Payroll Settings",
-				"insert_after": "credit_limit",
+				"insert_after": "hr_and_payroll_tab",
 			},
 			{
 				"depends_on": "eval:!doc.__islocal",


### PR DESCRIPTION
![image](https://github.com/frappe/hrms/assets/95610320/720f69cf-5fb8-4b24-a080-3c09cacaa007)

Relocating **HR and payroll settings** from the **Buying and Selling tab** to a separate section for improved clarity and ease of navigation

![image](https://github.com/frappe/hrms/assets/95610320/0aec51b5-7c95-40fb-978e-938a3ab64632)
