### PR TITLE
fix(expense-claim): resolve bug in description field while saving

### DIFF
--- a/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -58,8 +58,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "expense_type.description",
-   "fetch_if_empty": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "in_list_view": 1,


### PR DESCRIPTION
### Bug Description
When saving an ERPNext expense claim, the description field in the expenses table was not getting saved and whatever we write in the field, it disappears as soon as we save. This was due to the "fetch from" and "fetch_if_empty" properties in the expense_claim_detail.json file.

-Before changing the anything.
        As shown in the below picture description field in the expense claim detail child doctype has **fetch from: Expense Claim Type (expense_type)** and **field: Description (small text)**, due to this when we save the expense claim doctype the description entered will disappear. 
<img width="944" alt="image" src="https://github.com/BNMAHESH01/hrms/assets/108056582/61470fe7-9761-4969-9527-01187b997cfb">

##Solution for this bug

-By enabling the **fetch on save if empty.**
<img width="195" alt="image" src="https://github.com/BNMAHESH01/hrms/assets/108056582/c0f3597b-443b-4889-a5c2-f8c83863385b">

-By removing **fetch from** 
<img width="202" alt="image" src="https://github.com/BNMAHESH01/hrms/assets/108056582/c719b122-645f-41d9-a501-f16bed65f34c">


My suggestion would be removing unnecessary filed **fetch from**, so I have removed the problematic lines.



### Changes Made
Removed the problematic lines:
- "fetch_from": "expense_type.description"
- "fetch_if_empty": 1

### Testing
Tested the fix by creating and saving an expense claim with a description in the expenses table.
