### PR TITLE
fix: "is_query_report" check for Vehicle Expenses Report

### DIFF
--- a/hrms/hr/workspace/expense_claims/expense_claims.json
+++ b/hrms/hr/workspace/expense_claims/expense_claims.json
@@ -247,7 +247,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Vehicle Expenses",
    "link_count": 0,
    "link_to": "Vehicle Expenses",

--- a/hrms/hr/workspace/expense_claims/expense_claims.json
+++ b/hrms/hr/workspace/expense_claims/expense_claims.json
@@ -256,7 +256,7 @@
    "type": "Link"
   }
  ],
- "modified": "2023-08-02 10:19:14.376183",
+ "modified": "2024-02-05 09:10:45.636550",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claims",


### PR DESCRIPTION
![image](https://github.com/frappe/hrms/assets/95610320/682b2a14-0272-46f8-9a17-0b4f90f2bf0e)

When we click on 'Vehicle Expenses' in the workspace, it does not navigate to the report view; instead, it navigates to the doctype.

![image](https://github.com/frappe/hrms/assets/95610320/df9888e0-11fe-49b3-a6db-6fc4eda9a607)


