### PR TITLE
refactor: update exchange rate of reference document supplied by reconciliation tool

### DIFF
--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -28,7 +28,10 @@ class EmployeePaymentEntry(PaymentEntry):
 			return ("Expense Claim", "Journal Entry", "Employee Advance", "Gratuity")
 
 	def set_missing_ref_details(
-		self, force: bool = False, update_ref_details_only_for: list | None = None
+		self,
+		force: bool = False,
+		update_ref_details_only_for: list | None = None,
+		ref_exchange_rate: float | None = None,
 	) -> None:
 		for d in self.get("references"):
 			if d.allocated_amount:
@@ -40,6 +43,9 @@ class EmployeePaymentEntry(PaymentEntry):
 				ref_details = get_payment_reference_details(
 					d.reference_doctype, d.reference_name, self.party_account_currency
 				)
+
+				if ref_exchange_rate:
+					ref_details.update({"exchange_rate": ref_exchange_rate})
 
 				for field, value in ref_details.items():
 					if d.exchange_gain_loss:


### PR DESCRIPTION
While reconciling, use exchange_rate supplied by reconciliation tool
part of: https://github.com/frappe/erpnext/pull/40149