### PR TITLE
fix(Expense Claim): status update on document cancellation

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -54,32 +54,26 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 		precision = self.precision("grand_total")
 
-		if (
-			(
-				# set as paid
-				self.is_paid
-				or (
-					flt(self.total_sanctioned_amount) > 0
-					and (
-						# grand total is reimbursed
-						(flt(self.grand_total, precision) == flt(self.total_amount_reimbursed, precision))
-						# grand total (to be paid) is 0 since linked advances already cover the claimed amount
-						or (flt(self.grand_total, precision) == 0)
+		if self.docstatus == 1:
+			if self.approval_status == "Approved":
+				if (
+					# set as paid
+					self.is_paid
+					or (
+						flt(self.total_sanctioned_amount) > 0
+						and (
+							# grand total is reimbursed
+							(flt(self.grand_total, precision) == flt(self.total_amount_reimbursed, precision))
+							# grand total (to be paid) is 0 since linked advances already cover the claimed amount
+							or (flt(self.grand_total, precision) == 0)
+						)
 					)
-				)
-			)
-			and self.docstatus == 1
-			and self.approval_status == "Approved"
-		):
-			status = "Paid"
-		elif (
-			flt(self.total_sanctioned_amount) > 0
-			and self.docstatus == 1
-			and self.approval_status == "Approved"
-		):
-			status = "Unpaid"
-		elif self.docstatus == 1 and self.approval_status == "Rejected":
-			status = "Rejected"
+				):
+					status = "Paid"
+				elif flt(self.total_sanctioned_amount) > 0:
+					status = "Unpaid"
+			elif self.approval_status == "Rejected":
+				status = "Rejected"
 
 		if update:
 			self.db_set("status", status)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -55,21 +55,22 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		precision = self.precision("grand_total")
 
 		if (
-			# set as paid
-			self.is_paid
-			or (
-				flt(self.total_sanctioned_amount) > 0
-				and (
-					# grand total is reimbursed
-					(
-						self.docstatus == 1
-						and flt(self.grand_total, precision) == flt(self.total_amount_reimbursed, precision)
+			(
+				# set as paid
+				self.is_paid
+				or (
+					flt(self.total_sanctioned_amount) > 0
+					and (
+						# grand total is reimbursed
+						(flt(self.grand_total, precision) == flt(self.total_amount_reimbursed, precision))
+						# grand total (to be paid) is 0 since linked advances already cover the claimed amount
+						or (flt(self.grand_total, precision) == 0)
 					)
-					# grand total (to be paid) is 0 since linked advances already cover the claimed amount
-					or (flt(self.grand_total, precision) == 0)
 				)
 			)
-		) and self.approval_status == "Approved":
+			and self.docstatus == 1
+			and self.approval_status == "Approved"
+		):
 			status = "Paid"
 		elif (
 			flt(self.total_sanctioned_amount) > 0


### PR DESCRIPTION
Expense Claim status remains "Paid" after canceling, if it has been Paid and Approved, whereas it should be "Cancelled". 

`no-docs`