### PR TITLE
refactor: replace `in_list(array, member)` with `array.includes(member)`

### DIFF
--- a/hrms/public/js/erpnext/journal_entry.js
+++ b/hrms/public/js/erpnext/journal_entry.js
@@ -49,7 +49,7 @@ frappe.ui.form.on("Journal Entry", {
 				]
 			};
 
-			if (in_list(["Sales Invoice", "Purchase Invoice"], jvd.reference_type)) {
+			if (["Sales Invoice", "Purchase Invoice"].includes(jvd.reference_type)) {
 				out.filters.push([jvd.reference_type, "outstanding_amount", "!=", 0]);
 				// Filter by cost center
 				if (jvd.cost_center) {
@@ -61,7 +61,7 @@ frappe.ui.form.on("Journal Entry", {
 				out.filters.push([jvd.reference_type, party_account_field, "=", jvd.account]);
 			}
 
-			if (in_list(["Sales Order", "Purchase Order"], jvd.reference_type)) {
+			if (["Sales Order", "Purchase Order"].includes(jvd.reference_type)) {
 				// party_type and party mandatory
 				frappe.model.validate_missing(jvd, "party_type");
 				frappe.model.validate_missing(jvd, "party");


### PR DESCRIPTION
`in_list` is [discouraged by our semgrep rules](https://github.com/frappe/semgrep-rules/blob/92e1241cd9894caf478f644e8383f908824b1950/rules/code_quality.yml#L12-L18) and leads to a warning whenever we edit this file