### PR TITLE
fix: company fixture setup error handling & flags

### DIFF
--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -31,13 +31,11 @@ def delete_company_fixtures():
 		except (ImportError, AttributeError):
 			# regional file or method does not exist
 			pass
-		except Exception:
-			frappe.log_error("Unable to delete country fixtures for HRMS")
-			frappe.throw(
-				_("Failed to delete defaults for country {0}. Please contact support.").format(
-					frappe.bold(country)
-				)
-			)
+		except Exception as e:
+			frappe.log_error("Unable to delete country fixtures for Frappe HR")
+			msg = _("Failed to delete defaults for country {0}.").format(frappe.bold(country))
+			msg += "<br><br>" + _("{0}: {1}").format(frappe.bold(_("Error")), get_error_message(e))
+			frappe.throw(msg, title=_("Country Fixture Deletion Failed"))
 
 
 def run_regional_setup(country):
@@ -46,13 +44,24 @@ def run_regional_setup(country):
 		frappe.get_attr(module_name)()
 	except ImportError:
 		pass
+	except Exception as e:
+		frappe.log_error("Unable to setup country fixtures for Frappe HR")
+		msg = _("Failed to setup defaults for country {0}.").format(frappe.bold(country))
+		msg += "<br><br>" + _("{0}: {1}").format(frappe.bold(_("Error")), get_error_message(e))
+		frappe.throw(msg, title=_("Country Setup failed"))
+
+
+def get_error_message(error) -> str:
+	try:
+		message_log = frappe.message_log.pop() if frappe.message_log else str(error)
+		if isinstance(message_log, str):
+			error_message = json.loads(message_log).get("message")
+		else:
+			error_message = message_log.get("message")
 	except Exception:
-		frappe.log_error("Unable to setup country fixtures for HRMS")
-		frappe.throw(
-			_("Failed to setup defaults for country {0}. Please contact support.").format(
-				frappe.bold(country)
-			)
-		)
+		error_message = message_log
+
+	return error_message
 
 
 def make_salary_components(country):

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -240,7 +240,8 @@ def add_custom_roles_for_reports():
 		"Income Tax Deductions",
 	):
 		if not frappe.db.get_value("Custom Role", dict(report=report_name)):
-			frappe.get_doc(
+			doc = frappe.new_doc("Custom Role")
+			doc.update(
 				dict(
 					doctype="Custom Role",
 					report=report_name,

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -246,7 +246,7 @@ def add_custom_roles_for_reports():
 					report=report_name,
 					roles=[dict(role="HR User"), dict(role="HR Manager"), dict(role="Employee")],
 				)
-			).insert()
+			).insert(ignore_permissions=True)
 
 
 def create_gratuity_rule_for_india():
@@ -272,5 +272,4 @@ def create_gratuity_rule_for_india():
 			],
 		}
 	)
-	rule.flags.ignore_mandatory = True
-	rule.save()
+	rule.insert(ignore_permissions=True, ignore_mandatory=True)

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -243,7 +243,6 @@ def add_custom_roles_for_reports():
 			doc = frappe.new_doc("Custom Role")
 			doc.update(
 				dict(
-					doctype="Custom Role",
 					report=report_name,
 					roles=[dict(role="HR User"), dict(role="HR Manager"), dict(role="Employee")],
 				)

--- a/hrms/regional/united_arab_emirates/setup.py
+++ b/hrms/regional/united_arab_emirates/setup.py
@@ -12,9 +12,7 @@ def create_gratuity_rules_for_uae():
 	docs = get_gratuity_rules()
 	for d in docs:
 		doc = frappe.get_doc(d)
-		doc.flags.ignore_mandatory = True
-		doc.flags.ignore_permissions = True
-		doc.insert(ignore_if_duplicate=True)
+		doc.insert(ignore_if_duplicate=True, ignore_permissions=True, ignore_mandatory=True)
 
 
 def get_gratuity_rules():

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -12,7 +12,7 @@ from hrms.overrides.company import delete_company_fixtures
 
 
 def after_install():
-	create_custom_fields(get_custom_fields())
+	create_custom_fields(get_custom_fields(), ignore_validate=True)
 	create_salary_slip_loan_fields()
 	make_fixtures()
 	setup_notifications()
@@ -302,7 +302,7 @@ def get_custom_fields():
 
 def create_salary_slip_loan_fields():
 	if "lending" in frappe.get_installed_apps():
-		create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
+		create_custom_fields(SALARY_SLIP_LOAN_FIELDS, ignore_validate=True)
 
 
 def after_app_install(app_name):
@@ -311,7 +311,7 @@ def after_app_install(app_name):
 		return
 
 	print("Updating payroll setup for loans")
-	create_custom_fields(SALARY_SLIP_LOAN_FIELDS)
+	create_custom_fields(SALARY_SLIP_LOAN_FIELDS, ignore_validate=True)
 
 
 def before_app_uninstall(app_name):


### PR DESCRIPTION
If the user creating a company does not have access to custom fields, the company set up fails but the error message is very generic - Failed to setup defaults for country India

- Improve the error message
   <img width="1296" alt="image" src="https://github.com/frappe/hrms/assets/24353136/4c6f13eb-fcfe-46e3-8857-12b9530b7b67">
- Ignore mandatory, permissions wherever possible
