### PR TITLE
fix: honour 'Consider Marked Attendance on Holidays' for Half Day

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -676,7 +676,7 @@ class SalarySlip(TransactionBase):
 
 			# skip counting absent on holidays
 			if not consider_marked_attendance_on_holidays and getdate(d.attendance_date) in holidays:
-				if d.status == "Absent" or (
+				if d.status in ["Absent", "Half Day"] or (
 					d.leave_type
 					and d.leave_type in leave_type_map.keys()
 					and not leave_type_map[d.leave_type]["include_holiday"]

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -570,6 +570,55 @@ class TestSalarySlip(FrappeTestCase):
 		# no_of_days - period before DOJ
 		self.assertEqual(ss.payment_days, no_of_days[0] - 3 - 1)
 
+	@change_settings(
+		"Payroll Settings",
+		{
+			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Present",
+			"include_holidays_in_total_working_days": 1,
+			"consider_marked_attendance_on_holidays": 0,
+		},
+	)
+	def test_consider_marked_attendance_on_holidays_with_half_day_on_holiday(self):
+		from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
+
+		no_of_days = get_no_of_days()
+		month_start_date, month_end_date = get_first_day(nowdate()), get_last_day(nowdate())
+		joining_date = add_days(month_start_date, 3)
+
+		emp_id = make_employee(
+			"test_salary_slip_with_holidays_included1@salary.com",
+			status="Active",
+			date_of_joining=joining_date,
+			relieving_date=None,
+		)
+
+		for days in range(date_diff(month_end_date, joining_date) + 1):
+			date = add_days(joining_date, days)
+			if not is_holiday("Salary Slip Test Holiday List", date):
+				mark_attendance(emp_id, date, "Present", ignore_validate=True)
+
+		# mark half day on holiday
+		first_sunday = get_first_sunday(for_date=joining_date, find_after_for_date=True)
+		mark_attendance(emp_id, first_sunday, "Half Day", ignore_validate=True)
+
+		ss = make_employee_salary_slip(
+			emp_id,
+			"Monthly",
+			"Test Salary Slip With Holidays Included",
+		)
+
+		self.assertEqual(ss.total_working_days, no_of_days[0])
+		# no_of_days - period before DOJ
+		self.assertEqual(ss.payment_days, no_of_days[0] - 3)
+
+		# enable consider marked attendance on holidays
+		frappe.db.set_single_value("Payroll Settings", "consider_marked_attendance_on_holidays", 1)
+		ss.save()
+		self.assertEqual(ss.total_working_days, no_of_days[0])
+		# no_of_days - period before DOJ - 0.5 LWP on holiday (half day present)
+		self.assertEqual(ss.payment_days, no_of_days[0] - 3 - 0.5)
+
 	@change_settings("Payroll Settings", {"include_holidays_in_total_working_days": 1})
 	def test_payment_days(self):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import (


### PR DESCRIPTION
**Before**:

- **Consider Marked Attendance on Holidays** is disabled
- Half Day Attendance marked for a day without Leave Type
- This counts as 0.5 LWP and reduces pay

<img width="1168" alt="image" src="https://github.com/frappe/hrms/assets/24353136/594db464-c61e-420c-ab67-b3c07cbe7dcd">


**After**:

- Honour 'Consider Marked Attendance on Holidays' for Half Day too. Currently only checks for Absent assuming Half Day attendance has a leave type linked

<img width="1168" alt="image" src="https://github.com/frappe/hrms/assets/24353136/bbcf24f0-8f85-4195-8dcf-70f4bd573eea">
