### PR TITLE
fix: don't consider holidays as Absent when 'Consider Unmarked Attendance As' = Absent

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -543,16 +543,19 @@ class SalarySlip(TransactionBase):
 
 	def _get_marked_attendance_days(self, holidays: list | None = None) -> float:
 		Attendance = frappe.qb.DocType("Attendance")
-		return (
+		query = (
 			frappe.qb.from_(Attendance)
 			.select(Count("*"))
 			.where(
 				(Attendance.attendance_date.between(self.actual_start_date, self.actual_end_date))
 				& (Attendance.employee == self.employee)
 				& (Attendance.docstatus == 1)
-				& (Attendance.attendance_date.notin(holidays))
 			)
-		).run()[0][0]
+		)
+		if holidays:
+			query = query.where(Attendance.attendance_date.notin(holidays))
+
+		return query.run()[0][0]
 
 	def get_payment_days(self, include_holidays_in_total_working_days):
 		if self.joining_date and self.joining_date > getdate(self.end_date):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -232,14 +232,11 @@ class TestSalarySlip(FrappeTestCase):
 
 		new_emp_id = make_employee("test_payment_days_based_on_joining_date@salary.com")
 		joining_date, relieving_date = add_days(month_start_date, 3), add_days(month_end_date, -5)
-		holidays = 0
 
 		for days in range(date_diff(relieving_date, joining_date) + 1):
 			date = add_days(joining_date, days)
 			if not is_holiday("Salary Slip Test Holiday List", date):
 				mark_attendance(new_emp_id, date, "Present", ignore_validate=True)
-			else:
-				holidays += 1
 
 		frappe.db.set_value(
 			"Employee",
@@ -518,6 +515,55 @@ class TestSalarySlip(FrappeTestCase):
 		frappe.db.set_single_value("Payroll Settings", "consider_marked_attendance_on_holidays", 0)
 		ss.save()
 		self.assertEqual(ss.total_working_days, no_of_days[0])
+
+	@change_settings(
+		"Payroll Settings",
+		{
+			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Absent",
+			"include_holidays_in_total_working_days": 1,
+			"consider_marked_attendance_on_holidays": 1,
+		},
+	)
+	def test_consider_marked_attendance_on_holidays_with_unmarked_attendance(self):
+		from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
+
+		no_of_days = get_no_of_days()
+		month_start_date, month_end_date = get_first_day(nowdate()), get_last_day(nowdate())
+		joining_date = add_days(month_start_date, 3)
+
+		emp_id = make_employee(
+			"test_salary_slip_with_holidays_included@salary.com",
+			status="Active",
+			joining_date=joining_date,
+			relieving_date=None,
+		)
+
+		for days in range(date_diff(month_end_date, add_days(joining_date, 1)) + 1):
+			date = add_days(joining_date, days)
+			if not is_holiday("Salary Slip Test Holiday List", date):
+				mark_attendance(emp_id, date, "Present", ignore_validate=True)
+
+		# mark absent on holiday
+		first_sunday = get_first_sunday(for_date=getdate())
+		mark_attendance(emp_id, first_sunday, "Absent", ignore_validate=True)
+
+		ss = make_employee_salary_slip(
+			emp_id,
+			"Monthly",
+			"Test Salary Slip With Holidays Included",
+		)
+
+		self.assertEqual(ss.total_working_days, no_of_days[0])
+		# no_of_days - absent on holiday - period before DOJ - 1 unmarked attendance
+		self.assertEqual(ss.payment_days, no_of_days[0] - 1 - 3 - 1)
+
+		# disable consider marked attendance on holidays
+		frappe.db.set_single_value("Payroll Settings", "consider_marked_attendance_on_holidays", 0)
+		ss.save()
+		self.assertEqual(ss.total_working_days, no_of_days[0])
+		# no_of_days - period before DOJ
+		self.assertEqual(ss.payment_days, no_of_days[0] - 3 - 1)
 
 	@change_settings("Payroll Settings", {"include_holidays_in_total_working_days": 1})
 	def test_payment_days(self):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -254,7 +254,7 @@ class TestSalarySlip(FrappeTestCase):
 		)
 
 		self.assertEqual(new_ss.total_working_days, no_of_days[0])
-		self.assertEqual(new_ss.payment_days, no_of_days[0] - holidays - 8)
+		self.assertEqual(new_ss.payment_days, no_of_days[0] - 8)
 
 	@change_settings(
 		"Payroll Settings",


### PR DESCRIPTION
## Problem:

**Payroll Settings:** 

<img width="1315" alt="image" src="https://github.com/frappe/hrms/assets/24353136/f9f1539a-bace-4cd1-b5be-ad546433903a">
<br>

**Employee with complete attendance marked for the month but has 4 holidays - these are being considered under absent days because of unmarked attendance**

<img width="1109" alt="image" src="https://github.com/frappe/hrms/assets/24353136/e4e6f6d9-2055-435f-89b0-1f0db2d1640e">

## After Fix

<img width="1126" alt="image" src="https://github.com/frappe/hrms/assets/24353136/45c7cdb2-2772-403e-8fd5-9fb8af432390">

- [x] Simplify `get_unmarked_days`
- [x] Check consider marked attendance on holidays setting impact

