### PR TITLE
feat: pass doctype as context when translating label

### DIFF
--- a/hrms/hr/employee_property_update.js
+++ b/hrms/hr/employee_property_update.js
@@ -57,7 +57,7 @@ frappe.ui.form.on(cur_frm.doctype, {
 			frappe.model.with_doctype("Employee", () => {
 				const field_label_map = {};
 				frappe.get_meta("Employee").fields.forEach(d => {
-					field_label_map[d.fieldname] = __(d.label) + ` (${d.fieldname})`;
+					field_label_map[d.fieldname] = __(d.label, null, d.parent) + ` (${d.fieldname})`;
 					if (
 						!in_list(exclude_field_types, d.fieldtype)
 						&& !in_list(exclude_fields, d.fieldname)


### PR DESCRIPTION
Whenever a field label is translated, pass the parent doctype as context. This way, the same label can be translated differently for different doctypes. (The doctype is already passed as context when generating translation files.)

> no-docs