### PR TITLE
chore(Employee Onboarding): Grant access to HR Manager

### DIFF
--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
@@ -195,7 +195,7 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  }
+  },
   {
     "amend": 1,
     "cancel": 1,

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
@@ -196,6 +196,18 @@
    "submit": 1,
    "write": 1
   }
+  {
+    "amend": 1,
+    "cancel": 1,
+    "create": 1,
+    "export": 1,
+    "print": 1,
+    "read": 1,
+    "role": "HR Manager",
+    "share": 1,
+    "submit": 1,
+    "write": 1
+   }
  ],
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
### Description:
This pull request addresses the need to grant HR Managers access to the employee onboarding doctype in ERPNext. Currently, only system administrators have access to this doctype, which limits the ability of HR Managers to efficiently onboard new employees.

### Changes Made:
- Added permissions for HR Managers to create and manage records in the employee onboarding doctype.
- Updated role permissions to include HR Managers in the appropriate access groups.

### Testing:
- Tested the new permissions by logging in as an HR Manager and verifying that they can create and manage employee onboarding records.
- Conducted thorough testing to ensure that granting access to HR Managers does not impact existing functionality or security measures.
- Verified that permissions are correctly enforced and that HR Managers are only able to access the employee onboarding doctype.

### Notes:
- This change aligns with the organization's requirements for delegation of HR tasks and improves efficiency in the employee onboarding process.
- ERPNext version 15.

### Labels:
- Feature
