### PR TITLE
fix: bold in group by and options mapping

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -84,6 +84,10 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 		const group_by = frappe.query_report.get_filter_value('group_by');
 
 		if (!summarized_view) {
+			if (group_by && column.colIndex === 1) {
+				value = "<strong>" + value + "</strong>";
+			}
+
 			if ((group_by && column.colIndex > 3) || (!group_by && column.colIndex > 2)) {
 				if (value == 'P' || value == 'WFH')
 					value = "<span style='color:green'>" + value + "</span>";

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -83,11 +83,11 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 		const summarized_view = frappe.query_report.get_filter_value('summarized_view');
 		const group_by = frappe.query_report.get_filter_value('group_by');
 
-		if (!summarized_view) {
-			if (group_by && column.colIndex === 1) {
-				value = "<strong>" + value + "</strong>";
-			}
+		if (group_by && column.colIndex === 1) {
+			value = "<strong>" + value + "</strong>";
+		}
 
+		if (!summarized_view) {
 			if ((group_by && column.colIndex > 3) || (!group_by && column.colIndex > 2)) {
 				if (value == 'P' || value == 'WFH')
 					value = "<span style='color:green'>" + value + "</span>";

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -72,12 +72,19 @@ def get_columns(filters: Filters) -> List[Dict]:
 	columns = []
 
 	if filters.group_by:
+		options_mapping = {
+			"Branch": "Branch",
+			"Grade": "Employee Grade",
+			"Department": "Department",
+			"Designation": "Designation",
+		}
+		options = options_mapping.get(filters.group_by)
 		columns.append(
 			{
 				"label": _(filters.group_by),
 				"fieldname": frappe.scrub(filters.group_by),
 				"fieldtype": "Link",
-				"options": "Branch",
+				"options": options,
 				"width": 120,
 			}
 		)
@@ -191,7 +198,7 @@ def get_data(filters: Filters, attendance_map: Dict) -> List[Dict]:
 			records = get_rows(employee_details[value], filters, holiday_map, attendance_map)
 
 			if records:
-				data.append({group_by_column: frappe.bold(value)})
+				data.append({group_by_column: value})
 				data.extend(records)
 	else:
 		data = get_rows(employee_details, filters, holiday_map, attendance_map)


### PR DESCRIPTION
Version 15 and 14

fixes: #1554 and
https://discuss.frappe.io/t/monthly-attendance-sheet-group-by-getting-html-tag-strong/119269?u=ncp

**Before:**
- When you use the 'group by' function, the `<strong>` tag shows up and looks messy. Additionally, all links lead directly to the branch doctype.


https://github.com/frappe/hrms/assets/141945075/6bf6caf6-c088-494e-b7c6-a6f777cc8676


<br>

**After:**

- To fix this, we removed the frappe.bold from py and added a condition in the formatter in js. We also corrected the options_mapping.


https://github.com/frappe/hrms/assets/141945075/5e893564-74d4-4da5-a341-af4d21a4b5a8


<br>

Thank You!