### PR TITLE
fix: change server-action args

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -187,18 +187,13 @@ def get_skill_wise_average_rating(interview: str) -> list[dict]:
 
 
 @frappe.whitelist()
-def update_job_applicant_status(args):
-	import json
-
+def update_job_applicant_status(status: str, job_applicant: str):
 	try:
-		if isinstance(args, str):
-			args = json.loads(args)
-
-		if not args.get("job_applicant"):
+		if not job_applicant:
 			frappe.throw(_("Please specify the job applicant to be updated."))
 
-		job_applicant = frappe.get_doc("Job Applicant", args["job_applicant"])
-		job_applicant.status = args["status"]
+		job_applicant = frappe.get_doc("Job Applicant", job_applicant)
+		job_applicant.status = status
 		job_applicant.save()
 
 		frappe.msgprint(

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -188,7 +188,7 @@ class TestInterview(FrappeTestCase):
 		job_applicant = create_job_applicant()
 		interview = create_interview_and_dependencies(job_applicant.name, status="Cleared")
 
-		update_job_applicant_status({"job_applicant": job_applicant.name, "status": "Accepted"})
+		update_job_applicant_status(job_applicant=job_applicant.name, status="Accepted")
 		job_applicant.reload()
 
 		self.assertEqual(job_applicant.status, "Accepted")


### PR DESCRIPTION
We accept flat argument instead of `args` now. Ref: https://github.com/frappe/frappe/pull/24782
