### PR TITLE
feat(Gratuity): allow setting work experience manually

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.js
+++ b/hrms/payroll/doctype/gratuity/gratuity.js
@@ -48,22 +48,18 @@ frappe.ui.form.on('Gratuity', {
 			});
 		}
 	},
+
 	employee: function (frm) {
 		frm.events.calculate_work_experience_and_amount(frm);
 	},
+
 	gratuity_rule: function (frm) {
 		frm.events.calculate_work_experience_and_amount(frm);
 	},
-	calculate_work_experience_and_amount: function (frm) {
 
+	calculate_work_experience_and_amount: function (frm) {
 		if (frm.doc.employee && frm.doc.gratuity_rule) {
-			frappe.call({
-				method: "hrms.payroll.doctype.gratuity.gratuity.calculate_work_experience_and_amount",
-				args: {
-					employee: frm.doc.employee,
-					gratuity_rule: frm.doc.gratuity_rule
-				}
-			}).then((r) => {
+			frm.call("calculate_work_experience_and_amount").then((r) => {
 				frm.set_value("current_work_experience", r.message['current_work_experience']);
 				frm.set_value("amount", r.message['amount']);
 			});

--- a/hrms/payroll/doctype/gratuity/gratuity.json
+++ b/hrms/payroll/doctype/gratuity/gratuity.json
@@ -60,8 +60,7 @@
    "default": "0",
    "fieldname": "current_work_experience",
    "fieldtype": "Int",
-   "label": "Current Work Experience",
-   "read_only": 1
+   "label": "Current Work Experience"
   },
   {
    "default": "0",
@@ -200,7 +199,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-09 15:47:13.353555",
+ "modified": "2024-03-15 02:50:10.282517",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Gratuity",

--- a/hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+++ b/hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
@@ -63,8 +63,8 @@
    "default": "Round off Work Experience",
    "fieldname": "work_experience_calculation_function",
    "fieldtype": "Select",
-   "label": "Work Experience Calculation method",
-   "options": "Round off Work Experience\nTake Exact Completed Years"
+   "label": "Work Experience Calculation Method",
+   "options": "Round off Work Experience\nTake Exact Completed Years\nManual"
   },
   {
    "default": "365",
@@ -93,7 +93,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-01-05 12:36:32.412409",
+ "modified": "2024-03-15 01:48:52.295003",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Gratuity Rule",


### PR DESCRIPTION
Added an option to manually set work experience in gratuity
<img width="1328" alt="image" src="https://github.com/frappe/hrms/assets/24353136/10cd1356-8028-4781-b059-97fb2eba1fda">

Will refactor the code in a separate PR

`no-docs` (temp)

Useful if historical attendance data is not present in the system or need to conditionally count a year in years of experience