### PR TITLE
fix: calculate lwp based on LA for leave types including holidays on salary slip

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -605,7 +605,7 @@ class SalarySlip(TransactionBase):
 			if not leave:
 				continue
 
-			if not leave.include_holidays and getdate(d) in holidays:
+			if not leave.include_holiday and getdate(d) in holidays:
 				continue
 
 			equivalent_lwp_count = 0


### PR DESCRIPTION
Fixes #1573 