### PR TITLE
fix: employee advance option added to payment entry

### DIFF
--- a/hrms/public/js/erpnext/payment_entry.js
+++ b/hrms/public/js/erpnext/payment_entry.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Payment Entry", {
 			} else if (frm.doc.party_type == "Supplier") {
 				doctypes = ["Purchase Order", "Purchase Invoice", "Journal Entry"];
 			} else if (frm.doc.party_type == "Employee") {
-				doctypes = ["Expense Claim", "Employee Advance","Journal Entry"];
+				doctypes = ["Expense Claim", "Employee Advance", "Journal Entry"];
 			} else {
 				doctypes = ["Journal Entry"];
 			}
@@ -32,7 +32,6 @@ frappe.ui.form.on("Payment Entry", {
 			}
 
 			if (child.reference_doctype == "Expense Claim") {
-				filters["docstatus"] = 1;
 				filters["is_paid"] = 0;
 			}
 

--- a/hrms/public/js/erpnext/payment_entry.js
+++ b/hrms/public/js/erpnext/payment_entry.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Payment Entry", {
 			} else if (frm.doc.party_type == "Supplier") {
 				doctypes = ["Purchase Order", "Purchase Invoice", "Journal Entry"];
 			} else if (frm.doc.party_type == "Employee") {
-				doctypes = ["Expense Claim", "Journal Entry"];
+				doctypes = ["Expense Claim", "Employee Advance","Journal Entry"];
 			} else {
 				doctypes = ["Journal Entry"];
 			}
@@ -34,6 +34,10 @@ frappe.ui.form.on("Payment Entry", {
 			if (child.reference_doctype == "Expense Claim") {
 				filters["docstatus"] = 1;
 				filters["is_paid"] = 0;
+			}
+
+			if (child.reference_doctype == "Employee Advance") {
+				filters["status"] = "Unpaid";
 			}
 
 			return {


### PR DESCRIPTION
We can create a payment entry for an employee advance using a custom button within the 'Employee Advance' Doctype. However, currently, there is no direct way to select and process multiple employee advances together within the payment entry.

Before:
![before](https://github.com/frappe/hrms/assets/34086262/b41df58b-04ca-47e2-9490-5ae9e4c0dc30)


After:
![after](https://github.com/frappe/hrms/assets/34086262/3b67b6fe-f772-4ea7-9a32-9bdd53e31749)
