### PR TITLE
fix(Payroll Entry): consideration of Salary Slip Based on Timesheet as a filter query when it is disabled

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -217,7 +217,7 @@ frappe.ui.form.on('Payroll Entry', {
 			'currency', 'department', 'branch', 'designation', 'salary_slip_based_on_timesheet','grade'];
 
 		fields.forEach(field => {
-			if (frm.doc[field]) {
+			if (frm.doc[field] || frm.doc[field] === 0) {
 				filters[field] = frm.doc[field];
 			}
 		});


### PR DESCRIPTION
### Problem

Currently, the **Employee Details** table returns no results when **Salary Slip Based on Timesheet** is disabled. This is  due to a condition which permits only truthly values while adding filters. As a result, a disabled `salary_slip_based_on_timesheet` field having a value of `0` is ignored.

### Solution

Updating said condition to permit `0` values as well fixes it.