### PR TITLE
fix: connections in organizational chart cards to show active employees

### DIFF
--- a/hrms/hr/page/organizational_chart/organizational_chart.py
+++ b/hrms/hr/page/organizational_chart/organizational_chart.py
@@ -43,7 +43,7 @@ def get_connections(employee: str, lft: int, rgt: int) -> int:
 	query = (
 		frappe.qb.from_(Employee)
 		.select(Count(Employee.name))
-		.where((Employee.lft > lft) & (Employee.rgt < rgt))
+		.where((Employee.lft > lft) & (Employee.rgt < rgt) & (Employee.status == "Active"))
 	).run()
 
 	return query[0][0]


### PR DESCRIPTION
Before: The employee card in the organizational chart shows all employee - active and inactive as connections
<img width="400" alt="Screenshot 2024-03-12 at 10 17 05 PM" src="https://github.com/frappe/hrms/assets/52369157/2a26ef21-8352-4533-b2b2-2fdd6f0c198f">
After:  It shows only the active employees maintaining consistency with the number of connection nodes in the chart
<img width="400" alt="Screenshot 2024-03-12 at 10 17 22 PM" src="https://github.com/frappe/hrms/assets/52369157/c6294a7b-beb0-467b-8483-57277c75e351">
(closes #1511)
