### PR TITLE
fix(PWA): decouple FCM initialization failures from service worker registrations

### DIFF
--- a/frontend/public/frappe-push-notification.js
+++ b/frontend/public/frappe-push-notification.js
@@ -87,11 +87,17 @@ class FrappePushNotification {
 		if (this.webConfig !== null && this.webConfig !== undefined) {
 			return this.webConfig
 		}
-		let url = `${FrappePushNotification.relayServerBaseURL}/api/method/notification_relay.api.get_config?project_name=${this.projectName}`
-		let response = await fetch(url)
-		let response_json = await response.json()
-		this.webConfig = response_json.config
-		return this.webConfig
+		try {
+			let url = `${FrappePushNotification.relayServerBaseURL}/api/method/notification_relay.api.get_config?project_name=${this.projectName}`
+			let response = await fetch(url)
+			let response_json = await response.json()
+			this.webConfig = response_json.config
+			return this.webConfig
+		} catch (e) {
+			throw new Error(
+				"Push Notification Relay is not configured properly on your site."
+			)
+		}
 	}
 
 	/**
@@ -103,11 +109,17 @@ class FrappePushNotification {
 		if (this.vapidPublicKey !== "") {
 			return this.vapidPublicKey
 		}
-		let url = `${FrappePushNotification.relayServerBaseURL}/api/method/notification_relay.api.get_config?project_name=${this.projectName}`
-		let response = await fetch(url)
-		let response_json = await response.json()
-		this.vapidPublicKey = response_json.vapid_public_key
-		return this.vapidPublicKey
+		try {
+			let url = `${FrappePushNotification.relayServerBaseURL}/api/method/notification_relay.api.get_config?project_name=${this.projectName}`
+			let response = await fetch(url)
+			let response_json = await response.json()
+			this.vapidPublicKey = response_json.vapid_public_key
+			return this.vapidPublicKey
+		} catch (e) {
+			throw new Error(
+				"Push Notification Relay is not configured properly on your site."
+			)
+		}
 	}
 
 	/**

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -11,47 +11,54 @@ precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
 const jsonConfig = new URL(location).searchParams.get("config")
-const firebaseApp = initializeApp(JSON.parse(jsonConfig))
-const messaging = getMessaging(firebaseApp)
 
-function isChrome() {
-	return navigator.userAgent.toLowerCase().includes("chrome")
-}
+// Firebase config initialization
+try {
+	const firebaseApp = initializeApp(JSON.parse(jsonConfig))
+	const messaging = getMessaging(firebaseApp)
 
-onBackgroundMessage(messaging, (payload) => {
-	const notificationTitle = payload.data.title
-	let notificationOptions = {
-		body: payload.data.body || "",
+	function isChrome() {
+		return navigator.userAgent.toLowerCase().includes("chrome")
 	}
-	if (payload.data.notification_icon) {
-		notificationOptions["icon"] = payload.data.notification_icon
-	}
-	if (isChrome()) {
-		notificationOptions["data"] = {
-			url: payload.data.click_action,
-		}
-	} else {
-		if (payload.data.click_action) {
-			notificationOptions["actions"] = [
-				{
-					action: payload.data.click_action,
-					title: "View Details",
-				},
-			]
-		}
-	}
-	self.registration.showNotification(notificationTitle, notificationOptions)
-})
 
-if (isChrome()) {
-	self.addEventListener("notificationclick", (event) => {
-		event.stopImmediatePropagation()
-		event.notification.close()
-		if (event.notification.data && event.notification.data.url) {
-			clients.openWindow(event.notification.data.url)
+	onBackgroundMessage(messaging, (payload) => {
+		const notificationTitle = payload.data.title
+		let notificationOptions = {
+			body: payload.data.body || "",
 		}
+		if (payload.data.notification_icon) {
+			notificationOptions["icon"] = payload.data.notification_icon
+		}
+		if (isChrome()) {
+			notificationOptions["data"] = {
+				url: payload.data.click_action,
+			}
+		} else {
+			if (payload.data.click_action) {
+				notificationOptions["actions"] = [
+					{
+						action: payload.data.click_action,
+						title: "View Details",
+					},
+				]
+			}
+		}
+		self.registration.showNotification(notificationTitle, notificationOptions)
 	})
+
+	if (isChrome()) {
+		self.addEventListener("notificationclick", (event) => {
+			event.stopImmediatePropagation()
+			event.notification.close()
+			if (event.notification.data && event.notification.data.url) {
+				clients.openWindow(event.notification.data.url)
+			}
+		})
+	}
+} catch (error) {
+	console.log("Failed to initialize Firebase", error)
 }
 
 self.skipWaiting()
 clientsClaim()
+console.log("Service Worker Initialized")


### PR DESCRIPTION
Continued fixes in https://github.com/frappe/hrms/pull/1384

**Problem**:

If the site is not hosted on FC - the default relay server is not available for push. Incorrect URL set in site config will cause FCM initialization to fail and in turn, fail service worker registration too.

Handle service worker registration successfully even if FCM initialization fails