### PR TITLE
refactor(UX): show leave application links in leave allocation cancellation message

### DIFF
--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -38,9 +38,12 @@ def validate_leave_allocation_against_leave_application(ledger):
 	)
 
 	if leave_application_records:
+		leave_application_links = []
+		for leave_application in leave_application_records:
+			leave_application_links.append(frappe.utils.get_link_to_form("Leave Application", leave_application))
 		frappe.throw(
 			_("Leave allocation {0} is linked with the Leave Application {1}").format(
-				ledger.transaction_name, ", ".join(leave_application_records)
+				ledger.transaction_name, ", ".join(leave_application_links)
 			)
 		)
 

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -43,7 +43,7 @@ def validate_leave_allocation_against_leave_application(ledger):
 			leave_application_links.append(frappe.utils.get_link_to_form("Leave Application", leave_application))
 		frappe.throw(
 			_("Leave allocation {0} is linked with the Leave Application {1}").format(
-				ledger.transaction_name, ", ".join(leave_application_links)
+				ledger.transaction_name, ", ".join(get_link_to_form("Leave Application", application) for application in leave_application_records)
 			)
 		)
 

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -40,7 +40,7 @@ def validate_leave_allocation_against_leave_application(ledger):
 	if leave_application_records:
 		frappe.throw(
 			_("Leave allocation {0} is linked with the Leave Application {1}").format(
-				ledger.transaction_name, 
+				ledger.transaction_name,
 				", ".join(
 					get_link_to_form("Leave Application", application)
 					for application in leave_application_records

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import DATE_FORMAT, flt, getdate, today
+from frappe.utils import DATE_FORMAT, flt, getdate, today, get_link_to_form
 
 
 class LeaveLedgerEntry(Document):

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -38,9 +38,6 @@ def validate_leave_allocation_against_leave_application(ledger):
 	)
 
 	if leave_application_records:
-		leave_application_links = []
-		for leave_application in leave_application_records:
-			leave_application_links.append(frappe.utils.get_link_to_form("Leave Application", leave_application))
 		frappe.throw(
 			_("Leave allocation {0} is linked with the Leave Application {1}").format(
 				ledger.transaction_name, ", ".join(get_link_to_form("Leave Application", application) for application in leave_application_records)

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import DATE_FORMAT, flt, getdate, today, get_link_to_form
+from frappe.utils import DATE_FORMAT, flt, get_link_to_form, getdate, today
 
 
 class LeaveLedgerEntry(Document):
@@ -40,7 +40,11 @@ def validate_leave_allocation_against_leave_application(ledger):
 	if leave_application_records:
 		frappe.throw(
 			_("Leave allocation {0} is linked with the Leave Application {1}").format(
-				ledger.transaction_name, ", ".join(get_link_to_form("Leave Application", application) for application in leave_application_records)
+				ledger.transaction_name, 
+				", ".join(
+					get_link_to_form("Leave Application", application)
+					for application in leave_application_records
+				),
 			)
 		)
 


### PR DESCRIPTION
Issue: #1519
When Cancel Leave allocation linked Leave Application Are Shown in Link Format
Before:
![image](https://github.com/frappe/hrms/assets/101092028/c8cefadd-867d-4215-84e3-18a87ed18999)
After:
[Screencast from 11-03-24 07:06:38 PM IST.webm](https://github.com/frappe/hrms/assets/101092028/9f52b7e0-0300-4bc1-bdec-b6f3e76d266a)
