### PR TITLE
fix(Leave Application): Corrected rendering of Leave Application email template when HTML format is used

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -588,7 +588,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			frappe.msgprint(_("Please set default template for Leave Status Notification in HR Settings."))
 			return
 		email_template = frappe.get_doc("Email Template", template)
-		message = frappe.render_template(email_template.response, args)
+		message = frappe.render_template(email_template.response_, args)
 
 		self.notify(
 			{
@@ -613,7 +613,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				)
 				return
 			email_template = frappe.get_doc("Email Template", template)
-			message = frappe.render_template(email_template.response, args)
+			message = frappe.render_template(email_template.response_, args)
 
 			self.notify(
 				{


### PR DESCRIPTION
Closes #1426 

When the Email Notification template for Leave Application uses HTML and the use HTML checkbox is selected, the correct property for referencing the template response is `response_` rather than `response`. The same has been corrected.
