### PR TITLE
chore: add crowin identifiers for in-context translation

### DIFF
--- a/hrms/locale/eo.po
+++ b/hrms/locale/eo.po
@@ -1,0 +1,17078 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: frappe\n"
+"Report-Msgid-Bugs-To: contact@frappe.io\n"
+"POT-Creation-Date: 2024-01-29 18:15+0053\n"
+"PO-Revision-Date: 2024-03-27 11:23\n"
+"Last-Translator: contact@frappe.io\n"
+"Language-Team: Esperanto\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: frappe\n"
+"X-Crowdin-Project-ID: 639578\n"
+"X-Crowdin-Language: eo\n"
+"X-Crowdin-File: /[frappe.hrms] develop/hrms/locale/main.pot\n"
+"X-Crowdin-File-ID: 58\n"
+"Language: eo_UY\n"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:32
+msgid "\n"
+"\t\t\t\t\t\tNot found any salary slip record(s) for the employee {0}. <br><br>\n"
+"\t\t\t\t\t\tPlease specify {1} and {2} (if any),\n"
+"\t\t\t\t\t\tfor the correct tax calculation in future salary slips.\n"
+"\t\t\t\t\t\t"
+msgstr "crwdns104708:0{0}crwdnd104708:0{1}crwdnd104708:0{2}crwdne104708:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:22
+msgid "\"From Date\" can not be greater than or equal to \"To Date\""
+msgstr "crwdns104710:0crwdne104710:0"
+
+#: public/frontend/assets/BaseLayout-1fb5efbf.js:1
+msgid "$user"
+msgstr "crwdns104712:0$usercrwdne104712:0"
+
+#: public/frontend/assets/LeaveBalance-814d62cc.js:1
+msgid "${c} balance"
+msgstr "crwdns104714:0${c}crwdne104714:0"
+
+#: public/frontend/assets/LeaveBalance-814d62cc.js:1
+msgid "${t.balance_leaves}/${t.allocated_leaves}"
+msgstr "crwdns104716:0${t.balance_leaves}crwdnd104716:0${t.allocated_leaves}crwdne104716:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:88
+msgid "% Utilization (B + NB) / T"
+msgstr "crwdns104718:0crwdne104718:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:94
+msgid "% Utilization (B / T)"
+msgstr "crwdns104720:0crwdne104720:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:84
+msgid "'employee_field_value' and 'timestamp' are required."
+msgstr "crwdns104722:0crwdne104722:0"
+
+#: hr/doctype/leave_application/leave_application.py:1264
+msgid "(Half Day)"
+msgstr "crwdns104724:0crwdne104724:0"
+
+#: hr/utils.py:234 payroll/doctype/payroll_period/payroll_period.py:53
+msgid ") for {0}"
+msgstr "crwdns104726:0{0}crwdne104726:0"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "0.25"
+msgstr "crwdns104728:0crwdne104728:0"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "0.5"
+msgstr "crwdns104730:0crwdne104730:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "00:00"
+msgstr "crwdns104732:0crwdne104732:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "01:00"
+msgstr "crwdns104734:0crwdne104734:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "02:00"
+msgstr "crwdns104736:0crwdne104736:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "03:00"
+msgstr "crwdns104738:0crwdne104738:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "04:00"
+msgstr "crwdns104740:0crwdne104740:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "05:00"
+msgstr "crwdns104742:0crwdne104742:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "06:00"
+msgstr "crwdns104744:0crwdne104744:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "07:00"
+msgstr "crwdns104746:0crwdne104746:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "08:00"
+msgstr "crwdns104748:0crwdne104748:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "09:00"
+msgstr "crwdns104750:0crwdne104750:0"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "1.0"
+msgstr "crwdns104752:0crwdne104752:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "10:00"
+msgstr "crwdns104754:0crwdne104754:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "11:00"
+msgstr "crwdns104756:0crwdne104756:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "12:00"
+msgstr "crwdns104758:0crwdne104758:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "13:00"
+msgstr "crwdns104760:0crwdne104760:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "14:00"
+msgstr "crwdns104762:0crwdne104762:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "15:00"
+msgstr "crwdns104764:0crwdne104764:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "16:00"
+msgstr "crwdns104766:0crwdne104766:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "17:00"
+msgstr "crwdns104768:0crwdne104768:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "18:00"
+msgstr "crwdns104770:0crwdne104770:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "19:00"
+msgstr "crwdns104772:0crwdne104772:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "20:00"
+msgstr "crwdns104774:0crwdne104774:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "21:00"
+msgstr "crwdns104776:0crwdne104776:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "22:00"
+msgstr "crwdns104778:0crwdne104778:0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "23:00"
+msgstr "crwdns104780:0crwdne104780:0"
+
+#. Description of the 'Password Policy' (Data) field in DocType 'Payroll
+#. Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "<b>Example:</b> SAL-{first_name}-{date_of_birth.year} <br>This will generate a password like SAL-Jane-1972"
+msgstr "crwdns104782:0{first_name}crwdnd104782:0{date_of_birth.year}crwdne104782:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:280
+#: hr/doctype/leave_allocation/leave_allocation.py:286
+msgid "<b>Total Leaves Allocated</b> are more than the number of days in the allocation period"
+msgstr "crwdns104784:0crwdne104784:0"
+
+#. Description of the Onboarding Step 'Data Import'
+#: hr/onboarding_step/data_import/data_import.json
+msgid "<h3>Data Import</h3>\n\n"
+"Data import is the tool to migrate your existing data like Employee, Customer, Supplier, and a lot more to our ERPNext system.\n"
+"Go through the video for a detailed explanation of this tool."
+msgstr "crwdns104786:0crwdne104786:0"
+
+#. Description of the Onboarding Step 'Create Employee'
+#: hr/onboarding_step/create_employee/create_employee.json
+msgid "<h3>Employee</h3>\n\n"
+"An individual who works and is recognized for his rights and duties in your company is your Employee. You can manage the Employee master. It captures the demographic, personal and professional details, joining and leave details, etc."
+msgstr "crwdns104788:0crwdne104788:0"
+
+#. Description of the Onboarding Step 'HR Settings'
+#: hr/onboarding_step/hr_settings/hr_settings.json
+msgid "<h3>HR Settings</h3>\n\n"
+"Hr Settings consists of major settings related to Employee Lifecycle, Leave Management, etc. Click on Explore, to explore Hr Settings."
+msgstr "crwdns104790:0crwdne104790:0"
+
+#. Content of the 'Help' (HTML) field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "<h3>Help</h3>\n\n"
+"<p>Notes:</p>\n\n"
+"<ol>\n"
+"<li>Use field <code>base</code> for using base salary of the Employee</li>\n"
+"<li>Use Salary Component abbreviations in conditions and formulas. <code>BS = Basic Salary</code></li>\n"
+"<li>Use field name for employee details in conditions and formulas. <code>Employment Type = employment_type</code><code>Branch = branch</code></li>\n"
+"<li>Use field name from Salary Slip in conditions and formulas. <code>Payment Days = payment_days</code><code>Leave without pay = leave_without_pay</code></li>\n"
+"<li>Direct Amount can also be entered based on Condition. See example 3</li></ol>\n\n"
+"<h4>Examples</h4>\n"
+"<ol>\n"
+"<li>Calculating Basic Salary based on <code>base</code>\n"
+"<pre><code>Condition: base &lt; 10000</code></pre>\n"
+"<pre><code>Formula: base * .2</code></pre></li>\n"
+"<li>Calculating HRA based on Basic Salary<code>BS</code> \n"
+"<pre><code>Condition: BS &gt; 2000</code></pre>\n"
+"<pre><code>Formula: BS * .1</code></pre></li>\n"
+"<li>Calculating TDS based on Employment Type<code>employment_type</code> \n"
+"<pre><code>Condition: employment_type==\"Intern\"</code></pre>\n"
+"<pre><code>Amount: 1000</code></pre></li>\n"
+"</ol>"
+msgstr "crwdns104792:0crwdne104792:0"
+
+#. Description of the Onboarding Step 'Create Holiday List'
+#: hr/onboarding_step/create_holiday_list/create_holiday_list.json
+msgid "<h3>Holiday List.</h3>\n\n"
+"Holiday List is a list which contains the dates of holidays. Most organizations have a standard Holiday List for their employees. However, some of them may have different holiday lists based on different Locations or Departments. In ERPNext, you can configure multiple Holiday Lists."
+msgstr "crwdns104794:0crwdne104794:0"
+
+#. Description of the Onboarding Step 'Create Leave Allocation'
+#: hr/onboarding_step/create_leave_allocation/create_leave_allocation.json
+msgid "<h3>Leave Allocation</h3>\n\n"
+"Leave Allocation enables you to allocate a specific number of leaves of a particular type to an Employee so that, an employee will be able to create a Leave Application only if Leaves are allocated. "
+msgstr "crwdns104796:0crwdne104796:0"
+
+#. Description of the Onboarding Step 'Create Leave Application'
+#: hr/onboarding_step/create_leave_application/create_leave_application.json
+msgid "<h3>Leave Application</h3>\n\n"
+"Leave Application is a formal document created by an Employee to apply for Leaves for a particular time period based on there leave allocation and leave type according to there need."
+msgstr "crwdns104798:0crwdne104798:0"
+
+#. Description of the Onboarding Step 'Create Leave Type'
+#: hr/onboarding_step/create_leave_type/create_leave_type.json
+msgid "<h3>Leave Type</h3>\n\n"
+"Leave type is defined based on many factors and features like encashment, earned leaves, partially paid, without pay and, a lot more. To check other options and to define your leave type click on Show Tour."
+msgstr "crwdns104800:0crwdne104800:0"
+
+#. Content of the 'html_6' (HTML) field in DocType 'Taxable Salary Slab'
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgctxt "Taxable Salary Slab"
+msgid "<h4>Condition Examples</h4>\n"
+"<ol>\n"
+"<li>Applying tax if employee born between 31-12-1937 and 01-01-1958 (Employees aged 60 to 80)<br>\n"
+"<code>Condition: date_of_birth&gt;date(1937, 12, 31) and date_of_birth&lt;date(1958, 01, 01)</code></li><br><li>Applying tax by employee gender<br>\n"
+"<code>Condition: gender==\"Male\"</code></li><br>\n"
+"<li>Applying tax by Salary Component<br>\n"
+"<code>Condition: base &gt; 10000</code></li></ol>"
+msgstr "crwdns104802:0crwdne104802:0"
+
+#: hr/doctype/job_requisition/job_requisition.py:30
+msgid "A Job Requisition for {0} requested by {1} already exists: {2}"
+msgstr "crwdns104804:0{0}crwdnd104804:0{1}crwdnd104804:0{2}crwdne104804:0"
+
+#: controllers/employee_reminders.py:123 controllers/employee_reminders.py:216
+msgid "A friendly reminder of an important date for our team."
+msgstr "crwdns104806:0crwdne104806:0"
+
+#: hr/utils.py:230 payroll/doctype/payroll_period/payroll_period.py:49
+msgid "A {0} exists between {1} and {2} ("
+msgstr "crwdns104808:0{0}crwdnd104808:0{1}crwdnd104808:0{2}crwdne104808:0"
+
+#. Label of a Data field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Abbr"
+msgstr "crwdns104810:0crwdne104810:0"
+
+#. Label of a Data field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Abbr"
+msgstr "crwdns104812:0crwdne104812:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Absent"
+msgstr "crwdns104814:0crwdne104814:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Absent"
+msgstr "crwdns104816:0crwdne104816:0"
+
+#. Option for the 'Consider Unmarked Attendance As' (Select) field in DocType
+#. 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Absent"
+msgstr "crwdns104818:0crwdne104818:0"
+
+#. Option for the 'Attendance' (Select) field in DocType 'Training Event
+#. Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Absent"
+msgstr "crwdns104820:0crwdne104820:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Absent Days"
+msgstr "crwdns104822:0crwdne104822:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:174
+msgid "Absent Records"
+msgstr "crwdns104824:0crwdne104824:0"
+
+#. Name of a role
+#: hr/doctype/interest/interest.json
+msgid "Academics User"
+msgstr "crwdns104826:0crwdne104826:0"
+
+#: overrides/employee_master.py:64 overrides/employee_master.py:80
+msgid "Accepted"
+msgstr "crwdns104828:0crwdne104828:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Accepted"
+msgstr "crwdns104830:0crwdne104830:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Accepted"
+msgstr "crwdns104832:0crwdne104832:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Accepted"
+msgstr "crwdns104834:0crwdne104834:0"
+
+#. Label of a Link field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Account"
+msgstr "crwdns104836:0crwdne104836:0"
+
+#. Label of a Link field in DocType 'Salary Component Account'
+#: payroll/doctype/salary_component_account/salary_component_account.json
+msgctxt "Salary Component Account"
+msgid "Account"
+msgstr "crwdns104838:0crwdne104838:0"
+
+#. Label of a Tab Break field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Account"
+msgstr "crwdns104840:0crwdne104840:0"
+
+#. Label of a Link field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Account Head"
+msgstr "crwdns104842:0crwdne104842:0"
+
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:49
+msgid "Account No"
+msgstr "crwdns104844:0crwdne104844:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:99
+msgid "Account type cannot be set for payroll payable account {0}, please remove and try again"
+msgstr "crwdns104846:0{0}crwdne104846:0"
+
+#: overrides/company.py:115
+msgid "Account {0} does not belong to company: {1}"
+msgstr "crwdns104848:0{0}crwdnd104848:0{1}crwdne104848:0"
+
+#: hr/doctype/expense_claim_type/expense_claim_type.py:29
+msgid "Account {0} does not match with Company {1}"
+msgstr "crwdns104850:0{0}crwdnd104850:0{1}crwdne104850:0"
+
+#. Label of a Card Break in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Accounting"
+msgstr "crwdns104852:0crwdne104852:0"
+
+#. Label of a Section Break field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Accounting"
+msgstr "crwdns104854:0crwdne104854:0"
+
+#. Label of a Tab Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Accounting"
+msgstr "crwdns104856:0crwdne104856:0"
+
+#. Label of a Tab Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Accounting & Payment"
+msgstr "crwdns104858:0crwdne104858:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Accounting Details"
+msgstr "crwdns104860:0crwdne104860:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Accounting Dimension"
+msgid "Accounting Dimension"
+msgstr "crwdns104862:0crwdne104862:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Accounting Dimensions"
+msgstr "crwdns104864:0crwdne104864:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Accounting Dimensions"
+msgstr "crwdns104866:0crwdne104866:0"
+
+#. Label of a Section Break field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Accounting Dimensions"
+msgstr "crwdns104868:0crwdne104868:0"
+
+#. Label of a Section Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Accounting Dimensions"
+msgstr "crwdns104870:0crwdne104870:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Accounting Dimensions"
+msgstr "crwdns104872:0crwdne104872:0"
+
+#: hr/doctype/expense_claim/expense_claim.js:216
+msgid "Accounting Ledger"
+msgstr "crwdns104874:0crwdne104874:0"
+
+#. Label of a Card Break in the Expense Claims Workspace
+#. Label of a Card Break in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Accounting Reports"
+msgstr "crwdns104876:0crwdne104876:0"
+
+#. Label of a Table field in DocType 'Expense Claim Type'
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+msgctxt "Expense Claim Type"
+msgid "Accounts"
+msgstr "crwdns104878:0crwdne104878:0"
+
+#. Label of a Section Break field in DocType 'Salary Component'
+#. Label of a Table field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Accounts"
+msgstr "crwdns104880:0crwdne104880:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Accounts Payable"
+msgstr "crwdns104882:0crwdne104882:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Accounts Receivable"
+msgstr "crwdns104884:0crwdne104884:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Accounts Settings"
+msgid "Accounts Settings"
+msgstr "crwdns104886:0crwdne104886:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:575
+msgid "Accrual Journal Entry for salaries from {0} to {1}"
+msgstr "crwdns104888:0{0}crwdnd104888:0{1}crwdne104888:0"
+
+#: hr/doctype/interview/interview.js:32
+#: hr/doctype/job_requisition/job_requisition.js:36
+#: hr/doctype/job_requisition/job_requisition.js:60
+#: hr/doctype/job_requisition/job_requisition.js:62
+#: payroll/doctype/salary_structure/salary_structure.js:121
+msgid "Actions"
+msgstr "crwdns104890:0crwdne104890:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.js:46
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:40
+msgid "Active"
+msgstr "crwdns104892:0crwdne104892:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Active"
+msgstr "crwdns104894:0crwdne104894:0"
+
+#. Label of a Table field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Activities"
+msgstr "crwdns104896:0crwdne104896:0"
+
+#. Label of a Section Break field in DocType 'Employee Onboarding Template'
+#. Label of a Table field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Activities"
+msgstr "crwdns104898:0crwdne104898:0"
+
+#. Label of a Table field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Activities"
+msgstr "crwdns104900:0crwdne104900:0"
+
+#. Label of a Section Break field in DocType 'Employee Separation Template'
+#. Label of a Table field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Activities"
+msgstr "crwdns104902:0crwdne104902:0"
+
+#. Label of a Data field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Activity Name"
+msgstr "crwdns104904:0crwdne104904:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Activity Type"
+msgid "Activity Type"
+msgstr "crwdns104906:0crwdne104906:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Proof
+#. Submission Detail'
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgctxt "Employee Tax Exemption Proof Submission Detail"
+msgid "Actual Amount"
+msgstr "crwdns104908:0crwdne104908:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:136
+msgid "Actual Encashable Days"
+msgstr "crwdns104910:0crwdne104910:0"
+
+#. Label of a Float field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Actual Encashable Days"
+msgstr "crwdns104912:0crwdne104912:0"
+
+#: hr/doctype/leave_application/leave_application.py:399
+msgid "Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
+msgstr "crwdns104914:0crwdne104914:0"
+
+#. Label of a Button field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Add Day-wise Dates"
+msgstr "crwdns104916:0crwdne104916:0"
+
+#: hr/employee_property_update.js:45
+msgid "Add Employee Property"
+msgstr "crwdns104918:0crwdne104918:0"
+
+#: public/js/performance/performance_feedback.js:93
+msgid "Add Feedback"
+msgstr "crwdns104920:0crwdne104920:0"
+
+#: hr/employee_property_update.js:88
+msgid "Add to Details"
+msgstr "crwdns104922:0crwdne104922:0"
+
+#. Label of a Check field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Add unused leaves from previous allocations"
+msgstr "crwdns104924:0crwdne104924:0"
+
+#. Label of a Check field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Add unused leaves from previous allocations"
+msgstr "crwdns104926:0crwdne104926:0"
+
+#. Description of the 'Carry Forward' (Check) field in DocType 'Leave Control
+#. Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Add unused leaves from previous leave period's allocation to this allocation"
+msgstr "crwdns104928:0crwdne104928:0"
+
+#. Label of a Datetime field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Added On"
+msgstr "crwdns104930:0crwdne104930:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1255
+msgid "Added tax components from the Salary Component master as the salary structure didn't have any tax component."
+msgstr "crwdns104932:0crwdne104932:0"
+
+#: hr/employee_property_update.js:163
+msgid "Added to details"
+msgstr "crwdns104934:0crwdne104934:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Additional Amount"
+msgstr "crwdns104936:0crwdne104936:0"
+
+#. Label of a Section Break field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Additional Information "
+msgstr "crwdns104938:0crwdne104938:0"
+
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:34
+msgid "Additional PF"
+msgstr "crwdns104940:0crwdne104940:0"
+
+#. Name of a DocType
+#: payroll/doctype/additional_salary/additional_salary.json
+msgid "Additional Salary"
+msgstr "crwdns104942:0crwdne104942:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a shortcut in the Tax & Benefits Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Additional Salary"
+msgid "Additional Salary"
+msgstr "crwdns104944:0crwdne104944:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Additional Salary"
+msgstr "crwdns104946:0crwdne104946:0"
+
+#. Label of a Link field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Additional Salary "
+msgstr "crwdns104948:0crwdne104948:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:110
+msgid "Additional Salary for referral bonus can only be created against Employee Referral with status {0}"
+msgstr "crwdns104950:0{0}crwdne104950:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:132
+msgid "Additional Salary for this salary component with {0} enabled already exists for this date"
+msgstr "crwdns104952:0{0}crwdne104952:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:62
+msgid "Additional Salary: {0} already exist for Salary Component: {1} for period {2} and {3}"
+msgstr "crwdns104954:0{0}crwdnd104954:0{1}crwdnd104954:0{2}crwdnd104954:0{3}crwdne104954:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Address of Organizer"
+msgstr "crwdns104956:0crwdne104956:0"
+
+#. Option for the 'Level' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Advance"
+msgstr "crwdns104958:0crwdne104958:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Advance Account"
+msgstr "crwdns104960:0crwdne104960:0"
+
+#. Label of a Link field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Advance Account"
+msgstr "crwdns104962:0crwdne104962:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:62
+msgid "Advance Amount"
+msgstr "crwdns104964:0crwdne104964:0"
+
+#. Label of a Currency field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Advance Amount"
+msgstr "crwdns104966:0crwdne104966:0"
+
+#. Label of a Data field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Advance Amount"
+msgstr "crwdns104968:0crwdne104968:0"
+
+#. Label of a Currency field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Advance Paid"
+msgstr "crwdns104970:0crwdne104970:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Advance Payments"
+msgstr "crwdns104972:0crwdne104972:0"
+
+#. Label of a Section Break field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Advanced Filters"
+msgstr "crwdns104974:0crwdne104974:0"
+
+#. Label of a Card Break in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgid "Advances"
+msgstr "crwdns104976:0crwdne104976:0"
+
+#. Label of a Table field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Advances"
+msgstr "crwdns104978:0crwdne104978:0"
+
+#. Name of a role
+#: hr/doctype/leave_application/leave_application.json
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgid "All"
+msgstr "crwdns104980:0crwdne104980:0"
+
+#: hr/doctype/goal/goal_tree.js:219
+msgid "All Goals"
+msgstr "crwdns104982:0crwdne104982:0"
+
+#: hr/doctype/job_opening/job_opening.py:106
+msgid "All Jobs"
+msgstr "crwdns104984:0crwdne104984:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:40
+msgid "All allocated assets should be returned before submission"
+msgstr "crwdns104986:0crwdne104986:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.py:48
+msgid "All the mandatory tasks for employee creation are not completed yet."
+msgstr "crwdns104988:0crwdne104988:0"
+
+#. Label of a Check field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Allocate Based On Leave Policy"
+msgstr "crwdns104990:0crwdne104990:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.js:206
+msgid "Allocate Leave"
+msgstr "crwdns104992:0crwdne104992:0"
+
+#. Label of a Select field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Allocate on Day"
+msgstr "crwdns104994:0crwdne104994:0"
+
+#. Label of a Currency field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Allocated Amount"
+msgstr "crwdns104996:0crwdne104996:0"
+
+#: hr/doctype/leave_application/leave_application.js:79
+msgid "Allocated Leaves"
+msgstr "crwdns104998:0crwdne104998:0"
+
+#: hr/utils.py:405
+msgid "Allocated {0} leave(s) via scheduler on {1} based on the 'Allocate on Day' option set to {2}"
+msgstr "crwdns105000:0{0}crwdnd105000:0{1}crwdnd105000:0{2}crwdne105000:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.js:228
+msgid "Allocating Leave"
+msgstr "crwdns105002:0crwdne105002:0"
+
+#. Label of a Card Break in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgid "Allocation"
+msgstr "crwdns105004:0crwdne105004:0"
+
+#. Label of a Section Break field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Allocation"
+msgstr "crwdns105006:0crwdne105006:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:56
+msgid "Allocation Expired!"
+msgstr "crwdns105008:0crwdne105008:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Allow Encashment"
+msgstr "crwdns105010:0crwdne105010:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:60
+msgid "Allow Multiple Shift Assignments for Same Date"
+msgstr "crwdns105012:0crwdne105012:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Allow Multiple Shift Assignments for Same Date"
+msgstr "crwdns105014:0crwdne105014:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Allow Negative Balance"
+msgstr "crwdns105016:0crwdne105016:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Allow Over Allocation"
+msgstr "crwdns105018:0crwdne105018:0"
+
+#. Label of a Check field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Allow Tax Exemption"
+msgstr "crwdns105020:0crwdne105020:0"
+
+#. Label of a Link field in DocType 'Leave Block List Allow'
+#: hr/doctype/leave_block_list_allow/leave_block_list_allow.json
+msgctxt "Leave Block List Allow"
+msgid "Allow User"
+msgstr "crwdns105022:0crwdne105022:0"
+
+#. Label of a Section Break field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Allow Users"
+msgstr "crwdns105024:0crwdne105024:0"
+
+#. Label of a Int field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Allow check-out after shift end time (in minutes)"
+msgstr "crwdns105026:0crwdne105026:0"
+
+#. Description of the 'Allow Users' (Section Break) field in DocType 'Leave
+#. Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Allow the following users to approve Leave Applications for block days."
+msgstr "crwdns105028:0crwdne105028:0"
+
+#. Description of the 'Allow Over Allocation' (Check) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Allows allocating more leaves than the number of days in the allocation period."
+msgstr "crwdns105030:0crwdne105030:0"
+
+#. Option for the 'Determine Check-in and Check-out' (Select) field in DocType
+#. 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Alternating entries as IN and OUT during the same shift"
+msgstr "crwdns105032:0crwdne105032:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Amended From"
+msgstr "crwdns105034:0crwdne105034:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Amended From"
+msgstr "crwdns105036:0crwdne105036:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Amended From"
+msgstr "crwdns105038:0crwdne105038:0"
+
+#. Label of a Link field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Amended From"
+msgstr "crwdns105040:0crwdne105040:0"
+
+#. Label of a Link field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Amended From"
+msgstr "crwdns105042:0crwdne105042:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Amended From"
+msgstr "crwdns105044:0crwdne105044:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Amended From"
+msgstr "crwdns105046:0crwdne105046:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Amended From"
+msgstr "crwdns105048:0crwdne105048:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Amended From"
+msgstr "crwdns105050:0crwdne105050:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Amended From"
+msgstr "crwdns105052:0crwdne105052:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Amended From"
+msgstr "crwdns105054:0crwdne105054:0"
+
+#. Label of a Link field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Amended From"
+msgstr "crwdns105056:0crwdne105056:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Amended From"
+msgstr "crwdns105058:0crwdne105058:0"
+
+#. Label of a Link field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Amended From"
+msgstr "crwdns105060:0crwdne105060:0"
+
+#. Label of a Link field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Amended From"
+msgstr "crwdns105062:0crwdne105062:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Amended From"
+msgstr "crwdns105064:0crwdne105064:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Amended From"
+msgstr "crwdns105066:0crwdne105066:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Amended From"
+msgstr "crwdns105068:0crwdne105068:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Amended From"
+msgstr "crwdns105070:0crwdne105070:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Amended From"
+msgstr "crwdns105072:0crwdne105072:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Amended From"
+msgstr "crwdns105074:0crwdne105074:0"
+
+#. Label of a Link field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Amended From"
+msgstr "crwdns105076:0crwdne105076:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Amended From"
+msgstr "crwdns105078:0crwdne105078:0"
+
+#. Label of a Link field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Amended From"
+msgstr "crwdns105080:0crwdne105080:0"
+
+#. Label of a Link field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Amended From"
+msgstr "crwdns105082:0crwdne105082:0"
+
+#. Label of a Link field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Amended From"
+msgstr "crwdns105084:0crwdne105084:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Amended From"
+msgstr "crwdns105086:0crwdne105086:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Amended From"
+msgstr "crwdns105088:0crwdne105088:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Amended From"
+msgstr "crwdns105090:0crwdne105090:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Amended From"
+msgstr "crwdns105092:0crwdne105092:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Amended From"
+msgstr "crwdns105094:0crwdne105094:0"
+
+#. Label of a Link field in DocType 'Leave Policy'
+#: hr/doctype/leave_policy/leave_policy.json
+msgctxt "Leave Policy"
+msgid "Amended From"
+msgstr "crwdns105096:0crwdne105096:0"
+
+#. Label of a Link field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Amended From"
+msgstr "crwdns105098:0crwdne105098:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Amended From"
+msgstr "crwdns105100:0crwdne105100:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Amended From"
+msgstr "crwdns105102:0crwdne105102:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Amended From"
+msgstr "crwdns105104:0crwdne105104:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Amended From"
+msgstr "crwdns105106:0crwdne105106:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Amended From"
+msgstr "crwdns105108:0crwdne105108:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Amended From"
+msgstr "crwdns105110:0crwdne105110:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Amended From"
+msgstr "crwdns105112:0crwdne105112:0"
+
+#. Label of a Link field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Amended From"
+msgstr "crwdns105114:0crwdne105114:0"
+
+#. Label of a Link field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Amended From"
+msgstr "crwdns105116:0crwdne105116:0"
+
+#. Label of a Link field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Amended From"
+msgstr "crwdns105118:0crwdne105118:0"
+
+#. Label of a Link field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Amended From"
+msgstr "crwdns105120:0crwdne105120:0"
+
+#. Label of a Link field in DocType 'Training Result'
+#: hr/doctype/training_result/training_result.json
+msgctxt "Training Result"
+msgid "Amended From"
+msgstr "crwdns105122:0crwdne105122:0"
+
+#. Label of a Link field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Amended From"
+msgstr "crwdns105124:0crwdne105124:0"
+
+#. Label of a Link field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Amended From"
+msgstr "crwdns105126:0crwdne105126:0"
+
+#: payroll/report/professional_tax_deductions/professional_tax_deductions.py:32
+msgid "Amount"
+msgstr "crwdns105128:0crwdne105128:0"
+
+#. Label of a Currency field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Amount"
+msgstr "crwdns105130:0crwdne105130:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application Detail'
+#: payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgctxt "Employee Benefit Application Detail"
+msgid "Amount"
+msgstr "crwdns105132:0crwdne105132:0"
+
+#. Label of a Currency field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Amount"
+msgstr "crwdns105134:0crwdne105134:0"
+
+#. Label of a Currency field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Amount"
+msgstr "crwdns105136:0crwdne105136:0"
+
+#. Label of a Currency field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Amount"
+msgstr "crwdns105138:0crwdne105138:0"
+
+#. Label of a Currency field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Amount"
+msgstr "crwdns105140:0crwdne105140:0"
+
+#. Label of a Currency field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Amount"
+msgstr "crwdns105142:0crwdne105142:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Amount"
+msgstr "crwdns105144:0crwdne105144:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:34
+msgid "Amount Based on Formula"
+msgstr "crwdns105146:0crwdne105146:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Amount based on formula"
+msgstr "crwdns105148:0crwdne105148:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Amount based on formula"
+msgstr "crwdns105150:0crwdne105150:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:31
+msgid "Amount should not be less than zero"
+msgstr "crwdns105152:0crwdne105152:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:58
+msgid "An amount of {0} already claimed for the component {1}, set the amount equal or greater than {2}"
+msgstr "crwdns105154:0{0}crwdnd105154:0{1}crwdnd105154:0{2}crwdne105154:0"
+
+#. Label of a Float field in DocType 'Leave Policy Detail'
+#: hr/doctype/leave_policy_detail/leave_policy_detail.json
+msgctxt "Leave Policy Detail"
+msgid "Annual Allocation"
+msgstr "crwdns105156:0crwdne105156:0"
+
+#: setup.py:395
+msgid "Annual Salary"
+msgstr "crwdns105158:0crwdne105158:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Annual Taxable Amount"
+msgstr "crwdns105160:0crwdne105160:0"
+
+#. Label of a Small Text field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Any other details"
+msgstr "crwdns105162:0crwdne105162:0"
+
+#. Description of the 'Remarks' (Text) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Any other remarks, noteworthy effort that should go in the records"
+msgstr "crwdns105164:0crwdne105164:0"
+
+#. Label of a Int field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Applicable After (Working Days)"
+msgstr "crwdns105166:0crwdne105166:0"
+
+#. Label of a Table MultiSelect field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Applicable Earnings Component"
+msgstr "crwdns105168:0crwdne105168:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Applicable For"
+msgstr "crwdns105170:0crwdne105170:0"
+
+#. Description of the 'Required for Employee Creation' (Check) field in DocType
+#. 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Applicable in the case of Employee Onboarding"
+msgstr "crwdns105172:0crwdne105172:0"
+
+#. Label of a Data field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Applicant Email Address"
+msgstr "crwdns105174:0crwdne105174:0"
+
+#. Label of a Data field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Applicant Name"
+msgstr "crwdns105176:0crwdne105176:0"
+
+#. Label of a Data field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Applicant Name"
+msgstr "crwdns105178:0crwdne105178:0"
+
+#. Label of a Data field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Applicant Name"
+msgstr "crwdns105180:0crwdne105180:0"
+
+#. Label of a Rating field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Applicant Rating"
+msgstr "crwdns105182:0crwdne105182:0"
+
+#: hr/report/recruitment_analytics/recruitment_analytics.py:45
+msgid "Applicant name"
+msgstr "crwdns105184:0crwdne105184:0"
+
+#. Label of a Card Break in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgid "Application"
+msgstr "crwdns105186:0crwdne105186:0"
+
+#: hr/report/recruitment_analytics/recruitment_analytics.py:47
+msgid "Application Status"
+msgstr "crwdns105188:0crwdne105188:0"
+
+#: hr/doctype/leave_application/leave_application.py:207
+msgid "Application period cannot be across two allocation records"
+msgstr "crwdns105190:0crwdne105190:0"
+
+#: hr/doctype/leave_application/leave_application.py:204
+msgid "Application period cannot be outside leave allocation period"
+msgstr "crwdns105192:0crwdne105192:0"
+
+#: templates/generators/job_opening.html:152
+msgid "Applications Received"
+msgstr "crwdns105194:0crwdne105194:0"
+
+#: www/jobs/index.html:211
+msgid "Applications received:"
+msgstr "crwdns105196:0crwdne105196:0"
+
+#. Label of a Check field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Applies to Company"
+msgstr "crwdns105198:0crwdne105198:0"
+
+#: templates/generators/job_opening.html:21
+#: templates/generators/job_opening.html:25
+msgid "Apply Now"
+msgstr "crwdns105200:0crwdne105200:0"
+
+#. Label of a Card Break in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgid "Appointment"
+msgstr "crwdns105202:0crwdne105202:0"
+
+#. Label of a Date field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Appointment Date"
+msgstr "crwdns105204:0crwdne105204:0"
+
+#. Name of a DocType
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgid "Appointment Letter"
+msgstr "crwdns105206:0crwdne105206:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Appointment Letter"
+msgid "Appointment Letter"
+msgstr "crwdns105208:0crwdne105208:0"
+
+#. Name of a DocType
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgid "Appointment Letter Template"
+msgstr "crwdns105210:0crwdne105210:0"
+
+#. Label of a Link field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Appointment Letter Template"
+msgstr "crwdns105212:0crwdne105212:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Appointment Letter Template"
+msgid "Appointment Letter Template"
+msgstr "crwdns105214:0crwdne105214:0"
+
+#. Name of a DocType
+#: hr/doctype/appointment_letter_content/appointment_letter_content.json
+msgid "Appointment Letter content"
+msgstr "crwdns105216:0crwdne105216:0"
+
+#. Name of a DocType
+#. Label of a Card Break in the Performance Workspace
+#: hr/doctype/appraisal/appraisal.json
+#: hr/report/appraisal_overview/appraisal_overview.py:44
+#: hr/workspace/performance/performance.json
+msgid "Appraisal"
+msgstr "crwdns105218:0crwdne105218:0"
+
+#. Label of a Link in the Performance Workspace
+#. Label of a shortcut in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Appraisal"
+msgid "Appraisal"
+msgstr "crwdns105220:0crwdne105220:0"
+
+#. Linked DocType in Appraisal Cycle's connections
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Appraisal"
+msgstr "crwdns105222:0crwdne105222:0"
+
+#. Linked DocType in Appraisal Template's connections
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Appraisal"
+msgstr "crwdns105224:0crwdne105224:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Appraisal"
+msgstr "crwdns105226:0crwdne105226:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hr/doctype/goal/goal_tree.js:17 hr/doctype/goal/goal_tree.js:107
+#: hr/report/appraisal_overview/appraisal_overview.js:18
+#: hr/report/appraisal_overview/appraisal_overview.py:37
+msgid "Appraisal Cycle"
+msgstr "crwdns105228:0crwdne105228:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Appraisal Cycle"
+msgstr "crwdns105230:0crwdne105230:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Appraisal Cycle"
+msgid "Appraisal Cycle"
+msgstr "crwdns105232:0crwdne105232:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Appraisal Cycle"
+msgstr "crwdns105234:0crwdne105234:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Appraisal Cycle"
+msgstr "crwdns105236:0crwdne105236:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgid "Appraisal Goal"
+msgstr "crwdns105238:0crwdne105238:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgid "Appraisal KRA"
+msgstr "crwdns105240:0crwdne105240:0"
+
+#: hr/doctype/goal/goal_tree.js:98
+msgid "Appraisal Linking"
+msgstr "crwdns105242:0crwdne105242:0"
+
+#. Label of a Section Break field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Appraisal Linking"
+msgstr "crwdns105244:0crwdne105244:0"
+
+#. Name of a report
+#. Label of a Link in the Performance Workspace
+#: hr/report/appraisal_overview/appraisal_overview.json
+#: hr/workspace/performance/performance.json
+msgid "Appraisal Overview"
+msgstr "crwdns105246:0crwdne105246:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgid "Appraisal Template"
+msgstr "crwdns105248:0crwdne105248:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Appraisal Template"
+msgstr "crwdns105250:0crwdne105250:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Appraisal Template"
+msgid "Appraisal Template"
+msgstr "crwdns105252:0crwdne105252:0"
+
+#. Label of a Link field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Appraisal Template"
+msgstr "crwdns105254:0crwdne105254:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgid "Appraisal Template Goal"
+msgstr "crwdns105256:0crwdne105256:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:142
+msgid "Appraisal Template Missing"
+msgstr "crwdns105258:0crwdne105258:0"
+
+#. Label of a Data field in DocType 'Appraisal Template'
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Appraisal Template Title"
+msgstr "crwdns105260:0crwdne105260:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:135
+msgid "Appraisal Template not found for some designations."
+msgstr "crwdns105262:0crwdne105262:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:125
+msgid "Appraisal creation is queued. It may take a few minutes."
+msgstr "crwdns105264:0crwdne105264:0"
+
+#: hr/doctype/appraisal/appraisal.py:54
+msgid "Appraisal {0} already exists for Employee {1} for this Appraisal Cycle or overlapping period"
+msgstr "crwdns105266:0{0}crwdnd105266:0{1}crwdne105266:0"
+
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.py:44
+msgid "Appraisal {0} does not belong to Employee {1}"
+msgstr "crwdns105268:0{0}crwdnd105268:0{1}crwdne105268:0"
+
+#. Name of a DocType
+#: hr/doctype/appraisee/appraisee.json
+msgid "Appraisee"
+msgstr "crwdns105270:0crwdne105270:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:113
+msgid "Appraisees: {0}"
+msgstr "crwdns105272:0{0}crwdne105272:0"
+
+#: setup.py:387
+msgid "Apprentice"
+msgstr "crwdns105274:0crwdne105274:0"
+
+#. Label of a Section Break field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Approval"
+msgstr "crwdns105276:0crwdne105276:0"
+
+#. Label of a Select field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Approval Status"
+msgstr "crwdns105278:0crwdne105278:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:118
+msgid "Approval Status must be 'Approved' or 'Rejected'"
+msgstr "crwdns105280:0crwdne105280:0"
+
+#. Option for the 'Approval Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Approved"
+msgstr "crwdns105282:0crwdne105282:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Approved"
+msgstr "crwdns105284:0crwdne105284:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Approved"
+msgstr "crwdns105286:0crwdne105286:0"
+
+#. Label of a Link field in DocType 'Department Approver'
+#: hr/doctype/department_approver/department_approver.json
+msgctxt "Department Approver"
+msgid "Approver"
+msgstr "crwdns105288:0crwdne105288:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Approver"
+msgstr "crwdns105290:0crwdne105290:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:16
+#: public/js/salary_slip_deductions_report_filters.js:22
+msgid "Apr"
+msgstr "crwdns105292:0crwdne105292:0"
+
+#: hr/doctype/goal/goal.js:68
+msgid "Archive"
+msgstr "crwdns105294:0crwdne105294:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Archived"
+msgstr "crwdns105296:0crwdne105296:0"
+
+#: payroll/doctype/salary_slip/salary_slip_list.js:11
+msgid "Are you sure you want to email the selected salary slips?"
+msgstr "crwdns105298:0crwdne105298:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:87
+msgid "Are you sure you want to proceed?"
+msgstr "crwdns105300:0crwdne105300:0"
+
+#: hr/doctype/employee_referral/employee_referral.js:9
+msgid "Are you sure you want to reject the Employee Referral?"
+msgstr "crwdns105302:0crwdne105302:0"
+
+#. Label of a Datetime field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Arrival Datetime"
+msgstr "crwdns105304:0crwdne105304:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:41
+msgid "As per your assigned Salary Structure you cannot apply for benefits"
+msgstr "crwdns105306:0crwdne105306:0"
+
+#. Label of a Data field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Asset Name"
+msgstr "crwdns105308:0crwdne105308:0"
+
+#. Label of a Section Break field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Assets Allocated"
+msgstr "crwdns105310:0crwdne105310:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:171
+msgid "Assign"
+msgstr "crwdns105312:0crwdne105312:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/assign_salary_structure/assign_salary_structure.json
+msgid "Assign Salary Structure"
+msgstr "crwdns105314:0crwdne105314:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:250
+msgid "Assigning Structures..."
+msgstr "crwdns105316:0crwdne105316:0"
+
+#. Label of a Select field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Assignment based on"
+msgstr "crwdns105318:0crwdne105318:0"
+
+#: hr/doctype/job_requisition/job_requisition.js:38
+#: hr/doctype/job_requisition/job_requisition.js:59
+msgid "Associate Job Opening"
+msgstr "crwdns105320:0crwdne105320:0"
+
+#. Label of a Dynamic Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Associated Document"
+msgstr "crwdns105322:0crwdne105322:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Associated Document Type"
+msgstr "crwdns105324:0crwdne105324:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:107
+msgid "At least one interview has to be selected."
+msgstr "crwdns105326:0crwdne105326:0"
+
+#. Label of a Attach field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Attachments"
+msgstr "crwdns105328:0crwdne105328:0"
+
+#. Label of a Attach field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Attachments"
+msgstr "crwdns105330:0crwdne105330:0"
+
+#. Name of a DocType
+#. Label of a Card Break in the HR Workspace
+#. Label of a Card Break in the Shift & Attendance Workspace
+#: hr/doctype/attendance/attendance.json hr/workspace/hr/hr.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+#: overrides/dashboard_overrides.py:10 templates/emails/training_event.html:9
+msgid "Attendance"
+msgstr "crwdns105332:0crwdne105332:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#. Label of a shortcut in the Shift & Attendance Workspace
+#: hr/workspace/hr/hr.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Attendance"
+msgid "Attendance"
+msgstr "crwdns105334:0crwdne105334:0"
+
+#. Option for the 'Calculate Payroll Working Days Based On' (Select) field in
+#. DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Attendance"
+msgstr "crwdns105336:0crwdne105336:0"
+
+#. Label of a Select field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Attendance"
+msgstr "crwdns105338:0crwdne105338:0"
+
+#. Label of a chart in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Attendance Count"
+msgstr "crwdns105340:0crwdne105340:0"
+
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Attendance Dashboard"
+msgstr "crwdns105342:0crwdne105342:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:43
+msgid "Attendance Date"
+msgstr "crwdns105344:0crwdne105344:0"
+
+#. Label of a Date field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Attendance Date"
+msgstr "crwdns105346:0crwdne105346:0"
+
+#. Label of a Date field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Attendance From Date"
+msgstr "crwdns105348:0crwdne105348:0"
+
+#: hr/doctype/upload_attendance/upload_attendance.js:20
+msgid "Attendance From Date and Attendance To Date is mandatory"
+msgstr "crwdns105350:0crwdne105350:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:123
+msgid "Attendance ID"
+msgstr "crwdns105352:0crwdne105352:0"
+
+#: hr/doctype/attendance/attendance_list.js:115
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:177
+msgid "Attendance Marked"
+msgstr "crwdns105354:0crwdne105354:0"
+
+#. Label of a Link field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Attendance Marked"
+msgstr "crwdns105356:0crwdne105356:0"
+
+#. Name of a DocType
+#: hr/doctype/attendance_request/attendance_request.json
+msgid "Attendance Request"
+msgstr "crwdns105358:0crwdne105358:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Attendance Request"
+msgstr "crwdns105360:0crwdne105360:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/hr/hr.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Attendance Request"
+msgid "Attendance Request"
+msgstr "crwdns105362:0crwdne105362:0"
+
+#. Label of a Date field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Attendance To Date"
+msgstr "crwdns105364:0crwdne105364:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:105
+msgid "Attendance Updated"
+msgstr "crwdns105366:0crwdne105366:0"
+
+#: hr/doctype/attendance_request/attendance_request.js:19
+msgid "Attendance Warnings"
+msgstr "crwdns105368:0crwdne105368:0"
+
+#: hr/doctype/attendance/attendance.py:56
+msgid "Attendance can not be marked for future dates: {0}"
+msgstr "crwdns105370:0{0}crwdne105370:0"
+
+#: hr/doctype/attendance/attendance.py:62
+msgid "Attendance date {0} can not be less than employee {1}'s joining date: {2}"
+msgstr "crwdns105372:0{0}crwdnd105372:0{1}crwdnd105372:0{2}crwdne105372:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:176
+msgid "Attendance for all the employees under this criteria has been marked already."
+msgstr "crwdns105374:0crwdne105374:0"
+
+#: hr/doctype/attendance/attendance.py:113
+msgid "Attendance for employee {0} is already marked for an overlapping shift {1}: {2}"
+msgstr "crwdns105376:0{0}crwdnd105376:0{1}crwdnd105376:0{2}crwdne105376:0"
+
+#: hr/doctype/attendance/attendance.py:74
+msgid "Attendance for employee {0} is already marked for the date {1}: {2}"
+msgstr "crwdns105378:0{0}crwdnd105378:0{1}crwdnd105378:0{2}crwdne105378:0"
+
+#: hr/doctype/leave_application/leave_application.py:545
+msgid "Attendance for employee {0} is already marked for this day"
+msgstr "crwdns105380:0{0}crwdne105380:0"
+
+#: hr/doctype/attendance/attendance_list.js:95
+msgid "Attendance from {0} to {1} has already been marked for the Employee {2}"
+msgstr "crwdns105382:0{0}crwdnd105382:0{1}crwdnd105382:0{2}crwdne105382:0"
+
+#: hr/doctype/shift_type/shift_type.js:29
+msgid "Attendance has been marked as per employee check-ins"
+msgstr "crwdns105384:0crwdne105384:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:218
+msgid "Attendance marked successfully"
+msgstr "crwdns105386:0crwdne105386:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:123
+msgid "Attendance not submitted for {0} as it is a Holiday."
+msgstr "crwdns105388:0{0}crwdne105388:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:132
+msgid "Attendance not submitted for {0} as {1} is on leave."
+msgstr "crwdns105390:0{0}crwdnd105390:0{1}crwdne105390:0"
+
+#. Description of the 'Process Attendance After' (Date) field in DocType 'Shift
+#. Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Attendance will be marked automatically only after this date."
+msgstr "crwdns105392:0crwdne105392:0"
+
+#. Label of a Section Break field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Attendees"
+msgstr "crwdns105394:0crwdne105394:0"
+
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py:45
+msgid "Attrition Count"
+msgstr "crwdns105396:0crwdne105396:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:20
+#: public/js/salary_slip_deductions_report_filters.js:26
+msgid "Aug"
+msgstr "crwdns105398:0crwdne105398:0"
+
+#. Label of a Section Break field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Auto Attendance Settings"
+msgstr "crwdns105400:0crwdne105400:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Auto Leave Encashment"
+msgstr "crwdns105402:0crwdne105402:0"
+
+#. Option for the 'KRA Evaluation Method' (Select) field in DocType 'Appraisal
+#. Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Automated Based on Goal Progress"
+msgstr "crwdns105404:0crwdne105404:0"
+
+#. Description of the 'Assets Allocated' (Section Break) field in DocType 'Full
+#. and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Automatically fetches all assets allocated to the employee, if any"
+msgstr "crwdns105406:0crwdne105406:0"
+
+#. Label of a Float field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Available Leave(s)"
+msgstr "crwdns105408:0crwdne105408:0"
+
+#. Label of a Float field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Average Feedback Score"
+msgstr "crwdns105410:0crwdne105410:0"
+
+#. Label of a Rating field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Average Rating"
+msgstr "crwdns105412:0crwdne105412:0"
+
+#. Description of the 'Final Score' (Float) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Average of Goal Score, Feedback Score, and Self Appraisal Score (out of 5)"
+msgstr "crwdns105414:0crwdne105414:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:52
+msgid "Avg Feedback Score"
+msgstr "crwdns105416:0crwdne105416:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:223
+msgid "Avg Utilization"
+msgstr "crwdns105418:0crwdne105418:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:229
+msgid "Avg Utilization (Billed Only)"
+msgstr "crwdns105420:0crwdne105420:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Awaiting Response"
+msgstr "crwdns105422:0crwdne105422:0"
+
+#: hr/doctype/leave_application/leave_application.py:166
+msgid "Backdated Leave Application is restricted. Please set the {} in {}"
+msgstr "crwdns105424:0crwdne105424:0"
+
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:48
+msgid "Bank"
+msgstr "crwdns105426:0crwdne105426:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Bank Account"
+msgstr "crwdns105428:0crwdne105428:0"
+
+#. Label of a Data field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Bank Account No"
+msgstr "crwdns105430:0crwdne105430:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Bank Details"
+msgstr "crwdns105432:0crwdne105432:0"
+
+#: hr/doctype/expense_claim/expense_claim.js:89
+msgid "Bank Entries"
+msgstr "crwdns105434:0crwdne105434:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:33
+msgid "Bank Name"
+msgstr "crwdns105436:0crwdne105436:0"
+
+#. Label of a Data field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Bank Name"
+msgstr "crwdns105438:0crwdne105438:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/report/bank_remittance/bank_remittance.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Bank Remittance"
+msgstr "crwdns105440:0crwdne105440:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:152
+msgid "Base"
+msgstr "crwdns105442:0crwdne105442:0"
+
+#. Label of a Currency field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Base"
+msgstr "crwdns105444:0crwdne105444:0"
+
+#. Label of a Section Break field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Base & Variable"
+msgstr "crwdns105446:0crwdne105446:0"
+
+#. Label of a Int field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Begin On (Days)"
+msgstr "crwdns105448:0crwdne105448:0"
+
+#. Label of a Int field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Begin check-in before shift start time (in minutes)"
+msgstr "crwdns105450:0crwdne105450:0"
+
+#. Option for the 'Level' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Beginner"
+msgstr "crwdns105452:0crwdne105452:0"
+
+#: controllers/employee_reminders.py:75
+msgid "Below is the list of upcoming holidays for you:"
+msgstr "crwdns105454:0crwdne105454:0"
+
+#: overrides/dashboard_overrides.py:30
+msgid "Benefit"
+msgstr "crwdns105456:0crwdne105456:0"
+
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Benefits"
+msgstr "crwdns105458:0crwdne105458:0"
+
+#. Label of a Section Break field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Benefits"
+msgstr "crwdns105460:0crwdne105460:0"
+
+#. Label of a Section Break field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Benefits"
+msgstr "crwdns105462:0crwdne105462:0"
+
+#: hr/report/project_profitability/project_profitability.py:171
+msgid "Bill Amount"
+msgstr "crwdns105464:0crwdne105464:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:254
+msgid "Billed Hours"
+msgstr "crwdns105466:0crwdne105466:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:70
+msgid "Billed Hours (B)"
+msgstr "crwdns105468:0crwdne105468:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Bimonthly"
+msgstr "crwdns105470:0crwdne105470:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Bimonthly"
+msgstr "crwdns105472:0crwdne105472:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Bimonthly"
+msgstr "crwdns105474:0crwdne105474:0"
+
+#: controllers/employee_reminders.py:134
+msgid "Birthday Reminder"
+msgstr "crwdns105476:0crwdne105476:0"
+
+#: controllers/employee_reminders.py:141
+msgid "Birthday Reminder 🎂"
+msgstr "crwdns105478:0crwdne105478:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Birthdays"
+msgstr "crwdns105480:0crwdne105480:0"
+
+#. Label of a Date field in DocType 'Leave Block List Date'
+#: hr/doctype/leave_block_list_date/leave_block_list_date.json
+msgctxt "Leave Block List Date"
+msgid "Block Date"
+msgstr "crwdns105482:0crwdne105482:0"
+
+#. Label of a Section Break field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Block Days"
+msgstr "crwdns105484:0crwdne105484:0"
+
+#. Label of a Section Break field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Body"
+msgstr "crwdns105486:0crwdne105486:0"
+
+#. Label of a Section Break field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Bonus"
+msgstr "crwdns105488:0crwdne105488:0"
+
+#. Label of a Currency field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Bonus Amount"
+msgstr "crwdns105490:0crwdne105490:0"
+
+#. Label of a Date field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Bonus Payment Date"
+msgstr "crwdns105492:0crwdne105492:0"
+
+#: payroll/doctype/retention_bonus/retention_bonus.py:17
+msgid "Bonus Payment Date cannot be a past date"
+msgstr "crwdns105494:0crwdne105494:0"
+
+#: hr/report/employee_analytics/employee_analytics.py:33
+#: hr/report/employee_birthday/employee_birthday.py:24
+#: payroll/doctype/salary_structure/salary_structure.js:142
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:29
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:21
+#: payroll/report/salary_register/salary_register.py:135
+#: public/js/salary_slip_deductions_report_filters.js:48
+msgid "Branch"
+msgstr "crwdns105496:0crwdne105496:0"
+
+#. Label of a Link field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Branch"
+msgstr "crwdns105498:0crwdne105498:0"
+
+#. Label of a Link field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Branch"
+msgstr "crwdns105500:0crwdne105500:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Branch"
+msgid "Branch"
+msgstr "crwdns105502:0crwdne105502:0"
+
+#. Label of a Link field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Branch"
+msgstr "crwdns105504:0crwdne105504:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Branch"
+msgstr "crwdns105506:0crwdne105506:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Branch"
+msgstr "crwdns105508:0crwdne105508:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Branch"
+msgstr "crwdns105510:0crwdne105510:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:190
+msgid "Branch: {0}"
+msgstr "crwdns105512:0{0}crwdne105512:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:106
+msgid "Bulk Assignments"
+msgstr "crwdns105514:0crwdne105514:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment_list.js:3
+msgid "Bulk Leave Policy Assignment"
+msgstr "crwdns105516:0crwdne105516:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:139
+msgid "Bulk Salary Structure Assignment"
+msgstr "crwdns105518:0crwdne105518:0"
+
+#: payroll/report/income_tax_computation/income_tax_computation.py:515
+msgid "CTC"
+msgstr "crwdns105520:0crwdne105520:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "CTC"
+msgstr "crwdns105522:0crwdne105522:0"
+
+#. Label of a Select field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Calculate Gratuity Amount Based On"
+msgstr "crwdns105524:0crwdne105524:0"
+
+#. Label of a Select field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Calculate Payroll Working Days Based On"
+msgstr "crwdns105526:0crwdne105526:0"
+
+#. Description of the 'Expire Carry Forwarded Leaves (Days)' (Int) field in
+#. DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Calculated in days"
+msgstr "crwdns105528:0crwdne105528:0"
+
+#: setup.py:323
+msgid "Calls"
+msgstr "crwdns105530:0crwdne105530:0"
+
+#: setup.py:392
+msgid "Campaign"
+msgstr "crwdns105532:0crwdne105532:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:126
+msgid "Cancellation Queued"
+msgstr "crwdns105534:0crwdne105534:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Cancelled"
+msgstr "crwdns105536:0crwdne105536:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Cancelled"
+msgstr "crwdns105538:0crwdne105538:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Cancelled"
+msgstr "crwdns105540:0crwdne105540:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Cancelled"
+msgstr "crwdns105542:0crwdne105542:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Cancelled"
+msgstr "crwdns105544:0crwdne105544:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Cancelled"
+msgstr "crwdns105546:0crwdne105546:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Cancelled"
+msgstr "crwdns105548:0crwdne105548:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Cancelled"
+msgstr "crwdns105550:0crwdne105550:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Cancelled"
+msgstr "crwdns105552:0crwdne105552:0"
+
+#. Option for the 'Event Status' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Cancelled"
+msgstr "crwdns105554:0crwdne105554:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Cancelled"
+msgstr "crwdns105556:0crwdne105556:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:255
+msgid "Cannot create Salary Slip for Employee joining after Payroll Period"
+msgstr "crwdns105558:0crwdne105558:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:258
+msgid "Cannot create Salary Slip for Employee who has left before Payroll Period"
+msgstr "crwdns105560:0crwdne105560:0"
+
+#: hr/doctype/job_applicant/job_applicant.py:49
+msgid "Cannot create a Job Applicant against a closed Job Opening"
+msgstr "crwdns105562:0crwdne105562:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:200
+msgid "Cannot create or change transactions against a {0} Appraisal Cycle."
+msgstr "crwdns105564:0{0}crwdne105564:0"
+
+#: hr/doctype/leave_application/leave_application.py:552
+msgid "Cannot find active Leave Period"
+msgstr "crwdns105566:0crwdne105566:0"
+
+#: hr/doctype/attendance/attendance.py:145
+msgid "Cannot mark attendance for an Inactive employee {0}"
+msgstr "crwdns105568:0{0}crwdne105568:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:59
+msgid "Cannot submit. Attendance is not marked for some employees."
+msgstr "crwdns105570:0crwdne105570:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:138
+msgid "Cannot update allocation for {0} after submission"
+msgstr "crwdns105572:0{0}crwdne105572:0"
+
+#: hr/doctype/goal/goal_list.js:104
+msgid "Cannot update status of Goal groups"
+msgstr "crwdns105574:0crwdne105574:0"
+
+#. Label of a Check field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Carry Forward"
+msgstr "crwdns105576:0crwdne105576:0"
+
+#. Label of a Section Break field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Carry Forward"
+msgstr "crwdns105578:0crwdne105578:0"
+
+#. Label of a Float field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Carry Forwarded Leaves"
+msgstr "crwdns105580:0crwdne105580:0"
+
+#: setup.py:338 setup.py:339
+msgid "Casual Leave"
+msgstr "crwdns105582:0crwdne105582:0"
+
+#. Label of a Text field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Cause of Grievance"
+msgstr "crwdns105584:0crwdne105584:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Change"
+msgstr "crwdns105586:0crwdne105586:0"
+
+#: hr/doctype/goal/goal.js:96
+msgid "Changing KRA in this parent goal will align all the child goals to the same KRA, if any."
+msgstr "crwdns105588:0crwdne105588:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Account"
+msgid "Chart of Accounts"
+msgstr "crwdns105590:0crwdne105590:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Cost Center"
+msgid "Chart of Cost Centers"
+msgstr "crwdns105592:0crwdne105592:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1365
+msgid "Check Error Log {0} for more details."
+msgstr "crwdns105594:0{0}crwdne105594:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Check Vacancies On Job Offer Creation"
+msgstr "crwdns105596:0crwdne105596:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:119
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:329
+msgid "Check {0} for more details"
+msgstr "crwdns105598:0{0}crwdne105598:0"
+
+#. Label of a Date field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Check-in Date"
+msgstr "crwdns105600:0crwdne105600:0"
+
+#. Label of a Date field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Check-out Date"
+msgstr "crwdns105602:0crwdne105602:0"
+
+#: hr/doctype/goal/goal_tree.js:52
+msgid "Child nodes can only be created under 'Group' type nodes"
+msgstr "crwdns105604:0crwdne105604:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Claim Benefit For"
+msgstr "crwdns105606:0crwdne105606:0"
+
+#. Label of a Date field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Claim Date"
+msgstr "crwdns105608:0crwdne105608:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Claimed"
+msgstr "crwdns105610:0crwdne105610:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:69
+msgid "Claimed Amount"
+msgstr "crwdns105612:0crwdne105612:0"
+
+#. Label of a Currency field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Claimed Amount"
+msgstr "crwdns105614:0crwdne105614:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Claimed Amount"
+msgstr "crwdns105616:0crwdne105616:0"
+
+#. Label of a Card Break in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: overrides/dashboard_overrides.py:81
+msgid "Claims"
+msgstr "crwdns105618:0crwdne105618:0"
+
+#: www/jobs/index.html:20
+msgid "Clear All"
+msgstr "crwdns105620:0crwdne105620:0"
+
+#. Label of a Date field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Clearance Date"
+msgstr "crwdns105622:0crwdne105622:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Cleared"
+msgstr "crwdns105624:0crwdne105624:0"
+
+#. Option for the 'Result' (Select) field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Cleared"
+msgstr "crwdns105626:0crwdne105626:0"
+
+#: hr/doctype/goal/goal.js:75
+msgid "Close"
+msgstr "crwdns105628:0crwdne105628:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Closed"
+msgstr "crwdns105630:0crwdne105630:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Closed"
+msgstr "crwdns105632:0crwdne105632:0"
+
+#: templates/generators/job_opening.html:170
+msgid "Closed On"
+msgstr "crwdns105634:0crwdne105634:0"
+
+#. Label of a Date field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Closed On"
+msgstr "crwdns105636:0crwdne105636:0"
+
+#: templates/generators/job_opening.html:170
+msgid "Closes On"
+msgstr "crwdns105638:0crwdne105638:0"
+
+#. Label of a Date field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Closes On"
+msgstr "crwdns105640:0crwdne105640:0"
+
+#: www/jobs/index.html:216
+msgid "Closes on:"
+msgstr "crwdns105642:0crwdne105642:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:78
+msgid "Closing Balance"
+msgstr "crwdns105644:0crwdne105644:0"
+
+#. Label of a Text field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Closing Notes"
+msgstr "crwdns105646:0crwdne105646:0"
+
+#. Label of a Text field in DocType 'Appointment Letter Template'
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgctxt "Appointment Letter Template"
+msgid "Closing Notes"
+msgstr "crwdns105648:0crwdne105648:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:117
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:122
+msgid "Collapse All"
+msgstr "crwdns105650:0crwdne105650:0"
+
+#. Label of a Color field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Color"
+msgstr "crwdns105652:0crwdne105652:0"
+
+#. Label of a Text field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Comments"
+msgstr "crwdns105654:0crwdne105654:0"
+
+#. Label of a Small Text field in DocType 'Travel Request Costing'
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgctxt "Travel Request Costing"
+msgid "Comments"
+msgstr "crwdns105656:0crwdne105656:0"
+
+#: setup.py:384
+msgid "Commission"
+msgstr "crwdns105658:0crwdne105658:0"
+
+#: hr/dashboard_chart_source/employees_by_age/employees_by_age.js:8
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.js:8
+#: hr/doctype/goal/goal_tree.js:10
+#: hr/doctype/leave_control_panel/leave_control_panel.js:172
+#: hr/report/appraisal_overview/appraisal_overview.js:9
+#: hr/report/employee_advance_summary/employee_advance_summary.js:29
+#: hr/report/employee_advance_summary/employee_advance_summary.py:54
+#: hr/report/employee_analytics/employee_analytics.js:9
+#: hr/report/employee_analytics/employee_analytics.py:14
+#: hr/report/employee_analytics/employee_analytics.py:37
+#: hr/report/employee_birthday/employee_birthday.js:16
+#: hr/report/employee_birthday/employee_birthday.py:28
+#: hr/report/employee_exits/employee_exits.js:21
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:9
+#: hr/report/employee_leave_balance/employee_leave_balance.js:21
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:16
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:50
+#: hr/report/project_profitability/project_profitability.js:9
+#: hr/report/recruitment_analytics/recruitment_analytics.js:9
+#: hr/report/shift_attendance/shift_attendance.js:40
+#: hr/report/shift_attendance/shift_attendance.py:104
+#: payroll/report/bank_remittance/bank_remittance.js:9
+#: payroll/report/income_tax_computation/income_tax_computation.js:9
+#: payroll/report/salary_register/salary_register.js:39
+#: payroll/report/salary_register/salary_register.py:156
+#: public/js/salary_slip_deductions_report_filters.js:7
+msgid "Company"
+msgstr "crwdns105660:0crwdne105660:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Company"
+msgstr "crwdns105662:0crwdne105662:0"
+
+#. Label of a Link field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Company"
+msgstr "crwdns105664:0crwdne105664:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Company"
+msgstr "crwdns105666:0crwdne105666:0"
+
+#. Label of a Link field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Company"
+msgstr "crwdns105668:0crwdne105668:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Company"
+msgstr "crwdns105670:0crwdne105670:0"
+
+#. Label of a Link field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Company"
+msgstr "crwdns105672:0crwdne105672:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Company"
+msgid "Company"
+msgstr "crwdns105674:0crwdne105674:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Company"
+msgstr "crwdns105676:0crwdne105676:0"
+
+#. Label of a Link field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Company"
+msgstr "crwdns105678:0crwdne105678:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Company"
+msgstr "crwdns105680:0crwdne105680:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Company"
+msgstr "crwdns105682:0crwdne105682:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Company"
+msgstr "crwdns105684:0crwdne105684:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Company"
+msgstr "crwdns105686:0crwdne105686:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Company"
+msgstr "crwdns105688:0crwdne105688:0"
+
+#. Label of a Link field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Company"
+msgstr "crwdns105690:0crwdne105690:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Company"
+msgstr "crwdns105692:0crwdne105692:0"
+
+#. Label of a Link field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Company"
+msgstr "crwdns105694:0crwdne105694:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Company"
+msgstr "crwdns105696:0crwdne105696:0"
+
+#. Label of a Link field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Company"
+msgstr "crwdns105698:0crwdne105698:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Company"
+msgstr "crwdns105700:0crwdne105700:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Company"
+msgstr "crwdns105702:0crwdne105702:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Company"
+msgstr "crwdns105704:0crwdne105704:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Company"
+msgstr "crwdns105706:0crwdne105706:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Company"
+msgstr "crwdns105708:0crwdne105708:0"
+
+#. Label of a Link field in DocType 'Expense Claim Account'
+#: hr/doctype/expense_claim_account/expense_claim_account.json
+msgctxt "Expense Claim Account"
+msgid "Company"
+msgstr "crwdns105710:0crwdne105710:0"
+
+#. Label of a Link field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Company"
+msgstr "crwdns105712:0crwdne105712:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Company"
+msgstr "crwdns105714:0crwdne105714:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Company"
+msgstr "crwdns105716:0crwdne105716:0"
+
+#. Label of a Link field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Company"
+msgstr "crwdns105718:0crwdne105718:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Company"
+msgstr "crwdns105720:0crwdne105720:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Company"
+msgstr "crwdns105722:0crwdne105722:0"
+
+#. Label of a Link field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Company"
+msgstr "crwdns105724:0crwdne105724:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Company"
+msgstr "crwdns105726:0crwdne105726:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Company"
+msgstr "crwdns105728:0crwdne105728:0"
+
+#. Label of a Link field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Company"
+msgstr "crwdns105730:0crwdne105730:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Company"
+msgstr "crwdns105732:0crwdne105732:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Company"
+msgstr "crwdns105734:0crwdne105734:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Company"
+msgstr "crwdns105736:0crwdne105736:0"
+
+#. Label of a Link field in DocType 'Leave Period'
+#: hr/doctype/leave_period/leave_period.json
+msgctxt "Leave Period"
+msgid "Company"
+msgstr "crwdns105738:0crwdne105738:0"
+
+#. Label of a Link field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Company"
+msgstr "crwdns105740:0crwdne105740:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Company"
+msgstr "crwdns105742:0crwdne105742:0"
+
+#. Label of a Link field in DocType 'Payroll Period'
+#: payroll/doctype/payroll_period/payroll_period.json
+msgctxt "Payroll Period"
+msgid "Company"
+msgstr "crwdns105744:0crwdne105744:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Company"
+msgstr "crwdns105746:0crwdne105746:0"
+
+#. Label of a Link field in DocType 'Salary Component Account'
+#: payroll/doctype/salary_component_account/salary_component_account.json
+msgctxt "Salary Component Account"
+msgid "Company"
+msgstr "crwdns105748:0crwdne105748:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Company"
+msgstr "crwdns105750:0crwdne105750:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Company"
+msgstr "crwdns105752:0crwdne105752:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Company"
+msgstr "crwdns105754:0crwdne105754:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Company"
+msgstr "crwdns105756:0crwdne105756:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Company"
+msgstr "crwdns105758:0crwdne105758:0"
+
+#. Label of a Link field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Company"
+msgstr "crwdns105760:0crwdne105760:0"
+
+#. Label of a Link field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Company"
+msgstr "crwdns105762:0crwdne105762:0"
+
+#. Label of a Link field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Company"
+msgstr "crwdns105764:0crwdne105764:0"
+
+#. Label of a Section Break field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Company Details"
+msgstr "crwdns105766:0crwdne105766:0"
+
+#. Name of a DocType
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgid "Compensatory Leave Request"
+msgstr "crwdns105768:0crwdne105768:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgctxt "Compensatory Leave Request"
+msgid "Compensatory Leave Request"
+msgstr "crwdns105770:0crwdne105770:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Compensatory Leave Request"
+msgstr "crwdns105772:0crwdne105772:0"
+
+#: setup.py:347 setup.py:348
+msgid "Compensatory Off"
+msgstr "crwdns105774:0crwdne105774:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Completed"
+msgstr "crwdns105776:0crwdne105776:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Completed"
+msgstr "crwdns105778:0crwdne105778:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Completed"
+msgstr "crwdns105780:0crwdne105780:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Completed"
+msgstr "crwdns105782:0crwdne105782:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Completed"
+msgstr "crwdns105784:0crwdne105784:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Completed"
+msgstr "crwdns105786:0crwdne105786:0"
+
+#. Option for the 'Event Status' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Completed"
+msgstr "crwdns105788:0crwdne105788:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Completed"
+msgstr "crwdns105790:0crwdne105790:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Completed"
+msgstr "crwdns105792:0crwdne105792:0"
+
+#. Label of a Date field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Completed On"
+msgstr "crwdns105794:0crwdne105794:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.js:95
+msgid "Completing onboarding"
+msgstr "crwdns105796:0crwdne105796:0"
+
+#. Label of a Data field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Component"
+msgstr "crwdns105798:0crwdne105798:0"
+
+#. Label of a Link field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Component"
+msgstr "crwdns105800:0crwdne105800:0"
+
+#. Label of a Section Break field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Component properties and references "
+msgstr "crwdns105802:0crwdne105802:0"
+
+#. Label of a Code field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Condition"
+msgstr "crwdns105804:0crwdne105804:0"
+
+#. Label of a Code field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Condition"
+msgstr "crwdns105806:0crwdne105806:0"
+
+#. Label of a Code field in DocType 'Taxable Salary Slab'
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgctxt "Taxable Salary Slab"
+msgid "Condition"
+msgstr "crwdns105808:0crwdne105808:0"
+
+#. Label of a Tab Break field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Condition & Formula"
+msgstr "crwdns105810:0crwdne105810:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:13
+msgid "Condition and Formula Help"
+msgstr "crwdns105812:0crwdne105812:0"
+
+#. Label of a Section Break field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Condition and formula"
+msgstr "crwdns105814:0crwdne105814:0"
+
+#. Label of a Section Break field in DocType 'Income Tax Slab Other Charges'
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgctxt "Income Tax Slab Other Charges"
+msgid "Conditions"
+msgstr "crwdns105816:0crwdne105816:0"
+
+#. Label of a HTML field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Conditions and Formula variable and example"
+msgstr "crwdns105818:0crwdne105818:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Conference"
+msgstr "crwdns105820:0crwdne105820:0"
+
+#. Label of a Tab Break field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Connections"
+msgstr "crwdns105822:0crwdne105822:0"
+
+#. Label of a Tab Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Connections"
+msgstr "crwdns105824:0crwdne105824:0"
+
+#: hr/report/shift_attendance/shift_attendance.js:58
+msgid "Consider Grace Period"
+msgstr "crwdns105826:0crwdne105826:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Consider Marked Attendance on Holidays"
+msgstr "crwdns105828:0crwdne105828:0"
+
+#: payroll/report/income_tax_computation/income_tax_computation.js:40
+msgid "Consider Tax Exemption Declaration"
+msgstr "crwdns105830:0crwdne105830:0"
+
+#. Label of a Select field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Consider Unmarked Attendance As"
+msgstr "crwdns105832:0crwdne105832:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.js:55
+msgid "Consolidate Leave Types"
+msgstr "crwdns105834:0crwdne105834:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Contact Email"
+msgstr "crwdns105836:0crwdne105836:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Contact No."
+msgstr "crwdns105838:0crwdne105838:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Contact Number"
+msgstr "crwdns105840:0crwdne105840:0"
+
+#. Label of a Data field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Contact Number"
+msgstr "crwdns105842:0crwdne105842:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Contact Number"
+msgstr "crwdns105844:0crwdne105844:0"
+
+#: setup.py:383
+msgid "Contract"
+msgstr "crwdns105846:0crwdne105846:0"
+
+#. Label of a Attach field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Copy of Invitation/Announcement"
+msgstr "crwdns105848:0crwdne105848:0"
+
+#: hr/report/project_profitability/project_profitability.py:178
+msgid "Cost"
+msgstr "crwdns105850:0crwdne105850:0"
+
+#. Label of a Link field in DocType 'Employee Cost Center'
+#: payroll/doctype/employee_cost_center/employee_cost_center.json
+msgctxt "Employee Cost Center"
+msgid "Cost Center"
+msgstr "crwdns105852:0crwdne105852:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Cost Center"
+msgstr "crwdns105854:0crwdne105854:0"
+
+#. Label of a Link field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Cost Center"
+msgstr "crwdns105856:0crwdne105856:0"
+
+#. Label of a Link field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Cost Center"
+msgstr "crwdns105858:0crwdne105858:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Cost Center"
+msgstr "crwdns105860:0crwdne105860:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Cost Center"
+msgstr "crwdns105862:0crwdne105862:0"
+
+#. Label of a Link field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Cost Center"
+msgstr "crwdns105864:0crwdne105864:0"
+
+#. Label of a Table field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Cost Centers"
+msgstr "crwdns105866:0crwdne105866:0"
+
+#. Label of a Table field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Costing"
+msgstr "crwdns105868:0crwdne105868:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Costing Details"
+msgstr "crwdns105870:0crwdne105870:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1426
+msgid "Could not submit some Salary Slips: {}"
+msgstr "crwdns105872:0crwdne105872:0"
+
+#: hr/doctype/goal/goal_tree.js:299
+msgid "Could not update Goal"
+msgstr "crwdns105874:0crwdne105874:0"
+
+#: hr/doctype/goal/goal_list.js:138
+msgid "Could not update goals"
+msgstr "crwdns105876:0crwdne105876:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Country"
+msgstr "crwdns105878:0crwdne105878:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Course"
+msgstr "crwdns105880:0crwdne105880:0"
+
+#. Label of a Data field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Course"
+msgstr "crwdns105882:0crwdne105882:0"
+
+#. Label of a Text field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Cover Letter"
+msgstr "crwdns105884:0crwdne105884:0"
+
+#: hr/doctype/employee_advance/employee_advance.js:50
+#: hr/doctype/employee_advance/employee_advance.js:61
+#: hr/doctype/employee_advance/employee_advance.js:72
+#: hr/doctype/employee_advance/employee_advance.js:76
+#: hr/doctype/employee_onboarding/employee_onboarding.js:44
+#: hr/doctype/employee_onboarding/employee_onboarding.js:45
+#: hr/doctype/expense_claim/expense_claim.js:235
+#: hr/doctype/job_applicant/job_applicant.js:26
+#: hr/doctype/job_applicant/job_applicant.js:46
+#: hr/doctype/vehicle_log/vehicle_log.js:9
+#: hr/doctype/vehicle_log/vehicle_log.js:10
+#: payroll/doctype/income_tax_slab/income_tax_slab.js:16
+#: payroll/doctype/income_tax_slab/income_tax_slab.js:18
+#: payroll/doctype/salary_component/salary_component.js:29
+#: payroll/doctype/salary_structure/salary_structure.js:104
+#: payroll/doctype/salary_structure/salary_structure.js:108
+#: payroll/doctype/salary_structure/salary_structure.js:115
+#: payroll/doctype/salary_structure/salary_structure.js:117
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.js:70
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.js:72
+#: public/js/erpnext/delivery_trip.js:12
+msgid "Create"
+msgstr "crwdns105886:0crwdne105886:0"
+
+#: hr/doctype/employee_referral/employee_referral.js:39
+msgid "Create Additional Salary"
+msgstr "crwdns105888:0crwdne105888:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:35
+msgid "Create Appraisals"
+msgstr "crwdns105890:0crwdne105890:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_department/create_department.json
+msgid "Create Department"
+msgstr "crwdns105892:0crwdne105892:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_designation/create_designation.json
+msgid "Create Designation"
+msgstr "crwdns105894:0crwdne105894:0"
+
+#. Title of an Onboarding Step
+#: hr/doctype/job_offer/job_offer.js:40
+#: hr/onboarding_step/create_employee/create_employee.json
+#: payroll/onboarding_step/create_employee/create_employee.json
+msgid "Create Employee"
+msgstr "crwdns105896:0crwdne105896:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_holiday_list/create_holiday_list.json
+msgid "Create Holiday List"
+msgstr "crwdns105898:0crwdne105898:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/create_income_tax_slab/create_income_tax_slab.json
+msgid "Create Income Tax Slab"
+msgstr "crwdns105900:0crwdne105900:0"
+
+#: hr/doctype/interview_round/interview_round.js:7
+msgid "Create Interview"
+msgstr "crwdns105902:0crwdne105902:0"
+
+#: hr/doctype/employee_referral/employee_referral.js:21
+msgid "Create Job Applicant"
+msgstr "crwdns105904:0crwdne105904:0"
+
+#: hr/doctype/job_requisition/job_requisition.js:31
+msgid "Create Job Opening"
+msgstr "crwdns105906:0crwdne105906:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.js:10
+msgid "Create Journal Entry"
+msgstr "crwdns105908:0crwdne105908:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_leave_allocation/create_leave_allocation.json
+msgid "Create Leave Allocation"
+msgstr "crwdns105910:0crwdne105910:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_leave_application/create_leave_application.json
+msgid "Create Leave Application"
+msgstr "crwdns105912:0crwdne105912:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/create_leave_type/create_leave_type.json
+msgid "Create Leave Type"
+msgstr "crwdns105914:0crwdne105914:0"
+
+#. Label of a Check field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Create New Employee Id"
+msgstr "crwdns105916:0crwdne105916:0"
+
+#: payroll/doctype/gratuity/gratuity.js:36
+msgid "Create Payment Entry"
+msgstr "crwdns105918:0crwdne105918:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/create_payroll_period/create_payroll_period.json
+msgid "Create Payroll Period"
+msgstr "crwdns105920:0crwdne105920:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/create_salary_component/create_salary_component.json
+msgid "Create Salary Component"
+msgstr "crwdns105922:0crwdne105922:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/create_salary_slip/create_salary_slip.json
+#: public/js/erpnext/timesheet.js:8
+msgid "Create Salary Slip"
+msgstr "crwdns105924:0crwdne105924:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:74
+#: payroll/doctype/payroll_entry/payroll_entry.js:81
+#: payroll/doctype/payroll_entry/payroll_entry.js:148
+msgid "Create Salary Slips"
+msgstr "crwdns105926:0crwdne105926:0"
+
+#. Title of an Onboarding Step
+#: payroll/onboarding_step/create_salary_structure/create_salary_structure.json
+msgid "Create Salary Structure"
+msgstr "crwdns105928:0crwdne105928:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Create Separate Payment Entry Against Benefit Claim"
+msgstr "crwdns105930:0crwdne105930:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:191
+msgid "Creating Appraisals"
+msgstr "crwdns105932:0crwdne105932:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:414
+msgid "Creating Payment Entries......"
+msgstr "crwdns105934:0crwdne105934:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1388
+msgid "Creating Salary Slips..."
+msgstr "crwdns105936:0crwdne105936:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:128
+msgid "Creation Failed"
+msgstr "crwdns105938:0crwdne105938:0"
+
+#: hr/doctype/appraisal_template/appraisal_template.py:23
+msgid "Criteria"
+msgstr "crwdns105940:0crwdne105940:0"
+
+#. Label of a Data field in DocType 'Employee Feedback Criteria'
+#: hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+msgctxt "Employee Feedback Criteria"
+msgid "Criteria"
+msgstr "crwdns105942:0crwdne105942:0"
+
+#. Label of a Link field in DocType 'Employee Feedback Rating'
+#: hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgctxt "Employee Feedback Rating"
+msgid "Criteria"
+msgstr "crwdns105944:0crwdne105944:0"
+
+#. Description of the 'Rating Criteria' (Table) field in DocType 'Appraisal
+#. Template'
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Criteria based on which employee should be rated in Performance Feedback and Self Appraisal"
+msgstr "crwdns105946:0crwdne105946:0"
+
+#: hr/report/project_profitability/project_profitability.py:206
+#: payroll/report/bank_remittance/bank_remittance.py:48
+#: payroll/report/salary_register/salary_register.js:26
+#: payroll/report/salary_register/salary_register.py:244
+msgid "Currency"
+msgstr "crwdns105948:0crwdne105948:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Currency"
+msgstr "crwdns105950:0crwdne105950:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Currency"
+msgid "Currency"
+msgstr "crwdns105952:0crwdne105952:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Currency"
+msgstr "crwdns105954:0crwdne105954:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Currency"
+msgstr "crwdns105956:0crwdne105956:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Currency"
+msgstr "crwdns105958:0crwdne105958:0"
+
+#. Label of a Link field in DocType 'Employee Grade'
+#: hr/doctype/employee_grade/employee_grade.json
+msgctxt "Employee Grade"
+msgid "Currency"
+msgstr "crwdns105960:0crwdne105960:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Currency"
+msgstr "crwdns105962:0crwdne105962:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Currency"
+msgstr "crwdns105964:0crwdne105964:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Currency"
+msgstr "crwdns105966:0crwdne105966:0"
+
+#. Label of a Link field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Currency"
+msgstr "crwdns105968:0crwdne105968:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Currency"
+msgstr "crwdns105970:0crwdne105970:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Currency"
+msgstr "crwdns105972:0crwdne105972:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Currency"
+msgstr "crwdns105974:0crwdne105974:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Currency"
+msgstr "crwdns105976:0crwdne105976:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Currency"
+msgstr "crwdns105978:0crwdne105978:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Currency"
+msgstr "crwdns105980:0crwdne105980:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Currency"
+msgstr "crwdns105982:0crwdne105982:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Currency"
+msgstr "crwdns105984:0crwdne105984:0"
+
+#. Label of a Section Break field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Currency "
+msgstr "crwdns105986:0crwdne105986:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:99
+msgid "Currency of selected Income Tax Slab should be {0} instead of {1}"
+msgstr "crwdns105988:0{0}crwdnd105988:0{1}crwdne105988:0"
+
+#: hr/employee_property_update.js:85
+msgid "Current"
+msgstr "crwdns105990:0crwdne105990:0"
+
+#. Label of a Data field in DocType 'Employee Property History'
+#: hr/doctype/employee_property_history/employee_property_history.json
+msgctxt "Employee Property History"
+msgid "Current"
+msgstr "crwdns105992:0crwdne105992:0"
+
+#. Label of a Currency field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Current CTC"
+msgstr "crwdns105994:0crwdne105994:0"
+
+#. Label of a Int field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Current Count"
+msgstr "crwdns105996:0crwdne105996:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Current Employer "
+msgstr "crwdns105998:0crwdne105998:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Current Job Title"
+msgstr "crwdns106000:0crwdne106000:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Current Month Income Tax"
+msgstr "crwdns106002:0crwdne106002:0"
+
+#: hr/doctype/vehicle_log/vehicle_log.py:15
+msgid "Current Odometer Value should be greater than Last Odometer Value {0}"
+msgstr "crwdns106004:0{0}crwdne106004:0"
+
+#. Label of a Int field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Current Odometer value "
+msgstr "crwdns106006:0crwdne106006:0"
+
+#. Label of a Int field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Current Openings"
+msgstr "crwdns106008:0crwdne106008:0"
+
+#. Option for the 'Calculate Gratuity Amount Based On' (Select) field in
+#. DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Current Slab"
+msgstr "crwdns106010:0crwdne106010:0"
+
+#. Label of a Int field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Current Work Experience"
+msgstr "crwdns106012:0crwdne106012:0"
+
+#. Label of a Table field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Current Work Experience"
+msgstr "crwdns106014:0crwdne106014:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:98
+msgid "Currently, there is no {0} leave period for this date to create/update leave allocation."
+msgstr "crwdns106016:0{0}crwdne106016:0"
+
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Custom Range"
+msgstr "crwdns106018:0crwdne106018:0"
+
+#: hr/report/project_profitability/project_profitability.js:31
+#: hr/report/project_profitability/project_profitability.py:135
+msgid "Customer"
+msgstr "crwdns106020:0crwdne106020:0"
+
+#. Label of a Data field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Cycle Name"
+msgstr "crwdns106022:0crwdne106022:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Daily"
+msgstr "crwdns106024:0crwdne106024:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Daily"
+msgstr "crwdns106026:0crwdne106026:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Daily"
+msgstr "crwdns106028:0crwdne106028:0"
+
+#. Name of a DocType
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.js:7
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgid "Daily Work Summary"
+msgstr "crwdns106030:0crwdne106030:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Daily Work Summary"
+msgid "Daily Work Summary"
+msgstr "crwdns106032:0crwdne106032:0"
+
+#. Name of a DocType
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+#: hr/page/team_updates/team_updates.js:12
+msgid "Daily Work Summary Group"
+msgstr "crwdns106034:0crwdne106034:0"
+
+#. Label of a Link field in DocType 'Daily Work Summary'
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+msgctxt "Daily Work Summary"
+msgid "Daily Work Summary Group"
+msgstr "crwdns106036:0crwdne106036:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgctxt "Daily Work Summary Group"
+msgid "Daily Work Summary Group"
+msgstr "crwdns106038:0crwdne106038:0"
+
+#. Name of a DocType
+#: hr/doctype/daily_work_summary_group_user/daily_work_summary_group_user.json
+msgid "Daily Work Summary Group User"
+msgstr "crwdns106040:0crwdne106040:0"
+
+#. Name of a report
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgid "Daily Work Summary Replies"
+msgstr "crwdns106042:0crwdne106042:0"
+
+#. Label of a shortcut in the Employee Lifecycle Workspace
+#. Label of a shortcut in the Expense Claims Workspace
+#. Label of a shortcut in the Recruitment Workspace
+#. Label of a shortcut in the Shift & Attendance Workspace
+#. Label of a shortcut in the Payroll Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/expense_claims/expense_claims.json
+#: hr/workspace/recruitment/recruitment.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+#: payroll/workspace/payroll/payroll.json
+msgid "Dashboard"
+msgstr "crwdns106044:0crwdne106044:0"
+
+#. Label of a Tab Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Dashboard"
+msgstr "crwdns106046:0crwdne106046:0"
+
+#. Title of an Onboarding Step
+#: hr/onboarding_step/data_import/data_import.json
+msgid "Data Import"
+msgstr "crwdns106048:0crwdne106048:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:27
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:9
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.py:22
+#: hr/report/vehicle_expenses/vehicle_expenses.py:42
+msgid "Date"
+msgstr "crwdns106050:0crwdne106050:0"
+
+#. Label of a Date field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Date"
+msgstr "crwdns106052:0crwdne106052:0"
+
+#. Label of a Date field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Date"
+msgstr "crwdns106054:0crwdne106054:0"
+
+#. Label of a Date field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Date"
+msgstr "crwdns106056:0crwdne106056:0"
+
+#. Label of a Date field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Date"
+msgstr "crwdns106058:0crwdne106058:0"
+
+#. Label of a Datetime field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Date"
+msgstr "crwdns106060:0crwdne106060:0"
+
+#. Label of a Date field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Date"
+msgstr "crwdns106062:0crwdne106062:0"
+
+#. Label of a Date field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Date "
+msgstr "crwdns106064:0crwdne106064:0"
+
+#: hr/doctype/goal/goal_tree.js:38
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.js:16
+msgid "Date Range"
+msgstr "crwdns106066:0crwdne106066:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.py:19
+msgid "Date is repeated"
+msgstr "crwdns106068:0crwdne106068:0"
+
+#: hr/report/employee_analytics/employee_analytics.py:32
+#: hr/report/employee_birthday/employee_birthday.py:23
+msgid "Date of Birth"
+msgstr "crwdns106070:0crwdne106070:0"
+
+#. Label of a Date field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Date of Birth"
+msgstr "crwdns106072:0crwdne106072:0"
+
+#: hr/report/employee_exits/employee_exits.py:32
+#: payroll/report/income_tax_computation/income_tax_computation.py:507
+#: payroll/report/salary_register/salary_register.py:129 setup.py:394
+msgid "Date of Joining"
+msgstr "crwdns106074:0crwdne106074:0"
+
+#. Label of a Date field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Date of Joining"
+msgstr "crwdns106076:0crwdne106076:0"
+
+#. Label of a Date field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Date of Joining"
+msgstr "crwdns106078:0crwdne106078:0"
+
+#. Label of a Date field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Date of Joining"
+msgstr "crwdns106080:0crwdne106080:0"
+
+#. Option for the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Date of Joining"
+msgstr "crwdns106082:0crwdne106082:0"
+
+#. Label of a Data field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Date of Joining"
+msgstr "crwdns106084:0crwdne106084:0"
+
+#. Label of a Section Break field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Dates & Reason"
+msgstr "crwdns106086:0crwdne106086:0"
+
+#. Label of a Select field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Dates Based On"
+msgstr "crwdns106088:0crwdne106088:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:19
+msgid "Debit A/C Number"
+msgstr "crwdns106090:0crwdne106090:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:24
+#: public/js/salary_slip_deductions_report_filters.js:30
+msgid "Dec"
+msgstr "crwdns106092:0crwdne106092:0"
+
+#: hr/report/employee_exits/employee_exits.py:193
+msgid "Decision Pending"
+msgstr "crwdns106094:0crwdne106094:0"
+
+#. Label of a Table field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Declarations"
+msgstr "crwdns106096:0crwdne106096:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Declaration
+#. Category'
+#: payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgctxt "Employee Tax Exemption Declaration Category"
+msgid "Declared Amount"
+msgstr "crwdns106098:0crwdne106098:0"
+
+#. Label of a Check field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Deduct Full Tax on Selected Payroll Date"
+msgstr "crwdns106100:0crwdne106100:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Deduct Full Tax on Selected Payroll Date"
+msgstr "crwdns106102:0crwdne106102:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Deduct Full Tax on Selected Payroll Date"
+msgstr "crwdns106104:0crwdne106104:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Deduct Tax For Unclaimed Employee Benefits"
+msgstr "crwdns106106:0crwdne106106:0"
+
+#. Label of a Check field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Deduct Tax For Unclaimed Employee Benefits"
+msgstr "crwdns106108:0crwdne106108:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Deduct Tax For Unsubmitted Tax Exemption Proof"
+msgstr "crwdns106110:0crwdne106110:0"
+
+#. Label of a Check field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Deduct Tax For Unsubmitted Tax Exemption Proof"
+msgstr "crwdns106112:0crwdne106112:0"
+
+#: payroll/report/salary_register/salary_register.py:84
+#: payroll/report/salary_register/salary_register.py:91
+msgid "Deduction"
+msgstr "crwdns106114:0crwdne106114:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Deduction"
+msgstr "crwdns106116:0crwdne106116:0"
+
+#. Label of a Card Break in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Deduction Reports"
+msgstr "crwdns106118:0crwdne106118:0"
+
+#: hr/doctype/employee_advance/employee_advance.js:74
+msgid "Deduction from Salary"
+msgstr "crwdns106120:0crwdne106120:0"
+
+#. Label of a Table field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Deductions"
+msgstr "crwdns106122:0crwdne106122:0"
+
+#. Label of a Table field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Deductions"
+msgstr "crwdns106124:0crwdne106124:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Deductions before tax calculation"
+msgstr "crwdns106126:0crwdne106126:0"
+
+#. Label of a Link field in DocType 'Expense Claim Account'
+#: hr/doctype/expense_claim_account/expense_claim_account.json
+msgctxt "Expense Claim Account"
+msgid "Default Account"
+msgstr "crwdns106128:0crwdne106128:0"
+
+#. Label of a Link field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Default Account"
+msgstr "crwdns106130:0crwdne106130:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Default Amount"
+msgstr "crwdns106132:0crwdne106132:0"
+
+#. Description of the 'Account' (Link) field in DocType 'Salary Component
+#. Account'
+#: payroll/doctype/salary_component_account/salary_component_account.json
+msgctxt "Salary Component Account"
+msgid "Default Bank / Cash account will be automatically updated in Salary Journal Entry when this mode is selected."
+msgstr "crwdns106134:0crwdne106134:0"
+
+#. Label of a Currency field in DocType 'Employee Grade'
+#: hr/doctype/employee_grade/employee_grade.json
+msgctxt "Employee Grade"
+msgid "Default Base Pay"
+msgstr "crwdns106136:0crwdne106136:0"
+
+#. Label of a Link field in DocType 'Employee Grade'
+#: hr/doctype/employee_grade/employee_grade.json
+msgctxt "Employee Grade"
+msgid "Default Salary Structure"
+msgstr "crwdns106138:0crwdne106138:0"
+
+#. Label of a Check field in DocType 'Expense Claim Type'
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+msgctxt "Expense Claim Type"
+msgid "Deferred Expense Account"
+msgstr "crwdns106140:0crwdne106140:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Define Opening Balance for Earning and Deductions"
+msgstr "crwdns106142:0crwdne106142:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Delivery Trip"
+msgstr "crwdns106144:0crwdne106144:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.js:177
+#: hr/report/appraisal_overview/appraisal_overview.js:29
+#: hr/report/appraisal_overview/appraisal_overview.py:61
+#: hr/report/employee_analytics/employee_analytics.py:34
+#: hr/report/employee_birthday/employee_birthday.py:25
+#: hr/report/employee_exits/employee_exits.js:27
+#: hr/report/employee_exits/employee_exits.py:65
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:37
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:62
+#: hr/report/employee_leave_balance/employee_leave_balance.js:30
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:30
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py:24
+#: hr/report/shift_attendance/shift_attendance.js:34
+#: hr/report/shift_attendance/shift_attendance.py:97
+#: payroll/doctype/salary_structure/salary_structure.js:144
+#: payroll/report/income_tax_computation/income_tax_computation.js:33
+#: payroll/report/income_tax_computation/income_tax_computation.py:494
+#: payroll/report/salary_register/salary_register.py:142
+#: public/js/salary_slip_deductions_report_filters.js:42 setup.py:400
+#: templates/generators/job_opening.html:82
+msgid "Department"
+msgstr "crwdns106146:0crwdne106146:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Department"
+msgstr "crwdns106148:0crwdne106148:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Department"
+msgstr "crwdns106150:0crwdne106150:0"
+
+#. Label of a Link field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Department"
+msgstr "crwdns106152:0crwdne106152:0"
+
+#. Label of a Link field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Department"
+msgstr "crwdns106154:0crwdne106154:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Department"
+msgstr "crwdns106156:0crwdne106156:0"
+
+#. Label of a Link field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Department"
+msgstr "crwdns106158:0crwdne106158:0"
+
+#. Label of a Link field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Department"
+msgstr "crwdns106160:0crwdne106160:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Department"
+msgid "Department"
+msgstr "crwdns106162:0crwdne106162:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Department"
+msgstr "crwdns106164:0crwdne106164:0"
+
+#. Label of a Link field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Department"
+msgstr "crwdns106166:0crwdne106166:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Department"
+msgstr "crwdns106168:0crwdne106168:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Department"
+msgstr "crwdns106170:0crwdne106170:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Department"
+msgstr "crwdns106172:0crwdne106172:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Department"
+msgstr "crwdns106174:0crwdne106174:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Department"
+msgstr "crwdns106176:0crwdne106176:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Department"
+msgstr "crwdns106178:0crwdne106178:0"
+
+#. Label of a Link field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Department"
+msgstr "crwdns106180:0crwdne106180:0"
+
+#. Label of a Link field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Department"
+msgstr "crwdns106182:0crwdne106182:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Department"
+msgstr "crwdns106184:0crwdne106184:0"
+
+#. Label of a Link field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Department"
+msgstr "crwdns106186:0crwdne106186:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Department"
+msgstr "crwdns106188:0crwdne106188:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Department"
+msgstr "crwdns106190:0crwdne106190:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Department"
+msgstr "crwdns106192:0crwdne106192:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Department"
+msgstr "crwdns106194:0crwdne106194:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Department"
+msgstr "crwdns106196:0crwdne106196:0"
+
+#. Label of a Link field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Department"
+msgstr "crwdns106198:0crwdne106198:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Department"
+msgstr "crwdns106200:0crwdne106200:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Department"
+msgstr "crwdns106202:0crwdne106202:0"
+
+#. Label of a Link field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Department"
+msgstr "crwdns106204:0crwdne106204:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Department"
+msgstr "crwdns106206:0crwdne106206:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Department"
+msgstr "crwdns106208:0crwdne106208:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Department"
+msgstr "crwdns106210:0crwdne106210:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Department"
+msgstr "crwdns106212:0crwdne106212:0"
+
+#. Label of a Link field in DocType 'Payroll Employee Detail'
+#: payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgctxt "Payroll Employee Detail"
+msgid "Department"
+msgstr "crwdns106214:0crwdne106214:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Department"
+msgstr "crwdns106216:0crwdne106216:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Department"
+msgstr "crwdns106218:0crwdne106218:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Department"
+msgstr "crwdns106220:0crwdne106220:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Department"
+msgstr "crwdns106222:0crwdne106222:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Department"
+msgstr "crwdns106224:0crwdne106224:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Department"
+msgstr "crwdns106226:0crwdne106226:0"
+
+#. Label of a Link field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Department"
+msgstr "crwdns106228:0crwdne106228:0"
+
+#. Label of a Link field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Department"
+msgstr "crwdns106230:0crwdne106230:0"
+
+#. Label of a Link field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Department"
+msgstr "crwdns106232:0crwdne106232:0"
+
+#. Label of a Link field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Department"
+msgstr "crwdns106234:0crwdne106234:0"
+
+#. Name of a DocType
+#: hr/doctype/department_approver/department_approver.json
+msgid "Department Approver"
+msgstr "crwdns106236:0crwdne106236:0"
+
+#. Label of a chart in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgid "Department Wise Openings"
+msgstr "crwdns106238:0crwdne106238:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:192
+msgid "Department: {0}"
+msgstr "crwdns106240:0{0}crwdne106240:0"
+
+#. Label of a Datetime field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Departure Datetime"
+msgstr "crwdns106242:0crwdne106242:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Depends on Payment Days"
+msgstr "crwdns106244:0crwdne106244:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Depends on Payment Days"
+msgstr "crwdns106246:0crwdne106246:0"
+
+#: hr/doctype/goal/goal_tree.js:156
+msgid "Description"
+msgstr "crwdns106248:0crwdne106248:0"
+
+#. Label of a Long Text field in DocType 'Appointment Letter content'
+#: hr/doctype/appointment_letter_content/appointment_letter_content.json
+msgctxt "Appointment Letter content"
+msgid "Description"
+msgstr "crwdns106250:0crwdne106250:0"
+
+#. Label of a Section Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Description"
+msgstr "crwdns106252:0crwdne106252:0"
+
+#. Label of a Section Break field in DocType 'Appraisal Template'
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Description"
+msgstr "crwdns106254:0crwdne106254:0"
+
+#. Label of a Text Editor field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Description"
+msgstr "crwdns106256:0crwdne106256:0"
+
+#. Label of a Text field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Description"
+msgstr "crwdns106258:0crwdne106258:0"
+
+#. Label of a Small Text field in DocType 'Expected Skill Set'
+#: hr/doctype/expected_skill_set/expected_skill_set.json
+msgctxt "Expected Skill Set"
+msgid "Description"
+msgstr "crwdns106260:0crwdne106260:0"
+
+#. Label of a Text Editor field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Description"
+msgstr "crwdns106262:0crwdne106262:0"
+
+#. Label of a Small Text field in DocType 'Expense Claim Type'
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+msgctxt "Expense Claim Type"
+msgid "Description"
+msgstr "crwdns106264:0crwdne106264:0"
+
+#. Label of a Small Text field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Description"
+msgstr "crwdns106266:0crwdne106266:0"
+
+#. Label of a Small Text field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Description"
+msgstr "crwdns106268:0crwdne106268:0"
+
+#. Label of a Section Break field in DocType 'Goal'
+#. Label of a Text Editor field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Description"
+msgstr "crwdns106270:0crwdne106270:0"
+
+#. Label of a Text field in DocType 'Grievance Type'
+#: hr/doctype/grievance_type/grievance_type.json
+msgctxt "Grievance Type"
+msgid "Description"
+msgstr "crwdns106272:0crwdne106272:0"
+
+#. Label of a Data field in DocType 'Income Tax Slab Other Charges'
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgctxt "Income Tax Slab Other Charges"
+msgid "Description"
+msgstr "crwdns106274:0crwdne106274:0"
+
+#. Label of a Text field in DocType 'Interview Type'
+#: hr/doctype/interview_type/interview_type.json
+msgctxt "Interview Type"
+msgid "Description"
+msgstr "crwdns106276:0crwdne106276:0"
+
+#. Label of a Text Editor field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Description"
+msgstr "crwdns106278:0crwdne106278:0"
+
+#. Label of a Small Text field in DocType 'KRA'
+#: hr/doctype/kra/kra.json
+msgctxt "KRA"
+msgid "Description"
+msgstr "crwdns106280:0crwdne106280:0"
+
+#. Label of a Small Text field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Description"
+msgstr "crwdns106282:0crwdne106282:0"
+
+#. Label of a Small Text field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Description"
+msgstr "crwdns106284:0crwdne106284:0"
+
+#. Label of a Text field in DocType 'Skill'
+#: hr/doctype/skill/skill.json
+msgctxt "Skill"
+msgid "Description"
+msgstr "crwdns106286:0crwdne106286:0"
+
+#. Label of a Text Editor field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Description"
+msgstr "crwdns106288:0crwdne106288:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Description"
+msgstr "crwdns106290:0crwdne106290:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.js:35
+#: hr/report/appraisal_overview/appraisal_overview.py:30
+#: hr/report/employee_analytics/employee_analytics.py:35
+#: hr/report/employee_birthday/employee_birthday.py:26
+#: hr/report/employee_exits/employee_exits.js:33
+#: hr/report/employee_exits/employee_exits.py:72
+#: hr/report/recruitment_analytics/recruitment_analytics.py:59
+#: payroll/doctype/salary_structure/salary_structure.js:143
+#: payroll/report/income_tax_computation/income_tax_computation.py:501
+#: payroll/report/salary_register/salary_register.py:149
+msgid "Designation"
+msgstr "crwdns106292:0crwdne106292:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Designation"
+msgstr "crwdns106294:0crwdne106294:0"
+
+#. Label of a Link field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Designation"
+msgstr "crwdns106296:0crwdne106296:0"
+
+#. Linked DocType in Appraisal Template's connections
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Designation"
+msgstr "crwdns106298:0crwdne106298:0"
+
+#. Label of a Data field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Designation"
+msgstr "crwdns106300:0crwdne106300:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Designation"
+msgid "Designation"
+msgstr "crwdns106302:0crwdne106302:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Designation"
+msgstr "crwdns106304:0crwdne106304:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Designation"
+msgstr "crwdns106306:0crwdne106306:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Designation"
+msgstr "crwdns106308:0crwdne106308:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Designation"
+msgstr "crwdns106310:0crwdne106310:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Designation"
+msgstr "crwdns106312:0crwdne106312:0"
+
+#. Label of a Link field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Designation"
+msgstr "crwdns106314:0crwdne106314:0"
+
+#. Label of a Read Only field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Designation"
+msgstr "crwdns106316:0crwdne106316:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Designation"
+msgstr "crwdns106318:0crwdne106318:0"
+
+#. Label of a Link field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Designation"
+msgstr "crwdns106320:0crwdne106320:0"
+
+#. Label of a Data field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Designation"
+msgstr "crwdns106322:0crwdne106322:0"
+
+#. Label of a Link field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Designation"
+msgstr "crwdns106324:0crwdne106324:0"
+
+#. Label of a Link field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Designation"
+msgstr "crwdns106326:0crwdne106326:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Designation"
+msgstr "crwdns106328:0crwdne106328:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Designation"
+msgstr "crwdns106330:0crwdne106330:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Designation"
+msgstr "crwdns106332:0crwdne106332:0"
+
+#. Label of a Link field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Designation"
+msgstr "crwdns106334:0crwdne106334:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Designation"
+msgstr "crwdns106336:0crwdne106336:0"
+
+#. Label of a Data field in DocType 'Payroll Employee Detail'
+#: payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgctxt "Payroll Employee Detail"
+msgid "Designation"
+msgstr "crwdns106338:0crwdne106338:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Designation"
+msgstr "crwdns106340:0crwdne106340:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Designation"
+msgstr "crwdns106342:0crwdne106342:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Designation"
+msgstr "crwdns106344:0crwdne106344:0"
+
+#. Label of a Link field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Designation"
+msgstr "crwdns106346:0crwdne106346:0"
+
+#. Name of a DocType
+#: hr/doctype/designation_skill/designation_skill.json
+msgid "Designation Skill"
+msgstr "crwdns106348:0crwdne106348:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:194
+msgid "Designation: {0}"
+msgstr "crwdns106350:0{0}crwdne106350:0"
+
+#: templates/emails/training_event.html:4
+msgid "Details"
+msgstr "crwdns106352:0crwdne106352:0"
+
+#. Label of a Section Break field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Details"
+msgstr "crwdns106354:0crwdne106354:0"
+
+#. Label of a Section Break field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Details"
+msgstr "crwdns106356:0crwdne106356:0"
+
+#. Label of a Section Break field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Details"
+msgstr "crwdns106358:0crwdne106358:0"
+
+#. Label of a Section Break field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Details"
+msgstr "crwdns106360:0crwdne106360:0"
+
+#. Label of a Text Editor field in DocType 'Job Applicant Source'
+#: hr/doctype/job_applicant_source/job_applicant_source.json
+msgctxt "Job Applicant Source"
+msgid "Details"
+msgstr "crwdns106362:0crwdne106362:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Details"
+msgstr "crwdns106364:0crwdne106364:0"
+
+#. Label of a Section Break field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Details"
+msgstr "crwdns106366:0crwdne106366:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Details of Sponsor (Name, Location)"
+msgstr "crwdns106368:0crwdne106368:0"
+
+#. Label of a Select field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Determine Check-in and Check-out"
+msgstr "crwdns106370:0crwdne106370:0"
+
+#. Label of a Check field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Disable"
+msgstr "crwdns106372:0crwdne106372:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Disable Rounded Total"
+msgstr "crwdns106374:0crwdne106374:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:96
+msgid "Disable {0} for the {1} component, to prevent the amount from being deducted twice, as its formula already uses a payment-days-based component."
+msgstr "crwdns106376:0{0}crwdnd106376:0{1}crwdne106376:0"
+
+#: hr/doctype/leave_type/leave_type.py:39
+msgid "Disable {0} or {1} to proceed."
+msgstr "crwdns106378:0{0}crwdnd106378:0{1}crwdne106378:0"
+
+#. Label of a Check field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Disabled"
+msgstr "crwdns106380:0crwdne106380:0"
+
+#. Label of a Check field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Disabled"
+msgstr "crwdns106382:0crwdne106382:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Disabled"
+msgstr "crwdns106384:0crwdne106384:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Dispensed Amount (Pro-rated)"
+msgstr "crwdns106386:0crwdne106386:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Do Not Include in Total"
+msgstr "crwdns106388:0crwdne106388:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Do not include in total"
+msgstr "crwdns106390:0crwdne106390:0"
+
+#: hr/doctype/goal/goal.js:98
+msgid "Do you still want to proceed?"
+msgstr "crwdns106392:0crwdne106392:0"
+
+#: hr/doctype/interview/interview.py:70
+msgid "Do you want to update the Job Applicant {0} as {1} based on this interview result?"
+msgstr "crwdns106394:0{0}crwdnd106394:0{1}crwdne106394:0"
+
+#: payroll/report/salary_register/salary_register.js:48
+msgid "Document Status"
+msgstr "crwdns106396:0crwdne106396:0"
+
+#. Option for the 'Travel Type' (Select) field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Domestic"
+msgstr "crwdns106398:0crwdne106398:0"
+
+#. Label of a Section Break field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Download Template"
+msgstr "crwdns106400:0crwdne106400:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Draft"
+msgstr "crwdns106402:0crwdne106402:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Draft"
+msgstr "crwdns106404:0crwdne106404:0"
+
+#. Option for the 'Approval Status' (Select) field in DocType 'Expense Claim'
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Draft"
+msgstr "crwdns106406:0crwdne106406:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Draft"
+msgstr "crwdns106408:0crwdne106408:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Draft"
+msgstr "crwdns106410:0crwdne106410:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Draft"
+msgstr "crwdns106412:0crwdne106412:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Draft"
+msgstr "crwdns106414:0crwdne106414:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Driver"
+msgid "Driver"
+msgstr "crwdns106416:0crwdne106416:0"
+
+#: hr/doctype/attendance/attendance.py:79
+msgid "Duplicate Attendance"
+msgstr "crwdns106418:0crwdne106418:0"
+
+#: hr/doctype/appraisal/appraisal.py:60
+#: payroll/doctype/payroll_entry/payroll_entry.py:93
+msgid "Duplicate Entry"
+msgstr "crwdns106420:0crwdne106420:0"
+
+#: hr/doctype/job_requisition/job_requisition.py:35
+msgid "Duplicate Job Requisition"
+msgstr "crwdns106422:0crwdne106422:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:139
+msgid "Duplicate Overwritten Salary"
+msgstr "crwdns106424:0crwdne106424:0"
+
+#. Label of a Int field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Duration (Days)"
+msgstr "crwdns106426:0crwdne106426:0"
+
+#: hr/report/shift_attendance/shift_attendance.js:53
+msgid "Early Exit"
+msgstr "crwdns106428:0crwdne106428:0"
+
+#. Label of a Check field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Early Exit"
+msgstr "crwdns106430:0crwdne106430:0"
+
+#. Label of a Check field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Early Exit"
+msgstr "crwdns106432:0crwdne106432:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:91
+msgid "Early Exit By"
+msgstr "crwdns106434:0crwdne106434:0"
+
+#. Label of a Int field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Early Exit Grace Period"
+msgstr "crwdns106436:0crwdne106436:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:186
+msgid "Early Exits"
+msgstr "crwdns106438:0crwdne106438:0"
+
+#. Label of a Section Break field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Earned Leave"
+msgstr "crwdns106440:0crwdne106440:0"
+
+#. Label of a Select field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Earned Leave Frequency"
+msgstr "crwdns106442:0crwdne106442:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:139
+msgid "Earned Leaves"
+msgstr "crwdns106444:0crwdne106444:0"
+
+#: hr/doctype/leave_type/leave_type.py:34
+msgid "Earned Leaves are allocated as per the configured frequency via scheduler."
+msgstr "crwdns106446:0crwdne106446:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:142
+msgid "Earned Leaves are auto-allocated via scheduler based on the annual allocation set in the Leave Policy: {0}"
+msgstr "crwdns106448:0{0}crwdne106448:0"
+
+#: hr/doctype/leave_type/leave_type.js:36
+msgid "Earned Leaves are leaves earned by an Employee after working with the company for a certain amount of time. Enabling this will allocate leaves on pro-rata basis by automatically updating Leave Allocation for leaves of this type at intervals set by 'Earned Leave Frequency."
+msgstr "crwdns106450:0crwdne106450:0"
+
+#: payroll/report/salary_register/salary_register.py:84
+#: payroll/report/salary_register/salary_register.py:90
+msgid "Earning"
+msgstr "crwdns106452:0crwdne106452:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Earning"
+msgstr "crwdns106454:0crwdne106454:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application Detail'
+#: payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgctxt "Employee Benefit Application Detail"
+msgid "Earning Component"
+msgstr "crwdns106456:0crwdne106456:0"
+
+#. Label of a Link field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Earning Component"
+msgstr "crwdns106458:0crwdne106458:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:106
+msgid "Earning Salary Component is required for Employee Referral Bonus."
+msgstr "crwdns106460:0crwdne106460:0"
+
+#. Label of a Table field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Earnings"
+msgstr "crwdns106462:0crwdne106462:0"
+
+#. Label of a Table field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Earnings"
+msgstr "crwdns106464:0crwdne106464:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Earnings & Deductions"
+msgstr "crwdns106466:0crwdne106466:0"
+
+#. Label of a Tab Break field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Earnings & Deductions"
+msgstr "crwdns106468:0crwdne106468:0"
+
+#. Label of a Section Break field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Earnings and Taxation "
+msgstr "crwdns106470:0crwdne106470:0"
+
+#. Label of a Date field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Effective From"
+msgstr "crwdns106472:0crwdne106472:0"
+
+#. Label of a Date field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Effective To"
+msgstr "crwdns106474:0crwdne106474:0"
+
+#. Label of a Date field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Effective from"
+msgstr "crwdns106476:0crwdne106476:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Email"
+msgstr "crwdns106478:0crwdne106478:0"
+
+#. Label of a Section Break field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Email"
+msgstr "crwdns106480:0crwdne106480:0"
+
+#. Label of a Data field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Email Address"
+msgstr "crwdns106482:0crwdne106482:0"
+
+#. Label of a Data field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Email ID"
+msgstr "crwdns106484:0crwdne106484:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Email Salary Slip to Employee"
+msgstr "crwdns106486:0crwdne106486:0"
+
+#: payroll/doctype/salary_slip/salary_slip_list.js:5
+msgid "Email Salary Slips"
+msgstr "crwdns106488:0crwdne106488:0"
+
+#. Label of a Code field in DocType 'Daily Work Summary'
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+msgctxt "Daily Work Summary"
+msgid "Email Sent To"
+msgstr "crwdns106490:0crwdne106490:0"
+
+#: hr/doctype/leave_application/leave_application.py:648
+msgid "Email sent to {0}"
+msgstr "crwdns106492:0{0}crwdne106492:0"
+
+#. Description of the 'Email Salary Slip to Employee' (Check) field in DocType
+#. 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Emails salary slip to employee based on preferred email selected in Employee"
+msgstr "crwdns106494:0crwdne106494:0"
+
+#. Name of a role
+#. Label of a Card Break in the HR Workspace
+#: hr/doctype/appraisal/appraisal.json
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hr/doctype/appraisal_template/appraisal_template.json
+#: hr/doctype/attendance_request/attendance_request.json
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+#: hr/doctype/employee_advance/employee_advance.json
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:139
+#: hr/doctype/employee_checkin/employee_checkin.json
+#: hr/doctype/employee_grievance/employee_grievance.json
+#: hr/doctype/employee_onboarding/employee_onboarding.js:26
+#: hr/doctype/employee_onboarding/employee_onboarding.js:39
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hr/doctype/employee_promotion/employee_promotion.json
+#: hr/doctype/employee_referral/employee_referral.json
+#: hr/doctype/employee_separation/employee_separation.js:14
+#: hr/doctype/employee_transfer/employee_transfer.json
+#: hr/doctype/expense_claim/expense_claim.json
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+#: hr/doctype/goal/goal.json hr/doctype/goal/goal_tree.js:33
+#: hr/doctype/goal/goal_tree.js:62
+#: hr/doctype/grievance_type/grievance_type.json
+#: hr/doctype/interest/interest.json
+#: hr/doctype/leave_application/leave_application.json
+#: hr/doctype/leave_control_panel/leave_control_panel.js:162
+#: hr/doctype/leave_encashment/leave_encashment.json
+#: hr/doctype/leave_type/leave_type.json
+#: hr/doctype/pwa_notification/pwa_notification.json
+#: hr/doctype/shift_assignment/shift_assignment.json
+#: hr/doctype/shift_request/shift_request.json
+#: hr/doctype/shift_type/shift_type.json
+#: hr/doctype/training_feedback/training_feedback.json
+#: hr/report/appraisal_overview/appraisal_overview.js:24
+#: hr/report/appraisal_overview/appraisal_overview.py:22
+#: hr/report/employee_advance_summary/employee_advance_summary.js:9
+#: hr/report/employee_advance_summary/employee_advance_summary.py:47
+#: hr/report/employee_analytics/employee_analytics.py:30
+#: hr/report/employee_birthday/employee_birthday.py:21
+#: hr/report/employee_exits/employee_exits.js:39
+#: hr/report/employee_exits/employee_exits.py:24
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:31
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:55
+#: hr/report/employee_leave_balance/employee_leave_balance.js:36
+#: hr/report/employee_leave_balance/employee_leave_balance.py:40
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:24
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py:22
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.py:20
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:36
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:88
+#: hr/report/project_profitability/project_profitability.js:37
+#: hr/report/project_profitability/project_profitability.py:142
+#: hr/report/shift_attendance/shift_attendance.js:22
+#: hr/report/shift_attendance/shift_attendance.py:22
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.js:8
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:18
+#: hr/report/vehicle_expenses/vehicle_expenses.js:46
+#: hr/report/vehicle_expenses/vehicle_expenses.py:55 hr/workspace/hr/hr.json
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: payroll/doctype/employee_incentive/employee_incentive.json
+#: payroll/doctype/employee_other_income/employee_other_income.json
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: payroll/doctype/retention_bonus/retention_bonus.json
+#: payroll/doctype/salary_component/salary_component.json
+#: payroll/doctype/salary_slip/salary_slip.json
+#: payroll/doctype/salary_structure/salary_structure.js:146
+#: payroll/doctype/salary_structure/salary_structure.js:209
+#: payroll/report/income_tax_computation/income_tax_computation.js:26
+#: payroll/report/income_tax_computation/income_tax_computation.py:481
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:25
+#: payroll/report/professional_tax_deductions/professional_tax_deductions.py:21
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:20
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:35
+#: payroll/report/salary_register/salary_register.js:32
+#: payroll/report/salary_register/salary_register.py:116
+msgid "Employee"
+msgstr "crwdns106496:0crwdne106496:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Employee"
+msgstr "crwdns106498:0crwdne106498:0"
+
+#. Label of a Link field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Employee"
+msgstr "crwdns106500:0crwdne106500:0"
+
+#. Label of a Link field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Employee"
+msgstr "crwdns106502:0crwdne106502:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Employee"
+msgstr "crwdns106504:0crwdne106504:0"
+
+#. Label of a Link field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Employee"
+msgstr "crwdns106506:0crwdne106506:0"
+
+#. Label of a Link field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Employee"
+msgstr "crwdns106508:0crwdne106508:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Employee"
+msgid "Employee"
+msgstr "crwdns106510:0crwdne106510:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Employee"
+msgstr "crwdns106512:0crwdne106512:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Employee"
+msgstr "crwdns106514:0crwdne106514:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Employee"
+msgstr "crwdns106516:0crwdne106516:0"
+
+#. Label of a Link field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Employee"
+msgstr "crwdns106518:0crwdne106518:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#. Label of a Section Break field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Employee"
+msgstr "crwdns106520:0crwdne106520:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Employee"
+msgstr "crwdns106522:0crwdne106522:0"
+
+#. Label of a Link field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Employee"
+msgstr "crwdns106524:0crwdne106524:0"
+
+#. Label of a Link field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Employee"
+msgstr "crwdns106526:0crwdne106526:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Employee"
+msgstr "crwdns106528:0crwdne106528:0"
+
+#. Label of a Link field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Employee"
+msgstr "crwdns106530:0crwdne106530:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Employee"
+msgstr "crwdns106532:0crwdne106532:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#. Label of a Tab Break field in DocType 'Employee Tax Exemption Proof
+#. Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Employee"
+msgstr "crwdns106534:0crwdne106534:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Employee"
+msgstr "crwdns106536:0crwdne106536:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Employee"
+msgstr "crwdns106538:0crwdne106538:0"
+
+#. Label of a Link field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Employee"
+msgstr "crwdns106540:0crwdne106540:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Employee"
+msgstr "crwdns106542:0crwdne106542:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Employee"
+msgstr "crwdns106544:0crwdne106544:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Employee"
+msgstr "crwdns106546:0crwdne106546:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Employee"
+msgstr "crwdns106548:0crwdne106548:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Employee"
+msgstr "crwdns106550:0crwdne106550:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Employee"
+msgstr "crwdns106552:0crwdne106552:0"
+
+#. Label of a Link field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Employee"
+msgstr "crwdns106554:0crwdne106554:0"
+
+#. Label of a Link field in DocType 'Payroll Employee Detail'
+#: payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgctxt "Payroll Employee Detail"
+msgid "Employee"
+msgstr "crwdns106556:0crwdne106556:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#. Label of a Section Break field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Employee"
+msgstr "crwdns106558:0crwdne106558:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Employee"
+msgstr "crwdns106560:0crwdne106560:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Employee"
+msgstr "crwdns106562:0crwdne106562:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Employee"
+msgstr "crwdns106564:0crwdne106564:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Employee"
+msgstr "crwdns106566:0crwdne106566:0"
+
+#. Label of a Link field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Employee"
+msgstr "crwdns106568:0crwdne106568:0"
+
+#. Label of a Link field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Employee"
+msgstr "crwdns106570:0crwdne106570:0"
+
+#. Label of a Link field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Employee"
+msgstr "crwdns106572:0crwdne106572:0"
+
+#. Label of a Link field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Employee"
+msgstr "crwdns106574:0crwdne106574:0"
+
+#. Label of a Link field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Employee"
+msgstr "crwdns106576:0crwdne106576:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:35
+msgid "Employee A/C Number"
+msgstr "crwdns106578:0crwdne106578:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_advance/employee_advance.json
+msgid "Employee Advance"
+msgstr "crwdns106580:0crwdne106580:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a shortcut in the Expense Claims Workspace
+#. Label of a Link in the HR Workspace
+#: hr/workspace/expense_claims/expense_claims.json hr/workspace/hr/hr.json
+msgctxt "Employee Advance"
+msgid "Employee Advance"
+msgstr "crwdns106582:0crwdne106582:0"
+
+#. Label of a Link field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Employee Advance"
+msgstr "crwdns106584:0crwdne106584:0"
+
+#. Name of a report
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/employee_advance_summary/employee_advance_summary.json
+#: hr/workspace/expense_claims/expense_claims.json hr/workspace/hr/hr.json
+msgid "Employee Advance Summary"
+msgstr "crwdns106586:0crwdne106586:0"
+
+#: overrides/company.py:104
+msgid "Employee Advances"
+msgstr "crwdns106588:0crwdne106588:0"
+
+#. Name of a report
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/employee_analytics/employee_analytics.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgid "Employee Analytics"
+msgstr "crwdns106590:0crwdne106590:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Employee Attendance Tool"
+msgstr "crwdns106592:0crwdne106592:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Employee Attendance Tool"
+msgid "Employee Attendance Tool"
+msgstr "crwdns106594:0crwdne106594:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgid "Employee Benefit Application"
+msgstr "crwdns106596:0crwdne106596:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Benefit Application"
+msgid "Employee Benefit Application"
+msgstr "crwdns106598:0crwdne106598:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgid "Employee Benefit Application Detail"
+msgstr "crwdns106600:0crwdne106600:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgid "Employee Benefit Claim"
+msgstr "crwdns106602:0crwdne106602:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Benefit Claim"
+msgid "Employee Benefit Claim"
+msgstr "crwdns106604:0crwdne106604:0"
+
+#: setup.py:397
+msgid "Employee Benefits"
+msgstr "crwdns106606:0crwdne106606:0"
+
+#. Label of a Table field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Employee Benefits"
+msgstr "crwdns106608:0crwdne106608:0"
+
+#. Name of a report
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/employee_birthday/employee_birthday.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgid "Employee Birthday"
+msgstr "crwdns106610:0crwdne106610:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgid "Employee Boarding Activity"
+msgstr "crwdns106612:0crwdne106612:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgid "Employee Checkin"
+msgstr "crwdns106614:0crwdne106614:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#. Label of a shortcut in the Shift & Attendance Workspace
+#: hr/workspace/hr/hr.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Employee Checkin"
+msgid "Employee Checkin"
+msgstr "crwdns106616:0crwdne106616:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_cost_center/employee_cost_center.json
+msgid "Employee Cost Center"
+msgstr "crwdns106618:0crwdne106618:0"
+
+#. Label of a Section Break field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Employee Details"
+msgstr "crwdns106620:0crwdne106620:0"
+
+#. Label of a Section Break field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Employee Details"
+msgstr "crwdns106622:0crwdne106622:0"
+
+#. Label of a Tab Break field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Employee Details"
+msgstr "crwdns106624:0crwdne106624:0"
+
+#. Label of a Section Break field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Employee Details"
+msgstr "crwdns106626:0crwdne106626:0"
+
+#. Label of a Section Break field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Employee Details"
+msgstr "crwdns106628:0crwdne106628:0"
+
+#. Label of a Section Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Employee Details"
+msgstr "crwdns106630:0crwdne106630:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Employee Details"
+msgstr "crwdns106632:0crwdne106632:0"
+
+#. Label of a Small Text field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Employee Emails"
+msgstr "crwdns106634:0crwdne106634:0"
+
+#. Label of a Small Text field in DocType 'Training Result'
+#: hr/doctype/training_result/training_result.json
+msgctxt "Training Result"
+msgid "Employee Emails"
+msgstr "crwdns106636:0crwdne106636:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Employee Exit Settings"
+msgstr "crwdns106638:0crwdne106638:0"
+
+#. Name of a report
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/employee_exits/employee_exits.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgid "Employee Exits"
+msgstr "crwdns106640:0crwdne106640:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+msgid "Employee Feedback Criteria"
+msgstr "crwdns106642:0crwdne106642:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Employee Feedback Criteria"
+msgid "Employee Feedback Criteria"
+msgstr "crwdns106644:0crwdne106644:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgid "Employee Feedback Rating"
+msgstr "crwdns106646:0crwdne106646:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:141
+msgid "Employee Filters"
+msgstr "crwdns106648:0crwdne106648:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_grade/employee_grade.json
+#: payroll/doctype/salary_structure/salary_structure.js:145
+msgid "Employee Grade"
+msgstr "crwdns106650:0crwdne106650:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Employee Grade"
+msgid "Employee Grade"
+msgstr "crwdns106652:0crwdne106652:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Employee Grade"
+msgstr "crwdns106654:0crwdne106654:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Employee Grade"
+msgstr "crwdns106656:0crwdne106656:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Employee Grade"
+msgstr "crwdns106658:0crwdne106658:0"
+
+#. Label of a Link field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Employee Grade"
+msgstr "crwdns106660:0crwdne106660:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Employee Grade"
+msgstr "crwdns106662:0crwdne106662:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgid "Employee Grievance"
+msgstr "crwdns106664:0crwdne106664:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a shortcut in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Grievance"
+msgid "Employee Grievance"
+msgstr "crwdns106666:0crwdne106666:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "Employee Group"
+msgid "Employee Group"
+msgstr "crwdns106668:0crwdne106668:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_health_insurance/employee_health_insurance.json
+msgid "Employee Health Insurance"
+msgstr "crwdns106670:0crwdne106670:0"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employee Hours Utilization Based On Timesheet"
+msgstr "crwdns106672:0crwdne106672:0"
+
+#. Label of a Attach Image field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Employee Image"
+msgstr "crwdns106674:0crwdne106674:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgid "Employee Incentive"
+msgstr "crwdns106676:0crwdne106676:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Employee Incentive"
+msgid "Employee Incentive"
+msgstr "crwdns106678:0crwdne106678:0"
+
+#. Label of a Section Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Employee Info"
+msgstr "crwdns106680:0crwdne106680:0"
+
+#. Name of a report
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the HR Workspace
+#: hr/report/employee_information/employee_information.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/hr/hr.json
+msgid "Employee Information"
+msgstr "crwdns106682:0crwdne106682:0"
+
+#. Name of a report
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Leaves Workspace
+#: hr/report/employee_leave_balance/employee_leave_balance.json
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgid "Employee Leave Balance"
+msgstr "crwdns106684:0crwdne106684:0"
+
+#. Name of a report
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Leaves Workspace
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.json
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgid "Employee Leave Balance Summary"
+msgstr "crwdns106686:0crwdne106686:0"
+
+#. Name of a Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgid "Employee Lifecycle"
+msgstr "crwdns106688:0crwdne106688:0"
+
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Employee Lifecycle Dashboard"
+msgstr "crwdns106690:0crwdne106690:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:26
+#: hr/report/employee_exits/employee_exits.py:30
+#: hr/report/employee_leave_balance/employee_leave_balance.py:47
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py:23
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:94
+#: hr/report/project_profitability/project_profitability.py:147
+#: hr/report/shift_attendance/shift_attendance.py:31
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:19
+#: payroll/report/bank_remittance/bank_remittance.py:27
+#: payroll/report/income_tax_computation/income_tax_computation.py:488
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:32
+#: payroll/report/professional_tax_deductions/professional_tax_deductions.py:28
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:27
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:28
+#: payroll/report/salary_register/salary_register.py:123
+msgid "Employee Name"
+msgstr "crwdns106692:0crwdne106692:0"
+
+#. Label of a Data field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Employee Name"
+msgstr "crwdns106694:0crwdne106694:0"
+
+#. Label of a Data field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Employee Name"
+msgstr "crwdns106696:0crwdne106696:0"
+
+#. Label of a Data field in DocType 'Appraisee'
+#: hr/doctype/appraisee/appraisee.json
+msgctxt "Appraisee"
+msgid "Employee Name"
+msgstr "crwdns106698:0crwdne106698:0"
+
+#. Label of a Data field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Employee Name"
+msgstr "crwdns106700:0crwdne106700:0"
+
+#. Label of a Data field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Employee Name"
+msgstr "crwdns106702:0crwdne106702:0"
+
+#. Label of a Data field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Employee Name"
+msgstr "crwdns106704:0crwdne106704:0"
+
+#. Label of a Read Only field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Employee Name"
+msgstr "crwdns106706:0crwdne106706:0"
+
+#. Label of a Data field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Employee Name"
+msgstr "crwdns106708:0crwdne106708:0"
+
+#. Label of a Data field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Employee Name"
+msgstr "crwdns106710:0crwdne106710:0"
+
+#. Label of a Data field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Employee Name"
+msgstr "crwdns106712:0crwdne106712:0"
+
+#. Label of a Data field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Employee Name"
+msgstr "crwdns106714:0crwdne106714:0"
+
+#. Label of a Data field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Employee Name"
+msgstr "crwdns106716:0crwdne106716:0"
+
+#. Label of a Data field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Employee Name"
+msgstr "crwdns106718:0crwdne106718:0"
+
+#. Label of a Data field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Employee Name"
+msgstr "crwdns106720:0crwdne106720:0"
+
+#. Label of a Data field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Employee Name"
+msgstr "crwdns106722:0crwdne106722:0"
+
+#. Label of a Data field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Employee Name"
+msgstr "crwdns106724:0crwdne106724:0"
+
+#. Label of a Data field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Employee Name"
+msgstr "crwdns106726:0crwdne106726:0"
+
+#. Label of a Read Only field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Employee Name"
+msgstr "crwdns106728:0crwdne106728:0"
+
+#. Label of a Data field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Employee Name"
+msgstr "crwdns106730:0crwdne106730:0"
+
+#. Label of a Data field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Employee Name"
+msgstr "crwdns106732:0crwdne106732:0"
+
+#. Label of a Data field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Employee Name"
+msgstr "crwdns106734:0crwdne106734:0"
+
+#. Label of a Data field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Employee Name"
+msgstr "crwdns106736:0crwdne106736:0"
+
+#. Label of a Data field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Employee Name"
+msgstr "crwdns106738:0crwdne106738:0"
+
+#. Label of a Data field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Employee Name"
+msgstr "crwdns106740:0crwdne106740:0"
+
+#. Label of a Data field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Employee Name"
+msgstr "crwdns106742:0crwdne106742:0"
+
+#. Label of a Data field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Employee Name"
+msgstr "crwdns106744:0crwdne106744:0"
+
+#. Label of a Data field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Employee Name"
+msgstr "crwdns106746:0crwdne106746:0"
+
+#. Label of a Data field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Employee Name"
+msgstr "crwdns106748:0crwdne106748:0"
+
+#. Label of a Data field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Employee Name"
+msgstr "crwdns106750:0crwdne106750:0"
+
+#. Label of a Data field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Employee Name"
+msgstr "crwdns106752:0crwdne106752:0"
+
+#. Label of a Data field in DocType 'Payroll Employee Detail'
+#: payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgctxt "Payroll Employee Detail"
+msgid "Employee Name"
+msgstr "crwdns106754:0crwdne106754:0"
+
+#. Label of a Data field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Employee Name"
+msgstr "crwdns106756:0crwdne106756:0"
+
+#. Label of a Read Only field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Employee Name"
+msgstr "crwdns106758:0crwdne106758:0"
+
+#. Label of a Data field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Employee Name"
+msgstr "crwdns106760:0crwdne106760:0"
+
+#. Label of a Data field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Employee Name"
+msgstr "crwdns106762:0crwdne106762:0"
+
+#. Label of a Data field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Employee Name"
+msgstr "crwdns106764:0crwdne106764:0"
+
+#. Label of a Read Only field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Employee Name"
+msgstr "crwdns106766:0crwdne106766:0"
+
+#. Label of a Read Only field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Employee Name"
+msgstr "crwdns106768:0crwdne106768:0"
+
+#. Label of a Read Only field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Employee Name"
+msgstr "crwdns106770:0crwdne106770:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Employee Name"
+msgstr "crwdns106772:0crwdne106772:0"
+
+#. Label of a Select field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Employee Naming By"
+msgstr "crwdns106774:0crwdne106774:0"
+
+#. Option for the 'Employee Naming By' (Select) field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Employee Number"
+msgstr "crwdns106776:0crwdne106776:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgid "Employee Onboarding"
+msgstr "crwdns106778:0crwdne106778:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a shortcut in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Onboarding"
+msgid "Employee Onboarding"
+msgstr "crwdns106780:0crwdne106780:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgid "Employee Onboarding Template"
+msgstr "crwdns106782:0crwdne106782:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Employee Onboarding Template"
+msgstr "crwdns106784:0crwdne106784:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Onboarding Template"
+msgid "Employee Onboarding Template"
+msgstr "crwdns106786:0crwdne106786:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.py:32
+msgid "Employee Onboarding: {0} already exists for Job Applicant: {1}"
+msgstr "crwdns106788:0{0}crwdnd106788:0{1}crwdne106788:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgid "Employee Other Income"
+msgstr "crwdns106790:0crwdne106790:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Employee Performance Feedback"
+msgstr "crwdns106792:0crwdne106792:0"
+
+#. Linked DocType in Appraisal Cycle's connections
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Employee Performance Feedback"
+msgstr "crwdns106794:0crwdne106794:0"
+
+#. Label of a Link in the Performance Workspace
+#. Label of a shortcut in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Employee Performance Feedback"
+msgid "Employee Performance Feedback"
+msgstr "crwdns106796:0crwdne106796:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgid "Employee Promotion"
+msgstr "crwdns106798:0crwdne106798:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/performance/performance.json
+msgctxt "Employee Promotion"
+msgid "Employee Promotion"
+msgstr "crwdns106800:0crwdne106800:0"
+
+#. Label of a Section Break field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Employee Promotion Details"
+msgstr "crwdns106802:0crwdne106802:0"
+
+#: hr/doctype/employee_promotion/employee_promotion.py:20
+msgid "Employee Promotion cannot be submitted before Promotion Date"
+msgstr "crwdns106804:0crwdne106804:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_property_history/employee_property_history.json
+msgid "Employee Property History"
+msgstr "crwdns106806:0crwdne106806:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_referral/employee_referral.json setup.py:391
+msgid "Employee Referral"
+msgstr "crwdns106808:0crwdne106808:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Employee Referral"
+msgid "Employee Referral"
+msgstr "crwdns106810:0crwdne106810:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Employee Referral"
+msgstr "crwdns106812:0crwdne106812:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:102
+msgid "Employee Referral {0} is not applicable for referral bonus."
+msgstr "crwdns106814:0{0}crwdne106814:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Employee Responsible "
+msgstr "crwdns106816:0crwdne106816:0"
+
+#. Option for the 'Final Decision' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Employee Retained"
+msgstr "crwdns106818:0crwdne106818:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_separation/employee_separation.json
+msgid "Employee Separation"
+msgstr "crwdns106820:0crwdne106820:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#. Label of a shortcut in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Separation"
+msgid "Employee Separation"
+msgstr "crwdns106822:0crwdne106822:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgid "Employee Separation Template"
+msgstr "crwdns106824:0crwdne106824:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Employee Separation Template"
+msgstr "crwdns106826:0crwdne106826:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Separation Template"
+msgid "Employee Separation Template"
+msgstr "crwdns106828:0crwdne106828:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Employee Settings"
+msgstr "crwdns106830:0crwdne106830:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_skill/employee_skill.json
+msgid "Employee Skill"
+msgstr "crwdns106832:0crwdne106832:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgid "Employee Skill Map"
+msgstr "crwdns106834:0crwdne106834:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Skill Map"
+msgid "Employee Skill Map"
+msgstr "crwdns106836:0crwdne106836:0"
+
+#. Label of a Table field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Employee Skills"
+msgstr "crwdns106838:0crwdne106838:0"
+
+#: hr/report/employee_exits/employee_exits.py:194
+#: hr/report/employee_leave_balance/employee_leave_balance.js:42
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:36
+msgid "Employee Status"
+msgstr "crwdns106840:0crwdne106840:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+msgid "Employee Tax Exemption Category"
+msgstr "crwdns106842:0crwdne106842:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgid "Employee Tax Exemption Declaration"
+msgstr "crwdns106844:0crwdne106844:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#. Label of a shortcut in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Employee Tax Exemption Declaration"
+msgstr "crwdns106846:0crwdne106846:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgid "Employee Tax Exemption Declaration Category"
+msgstr "crwdns106848:0crwdne106848:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Tax Exemption Declaration Category"
+msgid "Employee Tax Exemption Declaration Category"
+msgstr "crwdns106850:0crwdne106850:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Employee Tax Exemption Proof Submission"
+msgstr "crwdns106852:0crwdne106852:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Employee Tax Exemption Proof Submission"
+msgstr "crwdns106854:0crwdne106854:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Employee Tax Exemption Proof Submission Detail"
+msgstr "crwdns106856:0crwdne106856:0"
+
+#. Name of a DocType
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgid "Employee Tax Exemption Sub Category"
+msgstr "crwdns106858:0crwdne106858:0"
+
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Employee Tax Exemption Sub Category"
+msgid "Employee Tax Exemption Sub Category"
+msgstr "crwdns106860:0crwdne106860:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_training/employee_training.json
+msgid "Employee Training"
+msgstr "crwdns106862:0crwdne106862:0"
+
+#. Name of a DocType
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgid "Employee Transfer"
+msgstr "crwdns106864:0crwdne106864:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Employee Transfer"
+msgid "Employee Transfer"
+msgstr "crwdns106866:0crwdne106866:0"
+
+#. Label of a Table field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Employee Transfer Detail"
+msgstr "crwdns106868:0crwdne106868:0"
+
+#. Label of a Section Break field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Employee Transfer Details"
+msgstr "crwdns106870:0crwdne106870:0"
+
+#: hr/doctype/employee_transfer/employee_transfer.py:17
+msgid "Employee Transfer cannot be submitted before Transfer Date"
+msgstr "crwdns106872:0crwdne106872:0"
+
+#: hr/doctype/hr_settings/hr_settings.js:27
+msgid "Employee can be named by Employee ID if you assign one, or via Naming Series. Select your preference here."
+msgstr "crwdns106874:0crwdne106874:0"
+
+#. Label of a Data field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Employee name"
+msgstr "crwdns106876:0crwdne106876:0"
+
+#. Description of the 'Employee Naming By' (Select) field in DocType 'HR
+#. Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Employee records are created using the selected option"
+msgstr "crwdns106878:0crwdne106878:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:548
+msgid "Employee relieved on {0} must be set as 'Left'"
+msgstr "crwdns106880:0{0}crwdne106880:0"
+
+#: hr/doctype/shift_type/shift_type.py:168
+msgid "Employee was marked Absent due to missing Employee Checkins."
+msgstr "crwdns106882:0crwdne106882:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:161
+msgid "Employee was marked Absent for not meeting the working hours threshold."
+msgstr "crwdns106884:0crwdne106884:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:52
+msgid "Employee {0} already has an Attendance Request {1} that overlaps with this period"
+msgstr "crwdns106886:0{0}crwdnd106886:0{1}crwdne106886:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:116
+msgid "Employee {0} already has an active Shift {1}: {2} that overlaps within this period."
+msgstr "crwdns106888:0{0}crwdnd106888:0{1}crwdnd106888:0{2}crwdne106888:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:151
+msgid "Employee {0} already submitted an application {1} for the payroll period {2}"
+msgstr "crwdns106890:0{0}crwdnd106890:0{1}crwdnd106890:0{2}crwdne106890:0"
+
+#: hr/doctype/shift_request/shift_request.py:128
+msgid "Employee {0} has already applied for Shift {1}: {2} that overlaps within this period"
+msgstr "crwdns106892:0{0}crwdnd106892:0{1}crwdnd106892:0{2}crwdne106892:0"
+
+#: hr/doctype/leave_application/leave_application.py:455
+msgid "Employee {0} has already applied for {1} between {2} and {3} : {4}"
+msgstr "crwdns106894:0{0}crwdnd106894:0{1}crwdnd106894:0{2}crwdnd106894:0{3}crwdnd106894:0{4}crwdne106894:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:25
+msgid "Employee {0} has no maximum benefit amount"
+msgstr "crwdns106896:0{0}crwdne106896:0"
+
+#: hr/doctype/attendance/attendance.py:198
+msgid "Employee {0} is not active or does not exist"
+msgstr "crwdns106898:0{0}crwdne106898:0"
+
+#: hr/doctype/attendance/attendance.py:178
+msgid "Employee {0} is on Leave on {1}"
+msgstr "crwdns106900:0{0}crwdnd106900:0{1}crwdne106900:0"
+
+#: hr/doctype/training_feedback/training_feedback.py:25
+msgid "Employee {0} not found in Training Event Participants."
+msgstr "crwdns106902:0{0}crwdne106902:0"
+
+#: hr/doctype/attendance/attendance.py:173
+msgid "Employee {0} on Half day on {1}"
+msgstr "crwdns106904:0{0}crwdnd106904:0{1}crwdne106904:0"
+
+#. Subtitle of the Module Onboarding 'Human Resource'
+#: hr/module_onboarding/human_resource/human_resource.json
+msgid "Employee, Leaves, and more."
+msgstr "crwdns106906:0crwdne106906:0"
+
+#: payroll/doctype/gratuity/gratuity.py:195
+msgid "Employee: {0} have to complete minimum {1} years for gratuity"
+msgstr "crwdns106908:0{0}crwdnd106908:0{1}crwdne106908:0"
+
+#: hr/dashboard_chart_source/employees_by_age/employees_by_age.py:42
+msgid "Employees"
+msgstr "crwdns106910:0crwdne106910:0"
+
+#. Label of a Section Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Employees"
+msgstr "crwdns106912:0crwdne106912:0"
+
+#. Label of a Tab Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Employees"
+msgstr "crwdns106914:0crwdne106914:0"
+
+#. Label of a Table field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Employees"
+msgstr "crwdns106916:0crwdne106916:0"
+
+#. Label of a Table field in DocType 'Training Result'
+#: hr/doctype/training_result/training_result.json
+msgctxt "Training Result"
+msgid "Employees"
+msgstr "crwdns106918:0crwdne106918:0"
+
+#. Label of a HTML field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Employees HTML"
+msgstr "crwdns106920:0crwdne106920:0"
+
+#. Label of a HTML field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Employees HTML"
+msgstr "crwdns106922:0crwdne106922:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Employees Working on a Holiday"
+msgstr "crwdns106924:0crwdne106924:0"
+
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.py:31
+msgid "Employees cannot give feedback to themselves. Use {0} instead: {1}"
+msgstr "crwdns106926:0{0}crwdnd106926:0{1}crwdne106926:0"
+
+#: hr/doctype/hr_settings/hr_settings.py:79
+msgid "Employees will miss holiday reminders from {} until {}. <br> Do you want to proceed with this change?"
+msgstr "crwdns106928:0crwdne106928:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:115
+msgid "Employees without Feedback: {0}"
+msgstr "crwdns106930:0{0}crwdne106930:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:116
+msgid "Employees without Goals: {0}"
+msgstr "crwdns106932:0{0}crwdne106932:0"
+
+#. Name of a report
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.json
+#: hr/workspace/leaves/leaves.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employees working on a holiday"
+msgstr "crwdns106934:0crwdne106934:0"
+
+#. Name of a DocType
+#: hr/doctype/employment_type/employment_type.json
+#: templates/generators/job_opening.html:134
+msgid "Employment Type"
+msgstr "crwdns106936:0crwdne106936:0"
+
+#. Label of a Data field in DocType 'Employment Type'
+#: hr/doctype/employment_type/employment_type.json
+msgctxt "Employment Type"
+msgid "Employment Type"
+msgstr "crwdns106938:0crwdne106938:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Employment Type"
+msgstr "crwdns106940:0crwdne106940:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Employment Type"
+msgstr "crwdns106942:0crwdne106942:0"
+
+#. Label of a Check field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Enable Auto Attendance"
+msgstr "crwdns106944:0crwdne106944:0"
+
+#. Label of a Check field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Enable Early Exit Marking"
+msgstr "crwdns106946:0crwdne106946:0"
+
+#. Label of a Check field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Enable Late Entry Marking"
+msgstr "crwdns106948:0crwdne106948:0"
+
+#. Label of a Check field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Enabled"
+msgstr "crwdns106950:0crwdne106950:0"
+
+#. Label of a Section Break field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Encashment"
+msgstr "crwdns106952:0crwdne106952:0"
+
+#. Label of a Currency field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Encashment Amount"
+msgstr "crwdns106954:0crwdne106954:0"
+
+#. Label of a Date field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Encashment Date"
+msgstr "crwdns106956:0crwdne106956:0"
+
+#. Label of a Float field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Encashment Days"
+msgstr "crwdns106958:0crwdne106958:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:135
+msgid "Encashment Days cannot exceed {0} {1} as per Leave Type settings"
+msgstr "crwdns106960:0{0}crwdnd106960:0{1}crwdne106960:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:125
+msgid "Encashment Limit Applied"
+msgstr "crwdns106962:0crwdne106962:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Encrypt Salary Slips in Emails"
+msgstr "crwdns106964:0crwdne106964:0"
+
+#: hr/doctype/attendance/attendance_list.js:58
+msgid "End"
+msgstr "crwdns106966:0crwdne106966:0"
+
+#: hr/doctype/goal/goal_tree.js:93
+#: hr/report/project_profitability/project_profitability.js:24
+#: hr/report/project_profitability/project_profitability.py:204
+#: payroll/report/salary_register/salary_register.py:169
+msgid "End Date"
+msgstr "crwdns106968:0crwdne106968:0"
+
+#. Label of a Date field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "End Date"
+msgstr "crwdns106970:0crwdne106970:0"
+
+#. Label of a Date field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "End Date"
+msgstr "crwdns106972:0crwdne106972:0"
+
+#. Label of a Date field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "End Date"
+msgstr "crwdns106974:0crwdne106974:0"
+
+#. Label of a Date field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "End Date"
+msgstr "crwdns106976:0crwdne106976:0"
+
+#. Label of a Date field in DocType 'Payroll Period'
+#: payroll/doctype/payroll_period/payroll_period.json
+msgctxt "Payroll Period"
+msgid "End Date"
+msgstr "crwdns106978:0crwdne106978:0"
+
+#. Label of a Date field in DocType 'Payroll Period Date'
+#: payroll/doctype/payroll_period_date/payroll_period_date.json
+msgctxt "Payroll Period Date"
+msgid "End Date"
+msgstr "crwdns106980:0crwdne106980:0"
+
+#. Label of a Date field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "End Date"
+msgstr "crwdns106982:0crwdne106982:0"
+
+#. Label of a Date field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "End Date"
+msgstr "crwdns106984:0crwdne106984:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:34
+#: templates/emails/training_event.html:8
+msgid "End Time"
+msgstr "crwdns106986:0crwdne106986:0"
+
+#. Label of a Time field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "End Time"
+msgstr "crwdns106988:0crwdne106988:0"
+
+#. Label of a Datetime field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "End Time"
+msgstr "crwdns106990:0crwdne106990:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:198
+msgid "End date: {0}"
+msgstr "crwdns106992:0{0}crwdne106992:0"
+
+#: hr/doctype/training_event/training_event.py:26
+msgid "End time cannot be before start time"
+msgstr "crwdns106994:0crwdne106994:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Energy Point Log"
+msgid "Energy Point Log"
+msgstr "crwdns106996:0crwdne106996:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Energy Point Rule"
+msgid "Energy Point Rule"
+msgstr "crwdns106998:0crwdne106998:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "Energy Point Settings"
+msgid "Energy Point Settings"
+msgstr "crwdns107000:0crwdne107000:0"
+
+#. Label of a Card Break in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgid "Energy Points"
+msgstr "crwdns107002:0crwdne107002:0"
+
+#: hr/doctype/hr_settings/hr_settings.js:32
+msgid "Enter the Standard Working Hours for a normal work day. These hours will be used in calculations of reports such as Employee Hours Utilization and Project Profitability analysis."
+msgstr "crwdns107004:0crwdne107004:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:136
+msgid "Enter the number of leaves you want to allocate for the period."
+msgstr "crwdns107006:0crwdne107006:0"
+
+#: hr/doctype/goal/goal_list.js:103 hr/doctype/goal/goal_list.js:113
+#: payroll/doctype/additional_salary/additional_salary.py:234
+msgid "Error"
+msgstr "crwdns107008:0crwdne107008:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:121
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:331
+msgid "Error Log"
+msgstr "crwdns107010:0crwdne107010:0"
+
+#. Label of a Small Text field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Error Message"
+msgstr "crwdns107012:0crwdne107012:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1177
+msgid "Error in formula or condition"
+msgstr "crwdns107014:0crwdne107014:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:2117
+msgid "Error in formula or condition: {0} in Income Tax Slab"
+msgstr "crwdns107016:0{0}crwdne107016:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:2196
+msgid "Error while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
+msgstr "crwdns107018:0{doctype}crwdnd107018:0{doclink}crwdnd107018:0{row_id}crwdnd107018:0{error}crwdnd107018:0{description}crwdne107018:0"
+
+#. Label of a Currency field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Estimated Cost Per Position"
+msgstr "crwdns107020:0crwdne107020:0"
+
+#: overrides/dashboard_overrides.py:47
+msgid "Evaluation"
+msgstr "crwdns107022:0crwdne107022:0"
+
+#. Label of a Date field in DocType 'Employee Skill'
+#: hr/doctype/employee_skill/employee_skill.json
+msgctxt "Employee Skill"
+msgid "Evaluation Date"
+msgstr "crwdns107024:0crwdne107024:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:25
+msgid "Evaluation Method cannot be changed as there are existing appraisals created for this cycle"
+msgstr "crwdns107026:0crwdne107026:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Event Details"
+msgstr "crwdns107028:0crwdne107028:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:37
+msgid "Event Link"
+msgstr "crwdns107030:0crwdne107030:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:23
+#: templates/emails/training_event.html:6
+msgid "Event Location"
+msgstr "crwdns107032:0crwdne107032:0"
+
+#: templates/emails/training_event.html:5
+msgid "Event Name"
+msgstr "crwdns107034:0crwdne107034:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Event Name"
+msgstr "crwdns107036:0crwdne107036:0"
+
+#. Label of a Data field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Event Name"
+msgstr "crwdns107038:0crwdne107038:0"
+
+#. Label of a Select field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Event Status"
+msgstr "crwdns107040:0crwdne107040:0"
+
+#. Option for the 'Working Hours Calculation Based On' (Select) field in
+#. DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Every Valid Check-in and Check-out"
+msgstr "crwdns107042:0crwdne107042:0"
+
+#: controllers/employee_reminders.py:218
+msgid "Everyone, let’s congratulate them on their work anniversary!"
+msgstr "crwdns107044:0crwdne107044:0"
+
+#: controllers/employee_reminders.py:125
+msgid "Everyone, let’s congratulate {0} on their birthday."
+msgstr "crwdns107046:0{0}crwdne107046:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Exam"
+msgstr "crwdns107048:0crwdne107048:0"
+
+#. Label of a Float field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Exchange Rate"
+msgstr "crwdns107050:0crwdne107050:0"
+
+#. Label of a Float field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Exchange Rate"
+msgstr "crwdns107052:0crwdne107052:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Exchange Rate"
+msgstr "crwdns107054:0crwdne107054:0"
+
+#: hr/doctype/attendance/attendance_list.js:78
+msgid "Exclude Holidays"
+msgstr "crwdns107056:0crwdne107056:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:111
+msgid "Excluded {0} Non-Encashable Leaves for {1}"
+msgstr "crwdns107058:0{0}crwdnd107058:0{1}crwdne107058:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Exempted from Income Tax"
+msgstr "crwdns107060:0crwdne107060:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Exempted from Income Tax"
+msgstr "crwdns107062:0crwdne107062:0"
+
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Exemption"
+msgstr "crwdns107064:0crwdne107064:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration
+#. Category'
+#: payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgctxt "Employee Tax Exemption Declaration Category"
+msgid "Exemption Category"
+msgstr "crwdns107066:0crwdne107066:0"
+
+#. Label of a Read Only field in DocType 'Employee Tax Exemption Proof
+#. Submission Detail'
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgctxt "Employee Tax Exemption Proof Submission Detail"
+msgid "Exemption Category"
+msgstr "crwdns107068:0crwdne107068:0"
+
+#. Label of a Tab Break field in DocType 'Employee Tax Exemption Proof
+#. Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Exemption Proofs"
+msgstr "crwdns107070:0crwdne107070:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration
+#. Category'
+#: payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgctxt "Employee Tax Exemption Declaration Category"
+msgid "Exemption Sub Category"
+msgstr "crwdns107072:0crwdne107072:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission
+#. Detail'
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgctxt "Employee Tax Exemption Proof Submission Detail"
+msgid "Exemption Sub Category"
+msgstr "crwdns107074:0crwdne107074:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: overrides/dashboard_overrides.py:25
+msgid "Exit"
+msgstr "crwdns107076:0crwdne107076:0"
+
+#: hr/report/employee_exits/employee_exits.py:193
+msgid "Exit Confirmed"
+msgstr "crwdns107078:0crwdne107078:0"
+
+#. Option for the 'Final Decision' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Exit Confirmed"
+msgstr "crwdns107080:0crwdne107080:0"
+
+#. Name of a DocType
+#: hr/doctype/exit_interview/exit_interview.json
+#: hr/report/employee_exits/employee_exits.py:39
+msgid "Exit Interview"
+msgstr "crwdns107082:0crwdne107082:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Exit Interview"
+msgid "Exit Interview"
+msgstr "crwdns107084:0crwdne107084:0"
+
+#: hr/report/employee_exits/employee_exits.js:63
+msgid "Exit Interview Pending"
+msgstr "crwdns107086:0crwdne107086:0"
+
+#. Label of a Text Editor field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Exit Interview Summary"
+msgstr "crwdns107088:0crwdne107088:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:33
+msgid "Exit Interview {0} already exists for Employee: {1}"
+msgstr "crwdns107090:0{0}crwdnd107090:0{1}crwdne107090:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:145
+msgid "Exit Questionnaire"
+msgstr "crwdns107092:0crwdne107092:0"
+
+#. Label of a Section Break field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Exit Questionnaire"
+msgstr "crwdns107094:0crwdne107094:0"
+
+#: hr/doctype/exit_interview/test_exit_interview.py:108
+#: hr/doctype/exit_interview/test_exit_interview.py:118
+#: hr/doctype/exit_interview/test_exit_interview.py:120 setup.py:472
+#: setup.py:474 setup.py:495
+msgid "Exit Questionnaire Notification"
+msgstr "crwdns107096:0crwdne107096:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Exit Questionnaire Notification Template"
+msgstr "crwdns107098:0crwdne107098:0"
+
+#: hr/report/employee_exits/employee_exits.js:68
+msgid "Exit Questionnaire Pending"
+msgstr "crwdns107100:0crwdne107100:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Exit Questionnaire Web Form"
+msgstr "crwdns107102:0crwdne107102:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:112
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:116
+msgid "Expand All"
+msgstr "crwdns107104:0crwdne107104:0"
+
+#. Label of a Rating field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Expected Average Rating"
+msgstr "crwdns107106:0crwdne107106:0"
+
+#. Label of a Rating field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Expected Average Rating"
+msgstr "crwdns107108:0crwdne107108:0"
+
+#. Label of a Date field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Expected By"
+msgstr "crwdns107110:0crwdne107110:0"
+
+#. Label of a Currency field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Expected Compensation"
+msgstr "crwdns107112:0crwdne107112:0"
+
+#. Name of a DocType
+#: hr/doctype/expected_skill_set/expected_skill_set.json
+msgid "Expected Skill Set"
+msgstr "crwdns107114:0crwdne107114:0"
+
+#. Label of a Section Break field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Expected Skillset"
+msgstr "crwdns107116:0crwdne107116:0"
+
+#: overrides/dashboard_overrides.py:29
+msgid "Expense"
+msgstr "crwdns107118:0crwdne107118:0"
+
+#. Label of a Currency field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Expense"
+msgstr "crwdns107120:0crwdne107120:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Expense Account"
+msgstr "crwdns107122:0crwdne107122:0"
+
+#. Name of a role
+#: hr/doctype/employee_advance/employee_advance.json
+#: hr/doctype/expense_claim/expense_claim.json
+msgid "Expense Approver"
+msgstr "crwdns107124:0crwdne107124:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Expense Approver"
+msgstr "crwdns107126:0crwdne107126:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Expense Approver Mandatory In Expense Claim"
+msgstr "crwdns107128:0crwdne107128:0"
+
+#. Name of a DocType
+#. Label of a Card Break in the HR Workspace
+#: hr/doctype/employee_advance/employee_advance.js:57
+#: hr/doctype/expense_claim/expense_claim.json
+#: hr/doctype/vehicle_log/vehicle_log.js:7
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:20
+#: hr/workspace/hr/hr.json public/js/erpnext/delivery_trip.js:7
+msgid "Expense Claim"
+msgstr "crwdns107130:0crwdne107130:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a shortcut in the Expense Claims Workspace
+#. Label of a Link in the HR Workspace
+#: hr/workspace/expense_claims/expense_claims.json hr/workspace/hr/hr.json
+msgctxt "Expense Claim"
+msgid "Expense Claim"
+msgstr "crwdns107132:0crwdne107132:0"
+
+#. Name of a DocType
+#: hr/doctype/expense_claim_account/expense_claim_account.json
+msgid "Expense Claim Account"
+msgstr "crwdns107134:0crwdne107134:0"
+
+#. Name of a DocType
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgid "Expense Claim Advance"
+msgstr "crwdns107136:0crwdne107136:0"
+
+#. Name of a DocType
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgid "Expense Claim Detail"
+msgstr "crwdns107138:0crwdne107138:0"
+
+#. Name of a DocType
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+msgid "Expense Claim Type"
+msgstr "crwdns107140:0crwdne107140:0"
+
+#. Label of a Link field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Expense Claim Type"
+msgstr "crwdns107142:0crwdne107142:0"
+
+#. Label of a Data field in DocType 'Expense Claim Type'
+#. Label of a Link in the Expense Claims Workspace
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Expense Claim Type"
+msgid "Expense Claim Type"
+msgstr "crwdns107144:0crwdne107144:0"
+
+#: hr/doctype/vehicle_log/vehicle_log.py:48
+msgid "Expense Claim for Vehicle Log {0}"
+msgstr "crwdns107146:0{0}crwdne107146:0"
+
+#: hr/doctype/vehicle_log/vehicle_log.py:36
+msgid "Expense Claim {0} already exists for the Vehicle Log"
+msgstr "crwdns107148:0{0}crwdne107148:0"
+
+#. Name of a Workspace
+#. Label of a chart in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgid "Expense Claims"
+msgstr "crwdns107150:0crwdne107150:0"
+
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Expense Claims Dashboard"
+msgstr "crwdns107152:0crwdne107152:0"
+
+#. Label of a Date field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Expense Date"
+msgstr "crwdns107154:0crwdne107154:0"
+
+#. Label of a Section Break field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Expense Proof"
+msgstr "crwdns107156:0crwdne107156:0"
+
+#. Name of a DocType
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgid "Expense Taxes and Charges"
+msgstr "crwdns107158:0crwdne107158:0"
+
+#. Label of a Table field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Expense Taxes and Charges"
+msgstr "crwdns107160:0crwdne107160:0"
+
+#. Label of a Link field in DocType 'Travel Request Costing'
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgctxt "Travel Request Costing"
+msgid "Expense Type"
+msgstr "crwdns107162:0crwdne107162:0"
+
+#. Label of a Table field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Expenses"
+msgstr "crwdns107164:0crwdne107164:0"
+
+#. Label of a Tab Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Expenses & Advances"
+msgstr "crwdns107166:0crwdne107166:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:32
+msgid "Expire Allocation"
+msgstr "crwdns107168:0crwdne107168:0"
+
+#. Label of a Int field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Expire Carry Forwarded Leaves (Days)"
+msgstr "crwdns107170:0crwdne107170:0"
+
+#: hr/doctype/leave_allocation/leave_allocation_list.js:8
+msgid "Expired"
+msgstr "crwdns107172:0crwdne107172:0"
+
+#. Label of a Check field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Expired"
+msgstr "crwdns107174:0crwdne107174:0"
+
+#. Label of a Float field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Expired Leave(s)"
+msgstr "crwdns107176:0crwdne107176:0"
+
+#. Label of a Small Text field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Explanation"
+msgstr "crwdns107178:0crwdne107178:0"
+
+#. Label of an action in the Onboarding Step 'HR Settings'
+#: hr/onboarding_step/hr_settings/hr_settings.json
+msgid "Explore"
+msgstr "crwdns107180:0crwdne107180:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:108
+msgid "Export"
+msgstr "crwdns107182:0crwdne107182:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:129
+msgid "Exporting..."
+msgstr "crwdns107184:0crwdne107184:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Failed"
+msgstr "crwdns107186:0crwdne107186:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:116
+msgid "Failed to create/submit {0} for employees:"
+msgstr "crwdns107188:0{0}crwdne107188:0"
+
+#: overrides/company.py:37
+msgid "Failed to delete defaults for country {0}. Please contact support."
+msgstr "crwdns107190:0{0}crwdne107190:0"
+
+#: api/__init__.py:589
+msgid "Failed to download Salary Slip PDF"
+msgstr "crwdns107192:0crwdne107192:0"
+
+#: hr/doctype/interview/interview.py:119
+msgid "Failed to send the Interview Reschedule notification. Please configure your email account."
+msgstr "crwdns107194:0crwdne107194:0"
+
+#: overrides/company.py:52
+msgid "Failed to setup defaults for country {0}. Please contact support."
+msgstr "crwdns107196:0{0}crwdne107196:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:326
+msgid "Failed to submit some leave policy assignments:"
+msgstr "crwdns107198:0crwdne107198:0"
+
+#: hr/doctype/interview/interview.py:212
+msgid "Failed to update the Job Applicant status"
+msgstr "crwdns107200:0crwdne107200:0"
+
+#. Label of a Tab Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Failure Details"
+msgstr "crwdns107202:0crwdne107202:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:14
+#: public/js/salary_slip_deductions_report_filters.js:20
+msgid "Feb"
+msgstr "crwdns107204:0crwdne107204:0"
+
+#: hr/doctype/interview/interview.js:151
+msgid "Feedback"
+msgstr "crwdns107206:0crwdne107206:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Feedback"
+msgstr "crwdns107208:0crwdne107208:0"
+
+#. Label of a Tab Break field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Feedback"
+msgstr "crwdns107210:0crwdne107210:0"
+
+#. Label of a Tab Break field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Feedback"
+msgstr "crwdns107212:0crwdne107212:0"
+
+#. Label of a Section Break field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Feedback"
+msgstr "crwdns107214:0crwdne107214:0"
+
+#. Label of a Text field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Feedback"
+msgstr "crwdns107216:0crwdne107216:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:48
+msgid "Feedback Count"
+msgstr "crwdns107218:0crwdne107218:0"
+
+#. Label of a HTML field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Feedback HTML"
+msgstr "crwdns107220:0crwdne107220:0"
+
+#. Label of a HTML field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Feedback HTML"
+msgstr "crwdns107222:0crwdne107222:0"
+
+#. Label of a Table field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Feedback Ratings"
+msgstr "crwdns107224:0crwdne107224:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Feedback Reminder Notification Template"
+msgstr "crwdns107226:0crwdne107226:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:124
+msgid "Feedback Score"
+msgstr "crwdns107228:0crwdne107228:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Feedback Submitted"
+msgstr "crwdns107230:0crwdne107230:0"
+
+#: hr/doctype/interview_feedback/interview_feedback.py:52
+msgid "Feedback already submitted for the Interview {0}. Please cancel the previous Interview Feedback {1} to continue."
+msgstr "crwdns107232:0{0}crwdnd107232:0{1}crwdne107232:0"
+
+#: hr/doctype/training_feedback/training_feedback.py:31
+msgid "Feedback cannot be recorded for an absent Employee."
+msgstr "crwdns107234:0crwdne107234:0"
+
+#: public/js/performance/performance_feedback.js:117
+msgid "Feedback {0} added successfully"
+msgstr "crwdns107236:0{0}crwdne107236:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:64
+#: payroll/doctype/payroll_entry/payroll_entry.js:112
+msgid "Fetching Employees"
+msgstr "crwdns107238:0crwdne107238:0"
+
+#. Label of a Data field in DocType 'Employee Property History'
+#: hr/doctype/employee_property_history/employee_property_history.json
+msgctxt "Employee Property History"
+msgid "Field Name"
+msgstr "crwdns107240:0crwdne107240:0"
+
+#: hr/doctype/expense_claim/expense_claim.js:106
+#: hr/doctype/leave_application/leave_application.js:104
+#: hr/doctype/leave_encashment/leave_encashment.js:28
+msgid "Fill the form and save it"
+msgstr "crwdns107242:0crwdne107242:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Filled"
+msgstr "crwdns107244:0crwdne107244:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.js:7
+msgid "Filter Based On"
+msgstr "crwdns107246:0crwdne107246:0"
+
+#. Label of a Section Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Filter Employees"
+msgstr "crwdns107248:0crwdne107248:0"
+
+#. Label of a HTML field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Filter List"
+msgstr "crwdns107250:0crwdne107250:0"
+
+#: www/jobs/index.html:19
+msgid "Filters"
+msgstr "crwdns107252:0crwdne107252:0"
+
+#. Label of a Section Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Filters"
+msgstr "crwdns107254:0crwdne107254:0"
+
+#. Label of a Section Break field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Filters"
+msgstr "crwdns107256:0crwdne107256:0"
+
+#: hr/report/employee_exits/employee_exits.js:57
+#: hr/report/employee_exits/employee_exits.py:52
+msgid "Final Decision"
+msgstr "crwdns107258:0crwdne107258:0"
+
+#. Label of a Select field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Final Decision"
+msgstr "crwdns107260:0crwdne107260:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:57
+#: hr/report/appraisal_overview/appraisal_overview.py:125
+msgid "Final Score"
+msgstr "crwdns107262:0crwdne107262:0"
+
+#. Label of a Float field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Final Score"
+msgstr "crwdns107264:0crwdne107264:0"
+
+#. Option for the 'Working Hours Calculation Based On' (Select) field in
+#. DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "First Check-in and Last Check-out"
+msgstr "crwdns107266:0crwdne107266:0"
+
+#. Option for the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "First Day"
+msgstr "crwdns107268:0crwdne107268:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "First Name "
+msgstr "crwdns107270:0crwdne107270:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.js:15
+msgid "Fiscal Year"
+msgstr "crwdns107272:0crwdne107272:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1320
+msgid "Fiscal Year {0} not found"
+msgstr "crwdns107274:0{0}crwdne107274:0"
+
+#. Label of a Card Break in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgid "Fleet Management"
+msgstr "crwdns107276:0crwdne107276:0"
+
+#. Name of a role
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgid "Fleet Manager"
+msgstr "crwdns107278:0crwdne107278:0"
+
+#. Label of a Tab Break field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Flexible Benefits"
+msgstr "crwdns107280:0crwdne107280:0"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Flight"
+msgstr "crwdns107282:0crwdne107282:0"
+
+#: hr/report/employee_exits/employee_exits.js:73
+msgid "FnF Pending"
+msgstr "crwdns107284:0crwdne107284:0"
+
+#. Label of a Check field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Follow via Email"
+msgstr "crwdns107286:0crwdne107286:0"
+
+#: setup.py:324
+msgid "Food"
+msgstr "crwdns107288:0crwdne107288:0"
+
+#. Label of a Link field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "For Designation "
+msgstr "crwdns107290:0crwdne107290:0"
+
+#: hr/doctype/attendance/attendance_list.js:29
+msgid "For Employee"
+msgstr "crwdns107292:0crwdne107292:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "For Employee"
+msgstr "crwdns107294:0crwdne107294:0"
+
+#. Description of the 'Fraction of Daily Salary per Leave' (Float) field in
+#. DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+#, python-format
+msgctxt "Leave Type"
+msgid "For a day of leave taken, if you still pay (say) 50% of the daily salary, then enter 0.50 in this field."
+msgstr "crwdns107296:0crwdne107296:0"
+
+#. Label of a Code field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Formula"
+msgstr "crwdns107298:0crwdne107298:0"
+
+#. Label of a Code field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Formula"
+msgstr "crwdns107300:0crwdne107300:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Fortnightly"
+msgstr "crwdns107302:0crwdne107302:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Fortnightly"
+msgstr "crwdns107304:0crwdne107304:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Fortnightly"
+msgstr "crwdns107306:0crwdne107306:0"
+
+#. Label of a Float field in DocType 'Gratuity Rule Slab'
+#: payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgctxt "Gratuity Rule Slab"
+msgid "Fraction of Applicable Earnings "
+msgstr "crwdns107308:0crwdne107308:0"
+
+#. Label of a Float field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Fraction of Daily Salary for Half Day"
+msgstr "crwdns107310:0crwdne107310:0"
+
+#. Label of a Float field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Fraction of Daily Salary per Leave"
+msgstr "crwdns107312:0crwdne107312:0"
+
+#: hr/report/project_profitability/project_profitability.py:193
+msgid "Fractional Cost"
+msgstr "crwdns107314:0crwdne107314:0"
+
+#. Label of a Select field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Frequency"
+msgstr "crwdns107316:0crwdne107316:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:57
+msgid "Friday"
+msgstr "crwdns107318:0crwdne107318:0"
+
+#: payroll/report/salary_register/salary_register.js:8
+msgid "From"
+msgstr "crwdns107320:0crwdne107320:0"
+
+#. Label of a Currency field in DocType 'Taxable Salary Slab'
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgctxt "Taxable Salary Slab"
+msgid "From Amount"
+msgstr "crwdns107322:0crwdne107322:0"
+
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.js:15
+#: hr/report/employee_advance_summary/employee_advance_summary.js:16
+#: hr/report/employee_exits/employee_exits.js:9
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:17
+#: hr/report/employee_leave_balance/employee_leave_balance.js:8
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.js:8
+#: hr/report/shift_attendance/shift_attendance.js:8
+#: hr/report/vehicle_expenses/vehicle_expenses.js:24
+#: payroll/doctype/salary_structure/salary_structure.js:149
+#: payroll/report/bank_remittance/bank_remittance.js:17
+msgid "From Date"
+msgstr "crwdns107324:0crwdne107324:0"
+
+#. Label of a Date field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "From Date"
+msgstr "crwdns107326:0crwdne107326:0"
+
+#. Label of a Date field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "From Date"
+msgstr "crwdns107328:0crwdne107328:0"
+
+#. Label of a Date field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "From Date"
+msgstr "crwdns107330:0crwdne107330:0"
+
+#. Label of a Date field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "From Date"
+msgstr "crwdns107332:0crwdne107332:0"
+
+#. Label of a Date field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "From Date"
+msgstr "crwdns107334:0crwdne107334:0"
+
+#. Label of a Date field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "From Date"
+msgstr "crwdns107336:0crwdne107336:0"
+
+#. Label of a Date field in DocType 'Leave Period'
+#: hr/doctype/leave_period/leave_period.json
+msgctxt "Leave Period"
+msgid "From Date"
+msgstr "crwdns107338:0crwdne107338:0"
+
+#. Label of a Date field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "From Date"
+msgstr "crwdns107340:0crwdne107340:0"
+
+#. Label of a Date field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "From Date"
+msgstr "crwdns107342:0crwdne107342:0"
+
+#. Label of a Date field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "From Date"
+msgstr "crwdns107344:0crwdne107344:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:29
+#: payroll/doctype/salary_structure/salary_structure.js:266
+msgid "From Date cannot be greater than To Date"
+msgstr "crwdns107346:0crwdne107346:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:30
+msgid "From Date must come before To Date"
+msgstr "crwdns107348:0crwdne107348:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:74
+msgid "From Date {0} cannot be after employee's relieving Date {1}"
+msgstr "crwdns107350:0{0}crwdnd107350:0{1}crwdne107350:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:66
+msgid "From Date {0} cannot be before employee's joining Date {1}"
+msgstr "crwdns107352:0{0}crwdnd107352:0{1}crwdne107352:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "From Employee"
+msgstr "crwdns107354:0crwdne107354:0"
+
+#. Label of a Time field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "From Time"
+msgstr "crwdns107356:0crwdne107356:0"
+
+#. Label of a Link field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "From User"
+msgstr "crwdns107358:0crwdne107358:0"
+
+#: hr/utils.py:179
+msgid "From date can not be less than employee's joining date"
+msgstr "crwdns107360:0crwdne107360:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:83
+msgid "From date can not be less than employee's joining date."
+msgstr "crwdns107362:0crwdne107362:0"
+
+#: hr/doctype/leave_type/leave_type.js:31
+msgid "From here, you can enable encashment for the balance leaves."
+msgstr "crwdns107364:0crwdne107364:0"
+
+#. Label of a Int field in DocType 'Gratuity Rule Slab'
+#: payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgctxt "Gratuity Rule Slab"
+msgid "From(Year)"
+msgstr "crwdns107366:0crwdne107366:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:45
+msgid "Fuel Expense"
+msgstr "crwdns107368:0crwdne107368:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:166
+msgid "Fuel Expenses"
+msgstr "crwdns107370:0crwdne107370:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:44
+msgid "Fuel Price"
+msgstr "crwdns107372:0crwdne107372:0"
+
+#. Label of a Currency field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Fuel Price"
+msgstr "crwdns107374:0crwdne107374:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:43
+msgid "Fuel Qty"
+msgstr "crwdns107376:0crwdne107376:0"
+
+#. Label of a Float field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Fuel Qty"
+msgstr "crwdns107378:0crwdne107378:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Full Name"
+msgstr "crwdns107380:0crwdne107380:0"
+
+#. Option for the 'Employee Naming By' (Select) field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Full Name"
+msgstr "crwdns107382:0crwdne107382:0"
+
+#. Name of a DocType
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgid "Full and Final Asset"
+msgstr "crwdns107384:0crwdne107384:0"
+
+#. Name of a DocType
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgid "Full and Final Outstanding Statement"
+msgstr "crwdns107386:0crwdne107386:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Full and Final Statement"
+msgid "Full and Final Settlement"
+msgstr "crwdns107388:0crwdne107388:0"
+
+#. Name of a DocType
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+#: hr/report/employee_exits/employee_exits.py:58
+msgid "Full and Final Statement"
+msgstr "crwdns107390:0crwdne107390:0"
+
+#: setup.py:380
+msgid "Full-time"
+msgstr "crwdns107392:0crwdne107392:0"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Fully Sponsored"
+msgstr "crwdns107394:0crwdne107394:0"
+
+#. Label of a Currency field in DocType 'Travel Request Costing'
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgctxt "Travel Request Costing"
+msgid "Funded Amount"
+msgstr "crwdns107396:0crwdne107396:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Future Income Tax"
+msgstr "crwdns107398:0crwdne107398:0"
+
+#: hr/utils.py:177
+msgid "Future dates not allowed"
+msgstr "crwdns107400:0crwdne107400:0"
+
+#: hr/report/employee_analytics/employee_analytics.py:36
+#: hr/report/employee_birthday/employee_birthday.py:27
+msgid "Gender"
+msgstr "crwdns107402:0crwdne107402:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "General Ledger"
+msgstr "crwdns107404:0crwdne107404:0"
+
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js:44
+msgid "Get Details From Declaration"
+msgstr "crwdns107406:0crwdne107406:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:59
+msgid "Get Employees"
+msgstr "crwdns107408:0crwdne107408:0"
+
+#. Label of a Button field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Get Employees"
+msgstr "crwdns107410:0crwdne107410:0"
+
+#. Label of a Button field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Get Job Requisitions"
+msgstr "crwdns107412:0crwdne107412:0"
+
+#. Label of a Button field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Get Template"
+msgstr "crwdns107414:0crwdne107414:0"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Gluten Free"
+msgstr "crwdns107416:0crwdne107416:0"
+
+#. Name of a DocType
+#: hr/doctype/goal/goal.json hr/doctype/goal/goal_tree.js:45
+msgid "Goal"
+msgstr "crwdns107418:0crwdne107418:0"
+
+#. Linked DocType in Appraisal Cycle's connections
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Goal"
+msgstr "crwdns107420:0crwdne107420:0"
+
+#. Label of a Small Text field in DocType 'Appraisal Goal'
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgctxt "Appraisal Goal"
+msgid "Goal"
+msgstr "crwdns107422:0crwdne107422:0"
+
+#. Label of a Data field in DocType 'Goal'
+#. Label of a Link in the Performance Workspace
+#. Label of a shortcut in the Performance Workspace
+#: hr/doctype/goal/goal.json hr/workspace/performance/performance.json
+msgctxt "Goal"
+msgid "Goal"
+msgstr "crwdns107424:0crwdne107424:0"
+
+#. Label of a Percent field in DocType 'Appraisal KRA'
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgctxt "Appraisal KRA"
+msgid "Goal Completion (%)"
+msgstr "crwdns107426:0crwdne107426:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:55
+#: hr/report/appraisal_overview/appraisal_overview.py:122
+msgid "Goal Score"
+msgstr "crwdns107428:0crwdne107428:0"
+
+#. Label of a Float field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Goal Score (%)"
+msgstr "crwdns107430:0crwdne107430:0"
+
+#. Label of a Float field in DocType 'Appraisal KRA'
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgctxt "Appraisal KRA"
+msgid "Goal Score (weighted)"
+msgstr "crwdns107432:0crwdne107432:0"
+
+#: hr/doctype/goal/goal.py:81
+msgid "Goal progress percentage cannot be more than 100."
+msgstr "crwdns107434:0crwdne107434:0"
+
+#: hr/doctype/goal/goal.py:71
+msgid "Goal should be aligned with the same KRA as its parent goal."
+msgstr "crwdns107436:0crwdne107436:0"
+
+#: hr/doctype/goal/goal.py:67
+msgid "Goal should be owned by the same employee as its parent goal."
+msgstr "crwdns107438:0crwdne107438:0"
+
+#: hr/doctype/goal/goal.py:75
+msgid "Goal should belong to the same Appraisal Cycle as its parent goal."
+msgstr "crwdns107440:0crwdne107440:0"
+
+#: hr/doctype/goal/goal_tree.js:295
+msgid "Goal updated successfully"
+msgstr "crwdns107442:0crwdne107442:0"
+
+#: hr/doctype/appraisal/appraisal.py:130
+msgid "Goals"
+msgstr "crwdns107444:0crwdne107444:0"
+
+#. Label of a Table field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Goals"
+msgstr "crwdns107446:0crwdne107446:0"
+
+#: hr/doctype/goal/goal_list.js:134
+msgid "Goals updated successfully"
+msgstr "crwdns107448:0crwdne107448:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Grade"
+msgstr "crwdns107450:0crwdne107450:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Grade"
+msgstr "crwdns107452:0crwdne107452:0"
+
+#. Label of a Data field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Grade"
+msgstr "crwdns107454:0crwdne107454:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Grand Total"
+msgstr "crwdns107456:0crwdne107456:0"
+
+#. Name of a DocType
+#: payroll/doctype/gratuity/gratuity.json
+#: payroll/doctype/gratuity_rule/gratuity_rule_dashboard.py:7
+msgid "Gratuity"
+msgstr "crwdns107458:0crwdne107458:0"
+
+#. Label of a Tab Break field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Gratuity"
+msgstr "crwdns107460:0crwdne107460:0"
+
+#. Label of a Section Break field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Gratuity"
+msgstr "crwdns107462:0crwdne107462:0"
+
+#. Name of a DocType
+#: payroll/doctype/gratuity_applicable_component/gratuity_applicable_component.json
+msgid "Gratuity Applicable Component"
+msgstr "crwdns107464:0crwdne107464:0"
+
+#. Name of a DocType
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Gratuity Rule"
+msgstr "crwdns107466:0crwdne107466:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Gratuity Rule"
+msgstr "crwdns107468:0crwdne107468:0"
+
+#. Name of a DocType
+#: payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgid "Gratuity Rule Slab"
+msgstr "crwdns107470:0crwdne107470:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgid "Grievance"
+msgstr "crwdns107472:0crwdne107472:0"
+
+#. Label of a Dynamic Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Grievance Against"
+msgstr "crwdns107474:0crwdne107474:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Grievance Against Party"
+msgstr "crwdns107476:0crwdne107476:0"
+
+#. Label of a Section Break field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Grievance Details"
+msgstr "crwdns107478:0crwdne107478:0"
+
+#. Name of a DocType
+#: hr/doctype/grievance_type/grievance_type.json
+msgid "Grievance Type"
+msgstr "crwdns107480:0crwdne107480:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Grievance Type"
+msgstr "crwdns107482:0crwdne107482:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Grievance Type"
+msgid "Grievance Type"
+msgstr "crwdns107484:0crwdne107484:0"
+
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:54
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:42
+#: payroll/report/salary_register/salary_register.py:201
+msgid "Gross Pay"
+msgstr "crwdns107486:0crwdne107486:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Gross Pay"
+msgstr "crwdns107488:0crwdne107488:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Gross Pay (Company Currency)"
+msgstr "crwdns107490:0crwdne107490:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Gross Year To Date"
+msgstr "crwdns107492:0crwdne107492:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Gross Year To Date(Company Currency)"
+msgstr "crwdns107494:0crwdne107494:0"
+
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.js:9
+msgid "Group"
+msgstr "crwdns107496:0crwdne107496:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:58
+msgid "Group By"
+msgstr "crwdns107498:0crwdne107498:0"
+
+#: hr/doctype/goal/goal.js:13
+msgid "Group goal's progress is auto-calculated based on the child goals."
+msgstr "crwdns107500:0crwdne107500:0"
+
+#. Name of a role
+#: hr/doctype/job_opening/job_opening.json
+msgid "Guest"
+msgstr "crwdns107502:0crwdne107502:0"
+
+#. Name of a Workspace
+#: hr/workspace/hr/hr.json
+msgid "HR"
+msgstr "crwdns107504:0crwdne107504:0"
+
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "HR Dashboard"
+msgstr "crwdns107506:0crwdne107506:0"
+
+#. Name of a role
+#: hr/doctype/appointment_letter/appointment_letter.json
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+#: hr/doctype/appraisal/appraisal.json
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hr/doctype/appraisal_template/appraisal_template.json
+#: hr/doctype/attendance/attendance.json
+#: hr/doctype/attendance_request/attendance_request.json
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hr/doctype/employee_checkin/employee_checkin.json
+#: hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+#: hr/doctype/employee_grade/employee_grade.json
+#: hr/doctype/employee_grievance/employee_grievance.json
+#: hr/doctype/employee_health_insurance/employee_health_insurance.json
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hr/doctype/employee_promotion/employee_promotion.json
+#: hr/doctype/employee_referral/employee_referral.json
+#: hr/doctype/employee_transfer/employee_transfer.json
+#: hr/doctype/employment_type/employment_type.json
+#: hr/doctype/expense_claim/expense_claim.json
+#: hr/doctype/expense_claim_type/expense_claim_type.json
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+#: hr/doctype/goal/goal.json hr/doctype/grievance_type/grievance_type.json
+#: hr/doctype/interest/interest.json hr/doctype/interview/interview.json
+#: hr/doctype/interview_feedback/interview_feedback.json
+#: hr/doctype/interview_round/interview_round.json
+#: hr/doctype/interview_type/interview_type.json
+#: hr/doctype/job_offer_term_template/job_offer_term_template.json
+#: hr/doctype/leave_allocation/leave_allocation.json
+#: hr/doctype/leave_application/leave_application.json
+#: hr/doctype/leave_encashment/leave_encashment.json
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hr/doctype/leave_period/leave_period.json
+#: hr/doctype/leave_policy/leave_policy.json
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hr/doctype/leave_type/leave_type.json
+#: hr/doctype/shift_assignment/shift_assignment.json
+#: hr/doctype/shift_request/shift_request.json
+#: hr/doctype/shift_type/shift_type.json hr/doctype/skill/skill.json
+#: hr/doctype/staffing_plan/staffing_plan.json
+#: hr/doctype/training_event/training_event.json
+#: hr/doctype/training_feedback/training_feedback.json
+#: hr/doctype/training_program/training_program.json
+#: hr/doctype/training_result/training_result.json
+#: hr/doctype/upload_attendance/upload_attendance.json
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: payroll/doctype/employee_incentive/employee_incentive.json
+#: payroll/doctype/employee_other_income/employee_other_income.json
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+#: payroll/doctype/gratuity/gratuity.json
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+#: payroll/doctype/payroll_entry/payroll_entry.json
+#: payroll/doctype/payroll_period/payroll_period.json
+#: payroll/doctype/retention_bonus/retention_bonus.json
+#: payroll/doctype/salary_slip/salary_slip.json
+#: payroll/doctype/salary_structure/salary_structure.json
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "HR Manager"
+msgstr "crwdns107508:0crwdne107508:0"
+
+#. Name of a DocType
+#. Title of an Onboarding Step
+#: hr/doctype/hr_settings/hr_settings.json
+#: hr/onboarding_step/hr_settings/hr_settings.json
+msgid "HR Settings"
+msgstr "crwdns107510:0crwdne107510:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgctxt "HR Settings"
+msgid "HR Settings"
+msgstr "crwdns107512:0crwdne107512:0"
+
+#. Name of a role
+#: hr/doctype/appraisal/appraisal.json
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hr/doctype/appraisal_template/appraisal_template.json
+#: hr/doctype/attendance/attendance.json
+#: hr/doctype/attendance_request/attendance_request.json
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+#: hr/doctype/employee_checkin/employee_checkin.json
+#: hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+#: hr/doctype/employee_grade/employee_grade.json
+#: hr/doctype/employee_grievance/employee_grievance.json
+#: hr/doctype/employee_health_insurance/employee_health_insurance.json
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hr/doctype/employee_promotion/employee_promotion.json
+#: hr/doctype/employee_referral/employee_referral.json
+#: hr/doctype/employee_transfer/employee_transfer.json
+#: hr/doctype/employment_type/employment_type.json
+#: hr/doctype/expense_claim/expense_claim.json
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+#: hr/doctype/goal/goal.json hr/doctype/grievance_type/grievance_type.json
+#: hr/doctype/interest/interest.json hr/doctype/interview/interview.json
+#: hr/doctype/interview_feedback/interview_feedback.json
+#: hr/doctype/interview_round/interview_round.json
+#: hr/doctype/interview_type/interview_type.json
+#: hr/doctype/job_applicant/job_applicant.json
+#: hr/doctype/job_applicant_source/job_applicant_source.json
+#: hr/doctype/job_offer/job_offer.json hr/doctype/job_opening/job_opening.json
+#: hr/doctype/leave_allocation/leave_allocation.json
+#: hr/doctype/leave_application/leave_application.json
+#: hr/doctype/leave_block_list/leave_block_list.json
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+#: hr/doctype/leave_encashment/leave_encashment.json
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hr/doctype/leave_period/leave_period.json
+#: hr/doctype/leave_policy/leave_policy.json
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hr/doctype/leave_type/leave_type.json hr/doctype/offer_term/offer_term.json
+#: hr/doctype/shift_assignment/shift_assignment.json
+#: hr/doctype/shift_request/shift_request.json
+#: hr/doctype/shift_type/shift_type.json
+#: hr/doctype/staffing_plan/staffing_plan.json
+#: hr/doctype/upload_attendance/upload_attendance.json
+#: payroll/doctype/additional_salary/additional_salary.json
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: payroll/doctype/employee_incentive/employee_incentive.json
+#: payroll/doctype/employee_other_income/employee_other_income.json
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+#: payroll/doctype/gratuity/gratuity.json
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+#: payroll/doctype/payroll_period/payroll_period.json
+#: payroll/doctype/retention_bonus/retention_bonus.json
+#: payroll/doctype/salary_component/salary_component.json
+#: payroll/doctype/salary_slip/salary_slip.json
+#: payroll/doctype/salary_structure/salary_structure.json
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "HR User"
+msgstr "crwdns107514:0crwdne107514:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "HR-ADS-.YY.-.MM.-"
+msgstr "crwdns107516:0crwdne107516:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "HR-APR-.YYYY.-"
+msgstr "crwdns107518:0crwdne107518:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "HR-ATT-.YYYY.-"
+msgstr "crwdns107520:0crwdne107520:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "HR-EAD-.YYYY.-"
+msgstr "crwdns107522:0crwdne107522:0"
+
+#. Option for the 'Naming Series' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "HR-EXIT-INT-"
+msgstr "crwdns107524:0crwdne107524:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "HR-EXP-.YYYY.-"
+msgstr "crwdns107526:0crwdne107526:0"
+
+#. Option for the 'Naming Series' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "HR-HIREQ-"
+msgstr "crwdns107528:0crwdne107528:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "HR-LAL-.YYYY.-"
+msgstr "crwdns107530:0crwdne107530:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "HR-LAP-.YYYY.-"
+msgstr "crwdns107532:0crwdne107532:0"
+
+#. Option for the 'Series' (Select) field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "HR-VLOG-.YYYY.-"
+msgstr "crwdns107534:0crwdne107534:0"
+
+#: config/desktop.py:5
+msgid "HRMS"
+msgstr "crwdns107536:0crwdne107536:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Half Day"
+msgstr "crwdns107538:0crwdne107538:0"
+
+#. Label of a Check field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Half Day"
+msgstr "crwdns107540:0crwdne107540:0"
+
+#. Label of a Check field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Half Day"
+msgstr "crwdns107542:0crwdne107542:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Half Day"
+msgstr "crwdns107544:0crwdne107544:0"
+
+#. Label of a Check field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Half Day"
+msgstr "crwdns107546:0crwdne107546:0"
+
+#. Label of a Date field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Half Day Date"
+msgstr "crwdns107548:0crwdne107548:0"
+
+#. Label of a Date field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Half Day Date"
+msgstr "crwdns107550:0crwdne107550:0"
+
+#. Label of a Date field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Half Day Date"
+msgstr "crwdns107552:0crwdne107552:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:26
+msgid "Half Day Date is mandatory"
+msgstr "crwdns107554:0crwdne107554:0"
+
+#: hr/doctype/leave_application/leave_application.py:191
+msgid "Half Day Date should be between From Date and To Date"
+msgstr "crwdns107556:0crwdne107556:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:30
+msgid "Half Day Date should be in between Work From Date and Work End Date"
+msgstr "crwdns107558:0crwdne107558:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:168
+msgid "Half Day Records"
+msgstr "crwdns107560:0crwdne107560:0"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Half Yearly"
+msgstr "crwdns107562:0crwdne107562:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:29
+msgid "Half day date should be in between from date and to date"
+msgstr "crwdns107564:0crwdne107564:0"
+
+#. Option for the 'Earned Leave Frequency' (Select) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Half-Yearly"
+msgstr "crwdns107566:0crwdne107566:0"
+
+#. Label of a Check field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Has Certificate"
+msgstr "crwdns107568:0crwdne107568:0"
+
+#. Label of a Data field in DocType 'Employee Health Insurance'
+#: hr/doctype/employee_health_insurance/employee_health_insurance.json
+msgctxt "Employee Health Insurance"
+msgid "Health Insurance Name"
+msgstr "crwdns107570:0crwdne107570:0"
+
+#: hr/notification/training_feedback/training_feedback.html:1
+msgid "Hello"
+msgstr "crwdns107572:0crwdne107572:0"
+
+#. Label of a HTML field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Help"
+msgstr "crwdns107574:0crwdne107574:0"
+
+#: controllers/employee_reminders.py:72
+msgid "Hey {}! This email is to remind you about the upcoming holidays."
+msgstr "crwdns107576:0crwdne107576:0"
+
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py:44
+msgid "Hiring Count"
+msgstr "crwdns107578:0crwdne107578:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Hiring Settings"
+msgstr "crwdns107580:0crwdne107580:0"
+
+#. Label of a chart in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Hiring vs Attrition Count"
+msgstr "crwdns107582:0crwdne107582:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Hold"
+msgstr "crwdns107584:0crwdne107584:0"
+
+#: hr/doctype/leave_application/leave_application.py:1304
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.py:24
+msgid "Holiday"
+msgstr "crwdns107586:0crwdne107586:0"
+
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.js:22
+msgid "Holiday List"
+msgstr "crwdns107588:0crwdne107588:0"
+
+#. Label of a Link field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Holiday List"
+msgstr "crwdns107590:0crwdne107590:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Holiday List"
+msgstr "crwdns107592:0crwdne107592:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Holiday List"
+msgid "Holiday List"
+msgstr "crwdns107594:0crwdne107594:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Holiday List"
+msgstr "crwdns107596:0crwdne107596:0"
+
+#. Label of a Link field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Holiday List"
+msgstr "crwdns107598:0crwdne107598:0"
+
+#. Label of a Link field in DocType 'Leave Period'
+#: hr/doctype/leave_period/leave_period.json
+msgctxt "Leave Period"
+msgid "Holiday List for Optional Leave"
+msgstr "crwdns107600:0crwdne107600:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Holidays"
+msgstr "crwdns107602:0crwdne107602:0"
+
+#: controllers/employee_reminders.py:65
+msgid "Holidays this Month."
+msgstr "crwdns107604:0crwdne107604:0"
+
+#: controllers/employee_reminders.py:65
+msgid "Holidays this Week."
+msgstr "crwdns107606:0crwdne107606:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Hour Rate"
+msgstr "crwdns107608:0crwdne107608:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Hour Rate"
+msgstr "crwdns107610:0crwdne107610:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Hour Rate (Company Currency)"
+msgstr "crwdns107612:0crwdne107612:0"
+
+#. Label of a Float field in DocType 'Training Result Employee'
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgctxt "Training Result Employee"
+msgid "Hours"
+msgstr "crwdns107614:0crwdne107614:0"
+
+#: regional/india/utils.py:182
+msgid "House rent paid days overlapping with {0}"
+msgstr "crwdns107616:0{0}crwdne107616:0"
+
+#: regional/india/utils.py:160
+msgid "House rented dates required for exemption calculation"
+msgstr "crwdns107618:0crwdne107618:0"
+
+#: regional/india/utils.py:163
+msgid "House rented dates should be atleast 15 days apart"
+msgstr "crwdns107620:0crwdne107620:0"
+
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:53
+msgid "IFSC"
+msgstr "crwdns107622:0crwdne107622:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:44
+msgid "IFSC Code"
+msgstr "crwdns107624:0crwdne107624:0"
+
+#. Option for the 'Log Type' (Select) field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "IN"
+msgstr "crwdns107626:0crwdne107626:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Identification Document Number"
+msgstr "crwdns107628:0crwdne107628:0"
+
+#. Name of a DocType
+#: hr/doctype/identification_document_type/identification_document_type.json
+msgid "Identification Document Type"
+msgstr "crwdns107630:0crwdne107630:0"
+
+#. Label of a Data field in DocType 'Identification Document Type'
+#: hr/doctype/identification_document_type/identification_document_type.json
+msgctxt "Identification Document Type"
+msgid "Identification Document Type"
+msgstr "crwdns107632:0crwdne107632:0"
+
+#. Label of a Link field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Identification Document Type"
+msgstr "crwdns107634:0crwdne107634:0"
+
+#. Description of the 'Process Payroll Accounting Entry based on Employee'
+#. (Check) field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "If checked, Payroll Payable will be booked against each employee"
+msgstr "crwdns107636:0crwdne107636:0"
+
+#. Description of the 'Disable Rounded Total' (Check) field in DocType 'Payroll
+#. Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "If checked, hides and disables Rounded Total field in Salary Slips"
+msgstr "crwdns107638:0crwdne107638:0"
+
+#. Description of the 'Exempted from Income Tax' (Check) field in DocType
+#. 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "If checked, the full amount will be deducted from taxable income before calculating income tax without any declaration or proof submission."
+msgstr "crwdns107640:0crwdne107640:0"
+
+#. Description of the 'Define Opening Balance for Earning and Deductions'
+#. (Check) field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "If checked, then the system will enable the provision to set the opening balance for earnings and deductions till date while creating a Salary Structure Assignment (if any)"
+msgstr "crwdns107642:0crwdne107642:0"
+
+#. Description of the 'Allow Tax Exemption' (Check) field in DocType 'Income
+#. Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "If enabled, Tax Exemption Declaration will be considered for income tax calculation."
+msgstr "crwdns107644:0crwdne107644:0"
+
+#. Description of the 'Mark Auto Attendance on Holidays' (Check) field in
+#. DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "If enabled, auto attendance will be marked on holidays if Employee Checkins exist"
+msgstr "crwdns107646:0crwdne107646:0"
+
+#. Description of the 'Consider Marked Attendance on Holidays' (Check) field in
+#. DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "If enabled, deducts payment days for absent attendance on holidays. By default, holidays are considered as paid"
+msgstr "crwdns107648:0crwdne107648:0"
+
+#. Description of the 'Variable Based On Taxable Salary' (Check) field in
+#. DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "If enabled, the component will be considered as a tax component and the amount will be auto-calculated as per the configured income tax slabs"
+msgstr "crwdns107650:0crwdne107650:0"
+
+#. Description of the 'Is Income Tax Component' (Check) field in DocType
+#. 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "If enabled, the component will be considered in the Income Tax Deductions report"
+msgstr "crwdns107652:0crwdne107652:0"
+
+#. Description of the 'Remove if Zero Valued' (Check) field in DocType 'Salary
+#. Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "If enabled, the component will not be displayed in the salary slip if the amount is zero"
+msgstr "crwdns107654:0crwdne107654:0"
+
+#. Description of the 'Statistical Component' (Check) field in DocType 'Salary
+#. Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "If enabled, the value specified or calculated in this component will not contribute to the earnings or deductions. However, it's value can be referenced by other components that can be added or deducted. "
+msgstr "crwdns107656:0crwdne107656:0"
+
+#. Description of the 'Include holidays in Total no. of Working Days' (Check)
+#. field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "If enabled, total no. of working days will include holidays, and this will reduce the value of Salary Per Day"
+msgstr "crwdns107658:0crwdne107658:0"
+
+#. Description of the 'Applies to Company' (Check) field in DocType 'Leave
+#. Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "If not checked, the list will have to be added to each Department where it has to be applied."
+msgstr "crwdns107660:0crwdne107660:0"
+
+#. Description of the 'Statistical Component' (Check) field in DocType 'Salary
+#. Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "If selected, the value specified or calculated in this component will not contribute to the earnings or deductions. However, it's value can be referenced by other components that can be added or deducted. "
+msgstr "crwdns107662:0crwdne107662:0"
+
+#. Description of the 'Closes On' (Date) field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "If set, the job opening will be closed automatically after this date"
+msgstr "crwdns107664:0crwdne107664:0"
+
+#: patches/v15_0/notify_about_loan_app_separation.py:17
+msgid "If you are using loans in salary slips, please install the {0} app from Frappe Cloud Marketplace or GitHub to continue using loan integration with payroll."
+msgstr "crwdns107666:0{0}crwdne107666:0"
+
+#. Label of a Section Break field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Import Attendance"
+msgstr "crwdns107668:0crwdne107668:0"
+
+#. Label of a HTML field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Import Log"
+msgstr "crwdns107670:0crwdne107670:0"
+
+#: hr/doctype/upload_attendance/upload_attendance.js:46
+msgid "Importing {0} of {1}"
+msgstr "crwdns107672:0{0}crwdnd107672:0{1}crwdne107672:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "In Process"
+msgstr "crwdns107674:0crwdne107674:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "In Process"
+msgstr "crwdns107676:0crwdne107676:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "In Process"
+msgstr "crwdns107678:0crwdne107678:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "In Progress"
+msgstr "crwdns107680:0crwdne107680:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "In Progress"
+msgstr "crwdns107682:0crwdne107682:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:67
+msgid "In Time"
+msgstr "crwdns107684:0crwdne107684:0"
+
+#. Label of a Datetime field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "In Time"
+msgstr "crwdns107686:0crwdne107686:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:120
+msgid "In case of any error during this background process, the system will add a comment about the error on this Payroll Entry and revert to the Submitted status"
+msgstr "crwdns107688:0crwdne107688:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.js:47
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:41
+msgid "Inactive"
+msgstr "crwdns107690:0crwdne107690:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Inactive"
+msgstr "crwdns107692:0crwdne107692:0"
+
+#. Label of a Section Break field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Incentive"
+msgstr "crwdns107694:0crwdne107694:0"
+
+#. Label of a Currency field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Incentive Amount"
+msgstr "crwdns107696:0crwdne107696:0"
+
+#. Label of a Card Break in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json setup.py:405
+msgid "Incentives"
+msgstr "crwdns107698:0crwdne107698:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Include holidays in Total no. of Working Days"
+msgstr "crwdns107700:0crwdne107700:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Include holidays within leaves as leaves"
+msgstr "crwdns107702:0crwdne107702:0"
+
+#. Label of a Section Break field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Income Source"
+msgstr "crwdns107704:0crwdne107704:0"
+
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:47
+msgid "Income Tax Amount"
+msgstr "crwdns107706:0crwdne107706:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Income Tax Breakup"
+msgstr "crwdns107708:0crwdne107708:0"
+
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:45
+msgid "Income Tax Component"
+msgstr "crwdns107710:0crwdne107710:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#. Label of a shortcut in the Tax & Benefits Workspace
+#: payroll/report/income_tax_computation/income_tax_computation.json
+#: payroll/workspace/salary_payout/salary_payout.json
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Income Tax Computation"
+msgstr "crwdns107712:0crwdne107712:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Income Tax Deducted Till Date"
+msgstr "crwdns107714:0crwdne107714:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/report/income_tax_deductions/income_tax_deductions.json
+#: payroll/workspace/salary_payout/salary_payout.json
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Income Tax Deductions"
+msgstr "crwdns107716:0crwdne107716:0"
+
+#. Name of a DocType
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+#: payroll/doctype/salary_structure/salary_structure.js:110
+#: payroll/doctype/salary_structure/salary_structure.js:150
+#: payroll/report/income_tax_computation/income_tax_computation.py:509
+msgid "Income Tax Slab"
+msgstr "crwdns107718:0crwdne107718:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgctxt "Income Tax Slab"
+msgid "Income Tax Slab"
+msgstr "crwdns107720:0crwdne107720:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Income Tax Slab"
+msgstr "crwdns107722:0crwdne107722:0"
+
+#. Name of a DocType
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgid "Income Tax Slab Other Charges"
+msgstr "crwdns107724:0crwdne107724:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1482
+msgid "Income Tax Slab must be effective on or before Payroll Period Start Date: {0}"
+msgstr "crwdns107726:0{0}crwdne107726:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1471
+msgid "Income Tax Slab not set in Salary Structure Assignment: {0}"
+msgstr "crwdns107728:0{0}crwdne107728:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1478
+msgid "Income Tax Slab: {0} is disabled"
+msgstr "crwdns107730:0{0}crwdne107730:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Income from Other Sources"
+msgstr "crwdns107732:0crwdne107732:0"
+
+#: hr/doctype/appraisal/appraisal.py:154
+#: hr/doctype/appraisal_template/appraisal_template.py:28
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.py:55
+msgid "Incorrect Weightage Allocation"
+msgstr "crwdns107734:0crwdne107734:0"
+
+#. Description of the 'Non-Encashable Leaves' (Int) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Indicates the number of leaves that cannot be encashed from the leave balance. E.g. with a leave balance of 10 and 4 Non-Encashable Leaves, you can encash 6, while the remaining 4 can be carried forward or expired"
+msgstr "crwdns107736:0crwdne107736:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Inspection"
+msgstr "crwdns107738:0crwdne107738:0"
+
+#: hr/doctype/leave_application/leave_application.py:412
+msgid "Insufficient Balance"
+msgstr "crwdns107740:0crwdne107740:0"
+
+#: hr/doctype/leave_application/leave_application.py:410
+msgid "Insufficient leave balance for Leave Type {0}"
+msgstr "crwdns107742:0{0}crwdne107742:0"
+
+#. Name of a DocType
+#: hr/doctype/interest/interest.json
+msgid "Interest"
+msgstr "crwdns107744:0crwdne107744:0"
+
+#. Label of a Data field in DocType 'Interest'
+#: hr/doctype/interest/interest.json
+msgctxt "Interest"
+msgid "Interest"
+msgstr "crwdns107746:0crwdne107746:0"
+
+#. Label of a Currency field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Interest Amount"
+msgstr "crwdns107748:0crwdne107748:0"
+
+#. Label of a Link field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Interest Income Account"
+msgstr "crwdns107750:0crwdne107750:0"
+
+#. Option for the 'Level' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Intermediate"
+msgstr "crwdns107752:0crwdne107752:0"
+
+#: setup.py:386
+msgid "Intern"
+msgstr "crwdns107754:0crwdne107754:0"
+
+#. Option for the 'Travel Type' (Select) field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "International"
+msgstr "crwdns107756:0crwdne107756:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Internet"
+msgstr "crwdns107758:0crwdne107758:0"
+
+#. Name of a DocType
+#: hr/doctype/interview/interview.json
+#: hr/doctype/job_applicant/job_applicant.js:24
+msgid "Interview"
+msgstr "crwdns107760:0crwdne107760:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Interview"
+msgid "Interview"
+msgstr "crwdns107762:0crwdne107762:0"
+
+#. Label of a Link field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Interview"
+msgstr "crwdns107764:0crwdne107764:0"
+
+#. Name of a DocType
+#: hr/doctype/interview_detail/interview_detail.json
+msgid "Interview Detail"
+msgstr "crwdns107766:0crwdne107766:0"
+
+#. Label of a Section Break field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Interview Details"
+msgstr "crwdns107768:0crwdne107768:0"
+
+#. Name of a DocType
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgid "Interview Feedback"
+msgstr "crwdns107770:0crwdne107770:0"
+
+#. Linked DocType in Interview's connections
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Interview Feedback"
+msgstr "crwdns107772:0crwdne107772:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Interview Feedback"
+msgid "Interview Feedback"
+msgstr "crwdns107774:0crwdne107774:0"
+
+#: hr/doctype/interview/test_interview.py:300
+#: hr/doctype/interview/test_interview.py:309
+#: hr/doctype/interview/test_interview.py:311
+#: hr/doctype/interview/test_interview.py:318 setup.py:458 setup.py:460
+#: setup.py:493
+msgid "Interview Feedback Reminder"
+msgstr "crwdns107776:0crwdne107776:0"
+
+#: hr/doctype/interview/interview.py:349
+msgid "Interview Feedback {0} submitted successfully"
+msgstr "crwdns107778:0{0}crwdne107778:0"
+
+#: hr/doctype/interview/interview.py:89
+msgid "Interview Not Rescheduled"
+msgstr "crwdns107780:0crwdne107780:0"
+
+#: hr/doctype/interview/test_interview.py:284
+#: hr/doctype/interview/test_interview.py:293
+#: hr/doctype/interview/test_interview.py:295
+#: hr/doctype/interview/test_interview.py:317 setup.py:446 setup.py:448
+#: setup.py:489
+msgid "Interview Reminder"
+msgstr "crwdns107782:0crwdne107782:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Interview Reminder Notification Template"
+msgstr "crwdns107784:0crwdne107784:0"
+
+#: hr/doctype/interview/interview.py:122
+msgid "Interview Rescheduled successfully"
+msgstr "crwdns107786:0crwdne107786:0"
+
+#. Name of a DocType
+#: hr/doctype/interview_round/interview_round.json
+msgid "Interview Round"
+msgstr "crwdns107788:0crwdne107788:0"
+
+#. Label of a Link field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Interview Round"
+msgstr "crwdns107790:0crwdne107790:0"
+
+#. Label of a Link field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Interview Round"
+msgstr "crwdns107792:0crwdne107792:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Interview Round"
+msgid "Interview Round"
+msgstr "crwdns107794:0crwdne107794:0"
+
+#. Linked DocType in Interview Type's connections
+#: hr/doctype/interview_type/interview_type.json
+msgctxt "Interview Type"
+msgid "Interview Round"
+msgstr "crwdns107796:0crwdne107796:0"
+
+#: hr/doctype/job_applicant/job_applicant.py:72
+msgid "Interview Round {0} is only applicable for the Designation {1}"
+msgstr "crwdns107798:0{0}crwdnd107798:0{1}crwdne107798:0"
+
+#: hr/doctype/interview/interview.py:52
+msgid "Interview Round {0} is only for Designation {1}. Job Applicant has applied for the role {2}"
+msgstr "crwdns107800:0{0}crwdnd107800:0{1}crwdnd107800:0{2}crwdne107800:0"
+
+#: hr/report/employee_exits/employee_exits.js:51
+#: hr/report/employee_exits/employee_exits.py:46
+msgid "Interview Status"
+msgstr "crwdns107802:0crwdne107802:0"
+
+#: hr/doctype/job_applicant/job_applicant.js:65
+msgid "Interview Summary"
+msgstr "crwdns107804:0crwdne107804:0"
+
+#. Label of a Text Editor field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Interview Summary"
+msgstr "crwdns107806:0crwdne107806:0"
+
+#. Label of a Section Break field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Interview Summary"
+msgstr "crwdns107808:0crwdne107808:0"
+
+#. Name of a DocType
+#: hr/doctype/interview_type/interview_type.json
+msgid "Interview Type"
+msgstr "crwdns107810:0crwdne107810:0"
+
+#. Label of a Link field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Interview Type"
+msgstr "crwdns107812:0crwdne107812:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Interview Type"
+msgid "Interview Type"
+msgstr "crwdns107814:0crwdne107814:0"
+
+#: hr/doctype/interview/interview.py:105
+msgid "Interview: {0} Rescheduled"
+msgstr "crwdns107816:0{0}crwdne107816:0"
+
+#. Name of a role
+#. Name of a DocType
+#: hr/doctype/interview/interview.json
+#: hr/doctype/interview_feedback/interview_feedback.json
+#: hr/doctype/interview_round/interview_round.json
+#: hr/doctype/interviewer/interviewer.json
+msgid "Interviewer"
+msgstr "crwdns107818:0crwdne107818:0"
+
+#. Label of a Link field in DocType 'Interview Detail'
+#: hr/doctype/interview_detail/interview_detail.json
+msgctxt "Interview Detail"
+msgid "Interviewer"
+msgstr "crwdns107820:0crwdne107820:0"
+
+#. Label of a Link field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Interviewer"
+msgstr "crwdns107822:0crwdne107822:0"
+
+#. Label of a Table MultiSelect field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Interviewers"
+msgstr "crwdns107824:0crwdne107824:0"
+
+#. Label of a Table field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Interviewers"
+msgstr "crwdns107826:0crwdne107826:0"
+
+#. Label of a Table MultiSelect field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Interviewers"
+msgstr "crwdns107828:0crwdne107828:0"
+
+#. Label of a Card Break in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgid "Interviews"
+msgstr "crwdns107830:0crwdne107830:0"
+
+#. Label of a Long Text field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Introduction"
+msgstr "crwdns107832:0crwdne107832:0"
+
+#. Label of a Long Text field in DocType 'Appointment Letter Template'
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgctxt "Appointment Letter Template"
+msgid "Introduction"
+msgstr "crwdns107834:0crwdne107834:0"
+
+#. Label of a Text Editor field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Introduction"
+msgstr "crwdns107836:0crwdne107836:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Invalid"
+msgstr "crwdns107838:0crwdne107838:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:281
+msgid "Invalid Payroll Payable Account. The account currency must be {0} or {1}"
+msgstr "crwdns107840:0{0}crwdnd107840:0{1}crwdne107840:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Investigated"
+msgstr "crwdns107842:0crwdne107842:0"
+
+#. Label of a Section Break field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Investigation Details"
+msgstr "crwdns107844:0crwdne107844:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Invited"
+msgstr "crwdns107846:0crwdne107846:0"
+
+#. Label of a Data field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Invoice Ref"
+msgstr "crwdns107848:0crwdne107848:0"
+
+#. Label of a Check field in DocType 'Employee Tax Exemption Category'
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+msgctxt "Employee Tax Exemption Category"
+msgid "Is Active"
+msgstr "crwdns107850:0crwdne107850:0"
+
+#. Label of a Check field in DocType 'Employee Tax Exemption Sub Category'
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgctxt "Employee Tax Exemption Sub Category"
+msgid "Is Active"
+msgstr "crwdns107852:0crwdne107852:0"
+
+#. Label of a Check field in DocType 'Leave Period'
+#: hr/doctype/leave_period/leave_period.json
+msgctxt "Leave Period"
+msgid "Is Active"
+msgstr "crwdns107854:0crwdne107854:0"
+
+#. Label of a Select field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Is Active"
+msgstr "crwdns107856:0crwdne107856:0"
+
+#. Label of a Check field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Is Applicable for Referral Bonus"
+msgstr "crwdns107858:0crwdne107858:0"
+
+#. Label of a Check field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Is Carry Forward"
+msgstr "crwdns107860:0crwdne107860:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Carry Forward"
+msgstr "crwdns107862:0crwdne107862:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Compensatory"
+msgstr "crwdns107864:0crwdne107864:0"
+
+#: hr/doctype/leave_type/leave_type.py:40
+msgid "Is Compensatory Leave"
+msgstr "crwdns107866:0crwdne107866:0"
+
+#. Label of a Select field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Is Default"
+msgstr "crwdns107868:0crwdne107868:0"
+
+#: hr/doctype/leave_type/leave_type.py:40
+msgid "Is Earned Leave"
+msgstr "crwdns107870:0crwdne107870:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Earned Leave"
+msgstr "crwdns107872:0crwdne107872:0"
+
+#. Label of a Check field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Is Expired"
+msgstr "crwdns107874:0crwdne107874:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Is Flexible Benefit"
+msgstr "crwdns107876:0crwdne107876:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Is Flexible Benefit"
+msgstr "crwdns107878:0crwdne107878:0"
+
+#: hr/doctype/goal/goal_tree.js:51
+msgid "Is Group"
+msgstr "crwdns107880:0crwdne107880:0"
+
+#. Label of a Check field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Is Group"
+msgstr "crwdns107882:0crwdne107882:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Is Income Tax Component"
+msgstr "crwdns107884:0crwdne107884:0"
+
+#. Label of a Check field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Is Leave Without Pay"
+msgstr "crwdns107886:0crwdne107886:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Leave Without Pay"
+msgstr "crwdns107888:0crwdne107888:0"
+
+#. Label of a Check field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Is Mandatory"
+msgstr "crwdns107890:0crwdne107890:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Optional Leave"
+msgstr "crwdns107892:0crwdne107892:0"
+
+#. Label of a Check field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Is Paid"
+msgstr "crwdns107894:0crwdne107894:0"
+
+#. Label of a Check field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Is Partially Paid Leave"
+msgstr "crwdns107896:0crwdne107896:0"
+
+#. Label of a Check field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Is Recurring"
+msgstr "crwdns107898:0crwdne107898:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Is Recurring Additional Salary"
+msgstr "crwdns107900:0crwdne107900:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Is Tax Applicable"
+msgstr "crwdns107902:0crwdne107902:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Is Tax Applicable"
+msgstr "crwdns107904:0crwdne107904:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:13
+#: public/js/salary_slip_deductions_report_filters.js:19
+msgid "Jan"
+msgstr "crwdns107906:0crwdne107906:0"
+
+#. Name of a DocType
+#: hr/doctype/job_applicant/job_applicant.json
+#: hr/report/recruitment_analytics/recruitment_analytics.py:39
+msgid "Job Applicant"
+msgstr "crwdns107908:0crwdne107908:0"
+
+#. Label of a Link field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Job Applicant"
+msgstr "crwdns107910:0crwdne107910:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Job Applicant"
+msgstr "crwdns107912:0crwdne107912:0"
+
+#. Label of a Link field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Job Applicant"
+msgstr "crwdns107914:0crwdne107914:0"
+
+#. Label of a Link field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Job Applicant"
+msgstr "crwdns107916:0crwdne107916:0"
+
+#. Label of a Link in the Recruitment Workspace
+#. Label of a shortcut in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Job Applicant"
+msgid "Job Applicant"
+msgstr "crwdns107918:0crwdne107918:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Job Applicant"
+msgstr "crwdns107920:0crwdne107920:0"
+
+#. Name of a DocType
+#: hr/doctype/job_applicant_source/job_applicant_source.json
+msgid "Job Applicant Source"
+msgstr "crwdns107922:0crwdne107922:0"
+
+#: hr/doctype/employee_referral/employee_referral.py:51
+msgid "Job Applicant {0} created successfully."
+msgstr "crwdns107924:0{0}crwdne107924:0"
+
+#: hr/doctype/interview/interview.py:39
+msgid "Job Applicants are not allowed to appear twice for the same Interview round. Interview {0} already scheduled for Job Applicant {1}"
+msgstr "crwdns107926:0{0}crwdnd107926:0{1}crwdne107926:0"
+
+#. Label of a Data field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Job Application Route"
+msgstr "crwdns107928:0crwdne107928:0"
+
+#: setup.py:401
+msgid "Job Description"
+msgstr "crwdns107930:0crwdne107930:0"
+
+#. Label of a Tab Break field in DocType 'Job Requisition'
+#. Label of a Text Editor field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Job Description"
+msgstr "crwdns107932:0crwdne107932:0"
+
+#. Name of a DocType
+#: hr/doctype/job_applicant/job_applicant.js:33
+#: hr/doctype/job_applicant/job_applicant.js:39
+#: hr/doctype/job_offer/job_offer.json
+#: hr/report/recruitment_analytics/recruitment_analytics.py:53
+msgid "Job Offer"
+msgstr "crwdns107934:0crwdne107934:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Job Offer"
+msgstr "crwdns107936:0crwdne107936:0"
+
+#. Label of a Link in the Recruitment Workspace
+#. Label of a shortcut in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Job Offer"
+msgid "Job Offer"
+msgstr "crwdns107938:0crwdne107938:0"
+
+#. Name of a DocType
+#: hr/doctype/job_offer_term/job_offer_term.json
+msgid "Job Offer Term"
+msgstr "crwdns107940:0crwdne107940:0"
+
+#. Name of a DocType
+#: hr/doctype/job_offer_term_template/job_offer_term_template.json
+msgid "Job Offer Term Template"
+msgstr "crwdns107942:0crwdne107942:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Job Offer Term Template"
+msgstr "crwdns107944:0crwdne107944:0"
+
+#. Label of a Table field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Job Offer Terms"
+msgstr "crwdns107946:0crwdne107946:0"
+
+#: hr/report/recruitment_analytics/recruitment_analytics.py:62
+msgid "Job Offer status"
+msgstr "crwdns107948:0crwdne107948:0"
+
+#: hr/doctype/job_offer/job_offer.py:24
+msgid "Job Offer: {0} is already for Job Applicant: {1}"
+msgstr "crwdns107950:0{0}crwdnd107950:0{1}crwdne107950:0"
+
+#. Name of a DocType
+#: hr/doctype/job_opening/job_opening.json
+#: hr/doctype/job_requisition/job_requisition.js:40
+#: hr/report/recruitment_analytics/recruitment_analytics.py:32
+msgid "Job Opening"
+msgstr "crwdns107952:0crwdne107952:0"
+
+#. Label of a Link field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Job Opening"
+msgstr "crwdns107954:0crwdne107954:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Job Opening"
+msgstr "crwdns107956:0crwdne107956:0"
+
+#. Label of a Link in the Recruitment Workspace
+#. Label of a shortcut in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Job Opening"
+msgid "Job Opening"
+msgstr "crwdns107958:0crwdne107958:0"
+
+#. Linked DocType in Job Requisition's connections
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Job Opening"
+msgstr "crwdns107960:0crwdne107960:0"
+
+#: hr/doctype/job_requisition/job_requisition.py:51
+msgid "Job Opening Associated"
+msgstr "crwdns107962:0crwdne107962:0"
+
+#: www/jobs/index.html:2 www/jobs/index.html:5
+msgid "Job Openings"
+msgstr "crwdns107964:0crwdne107964:0"
+
+#: hr/doctype/job_opening/job_opening.py:87
+msgid "Job Openings for the designation {0} are already open or the hiring is complete as per the Staffing Plan {1}"
+msgstr "crwdns107966:0{0}crwdnd107966:0{1}crwdne107966:0"
+
+#. Name of a DocType
+#: hr/doctype/job_requisition/job_requisition.json
+msgid "Job Requisition"
+msgstr "crwdns107968:0crwdne107968:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Job Requisition"
+msgstr "crwdns107970:0crwdne107970:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Job Requisition"
+msgid "Job Requisition"
+msgstr "crwdns107972:0crwdne107972:0"
+
+#: hr/doctype/job_requisition/job_requisition.py:48
+msgid "Job Requisition {0} has been associated with Job Opening {1}"
+msgstr "crwdns107974:0{0}crwdnd107974:0{1}crwdne107974:0"
+
+#. Label of a Data field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Job Title"
+msgstr "crwdns107976:0crwdne107976:0"
+
+#. Description of the 'Description' (Text Editor) field in DocType 'Job
+#. Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Job profile, qualifications required etc."
+msgstr "crwdns107978:0crwdne107978:0"
+
+#. Label of a Card Break in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgid "Jobs"
+msgstr "crwdns107980:0crwdne107980:0"
+
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Joining Date"
+msgstr "crwdns107982:0crwdne107982:0"
+
+#. Option for the 'Assignment based on' (Select) field in DocType 'Leave Policy
+#. Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Joining Date"
+msgstr "crwdns107984:0crwdne107984:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Journal Entry"
+msgid "Journal Entry"
+msgstr "crwdns107986:0crwdne107986:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Journal Entry"
+msgstr "crwdns107988:0crwdne107988:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgid "Journey"
+msgstr "crwdns107990:0crwdne107990:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:19
+#: public/js/salary_slip_deductions_report_filters.js:25
+msgid "July"
+msgstr "crwdns107992:0crwdne107992:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:18
+#: public/js/salary_slip_deductions_report_filters.js:24
+msgid "June"
+msgstr "crwdns107994:0crwdne107994:0"
+
+#. Name of a DocType
+#: hr/doctype/goal/goal_tree.js:136 hr/doctype/kra/kra.json
+msgid "KRA"
+msgstr "crwdns107996:0crwdne107996:0"
+
+#. Label of a Link field in DocType 'Appraisal KRA'
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgctxt "Appraisal KRA"
+msgid "KRA"
+msgstr "crwdns107998:0crwdne107998:0"
+
+#. Label of a Link field in DocType 'Appraisal Template Goal'
+#: hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgctxt "Appraisal Template Goal"
+msgid "KRA"
+msgstr "crwdns108000:0crwdne108000:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "KRA"
+msgstr "crwdns108002:0crwdne108002:0"
+
+#. Label of a Link in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgctxt "KRA"
+msgid "KRA"
+msgstr "crwdns108004:0crwdne108004:0"
+
+#. Label of a Select field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "KRA Evaluation Method"
+msgstr "crwdns108006:0crwdne108006:0"
+
+#: hr/doctype/goal/goal.py:99
+msgid "KRA updated for all child goals."
+msgstr "crwdns108008:0crwdne108008:0"
+
+#. Label of a Table field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "KRA vs Goals"
+msgstr "crwdns108010:0crwdne108010:0"
+
+#: hr/doctype/appraisal/appraisal.py:140
+#: hr/doctype/appraisal_template/appraisal_template.py:23
+msgid "KRAs"
+msgstr "crwdns108012:0crwdne108012:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "KRAs"
+msgstr "crwdns108014:0crwdne108014:0"
+
+#. Label of a Table field in DocType 'Appraisal Template'
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "KRAs"
+msgstr "crwdns108016:0crwdne108016:0"
+
+#. Description of the 'KRA' (Link) field in DocType 'Appraisal KRA'
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgctxt "Appraisal KRA"
+msgid "Key Performance Area"
+msgstr "crwdns108018:0crwdne108018:0"
+
+#. Label of a Card Break in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Key Reports"
+msgstr "crwdns108020:0crwdne108020:0"
+
+#. Description of the 'Goal' (Small Text) field in DocType 'Appraisal Goal'
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgctxt "Appraisal Goal"
+msgid "Key Responsibility Area"
+msgstr "crwdns108022:0crwdne108022:0"
+
+#. Description of the 'KRA' (Link) field in DocType 'Appraisal Template Goal'
+#: hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgctxt "Appraisal Template Goal"
+msgid "Key Result Area"
+msgstr "crwdns108024:0crwdne108024:0"
+
+#. Option for the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Last Day"
+msgstr "crwdns108026:0crwdne108026:0"
+
+#. Description of the 'Last Sync of Checkin' (Datetime) field in DocType 'Shift
+#. Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Last Known Successful Sync of Employee Checkin. Reset this only if you are sure that all Logs are synced from all the locations. Please don't modify this if you are unsure."
+msgstr "crwdns108028:0crwdne108028:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Last Name"
+msgstr "crwdns108030:0crwdne108030:0"
+
+#. Label of a Int field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Last Odometer Value "
+msgstr "crwdns108032:0crwdne108032:0"
+
+#. Label of a Datetime field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Last Sync of Checkin"
+msgstr "crwdns108034:0crwdne108034:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:180
+msgid "Late Entries"
+msgstr "crwdns108036:0crwdne108036:0"
+
+#: hr/report/shift_attendance/shift_attendance.js:48
+msgid "Late Entry"
+msgstr "crwdns108038:0crwdne108038:0"
+
+#. Label of a Check field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Late Entry"
+msgstr "crwdns108040:0crwdne108040:0"
+
+#. Label of a Check field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Late Entry"
+msgstr "crwdns108042:0crwdne108042:0"
+
+#. Label of a Section Break field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Late Entry & Early Exit Settings for Auto Attendance"
+msgstr "crwdns108044:0crwdne108044:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:85
+msgid "Late Entry By"
+msgstr "crwdns108046:0crwdne108046:0"
+
+#. Label of a Int field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Late Entry Grace Period"
+msgstr "crwdns108048:0crwdne108048:0"
+
+#: overrides/dashboard_overrides.py:12
+msgid "Leave"
+msgstr "crwdns108050:0crwdne108050:0"
+
+#. Option for the 'Calculate Payroll Working Days Based On' (Select) field in
+#. DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Leave"
+msgstr "crwdns108052:0crwdne108052:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgid "Leave Allocation"
+msgstr "crwdns108054:0crwdne108054:0"
+
+#. Label of a Link field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Leave Allocation"
+msgstr "crwdns108056:0crwdne108056:0"
+
+#. Label of a Link in the Leaves Workspace
+#. Label of a shortcut in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Allocation"
+msgid "Leave Allocation"
+msgstr "crwdns108058:0crwdne108058:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Leave Allocation"
+msgstr "crwdns108060:0crwdne108060:0"
+
+#. Label of a Section Break field in DocType 'Leave Policy'
+#: hr/doctype/leave_policy/leave_policy.json
+msgctxt "Leave Policy"
+msgid "Leave Allocations"
+msgstr "crwdns108062:0crwdne108062:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_application/leave_application.json
+msgid "Leave Application"
+msgstr "crwdns108064:0crwdne108064:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Leave Application"
+msgstr "crwdns108066:0crwdne108066:0"
+
+#. Label of a Link in the HR Workspace
+#. Label of a shortcut in the HR Workspace
+#. Label of a Link in the Leaves Workspace
+#. Label of a shortcut in the Leaves Workspace
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgctxt "Leave Application"
+msgid "Leave Application"
+msgstr "crwdns108068:0crwdne108068:0"
+
+#: hr/doctype/leave_application/leave_application.py:705
+msgid "Leave Application period cannot be across two non-consecutive leave allocations {0} and {1}."
+msgstr "crwdns108070:0{0}crwdnd108070:0{1}crwdne108070:0"
+
+#: setup.py:423 setup.py:425 setup.py:485
+msgid "Leave Approval Notification"
+msgstr "crwdns108072:0crwdne108072:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Leave Approval Notification Template"
+msgstr "crwdns108074:0crwdne108074:0"
+
+#. Name of a role
+#: hr/doctype/leave_application/leave_application.json
+msgid "Leave Approver"
+msgstr "crwdns108076:0crwdne108076:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Leave Approver"
+msgstr "crwdns108078:0crwdne108078:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Leave Approver Mandatory In Leave Application"
+msgstr "crwdns108080:0crwdne108080:0"
+
+#. Label of a Data field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Leave Approver Name"
+msgstr "crwdns108082:0crwdne108082:0"
+
+#. Label of a Float field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Leave Balance"
+msgstr "crwdns108084:0crwdne108084:0"
+
+#. Label of a Float field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Leave Balance Before Application"
+msgstr "crwdns108086:0crwdne108086:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgid "Leave Block List"
+msgstr "crwdns108088:0crwdne108088:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Block List"
+msgid "Leave Block List"
+msgstr "crwdns108090:0crwdne108090:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_block_list_allow/leave_block_list_allow.json
+msgid "Leave Block List Allow"
+msgstr "crwdns108092:0crwdne108092:0"
+
+#. Label of a Table field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Leave Block List Allowed"
+msgstr "crwdns108094:0crwdne108094:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_block_list_date/leave_block_list_date.json
+msgid "Leave Block List Date"
+msgstr "crwdns108096:0crwdne108096:0"
+
+#. Label of a Table field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Leave Block List Dates"
+msgstr "crwdns108098:0crwdne108098:0"
+
+#. Label of a Data field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Leave Block List Name"
+msgstr "crwdns108100:0crwdne108100:0"
+
+#: hr/doctype/leave_application/leave_application.py:1281
+msgid "Leave Blocked"
+msgstr "crwdns108102:0crwdne108102:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "Leave Control Panel"
+msgstr "crwdns108104:0crwdne108104:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Control Panel"
+msgid "Leave Control Panel"
+msgstr "crwdns108106:0crwdne108106:0"
+
+#. Label of a Table field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Leave Details"
+msgstr "crwdns108108:0crwdne108108:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgid "Leave Encashment"
+msgstr "crwdns108110:0crwdne108110:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Encashment"
+msgid "Leave Encashment"
+msgstr "crwdns108112:0crwdne108112:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Leave Encashment Amount Per Day"
+msgstr "crwdns108114:0crwdne108114:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgid "Leave Ledger Entry"
+msgstr "crwdns108116:0crwdne108116:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_period/leave_period.json
+msgid "Leave Period"
+msgstr "crwdns108118:0crwdne108118:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Leave Period"
+msgstr "crwdns108120:0crwdne108120:0"
+
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Leave Period"
+msgstr "crwdns108122:0crwdne108122:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Leave Period"
+msgstr "crwdns108124:0crwdne108124:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Period"
+msgid "Leave Period"
+msgstr "crwdns108126:0crwdne108126:0"
+
+#. Option for the 'Assignment based on' (Select) field in DocType 'Leave Policy
+#. Assignment'
+#. Label of a Link field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Leave Period"
+msgstr "crwdns108128:0crwdne108128:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_policy/leave_policy.json
+msgid "Leave Policy"
+msgstr "crwdns108130:0crwdne108130:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Leave Policy"
+msgstr "crwdns108132:0crwdne108132:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Leave Policy"
+msgstr "crwdns108134:0crwdne108134:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Policy"
+msgid "Leave Policy"
+msgstr "crwdns108136:0crwdne108136:0"
+
+#. Label of a Link field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Leave Policy"
+msgstr "crwdns108138:0crwdne108138:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Leave Policy Assignment"
+msgstr "crwdns108140:0crwdne108140:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Leave Policy Assignment"
+msgstr "crwdns108142:0crwdne108142:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Policy Assignment"
+msgid "Leave Policy Assignment"
+msgstr "crwdns108144:0crwdne108144:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:63
+msgid "Leave Policy Assignment Overlap"
+msgstr "crwdns108146:0crwdne108146:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_policy_detail/leave_policy_detail.json
+msgid "Leave Policy Detail"
+msgstr "crwdns108148:0crwdne108148:0"
+
+#. Label of a Table field in DocType 'Leave Policy'
+#: hr/doctype/leave_policy/leave_policy.json
+msgctxt "Leave Policy"
+msgid "Leave Policy Details"
+msgstr "crwdns108150:0crwdne108150:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:57
+msgid "Leave Policy: {0} already assigned for Employee {1} for period {2} to {3}"
+msgstr "crwdns108152:0{0}crwdnd108152:0{1}crwdnd108152:0{2}crwdnd108152:0{3}crwdne108152:0"
+
+#: setup.py:432 setup.py:434 setup.py:486
+msgid "Leave Status Notification"
+msgstr "crwdns108154:0crwdne108154:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Leave Status Notification Template"
+msgstr "crwdns108156:0crwdne108156:0"
+
+#. Name of a DocType
+#: hr/doctype/leave_type/leave_type.json
+#: hr/report/employee_leave_balance/employee_leave_balance.py:33
+msgid "Leave Type"
+msgstr "crwdns108158:0crwdne108158:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Leave Type"
+msgstr "crwdns108160:0crwdne108160:0"
+
+#. Label of a Link field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Leave Type"
+msgstr "crwdns108162:0crwdne108162:0"
+
+#. Label of a Link field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Leave Type"
+msgstr "crwdns108164:0crwdne108164:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Leave Type"
+msgstr "crwdns108166:0crwdne108166:0"
+
+#. Label of a Link field in DocType 'Leave Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Leave Type"
+msgstr "crwdns108168:0crwdne108168:0"
+
+#. Label of a Link field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Leave Type"
+msgstr "crwdns108170:0crwdne108170:0"
+
+#. Label of a Link field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Leave Type"
+msgstr "crwdns108172:0crwdne108172:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Leave Type"
+msgstr "crwdns108174:0crwdne108174:0"
+
+#. Label of a Link field in DocType 'Leave Policy Detail'
+#: hr/doctype/leave_policy_detail/leave_policy_detail.json
+msgctxt "Leave Policy Detail"
+msgid "Leave Type"
+msgstr "crwdns108176:0crwdne108176:0"
+
+#. Label of a Link in the Leaves Workspace
+#: hr/workspace/leaves/leaves.json
+msgctxt "Leave Type"
+msgid "Leave Type"
+msgstr "crwdns108178:0crwdne108178:0"
+
+#. Label of a Link field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Leave Type"
+msgstr "crwdns108180:0crwdne108180:0"
+
+#. Label of a Data field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Leave Type Name"
+msgstr "crwdns108182:0crwdne108182:0"
+
+#: hr/doctype/leave_type/leave_type.py:33
+msgid "Leave Type can either be compensatory or earned leave."
+msgstr "crwdns108184:0crwdne108184:0"
+
+#: hr/doctype/leave_type/leave_type.py:45
+msgid "Leave Type can either be without pay or partial pay"
+msgstr "crwdns108186:0crwdne108186:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:35
+msgid "Leave Type is mandatory"
+msgstr "crwdns108188:0crwdne108188:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:183
+msgid "Leave Type {0} cannot be allocated since it is leave without pay"
+msgstr "crwdns108190:0{0}crwdne108190:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:399
+msgid "Leave Type {0} cannot be carry-forwarded"
+msgstr "crwdns108192:0{0}crwdne108192:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:101
+msgid "Leave Type {0} is not encashable"
+msgstr "crwdns108194:0{0}crwdne108194:0"
+
+#: payroll/report/salary_register/salary_register.py:175 setup.py:372
+#: setup.py:373
+msgid "Leave Without Pay"
+msgstr "crwdns108196:0crwdne108196:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Leave Without Pay"
+msgstr "crwdns108198:0crwdne108198:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:460
+msgid "Leave Without Pay does not match with approved {} records"
+msgstr "crwdns108200:0crwdne108200:0"
+
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.py:42
+msgid "Leave allocation {0} is linked with the Leave Application {1}"
+msgstr "crwdns108202:0{0}crwdnd108202:0{1}crwdne108202:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:83
+msgid "Leave already have been assigned for this Leave Policy Assignment"
+msgstr "crwdns108204:0crwdne108204:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Leave and Expense Claim Settings"
+msgstr "crwdns108206:0crwdne108206:0"
+
+#: hr/doctype/leave_type/leave_type.py:26
+msgid "Leave application is linked with leave allocations {0}. Leave application cannot be set as leave without pay"
+msgstr "crwdns108208:0{0}crwdne108208:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:223
+msgid "Leave cannot be allocated before {0}, as leave balance has already been carry-forwarded in the future leave allocation record {1}"
+msgstr "crwdns108210:0{0}crwdnd108210:0{1}crwdne108210:0"
+
+#: hr/doctype/leave_application/leave_application.py:245
+msgid "Leave cannot be applied/cancelled before {0}, as leave balance has already been carry-forwarded in the future leave allocation record {1}"
+msgstr "crwdns108212:0{0}crwdnd108212:0{1}crwdne108212:0"
+
+#: hr/doctype/leave_application/leave_application.py:482
+msgid "Leave of type {0} cannot be longer than {1}."
+msgstr "crwdns108214:0{0}crwdnd108214:0{1}crwdne108214:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:72
+msgid "Leave(s) Expired"
+msgstr "crwdns108216:0crwdne108216:0"
+
+#. Label of a Float field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Leave(s) Pending Approval"
+msgstr "crwdns108218:0crwdne108218:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:66
+msgid "Leave(s) Taken"
+msgstr "crwdns108220:0crwdne108220:0"
+
+#. Label of a Card Break in the HR Workspace
+#. Name of a Workspace
+#: hr/doctype/leave_policy/leave_policy_dashboard.py:8
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment_dashboard.py:8
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgid "Leaves"
+msgstr "crwdns108222:0crwdne108222:0"
+
+#. Label of a Float field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Leaves"
+msgstr "crwdns108224:0crwdne108224:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Leaves"
+msgstr "crwdns108226:0crwdne108226:0"
+
+#. Label of a Check field in DocType 'Leave Policy Assignment'
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgctxt "Leave Policy Assignment"
+msgid "Leaves Allocated"
+msgstr "crwdns108228:0crwdne108228:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:76
+msgid "Leaves for the Leave Type {0} won't be carry-forwarded since carry-forwarding is disabled."
+msgstr "crwdns108230:0{0}crwdne108230:0"
+
+#: setup.py:403
+msgid "Leaves per Year"
+msgstr "crwdns108232:0crwdne108232:0"
+
+#: hr/doctype/leave_type/leave_type.js:26
+msgid "Leaves you can avail against a holiday you worked on. You can claim Compensatory Off Leave using Compensatory Leave request. Click"
+msgstr "crwdns108234:0crwdne108234:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.js:49
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:43
+msgid "Left"
+msgstr "crwdns108236:0crwdne108236:0"
+
+#. Label of a Int field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Left"
+msgstr "crwdns108238:0crwdne108238:0"
+
+#. Title of the Module Onboarding 'Human Resource'
+#: hr/module_onboarding/human_resource/human_resource.json
+msgid "Let's Set Up the Human Resource Module. "
+msgstr "crwdns108240:0crwdne108240:0"
+
+#. Title of the Module Onboarding 'Payroll'
+#: payroll/module_onboarding/payroll/payroll.json
+msgid "Let's Set Up the Payroll Module. "
+msgstr "crwdns108242:0crwdne108242:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Letter Head"
+msgstr "crwdns108244:0crwdne108244:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Letter Head"
+msgstr "crwdns108246:0crwdne108246:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Letter Head"
+msgstr "crwdns108248:0crwdne108248:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Letter Head"
+msgstr "crwdns108250:0crwdne108250:0"
+
+#. Label of a Select field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Level"
+msgstr "crwdns108252:0crwdne108252:0"
+
+#. Label of a Link field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "License Plate"
+msgstr "crwdns108254:0crwdne108254:0"
+
+#: overrides/dashboard_overrides.py:16
+msgid "Lifecycle"
+msgstr "crwdns108256:0crwdne108256:0"
+
+#: hr/doctype/goal/goal_tree.js:99
+msgid "Link the cycle and tag KRA to your goal to update the appraisal's goal score based on the goal progress"
+msgstr "crwdns108258:0crwdne108258:0"
+
+#. Description of the 'Appraisal Linking' (Section Break) field in DocType
+#. 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Link the cycle and tag KRA to your goal to update the appraisal's goal score based on the goal progress"
+msgstr "crwdns108260:0crwdne108260:0"
+
+#: controllers/employee_boarding_controller.py:154
+msgid "Linked Project {} and Tasks deleted."
+msgstr "crwdns108262:0crwdne108262:0"
+
+#. Label of a Link field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Loan"
+msgstr "crwdns108264:0crwdne108264:0"
+
+#. Label of a Link field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Loan Account"
+msgstr "crwdns108266:0crwdne108266:0"
+
+#. Label of a Link field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Loan Product"
+msgstr "crwdns108268:0crwdne108268:0"
+
+#: payroll/report/salary_register/salary_register.py:223
+msgid "Loan Repayment"
+msgstr "crwdns108270:0crwdne108270:0"
+
+#. Label of a Link field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Loan Repayment Entry"
+msgstr "crwdns108272:0crwdne108272:0"
+
+#: hr/utils.py:702
+msgid "Loan cannot be repayed from salary for Employee {0} because salary is processed in currency {1}"
+msgstr "crwdns108274:0{0}crwdnd108274:0{1}crwdne108274:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:33
+#: templates/generators/job_opening.html:61
+msgid "Location"
+msgstr "crwdns108276:0crwdne108276:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Location"
+msgstr "crwdns108278:0crwdne108278:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Location"
+msgstr "crwdns108280:0crwdne108280:0"
+
+#. Label of a Data field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Location / Device ID"
+msgstr "crwdns108282:0crwdne108282:0"
+
+#. Label of a Check field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Lodging Required"
+msgstr "crwdns108284:0crwdne108284:0"
+
+#. Label of a Select field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Log Type"
+msgstr "crwdns108286:0crwdne108286:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:50
+msgid "Log Type is required for check-ins falling in the shift: {0}."
+msgstr "crwdns108288:0{0}crwdne108288:0"
+
+#. Label of a Currency field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Lower Range"
+msgstr "crwdns108290:0crwdne108290:0"
+
+#. Label of a Currency field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Lower Range"
+msgstr "crwdns108292:0crwdne108292:0"
+
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:54
+msgid "MICR"
+msgstr "crwdns108294:0crwdne108294:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:31
+msgid "Make"
+msgstr "crwdns108296:0crwdne108296:0"
+
+#. Label of a Read Only field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Make"
+msgstr "crwdns108298:0crwdne108298:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:163
+msgid "Make Bank Entry"
+msgstr "crwdns108300:0crwdne108300:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:186
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:193
+#: hr/doctype/goal/goal.js:88
+msgid "Mandatory"
+msgstr "crwdns108302:0crwdne108302:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:189
+msgid "Mandatory fields required in {0}"
+msgstr "crwdns108304:0{0}crwdne108304:0"
+
+#. Option for the 'KRA Evaluation Method' (Select) field in DocType 'Appraisal
+#. Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Manual Rating"
+msgstr "crwdns108306:0crwdne108306:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:15
+#: public/js/salary_slip_deductions_report_filters.js:21
+msgid "Mar"
+msgstr "crwdns108308:0crwdne108308:0"
+
+#: hr/doctype/attendance/attendance_list.js:17
+#: hr/doctype/attendance/attendance_list.js:25
+#: hr/doctype/attendance/attendance_list.js:128
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:173
+#: hr/doctype/shift_type/shift_type.js:7
+msgid "Mark Attendance"
+msgstr "crwdns108310:0crwdne108310:0"
+
+#. Label of a Check field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Mark Auto Attendance on Holidays"
+msgstr "crwdns108312:0crwdne108312:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:48
+#: hr/doctype/employee_onboarding/employee_onboarding.js:48
+#: hr/doctype/goal/goal_tree.js:262
+msgid "Mark as Completed"
+msgstr "crwdns108314:0crwdne108314:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:52
+msgid "Mark as In Progress"
+msgstr "crwdns108316:0crwdne108316:0"
+
+#: hr/doctype/interview/interview.py:75
+msgid "Mark as {0}"
+msgstr "crwdns108318:0{0}crwdne108318:0"
+
+#: hr/doctype/attendance/attendance_list.js:102
+msgid "Mark attendance as {0} for {1} on selected dates?"
+msgstr "crwdns108320:0{0}crwdnd108320:0{1}crwdne108320:0"
+
+#. Description of the 'Enable Auto Attendance' (Check) field in DocType 'Shift
+#. Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Mark attendance based on 'Employee Checkin' for Employees assigned to this shift."
+msgstr "crwdns108322:0crwdne108322:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:204
+msgid "Mark the cycle as {0} if required."
+msgstr "crwdns108324:0{0}crwdne108324:0"
+
+#: hr/doctype/goal/goal_tree.js:269
+msgid "Mark {0} as Completed?"
+msgstr "crwdns108326:0{0}crwdne108326:0"
+
+#: hr/doctype/goal/goal_list.js:84
+msgid "Mark {0} {1} as {2}?"
+msgstr "crwdns108328:0{0}crwdnd108328:0{1}crwdnd108328:0{2}crwdne108328:0"
+
+#. Label of a Section Break field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Marked Attendance"
+msgstr "crwdns108330:0crwdne108330:0"
+
+#. Label of a HTML field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Marked Attendance HTML"
+msgstr "crwdns108332:0crwdne108332:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:215
+msgid "Marking Attendance"
+msgstr "crwdns108334:0crwdne108334:0"
+
+#. Label of a Card Break in the Performance Workspace
+#. Label of a Card Break in the Salary Payout Workspace
+#: hr/workspace/performance/performance.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Masters"
+msgstr "crwdns108336:0crwdne108336:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Max Amount Eligible"
+msgstr "crwdns108338:0crwdne108338:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application Detail'
+#: payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgctxt "Employee Benefit Application Detail"
+msgid "Max Benefit Amount"
+msgstr "crwdns108340:0crwdne108340:0"
+
+#. Label of a Currency field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Max Benefit Amount (Yearly)"
+msgstr "crwdns108342:0crwdne108342:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Max Benefits (Amount)"
+msgstr "crwdns108344:0crwdne108344:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Max Benefits (Yearly)"
+msgstr "crwdns108346:0crwdne108346:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Category'
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+msgctxt "Employee Tax Exemption Category"
+msgid "Max Exemption Amount"
+msgstr "crwdns108348:0crwdne108348:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Sub Category'
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgctxt "Employee Tax Exemption Sub Category"
+msgid "Max Exemption Amount"
+msgstr "crwdns108350:0crwdne108350:0"
+
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.py:18
+msgid "Max Exemption Amount cannot be greater than maximum exemption amount {0} of Tax Exemption Category {1}"
+msgstr "crwdns108352:0{0}crwdnd108352:0{1}crwdne108352:0"
+
+#. Label of a Currency field in DocType 'Income Tax Slab Other Charges'
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgctxt "Income Tax Slab Other Charges"
+msgid "Max Taxable Income"
+msgstr "crwdns108354:0crwdne108354:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:147
+msgid "Max benefits should be greater than zero to dispense benefits"
+msgstr "crwdns108356:0crwdne108356:0"
+
+#. Label of a Float field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Max working hours against Timesheet"
+msgstr "crwdns108358:0crwdne108358:0"
+
+#. Label of a Float field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Maximum Carry Forwarded Leaves"
+msgstr "crwdns108360:0crwdne108360:0"
+
+#. Label of a Int field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Maximum Consecutive Leaves Allowed"
+msgstr "crwdns108362:0crwdne108362:0"
+
+#: hr/doctype/leave_application/leave_application.py:490
+msgid "Maximum Consecutive Leaves Exceeded"
+msgstr "crwdns108364:0crwdne108364:0"
+
+#. Label of a Int field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Maximum Encashable Leaves"
+msgstr "crwdns108366:0crwdne108366:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Declaration
+#. Category'
+#: payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgctxt "Employee Tax Exemption Declaration Category"
+msgid "Maximum Exempted Amount"
+msgstr "crwdns108368:0crwdne108368:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Proof
+#. Submission Detail'
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgctxt "Employee Tax Exemption Proof Submission Detail"
+msgid "Maximum Exemption Amount"
+msgstr "crwdns108370:0crwdne108370:0"
+
+#. Label of a Float field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Maximum Leave Allocation Allowed"
+msgstr "crwdns108372:0crwdne108372:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:65
+msgid "Maximum amount eligible for the component {0} exceeds {1}"
+msgstr "crwdns108374:0{0}crwdnd108374:0{1}crwdne108374:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:139
+msgid "Maximum benefit amount of component {0} exceeds {1}"
+msgstr "crwdns108376:0{0}crwdnd108376:0{1}crwdne108376:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:119
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:54
+msgid "Maximum benefit amount of employee {0} exceeds {1}"
+msgstr "crwdns108378:0{0}crwdnd108378:0{1}crwdne108378:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:85
+msgid "Maximum benefit of employee {0} exceeds {1} by the sum {2} of benefit application pro-rata component amount and previous claimed amount"
+msgstr "crwdns108380:0{0}crwdnd108380:0{1}crwdnd108380:0{2}crwdne108380:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:46
+msgid "Maximum benefit of employee {0} exceeds {1} by the sum {2} of previous claimed amount"
+msgstr "crwdns108382:0{0}crwdnd108382:0{1}crwdnd108382:0{2}crwdne108382:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:122
+msgid "Maximum encashable leaves for {0} are {1}"
+msgstr "crwdns108384:0{0}crwdnd108384:0{1}crwdne108384:0"
+
+#: hr/doctype/leave_policy/leave_policy.py:19
+msgid "Maximum leave allowed in the leave type {0} is {1}"
+msgstr "crwdns108386:0{0}crwdnd108386:0{1}crwdne108386:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:17
+#: public/js/salary_slip_deductions_report_filters.js:23
+msgid "May"
+msgstr "crwdns108388:0crwdne108388:0"
+
+#. Label of a Select field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Meal Preference"
+msgstr "crwdns108390:0crwdne108390:0"
+
+#: setup.py:325
+msgid "Medical"
+msgstr "crwdns108392:0crwdne108392:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1398
+msgid "Message"
+msgstr "crwdns108394:0crwdne108394:0"
+
+#. Label of a Text Editor field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Message"
+msgstr "crwdns108396:0crwdne108396:0"
+
+#. Label of a Text Editor field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "Message"
+msgstr "crwdns108398:0crwdne108398:0"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Mileage"
+msgstr "crwdns108400:0crwdne108400:0"
+
+#. Label of a Currency field in DocType 'Income Tax Slab Other Charges'
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgctxt "Income Tax Slab Other Charges"
+msgid "Min Taxable Income"
+msgstr "crwdns108402:0crwdne108402:0"
+
+#. Label of a Int field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Minimum Year for Gratuity"
+msgstr "crwdns108404:0crwdne108404:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:202
+msgid "Missing Fields"
+msgstr "crwdns108406:0crwdne108406:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:29
+msgid "Missing Relieving Date"
+msgstr "crwdns108408:0crwdne108408:0"
+
+#. Label of a Select field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Mode Of Payment"
+msgstr "crwdns108410:0crwdne108410:0"
+
+#. Label of a Link field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Mode of Payment"
+msgstr "crwdns108412:0crwdne108412:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Mode of Payment"
+msgstr "crwdns108414:0crwdne108414:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Mode of Payment"
+msgstr "crwdns108416:0crwdne108416:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Mode of Payment"
+msgstr "crwdns108418:0crwdne108418:0"
+
+#. Label of a Select field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Mode of Travel"
+msgstr "crwdns108420:0crwdne108420:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:287
+msgid "Mode of payment is required to make a payment"
+msgstr "crwdns108422:0crwdne108422:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:32
+msgid "Model"
+msgstr "crwdns108424:0crwdne108424:0"
+
+#. Label of a Read Only field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Model"
+msgstr "crwdns108426:0crwdne108426:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:37
+msgid "Monday"
+msgstr "crwdns108428:0crwdne108428:0"
+
+#: hr/report/employee_birthday/employee_birthday.js:8
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:9
+#: public/js/salary_slip_deductions_report_filters.js:15
+msgid "Month"
+msgstr "crwdns108430:0crwdne108430:0"
+
+#. Option for the 'Salary Paid Per' (Select) field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Month"
+msgstr "crwdns108432:0crwdne108432:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Month To Date"
+msgstr "crwdns108434:0crwdne108434:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Month To Date(Company Currency)"
+msgstr "crwdns108436:0crwdne108436:0"
+
+#. Option for the 'Set the frequency for holiday reminders' (Select) field in
+#. DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Monthly"
+msgstr "crwdns108438:0crwdne108438:0"
+
+#. Option for the 'Earned Leave Frequency' (Select) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Monthly"
+msgstr "crwdns108440:0crwdne108440:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Monthly"
+msgstr "crwdns108442:0crwdne108442:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Monthly"
+msgstr "crwdns108444:0crwdne108444:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Monthly"
+msgstr "crwdns108446:0crwdne108446:0"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Monthly"
+msgstr "crwdns108448:0crwdne108448:0"
+
+#. Name of a report
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.json
+#: hr/workspace/hr/hr.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Monthly Attendance Sheet"
+msgstr "crwdns108450:0crwdne108450:0"
+
+#: hr/page/team_updates/team_updates.js:25
+msgid "More"
+msgstr "crwdns108452:0crwdne108452:0"
+
+#. Label of a Section Break field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "More Info"
+msgstr "crwdns108454:0crwdne108454:0"
+
+#. Label of a Tab Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "More Info"
+msgstr "crwdns108456:0crwdne108456:0"
+
+#: hr/utils.py:262
+msgid "More than one selection for {0} not allowed"
+msgstr "crwdns108458:0{0}crwdne108458:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:231
+msgid "Multiple Additional Salaries with overwrite property exist for Salary Component {0} between {1} and {2}."
+msgstr "crwdns108460:0{0}crwdnd108460:0{1}crwdnd108460:0{2}crwdne108460:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:65
+msgid "Multiple Shift Assignments"
+msgstr "crwdns108462:0crwdne108462:0"
+
+#: www/jobs/index.py:11
+msgid "My Account"
+msgstr "crwdns108464:0crwdne108464:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.js:167
+#: hr/report/employee_analytics/employee_analytics.py:31
+#: hr/report/employee_birthday/employee_birthday.py:22
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.py:21
+msgid "Name"
+msgstr "crwdns108466:0crwdne108466:0"
+
+#. Label of a Data field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Name"
+msgstr "crwdns108468:0crwdne108468:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1163
+#: payroll/doctype/salary_slip/salary_slip.py:2112
+msgid "Name error"
+msgstr "crwdns108470:0crwdne108470:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Name of Organizer"
+msgstr "crwdns108472:0crwdne108472:0"
+
+#. Label of a Select field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Naming Series"
+msgstr "crwdns108474:0crwdne108474:0"
+
+#. Option for the 'Employee Naming By' (Select) field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Naming Series"
+msgstr "crwdns108476:0crwdne108476:0"
+
+#. Label of a Select field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Naming Series"
+msgstr "crwdns108478:0crwdne108478:0"
+
+#: payroll/report/salary_register/salary_register.py:237
+msgid "Net Pay"
+msgstr "crwdns108480:0crwdne108480:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Net Pay"
+msgstr "crwdns108482:0crwdne108482:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Net Pay"
+msgstr "crwdns108484:0crwdne108484:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Net Pay (Company Currency)"
+msgstr "crwdns108486:0crwdne108486:0"
+
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Net Pay Info"
+msgstr "crwdns108488:0crwdne108488:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:181
+msgid "Net Pay cannot be less than 0"
+msgstr "crwdns108490:0crwdne108490:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:50
+msgid "Net Salary Amount"
+msgstr "crwdns108492:0crwdne108492:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:78
+msgid "Net pay cannot be negative"
+msgstr "crwdns108494:0crwdne108494:0"
+
+#: hr/employee_property_update.js:86 hr/employee_property_update.js:129
+msgid "New"
+msgstr "crwdns108496:0crwdne108496:0"
+
+#. Label of a Data field in DocType 'Employee Property History'
+#: hr/doctype/employee_property_history/employee_property_history.json
+msgctxt "Employee Property History"
+msgid "New"
+msgstr "crwdns108498:0crwdne108498:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "New Company"
+msgstr "crwdns108500:0crwdne108500:0"
+
+#. Label of a Link field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "New Employee ID"
+msgstr "crwdns108502:0crwdne108502:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:60
+msgid "New Leave(s) Allocated"
+msgstr "crwdns108504:0crwdne108504:0"
+
+#. Label of a Float field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "New Leaves Allocated"
+msgstr "crwdns108506:0crwdne108506:0"
+
+#. Label of a Float field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "New Leaves Allocated (In Days)"
+msgstr "crwdns108508:0crwdne108508:0"
+
+#. Option for the 'Is Active' (Select) field in DocType 'Salary Structure'
+#. Option for the 'Is Default' (Select) field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "No"
+msgstr "crwdns108510:0crwdne108510:0"
+
+#: payroll/doctype/gratuity/gratuity.py:310
+msgid "No Applicable Component is present in last month salary slip"
+msgstr "crwdns108512:0crwdne108512:0"
+
+#: payroll/doctype/gratuity/gratuity.py:283
+msgid "No Applicable Earnings Component found for Gratuity Rule: {0}"
+msgstr "crwdns108514:0{0}crwdne108514:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:122
+#: hr/doctype/leave_control_panel/leave_control_panel.js:144
+msgid "No Data"
+msgstr "crwdns108516:0crwdne108516:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:224
+msgid "No Employee Found"
+msgstr "crwdns108518:0crwdne108518:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:96
+msgid "No Employee found for the given employee field value. '{}': {}"
+msgstr "crwdns108520:0crwdne108520:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:111
+msgid "No Employees Selected"
+msgstr "crwdns108522:0crwdne108522:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:105
+msgid "No Leave Period Found"
+msgstr "crwdns108524:0crwdne108524:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:145
+msgid "No Leaves Allocated to Employee: {0} for Leave Type: {1}"
+msgstr "crwdns108526:0{0}crwdnd108526:0{1}crwdne108526:0"
+
+#: payroll/doctype/gratuity/gratuity.py:297
+msgid "No Salary Slip is found for Employee: {0}"
+msgstr "crwdns108528:0{0}crwdne108528:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:30
+msgid "No Salary Structure assigned to Employee {0} on the given date {1}"
+msgstr "crwdns108530:0{0}crwdnd108530:0{1}crwdne108530:0"
+
+#: hr/doctype/job_opening/job_opening.js:32
+msgid "No Staffing Plans found for this Designation"
+msgstr "crwdns108532:0crwdne108532:0"
+
+#: payroll/doctype/gratuity/gratuity.py:270
+msgid "No Suitable Slab found for Calculation of gratuity amount in Gratuity Rule: {0}"
+msgstr "crwdns108534:0{0}crwdne108534:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:380
+msgid "No active or default Salary Structure found for employee {0} for the given dates"
+msgstr "crwdns108536:0{0}crwdne108536:0"
+
+#: hr/doctype/vehicle_log/vehicle_log.py:43
+msgid "No additional expenses has been added"
+msgstr "crwdns108538:0crwdne108538:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:45
+msgid "No attendance records found for this criteria."
+msgstr "crwdns108540:0crwdne108540:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:37
+msgid "No attendance records found."
+msgstr "crwdns108542:0crwdne108542:0"
+
+#: hr/doctype/interview/interview.py:89
+msgid "No changes found in timings."
+msgstr "crwdns108544:0crwdne108544:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:33
+msgid "No employee(s) selected"
+msgstr "crwdns108546:0crwdne108546:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:199
+msgid "No employees found"
+msgstr "crwdns108548:0crwdne108548:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:182
+msgid "No employees found for the mentioned criteria:<br>Company: {0}<br> Currency: {1}<br>Payroll Payable Account: {2}"
+msgstr "crwdns108550:0{0}crwdnd108550:0{1}crwdnd108550:0{2}crwdne108550:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:67
+msgid "No employees found for the selected criteria"
+msgstr "crwdns108552:0crwdne108552:0"
+
+#: payroll/report/income_tax_computation/income_tax_computation.py:70
+msgid "No employees found with selected filters and active salary structure"
+msgstr "crwdns108554:0crwdne108554:0"
+
+#: hr/doctype/goal/goal_list.js:97
+msgid "No items selected"
+msgstr "crwdns108556:0crwdne108556:0"
+
+#: hr/doctype/attendance/attendance.py:184
+msgid "No leave record found for employee {0} on {1}"
+msgstr "crwdns108558:0{0}crwdnd108558:0{1}crwdne108558:0"
+
+#: hr/page/team_updates/team_updates.js:44
+msgid "No more updates"
+msgstr "crwdns108560:0crwdne108560:0"
+
+#. Label of a Int field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "No of. Positions"
+msgstr "crwdns108562:0crwdne108562:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:17
+msgid "No record found"
+msgstr "crwdns108564:0crwdne108564:0"
+
+#: hr/doctype/daily_work_summary/daily_work_summary.py:102
+msgid "No replies from"
+msgstr "crwdns108566:0crwdne108566:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1414
+msgid "No salary slip found to submit for the above selected criteria OR salary slip already submitted"
+msgstr "crwdns108568:0crwdne108568:0"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Non Diary"
+msgstr "crwdns108570:0crwdne108570:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Non Taxable Earnings"
+msgstr "crwdns108572:0crwdne108572:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:255
+msgid "Non-Billed Hours"
+msgstr "crwdns108574:0crwdne108574:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:76
+msgid "Non-Billed Hours (NB)"
+msgstr "crwdns108576:0crwdne108576:0"
+
+#. Label of a Int field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Non-Encashable Leaves"
+msgstr "crwdns108578:0crwdne108578:0"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Non-Vegetarian"
+msgstr "crwdns108580:0crwdne108580:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:28
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:206 hr/doctype/goal/goal.py:67
+#: hr/doctype/goal/goal.py:71 hr/doctype/goal/goal.py:76
+#: hr/doctype/interview/interview.py:27
+#: hr/doctype/job_applicant/job_applicant.py:49
+#: hr/doctype/leave_allocation/leave_allocation.py:145
+#: hr/doctype/leave_type/leave_type.py:42
+#: hr/doctype/leave_type/leave_type.py:45
+msgid "Not Allowed"
+msgstr "crwdns108582:0crwdne108582:0"
+
+#: utils/hierarchy_chart.py:15
+msgid "Not Permitted"
+msgstr "crwdns108584:0crwdne108584:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Not Started"
+msgstr "crwdns108586:0crwdne108586:0"
+
+#. Description of the 'Shift' (Link) field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Note: Shift will not be overwritten in existing attendance records"
+msgstr "crwdns108588:0crwdne108588:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:154
+msgid "Note: Total allocated leaves {0} shouldn't be less than already approved leaves {1} for the period"
+msgstr "crwdns108590:0{0}crwdnd108590:0{1}crwdne108590:0"
+
+#. Label of a Data field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Notes"
+msgstr "crwdns108592:0crwdne108592:0"
+
+#. Label of a Section Break field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Notes"
+msgstr "crwdns108594:0crwdne108594:0"
+
+#: hr/employee_property_update.js:146
+msgid "Nothing to change"
+msgstr "crwdns108596:0crwdne108596:0"
+
+#: setup.py:404
+msgid "Notice Period"
+msgstr "crwdns108598:0crwdne108598:0"
+
+#. Label of a Check field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Notify users by email"
+msgstr "crwdns108600:0crwdne108600:0"
+
+#. Label of a Check field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Notify users by email"
+msgstr "crwdns108602:0crwdne108602:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:23
+#: public/js/salary_slip_deductions_report_filters.js:29
+msgid "Nov"
+msgstr "crwdns108604:0crwdne108604:0"
+
+#. Label of a Int field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Number Of Employees"
+msgstr "crwdns108606:0crwdne108606:0"
+
+#. Label of a Int field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Number Of Positions"
+msgstr "crwdns108608:0crwdne108608:0"
+
+#. Description of the 'Actual Encashable Days' (Float) field in DocType 'Leave
+#. Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Number of leaves eligible for encashment based on leave type settings"
+msgstr "crwdns108610:0crwdne108610:0"
+
+#. Option for the 'Log Type' (Select) field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "OUT"
+msgstr "crwdns108612:0crwdne108612:0"
+
+#. Label of a Rating field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Obtained Average Rating"
+msgstr "crwdns108614:0crwdne108614:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:22
+#: public/js/salary_slip_deductions_report_filters.js:28
+msgid "Oct"
+msgstr "crwdns108616:0crwdne108616:0"
+
+#. Label of a Section Break field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Odometer Reading"
+msgstr "crwdns108618:0crwdne108618:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:41
+msgid "Odometer Value"
+msgstr "crwdns108620:0crwdne108620:0"
+
+#: hr/report/recruitment_analytics/recruitment_analytics.py:60
+msgid "Offer Date"
+msgstr "crwdns108622:0crwdne108622:0"
+
+#. Label of a Date field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Offer Date"
+msgstr "crwdns108624:0crwdne108624:0"
+
+#. Name of a DocType
+#: hr/doctype/offer_term/offer_term.json
+msgid "Offer Term"
+msgstr "crwdns108626:0crwdne108626:0"
+
+#. Label of a Link field in DocType 'Job Offer Term'
+#: hr/doctype/job_offer_term/job_offer_term.json
+msgctxt "Job Offer Term"
+msgid "Offer Term"
+msgstr "crwdns108628:0crwdne108628:0"
+
+#. Label of a Data field in DocType 'Offer Term'
+#: hr/doctype/offer_term/offer_term.json
+msgctxt "Offer Term"
+msgid "Offer Term"
+msgstr "crwdns108630:0crwdne108630:0"
+
+#. Label of a Table field in DocType 'Job Offer Term Template'
+#: hr/doctype/job_offer_term_template/job_offer_term_template.json
+msgctxt "Job Offer Term Template"
+msgid "Offer Terms"
+msgstr "crwdns108632:0crwdne108632:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Old Parent"
+msgstr "crwdns108634:0crwdne108634:0"
+
+#: hr/report/recruitment_analytics/recruitment_analytics.js:17
+msgid "On Date"
+msgstr "crwdns108636:0crwdne108636:0"
+
+#. Option for the 'Reason' (Select) field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "On Duty"
+msgstr "crwdns108638:0crwdne108638:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "On Hold"
+msgstr "crwdns108640:0crwdne108640:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "On Leave"
+msgstr "crwdns108642:0crwdne108642:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgid "Onboarding"
+msgstr "crwdns108644:0crwdne108644:0"
+
+#. Label of a Section Break field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Onboarding Activities"
+msgstr "crwdns108646:0crwdne108646:0"
+
+#. Label of a Date field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Onboarding Begins On"
+msgstr "crwdns108648:0crwdne108648:0"
+
+#: hr/doctype/shift_request/shift_request.py:78
+msgid "Only Approvers can Approve this Request."
+msgstr "crwdns108650:0crwdne108650:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:45
+msgid "Only Completed documents can be submitted"
+msgstr "crwdns108652:0crwdne108652:0"
+
+#: hr/doctype/employee_grievance/employee_grievance.py:13
+msgid "Only Employee Grievance with status {0} or {1} can be submitted"
+msgstr "crwdns108654:0{0}crwdnd108654:0{1}crwdne108654:0"
+
+#: hr/doctype/interview/interview.py:331
+msgid "Only Interviewer Are allowed to submit Interview Feedback"
+msgstr "crwdns108656:0crwdne108656:0"
+
+#: hr/doctype/interview/interview.py:26
+msgid "Only Interviews with Cleared or Rejected status can be submitted."
+msgstr "crwdns108658:0crwdne108658:0"
+
+#: hr/doctype/leave_application/leave_application.py:103
+msgid "Only Leave Applications with status 'Approved' and 'Rejected' can be submitted"
+msgstr "crwdns108660:0crwdne108660:0"
+
+#: hr/doctype/shift_request/shift_request.py:32
+msgid "Only Shift Request with status 'Approved' and 'Rejected' can be submitted"
+msgstr "crwdns108662:0crwdne108662:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Only Tax Impact (Cannot Claim But Part of Taxable Income)"
+msgstr "crwdns108664:0crwdne108664:0"
+
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.py:21
+msgid "Only expired allocation can be cancelled"
+msgstr "crwdns108666:0crwdne108666:0"
+
+#: hr/doctype/interview/interview.js:69
+msgid "Only interviewers can submit feedback"
+msgstr "crwdns108668:0crwdne108668:0"
+
+#: hr/doctype/leave_application/leave_application.py:174
+msgid "Only users with the {0} role can create backdated leave applications"
+msgstr "crwdns108670:0{0}crwdne108670:0"
+
+#: hr/doctype/goal/goal_list.js:115
+msgid "Only {0} Goals can be {1}"
+msgstr "crwdns108672:0{0}crwdnd108672:0{1}crwdne108672:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Daily Work Summary'
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+msgctxt "Daily Work Summary"
+msgid "Open"
+msgstr "crwdns108674:0crwdne108674:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Open"
+msgstr "crwdns108676:0crwdne108676:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Open"
+msgstr "crwdns108678:0crwdne108678:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Open"
+msgstr "crwdns108680:0crwdne108680:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Open"
+msgstr "crwdns108682:0crwdne108682:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Open"
+msgstr "crwdns108684:0crwdne108684:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Open & Approved"
+msgstr "crwdns108686:0crwdne108686:0"
+
+#: hr/doctype/leave_application/leave_application_email_template.html:30
+msgid "Open Now"
+msgstr "crwdns108688:0crwdne108688:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.py:54
+msgid "Opening Balance"
+msgstr "crwdns108690:0crwdne108690:0"
+
+#: templates/generators/job_opening.html:34
+msgid "Opening closed."
+msgstr "crwdns108692:0crwdne108692:0"
+
+#: hr/doctype/leave_application/leave_application.py:558
+msgid "Optional Holiday List not set for leave period {0}"
+msgstr "crwdns108694:0{0}crwdne108694:0"
+
+#: hr/doctype/leave_type/leave_type.js:21
+msgid "Optional Leaves are holidays that Employees can choose to avail from a list of holidays published by the company."
+msgstr "crwdns108696:0crwdne108696:0"
+
+#: hr/page/organizational_chart/organizational_chart.js:4
+msgid "Organizational Chart"
+msgstr "crwdns108698:0crwdne108698:0"
+
+#. Label of a Section Break field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Other Details"
+msgstr "crwdns108700:0crwdne108700:0"
+
+#. Label of a Small Text field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Other Details"
+msgstr "crwdns108702:0crwdne108702:0"
+
+#. Label of a Text field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Other Details"
+msgstr "crwdns108704:0crwdne108704:0"
+
+#. Label of a Card Break in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Other Reports"
+msgstr "crwdns108706:0crwdne108706:0"
+
+#. Label of a Section Break field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Other Settings"
+msgstr "crwdns108708:0crwdne108708:0"
+
+#. Label of a Table field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Other Taxes and Charges"
+msgstr "crwdns108710:0crwdne108710:0"
+
+#: setup.py:326
+msgid "Others"
+msgstr "crwdns108712:0crwdne108712:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:73
+msgid "Out Time"
+msgstr "crwdns108714:0crwdne108714:0"
+
+#. Label of a Datetime field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Out Time"
+msgstr "crwdns108716:0crwdne108716:0"
+
+#. Description of the 'Total Goal Score' (Float) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Out of 5"
+msgstr "crwdns108718:0crwdne108718:0"
+
+#. Label of a chart in the Payroll Workspace
+#: payroll/workspace/payroll/payroll.json
+msgid "Outgoing Salary"
+msgstr "crwdns108720:0crwdne108720:0"
+
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:23
+msgid "Outstanding Amount"
+msgstr "crwdns108722:0crwdne108722:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:288
+msgid "Over Allocation"
+msgstr "crwdns108724:0crwdne108724:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:60
+msgid "Overlapping Attendance Request"
+msgstr "crwdns108726:0crwdne108726:0"
+
+#: hr/doctype/attendance/attendance.py:118
+msgid "Overlapping Shift Attendance"
+msgstr "crwdns108728:0crwdne108728:0"
+
+#: hr/doctype/shift_request/shift_request.py:136
+msgid "Overlapping Shift Requests"
+msgstr "crwdns108730:0crwdne108730:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:123
+msgid "Overlapping Shifts"
+msgstr "crwdns108732:0crwdne108732:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Overview"
+msgstr "crwdns108734:0crwdne108734:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Overview"
+msgstr "crwdns108736:0crwdne108736:0"
+
+#. Label of a Tab Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Overview"
+msgstr "crwdns108738:0crwdne108738:0"
+
+#. Label of a Tab Break field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Overview"
+msgstr "crwdns108740:0crwdne108740:0"
+
+#. Label of a Check field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Overwrite Salary Structure Amount"
+msgstr "crwdns108742:0crwdne108742:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Owned"
+msgstr "crwdns108744:0crwdne108744:0"
+
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:41
+msgid "PAN Number"
+msgstr "crwdns108746:0crwdne108746:0"
+
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:31
+msgid "PF Account"
+msgstr "crwdns108748:0crwdne108748:0"
+
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:32
+msgid "PF Amount"
+msgstr "crwdns108750:0crwdne108750:0"
+
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:39
+msgid "PF Loan"
+msgstr "crwdns108752:0crwdne108752:0"
+
+#. Name of a DocType
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgid "PWA Notification"
+msgstr "crwdns108754:0crwdne108754:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Paid"
+msgstr "crwdns108756:0crwdne108756:0"
+
+#. Option for the 'Referral Bonus Payment Status' (Select) field in DocType
+#. 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Paid"
+msgstr "crwdns108758:0crwdne108758:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Paid"
+msgstr "crwdns108760:0crwdne108760:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Paid"
+msgstr "crwdns108762:0crwdne108762:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Paid"
+msgstr "crwdns108764:0crwdne108764:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:67
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:22
+msgid "Paid Amount"
+msgstr "crwdns108766:0crwdne108766:0"
+
+#. Label of a Currency field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Paid Amount"
+msgstr "crwdns108768:0crwdne108768:0"
+
+#. Label of a Currency field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Paid Amount"
+msgstr "crwdns108770:0crwdne108770:0"
+
+#. Label of a Check field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Paid via Salary Slip"
+msgstr "crwdns108772:0crwdne108772:0"
+
+#: hr/report/employee_analytics/employee_analytics.js:17
+msgid "Parameter"
+msgstr "crwdns108774:0crwdne108774:0"
+
+#. Label of a Link field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Parent Goal"
+msgstr "crwdns108776:0crwdne108776:0"
+
+#: setup.py:381
+msgid "Part-time"
+msgstr "crwdns108778:0crwdne108778:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:125
+msgid "Partial Success"
+msgstr "crwdns108780:0crwdne108780:0"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Partially Sponsored, Require Partial Funding"
+msgstr "crwdns108782:0crwdne108782:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Partly Claimed and Returned"
+msgstr "crwdns108784:0crwdne108784:0"
+
+#. Label of a Data field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Passport Number"
+msgstr "crwdns108786:0crwdne108786:0"
+
+#. Label of a Data field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Password Policy"
+msgstr "crwdns108788:0crwdne108788:0"
+
+#: payroll/doctype/payroll_settings/payroll_settings.js:24
+msgid "Password policy cannot contain spaces or simultaneous hyphens. The format will be restructured automatically"
+msgstr "crwdns108790:0crwdne108790:0"
+
+#: payroll/doctype/payroll_settings/payroll_settings.py:22
+msgid "Password policy for Salary Slips is not set"
+msgstr "crwdns108792:0crwdne108792:0"
+
+#. Label of a Check field in DocType 'Employee Benefit Application Detail'
+#: payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgctxt "Employee Benefit Application Detail"
+msgid "Pay Against Benefit Claim"
+msgstr "crwdns108794:0crwdne108794:0"
+
+#. Label of a Check field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Pay Against Benefit Claim"
+msgstr "crwdns108796:0crwdne108796:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Pay Against Benefit Claim"
+msgstr "crwdns108798:0crwdne108798:0"
+
+#. Label of a Check field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Pay via Salary Slip"
+msgstr "crwdns108800:0crwdne108800:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Payable Account"
+msgstr "crwdns108802:0crwdne108802:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Payable Account"
+msgstr "crwdns108804:0crwdne108804:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:100
+msgid "Payable Account is mandatory to submit an Expense Claim"
+msgstr "crwdns108806:0crwdne108806:0"
+
+#. Label of a Section Break field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Payables"
+msgstr "crwdns108808:0crwdne108808:0"
+
+#: hr/doctype/employee_advance/employee_advance.js:47
+#: hr/doctype/expense_claim/expense_claim.js:234
+#: hr/doctype/expense_claim/expense_claim_dashboard.py:9
+#: payroll/doctype/gratuity/gratuity_dashboard.py:10
+msgid "Payment"
+msgstr "crwdns108810:0crwdne108810:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Payment Account"
+msgstr "crwdns108812:0crwdne108812:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Payment Account"
+msgstr "crwdns108814:0crwdne108814:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:417
+msgid "Payment Account is mandatory"
+msgstr "crwdns108816:0crwdne108816:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:25
+msgid "Payment Date"
+msgstr "crwdns108818:0crwdne108818:0"
+
+#: payroll/report/salary_register/salary_register.py:181
+msgid "Payment Days"
+msgstr "crwdns108820:0crwdne108820:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#. Label of a Tab Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Payment Days"
+msgstr "crwdns108822:0crwdne108822:0"
+
+#. Label of a HTML field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Payment Days Calculation Help"
+msgstr "crwdns108824:0crwdne108824:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:101
+msgid "Payment Days Dependency"
+msgstr "crwdns108826:0crwdne108826:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the Salary Payout Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Payment Entry"
+msgid "Payment Entry"
+msgstr "crwdns108828:0crwdne108828:0"
+
+#. Label of a Section Break field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Payment Entry"
+msgstr "crwdns108830:0crwdne108830:0"
+
+#. Label of a Tab Break field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Payment and Accounting"
+msgstr "crwdns108832:0crwdne108832:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:989
+msgid "Payment of {0} from {1} to {2}"
+msgstr "crwdns108834:0{0}crwdnd108834:0{1}crwdnd108834:0{2}crwdne108834:0"
+
+#. Name of a Workspace
+#. Label of a Card Break in the Salary Payout Workspace
+#: overrides/dashboard_overrides.py:32 overrides/dashboard_overrides.py:74
+#: payroll/workspace/payroll/payroll.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Payroll"
+msgstr "crwdns108836:0crwdne108836:0"
+
+#. Label of a Section Break field in DocType 'Leave Encashment'
+#: hr/doctype/leave_encashment/leave_encashment.json
+msgctxt "Leave Encashment"
+msgid "Payroll"
+msgstr "crwdns108838:0crwdne108838:0"
+
+#. Label of a Section Break field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Payroll Cost Centers"
+msgstr "crwdns108840:0crwdne108840:0"
+
+#. Label of a Date field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Payroll Date"
+msgstr "crwdns108842:0crwdne108842:0"
+
+#. Label of a Date field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Payroll Date"
+msgstr "crwdns108844:0crwdne108844:0"
+
+#. Label of a Date field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Payroll Date"
+msgstr "crwdns108846:0crwdne108846:0"
+
+#. Name of a DocType
+#: payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgid "Payroll Employee Detail"
+msgstr "crwdns108848:0crwdne108848:0"
+
+#. Name of a DocType
+#: payroll/doctype/payroll_entry/payroll_entry.json
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.js:63
+msgid "Payroll Entry"
+msgstr "crwdns108850:0crwdne108850:0"
+
+#. Label of a Link in the Payroll Workspace
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a shortcut in the Salary Payout Workspace
+#: payroll/workspace/payroll/payroll.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Payroll Entry"
+msgid "Payroll Entry"
+msgstr "crwdns108852:0crwdne108852:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Payroll Entry"
+msgstr "crwdns108854:0crwdne108854:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:118
+msgid "Payroll Entry cancellation is queued. It may take a few minutes"
+msgstr "crwdns108856:0crwdne108856:0"
+
+#. Label of a Select field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Payroll Frequency"
+msgstr "crwdns108858:0crwdne108858:0"
+
+#. Label of a Select field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Payroll Frequency"
+msgstr "crwdns108860:0crwdne108860:0"
+
+#. Label of a Select field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Payroll Frequency"
+msgstr "crwdns108862:0crwdne108862:0"
+
+#. Label of a Section Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Payroll Info"
+msgstr "crwdns108864:0crwdne108864:0"
+
+#: payroll/report/bank_remittance/bank_remittance.py:12
+msgid "Payroll Number"
+msgstr "crwdns108866:0crwdne108866:0"
+
+#: overrides/company.py:97
+#: patches/post_install/updates_for_multi_currency_payroll.py:68
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:113
+msgid "Payroll Payable"
+msgstr "crwdns108868:0crwdne108868:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:147
+msgid "Payroll Payable Account"
+msgstr "crwdns108870:0crwdne108870:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Payroll Payable Account"
+msgstr "crwdns108872:0crwdne108872:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Payroll Payable Account"
+msgstr "crwdns108874:0crwdne108874:0"
+
+#. Name of a DocType
+#: payroll/doctype/payroll_period/payroll_period.json
+#: payroll/report/income_tax_computation/income_tax_computation.js:18
+msgid "Payroll Period"
+msgstr "crwdns108876:0crwdne108876:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Payroll Period"
+msgstr "crwdns108878:0crwdne108878:0"
+
+#. Label of a Link field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Payroll Period"
+msgstr "crwdns108880:0crwdne108880:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Payroll Period"
+msgstr "crwdns108882:0crwdne108882:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Payroll Period"
+msgstr "crwdns108884:0crwdne108884:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Payroll Period"
+msgid "Payroll Period"
+msgstr "crwdns108886:0crwdne108886:0"
+
+#. Name of a DocType
+#: payroll/doctype/payroll_period_date/payroll_period_date.json
+msgid "Payroll Period Date"
+msgstr "crwdns108888:0crwdne108888:0"
+
+#. Label of a Section Break field in DocType 'Payroll Period'
+#. Label of a Table field in DocType 'Payroll Period'
+#: payroll/doctype/payroll_period/payroll_period.json
+msgctxt "Payroll Period"
+msgid "Payroll Periods"
+msgstr "crwdns108890:0crwdne108890:0"
+
+#. Label of a Card Break in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Payroll Reports"
+msgstr "crwdns108892:0crwdne108892:0"
+
+#. Name of a DocType
+#. Title of an Onboarding Step
+#: payroll/doctype/payroll_settings/payroll_settings.json
+#: payroll/onboarding_step/payroll_settings/payroll_settings.json
+msgid "Payroll Settings"
+msgstr "crwdns108894:0crwdne108894:0"
+
+#. Label of a Link in the Payroll Workspace
+#: payroll/workspace/payroll/payroll.json
+msgctxt "Payroll Settings"
+msgid "Payroll Settings"
+msgstr "crwdns108896:0crwdne108896:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:89
+msgid "Payroll date can not be greater than employee's relieving date."
+msgstr "crwdns108898:0crwdne108898:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:81
+msgid "Payroll date can not be less than employee's joining date."
+msgstr "crwdns108900:0crwdne108900:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Pending"
+msgstr "crwdns108902:0crwdne108902:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Pending"
+msgstr "crwdns108904:0crwdne108904:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Pending"
+msgstr "crwdns108906:0crwdne108906:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Pending"
+msgstr "crwdns108908:0crwdne108908:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Pending"
+msgstr "crwdns108910:0crwdne108910:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Pending"
+msgstr "crwdns108912:0crwdne108912:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Pending"
+msgstr "crwdns108914:0crwdne108914:0"
+
+#. Label of a Currency field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Pending Amount"
+msgstr "crwdns108916:0crwdne108916:0"
+
+#: hr/report/employee_exits/employee_exits.py:227
+msgid "Pending FnF"
+msgstr "crwdns108918:0crwdne108918:0"
+
+#: hr/report/employee_exits/employee_exits.py:221
+msgid "Pending Interviews"
+msgstr "crwdns108920:0crwdne108920:0"
+
+#: hr/report/employee_exits/employee_exits.py:233
+msgid "Pending Questionnaires"
+msgstr "crwdns108922:0crwdne108922:0"
+
+#. Label of a Percent field in DocType 'Income Tax Slab Other Charges'
+#: payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgctxt "Income Tax Slab Other Charges"
+msgid "Percent"
+msgstr "crwdns108924:0crwdne108924:0"
+
+#. Label of a Percent field in DocType 'Taxable Salary Slab'
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgctxt "Taxable Salary Slab"
+msgid "Percent Deduction"
+msgstr "crwdns108926:0crwdne108926:0"
+
+#. Label of a Int field in DocType 'Employee Cost Center'
+#: payroll/doctype/employee_cost_center/employee_cost_center.json
+msgctxt "Employee Cost Center"
+msgid "Percentage (%)"
+msgstr "crwdns108928:0crwdne108928:0"
+
+#. Name of a Workspace
+#: hr/workspace/performance/performance.json
+msgid "Performance"
+msgstr "crwdns108930:0crwdne108930:0"
+
+#. Label of a Data field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Phone Number"
+msgstr "crwdns108932:0crwdne108932:0"
+
+#: setup.py:385
+msgid "Piecework"
+msgstr "crwdns108934:0crwdne108934:0"
+
+#. Label of a Int field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Planned number of Positions"
+msgstr "crwdns108936:0crwdne108936:0"
+
+#: hr/doctype/shift_type/shift_type.js:11
+msgid "Please Enable Auto Attendance and complete the setup first."
+msgstr "crwdns108938:0crwdne108938:0"
+
+#: payroll/doctype/retention_bonus/retention_bonus.js:8
+msgid "Please Select Company First"
+msgstr "crwdns108940:0crwdne108940:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:94
+msgid "Please add the remaining benefits {0} to any of the existing component"
+msgstr "crwdns108942:0{0}crwdne108942:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:106
+msgid "Please add the remaining benefits {0} to the application as pro-rata component"
+msgstr "crwdns108944:0{0}crwdne108944:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:729
+msgid "Please assign a Salary Structure for Employee {0} applicable from or before {1} first"
+msgstr "crwdns108946:0{0}crwdnd108946:0{1}crwdne108946:0"
+
+#: templates/emails/training_event.html:17
+msgid "Please confirm once you have completed your training"
+msgstr "crwdns108948:0crwdne108948:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:101
+msgid "Please create a new {0} for the date {1} first."
+msgstr "crwdns108950:0{0}crwdnd108950:0{1}crwdne108950:0"
+
+#: hr/doctype/employee_transfer/employee_transfer.py:57
+msgid "Please delete the Employee {0} to cancel this document"
+msgstr "crwdns108952:0{0}crwdne108952:0"
+
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.py:20
+msgid "Please enable default incoming account before creating Daily Work Summary Group"
+msgstr "crwdns108954:0crwdne108954:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.js:98
+msgid "Please enter the designation"
+msgstr "crwdns108956:0crwdne108956:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:224
+msgid "Please select Company and Designation"
+msgstr "crwdns108958:0crwdne108958:0"
+
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js:22
+msgid "Please select Employee"
+msgstr "crwdns108960:0crwdne108960:0"
+
+#: hr/doctype/department_approver/department_approver.py:19
+#: hr/employee_property_update.js:47
+msgid "Please select Employee first."
+msgstr "crwdns108962:0crwdne108962:0"
+
+#: hr/utils.py:696
+msgid "Please select a Company"
+msgstr "crwdns108964:0crwdne108964:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_mobile.js:229
+msgid "Please select a company first"
+msgstr "crwdns108966:0crwdne108966:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:95
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:290
+msgid "Please select a company first."
+msgstr "crwdns108968:0crwdne108968:0"
+
+#: hr/doctype/upload_attendance/upload_attendance.py:174
+msgid "Please select a csv file"
+msgstr "crwdns108970:0crwdne108970:0"
+
+#: hr/doctype/attendance/attendance.py:308
+msgid "Please select a date."
+msgstr "crwdns108972:0crwdne108972:0"
+
+#: hr/utils.py:693
+msgid "Please select an Applicant"
+msgstr "crwdns108974:0crwdne108974:0"
+
+#: hr/doctype/employee_advance/employee_advance.js:16
+msgid "Please select employee first"
+msgstr "crwdns108976:0crwdne108976:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:111
+msgid "Please select employees to create appraisals for"
+msgstr "crwdns108978:0crwdne108978:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:33
+msgid "Please select month and year."
+msgstr "crwdns108980:0crwdne108980:0"
+
+#: hr/doctype/goal/goal.js:87
+msgid "Please select the Appraisal Cycle first."
+msgstr "crwdns108982:0crwdne108982:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:192
+msgid "Please select the attendance status."
+msgstr "crwdns108984:0crwdne108984:0"
+
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:185
+msgid "Please select the employees you want to mark attendance for."
+msgstr "crwdns108986:0crwdne108986:0"
+
+#: payroll/doctype/salary_slip/salary_slip_list.js:7
+msgid "Please select the salary slips to email"
+msgstr "crwdns108988:0crwdne108988:0"
+
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.js:19
+msgid "Please select {0}"
+msgstr "crwdns108990:0{0}crwdne108990:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:271
+msgid "Please set \"Default Payroll Payable Account\" in Company Defaults"
+msgstr "crwdns108992:0crwdne108992:0"
+
+#: regional/india/utils.py:18
+msgid "Please set Basic and HRA component in Company {0}"
+msgstr "crwdns108994:0{0}crwdne108994:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:49
+msgid "Please set Earning Component for Leave type: {0}."
+msgstr "crwdns108996:0{0}crwdne108996:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:444
+msgid "Please set Payroll based on in Payroll settings"
+msgstr "crwdns108998:0crwdne108998:0"
+
+#: payroll/doctype/gratuity/gratuity.py:152
+msgid "Please set Relieving Date for employee: {0}"
+msgstr "crwdns109000:0{0}crwdne109000:0"
+
+#: hr/doctype/employee_advance/employee_advance.py:177
+#: hr/doctype/employee_advance/employee_advance.py:281
+msgid "Please set a Default Cash Account in Company defaults"
+msgstr "crwdns109002:0crwdne109002:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:307
+msgid "Please set account in Salary Component {0}"
+msgstr "crwdns109004:0{0}crwdne109004:0"
+
+#: hr/doctype/leave_application/leave_application.py:612
+msgid "Please set default template for Leave Approval Notification in HR Settings."
+msgstr "crwdns109006:0crwdne109006:0"
+
+#: hr/doctype/leave_application/leave_application.py:588
+msgid "Please set default template for Leave Status Notification in HR Settings."
+msgstr "crwdns109008:0crwdne109008:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:137
+msgid "Please set the Appraisal Template for all the {0} or select the template in the Employees table below."
+msgstr "crwdns109010:0{0}crwdne109010:0"
+
+#: hr/doctype/expense_claim/expense_claim.js:41
+msgid "Please set the Company"
+msgstr "crwdns109012:0crwdne109012:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:251
+msgid "Please set the Date Of Joining for employee {0}"
+msgstr "crwdns109014:0{0}crwdne109014:0"
+
+#: controllers/employee_boarding_controller.py:110
+msgid "Please set the Holiday List."
+msgstr "crwdns109016:0crwdne109016:0"
+
+#: hr/doctype/exit_interview/exit_interview.js:17
+#: hr/doctype/exit_interview/exit_interview.py:21
+msgid "Please set the relieving date for employee {0}"
+msgstr "crwdns109018:0{0}crwdne109018:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:124
+msgid "Please set {0} and {1} in {2}."
+msgstr "crwdns109020:0{0}crwdnd109020:0{1}crwdnd109020:0{2}crwdne109020:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:25
+msgid "Please set {0} for Employee {1}"
+msgstr "crwdns109022:0{0}crwdnd109022:0{1}crwdne109022:0"
+
+#: hr/doctype/department_approver/department_approver.py:86
+msgid "Please set {0} for the Employee: {1}"
+msgstr "crwdns109024:0{0}crwdnd109024:0{1}crwdne109024:0"
+
+#: hr/doctype/shift_type/shift_type.js:16
+#: hr/doctype/shift_type/shift_type.js:21
+msgid "Please set {0}."
+msgstr "crwdns109026:0{0}crwdne109026:0"
+
+#: overrides/employee_master.py:16
+msgid "Please setup Employee Naming System in Human Resource > HR Settings"
+msgstr "crwdns109028:0crwdne109028:0"
+
+#: hr/doctype/upload_attendance/upload_attendance.py:161
+msgid "Please setup numbering series for Attendance via Setup > Numbering Series"
+msgstr "crwdns109030:0crwdne109030:0"
+
+#: hr/notification/training_feedback/training_feedback.html:6
+msgid "Please share your feedback to the training by clicking on 'Training Feedback' and then 'New'"
+msgstr "crwdns109032:0crwdne109032:0"
+
+#: hr/doctype/interview/interview.py:198
+msgid "Please specify the job applicant to be updated."
+msgstr "crwdns109034:0crwdne109034:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:157
+msgid "Please submit the {0} before marking the cycle as Completed"
+msgstr "crwdns109036:0{0}crwdne109036:0"
+
+#: templates/emails/training_event.html:13
+msgid "Please update your status for this training event"
+msgstr "crwdns109038:0crwdne109038:0"
+
+#. Label of a Datetime field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Posted On"
+msgstr "crwdns109040:0crwdne109040:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:60
+#: payroll/report/income_tax_deductions/income_tax_deductions.py:60
+#: www/jobs/index.html:93
+msgid "Posting Date"
+msgstr "crwdns109042:0crwdne109042:0"
+
+#. Label of a Date field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Posting Date"
+msgstr "crwdns109044:0crwdne109044:0"
+
+#. Label of a Date field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Posting Date"
+msgstr "crwdns109046:0crwdne109046:0"
+
+#. Label of a Date field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Posting Date"
+msgstr "crwdns109048:0crwdne109048:0"
+
+#. Label of a Date field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Posting Date"
+msgstr "crwdns109050:0crwdne109050:0"
+
+#. Label of a Date field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Posting Date"
+msgstr "crwdns109052:0crwdne109052:0"
+
+#. Label of a Date field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Posting Date"
+msgstr "crwdns109054:0crwdne109054:0"
+
+#. Label of a Date field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Posting Date"
+msgstr "crwdns109056:0crwdne109056:0"
+
+#. Label of a Date field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Posting date"
+msgstr "crwdns109058:0crwdne109058:0"
+
+#. Label of a Data field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Preferred Area for Lodging"
+msgstr "crwdns109060:0crwdne109060:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Present"
+msgstr "crwdns109062:0crwdne109062:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Present"
+msgstr "crwdns109064:0crwdne109064:0"
+
+#. Option for the 'Consider Unmarked Attendance As' (Select) field in DocType
+#. 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Present"
+msgstr "crwdns109066:0crwdne109066:0"
+
+#. Option for the 'Attendance' (Select) field in DocType 'Training Event
+#. Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Present"
+msgstr "crwdns109068:0crwdne109068:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:162
+msgid "Present Records"
+msgstr "crwdns109070:0crwdne109070:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:119
+#: payroll/doctype/salary_structure/salary_structure.js:206
+msgid "Preview Salary Slip"
+msgstr "crwdns109072:0crwdne109072:0"
+
+#. Label of a Currency field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Principal Amount"
+msgstr "crwdns109074:0crwdne109074:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Print Heading"
+msgstr "crwdns109076:0crwdne109076:0"
+
+#. Label of a Section Break field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Printing Details"
+msgstr "crwdns109078:0crwdne109078:0"
+
+#: setup.py:364 setup.py:365
+msgid "Privilege Leave"
+msgstr "crwdns109080:0crwdne109080:0"
+
+#: setup.py:382
+msgid "Probation"
+msgstr "crwdns109082:0crwdne109082:0"
+
+#: setup.py:396
+msgid "Probationary Period"
+msgstr "crwdns109084:0crwdne109084:0"
+
+#. Label of a Date field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Process Attendance After"
+msgstr "crwdns109086:0crwdne109086:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Process Payroll Accounting Entry based on Employee"
+msgstr "crwdns109088:0crwdne109088:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/report/professional_tax_deductions/professional_tax_deductions.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Professional Tax Deductions"
+msgstr "crwdns109090:0crwdne109090:0"
+
+#. Label of a Rating field in DocType 'Employee Skill'
+#: hr/doctype/employee_skill/employee_skill.json
+msgctxt "Employee Skill"
+msgid "Proficiency"
+msgstr "crwdns109092:0crwdne109092:0"
+
+#: hr/report/project_profitability/project_profitability.py:185
+msgid "Profit"
+msgstr "crwdns109094:0crwdne109094:0"
+
+#: hr/doctype/goal/goal_tree.js:78
+msgid "Progress"
+msgstr "crwdns109096:0crwdne109096:0"
+
+#. Label of a Percent field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Progress"
+msgstr "crwdns109098:0crwdne109098:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.js:31
+#: hr/doctype/employee_separation/employee_separation.js:19
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:43
+#: hr/report/project_profitability/project_profitability.js:43
+#: hr/report/project_profitability/project_profitability.py:164
+msgid "Project"
+msgstr "crwdns109100:0crwdne109100:0"
+
+#. Label of a Link field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Project"
+msgstr "crwdns109102:0crwdne109102:0"
+
+#. Label of a Link field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Project"
+msgstr "crwdns109104:0crwdne109104:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Project"
+msgstr "crwdns109106:0crwdne109106:0"
+
+#. Label of a Link field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Project"
+msgstr "crwdns109108:0crwdne109108:0"
+
+#. Label of a Link field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Project"
+msgstr "crwdns109110:0crwdne109110:0"
+
+#. Label of a Link field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Project"
+msgstr "crwdns109112:0crwdne109112:0"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/report/project_profitability/project_profitability.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Project Profitability"
+msgstr "crwdns109114:0crwdne109114:0"
+
+#. Label of a Card Break in the Performance Workspace
+#: hr/workspace/performance/performance.json
+msgid "Promotion"
+msgstr "crwdns109116:0crwdne109116:0"
+
+#. Label of a Date field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Promotion Date"
+msgstr "crwdns109118:0crwdne109118:0"
+
+#. Label of a Data field in DocType 'Employee Property History'
+#: hr/doctype/employee_property_history/employee_property_history.json
+msgctxt "Employee Property History"
+msgid "Property"
+msgstr "crwdns109120:0crwdne109120:0"
+
+#: hr/employee_property_update.js:142
+msgid "Property already added"
+msgstr "crwdns109122:0crwdne109122:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Provident Fund Deductions"
+msgstr "crwdns109124:0crwdne109124:0"
+
+#. Label of a Check field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Publish Salary Range"
+msgstr "crwdns109126:0crwdne109126:0"
+
+#. Label of a Check field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Publish on website"
+msgstr "crwdns109128:0crwdne109128:0"
+
+#. Label of a Small Text field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Purpose"
+msgstr "crwdns109130:0crwdne109130:0"
+
+#. Label of a Section Break field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Purpose & Amount"
+msgstr "crwdns109132:0crwdne109132:0"
+
+#. Name of a DocType
+#: hr/doctype/purpose_of_travel/purpose_of_travel.json
+msgid "Purpose of Travel"
+msgstr "crwdns109134:0crwdne109134:0"
+
+#. Label of a Data field in DocType 'Purpose of Travel'
+#. Label of a Link in the Expense Claims Workspace
+#: hr/doctype/purpose_of_travel/purpose_of_travel.json
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Purpose of Travel"
+msgid "Purpose of Travel"
+msgstr "crwdns109136:0crwdne109136:0"
+
+#. Label of a Link field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Purpose of Travel"
+msgstr "crwdns109138:0crwdne109138:0"
+
+#. Option for the 'Earned Leave Frequency' (Select) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Quarterly"
+msgstr "crwdns109140:0crwdne109140:0"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Quarterly"
+msgstr "crwdns109142:0crwdne109142:0"
+
+#. Label of a Check field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Questionnaire Email Sent"
+msgstr "crwdns109144:0crwdne109144:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Queued"
+msgstr "crwdns109146:0crwdne109146:0"
+
+#. Label of a Section Break field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Quick Filters"
+msgstr "crwdns109148:0crwdne109148:0"
+
+#. Label of a Card Break in the Payroll Workspace
+#: payroll/workspace/payroll/payroll.json
+msgid "Quick Links"
+msgstr "crwdns109150:0crwdne109150:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Raised By"
+msgstr "crwdns109152:0crwdne109152:0"
+
+#. Label of a Float field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Rate"
+msgstr "crwdns109154:0crwdne109154:0"
+
+#. Label of a Check field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Rate Goals Manually"
+msgstr "crwdns109156:0crwdne109156:0"
+
+#: hr/doctype/interview/interview.js:191
+msgid "Rating"
+msgstr "crwdns109158:0crwdne109158:0"
+
+#. Label of a Rating field in DocType 'Employee Feedback Rating'
+#: hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgctxt "Employee Feedback Rating"
+msgid "Rating"
+msgstr "crwdns109160:0crwdne109160:0"
+
+#. Label of a Rating field in DocType 'Skill Assessment'
+#: hr/doctype/skill_assessment/skill_assessment.json
+msgctxt "Skill Assessment"
+msgid "Rating"
+msgstr "crwdns109162:0crwdne109162:0"
+
+#. Label of a Table field in DocType 'Appraisal Template'
+#: hr/doctype/appraisal_template/appraisal_template.json
+msgctxt "Appraisal Template"
+msgid "Rating Criteria"
+msgstr "crwdns109164:0crwdne109164:0"
+
+#. Label of a Section Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Ratings"
+msgstr "crwdns109166:0crwdne109166:0"
+
+#. Label of a Section Break field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Ratings"
+msgstr "crwdns109168:0crwdne109168:0"
+
+#. Label of a Check field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Re-allocate Leaves"
+msgstr "crwdns109170:0crwdne109170:0"
+
+#. Label of a Check field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "Read"
+msgstr "crwdns109172:0crwdne109172:0"
+
+#. Label of a Section Break field in DocType 'Attendance Request'
+#. Label of a Select field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Reason"
+msgstr "crwdns109174:0crwdne109174:0"
+
+#. Label of a Small Text field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Reason"
+msgstr "crwdns109176:0crwdne109176:0"
+
+#. Label of a Small Text field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Reason"
+msgstr "crwdns109178:0crwdne109178:0"
+
+#. Label of a Text field in DocType 'Leave Block List Date'
+#: hr/doctype/leave_block_list_date/leave_block_list_date.json
+msgctxt "Leave Block List Date"
+msgid "Reason"
+msgstr "crwdns109180:0crwdne109180:0"
+
+#. Label of a Text field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Reason for Requesting"
+msgstr "crwdns109182:0crwdne109182:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:251
+msgid "Reason for skipping auto attendance:"
+msgstr "crwdns109184:0crwdne109184:0"
+
+#. Label of a Section Break field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Receivables"
+msgstr "crwdns109186:0crwdne109186:0"
+
+#. Name of a Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgid "Recruitment"
+msgstr "crwdns109188:0crwdne109188:0"
+
+#. Name of a report
+#. Label of a Link in the HR Workspace
+#. Label of a Link in the Recruitment Workspace
+#: hr/report/recruitment_analytics/recruitment_analytics.json
+#: hr/workspace/hr/hr.json hr/workspace/recruitment/recruitment.json
+msgid "Recruitment Analytics"
+msgstr "crwdns109190:0crwdne109190:0"
+
+#. Label of a shortcut in the HR Workspace
+#: hr/workspace/hr/hr.json
+msgid "Recruitment Dashboard"
+msgstr "crwdns109192:0crwdne109192:0"
+
+#: hr/doctype/expense_claim/expense_claim_dashboard.py:10
+#: hr/doctype/leave_allocation/leave_allocation.py:207
+msgid "Reference"
+msgstr "crwdns109194:0crwdne109194:0"
+
+#. Label of a Link field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Reference"
+msgstr "crwdns109196:0crwdne109196:0"
+
+#. Label of a Dynamic Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Reference Document"
+msgstr "crwdns109198:0crwdne109198:0"
+
+#. Label of a Dynamic Link field in DocType 'Full and Final Outstanding
+#. Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Reference Document"
+msgstr "crwdns109200:0crwdne109200:0"
+
+#. Label of a Dynamic Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Reference Document Name"
+msgstr "crwdns109202:0crwdne109202:0"
+
+#. Label of a Data field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "Reference Document Name"
+msgstr "crwdns109204:0crwdne109204:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Reference Document Type"
+msgstr "crwdns109206:0crwdne109206:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Reference Document Type"
+msgstr "crwdns109208:0crwdne109208:0"
+
+#. Label of a Link field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Reference Document Type"
+msgstr "crwdns109210:0crwdne109210:0"
+
+#. Label of a Link field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "Reference Document Type"
+msgstr "crwdns109212:0crwdne109212:0"
+
+#: hr/doctype/leave_application/leave_application.py:486
+#: payroll/doctype/additional_salary/additional_salary.py:136
+#: payroll/doctype/payroll_entry/payroll_entry.py:88
+msgid "Reference: {0}"
+msgstr "crwdns109214:0{0}crwdne109214:0"
+
+#. Label of a Section Break field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "References"
+msgstr "crwdns109216:0crwdne109216:0"
+
+#. Label of a Section Break field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "References"
+msgstr "crwdns109218:0crwdne109218:0"
+
+#. Label of a Select field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Referral Bonus Payment Status"
+msgstr "crwdns109220:0crwdne109220:0"
+
+#. Label of a Section Break field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Referral Details"
+msgstr "crwdns109222:0crwdne109222:0"
+
+#. Label of a Link field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Referrer"
+msgstr "crwdns109224:0crwdne109224:0"
+
+#. Label of a Section Break field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Referrer Details"
+msgstr "crwdns109226:0crwdne109226:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Referrer Name"
+msgstr "crwdns109228:0crwdne109228:0"
+
+#. Label of a Section Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Reflections"
+msgstr "crwdns109230:0crwdne109230:0"
+
+#. Label of a Section Break field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Refuelling Details"
+msgstr "crwdns109232:0crwdne109232:0"
+
+#: hr/doctype/employee_referral/employee_referral.js:7
+msgid "Reject Employee Referral"
+msgstr "crwdns109234:0crwdne109234:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Rejected"
+msgstr "crwdns109236:0crwdne109236:0"
+
+#. Option for the 'Approval Status' (Select) field in DocType 'Expense Claim'
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Rejected"
+msgstr "crwdns109238:0crwdne109238:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Rejected"
+msgstr "crwdns109240:0crwdne109240:0"
+
+#. Option for the 'Result' (Select) field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Rejected"
+msgstr "crwdns109242:0crwdne109242:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Rejected"
+msgstr "crwdns109244:0crwdne109244:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Rejected"
+msgstr "crwdns109246:0crwdne109246:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Rejected"
+msgstr "crwdns109248:0crwdne109248:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Rejected"
+msgstr "crwdns109250:0crwdne109250:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Rejected"
+msgstr "crwdns109252:0crwdne109252:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:26
+#: hr/report/employee_exits/employee_exits.py:37
+msgid "Relieving Date"
+msgstr "crwdns109254:0crwdne109254:0"
+
+#. Label of a Date field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Relieving Date"
+msgstr "crwdns109256:0crwdne109256:0"
+
+#. Label of a Date field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Relieving Date "
+msgstr "crwdns109258:0crwdne109258:0"
+
+#: hr/doctype/exit_interview/exit_interview.js:19
+#: hr/doctype/exit_interview/exit_interview.py:24
+msgid "Relieving Date Missing"
+msgstr "crwdns109260:0crwdne109260:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Remaining Benefits (Yearly)"
+msgstr "crwdns109262:0crwdne109262:0"
+
+#. Label of a Small Text field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Remark"
+msgstr "crwdns109264:0crwdne109264:0"
+
+#. Label of a Small Text field in DocType 'Full and Final Outstanding
+#. Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Remark"
+msgstr "crwdns109266:0crwdne109266:0"
+
+#. Label of a Text field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Remarks"
+msgstr "crwdns109268:0crwdne109268:0"
+
+#. Label of a Time field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Remind Before"
+msgstr "crwdns109270:0crwdne109270:0"
+
+#. Label of a Check field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Reminded"
+msgstr "crwdns109272:0crwdne109272:0"
+
+#. Label of a Section Break field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Reminder"
+msgstr "crwdns109274:0crwdne109274:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Reminders"
+msgstr "crwdns109276:0crwdne109276:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Remove if Zero Valued"
+msgstr "crwdns109278:0crwdne109278:0"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Rented Car"
+msgstr "crwdns109280:0crwdne109280:0"
+
+#: hr/doctype/goal/goal.js:61
+msgid "Reopen"
+msgstr "crwdns109282:0crwdne109282:0"
+
+#: hr/utils.py:708
+msgid "Repay From Salary can be selected only for term loans"
+msgstr "crwdns109284:0crwdne109284:0"
+
+#. Label of a Check field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Repay Unclaimed Amount from Salary"
+msgstr "crwdns109286:0crwdne109286:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Replied"
+msgstr "crwdns109288:0crwdne109288:0"
+
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.py:22
+msgid "Replies"
+msgstr "crwdns109290:0crwdne109290:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#. Label of a Card Break in the Expense Claims Workspace
+#. Label of a Card Break in the Leaves Workspace
+#. Label of a Card Break in the Performance Workspace
+#. Label of a Card Break in the Recruitment Workspace
+#. Label of a Card Break in the Shift & Attendance Workspace
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: hr/doctype/leave_application/leave_application_dashboard.py:8
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: hr/workspace/expense_claims/expense_claims.json
+#: hr/workspace/leaves/leaves.json hr/workspace/performance/performance.json
+#: hr/workspace/recruitment/recruitment.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Reports"
+msgstr "crwdns109292:0crwdne109292:0"
+
+#: hr/report/employee_exits/employee_exits.js:45
+#: hr/report/employee_exits/employee_exits.py:79
+msgid "Reports To"
+msgstr "crwdns109294:0crwdne109294:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Reports To"
+msgstr "crwdns109296:0crwdne109296:0"
+
+#. Label of a Link field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Reports To"
+msgstr "crwdns109298:0crwdne109298:0"
+
+#. Label of a Link field in DocType 'Job Requisition'
+#. Label of a Section Break field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Requested By"
+msgstr "crwdns109300:0crwdne109300:0"
+
+#. Label of a Data field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Requested By (Name)"
+msgstr "crwdns109302:0crwdne109302:0"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Require Full Funding"
+msgstr "crwdns109304:0crwdne109304:0"
+
+#. Label of a Check field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Required for Employee Creation"
+msgstr "crwdns109306:0crwdne109306:0"
+
+#: hr/doctype/interview/interview.js:29
+msgid "Reschedule Interview"
+msgstr "crwdns109308:0crwdne109308:0"
+
+#. Label of a Date field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Resignation Letter Date"
+msgstr "crwdns109310:0crwdne109310:0"
+
+#. Label of a Date field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Resolution Date"
+msgstr "crwdns109312:0crwdne109312:0"
+
+#. Label of a Section Break field in DocType 'Employee Grievance'
+#. Label of a Small Text field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Resolution Details"
+msgstr "crwdns109314:0crwdne109314:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Resolved"
+msgstr "crwdns109316:0crwdne109316:0"
+
+#. Label of a Link field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Resolved By"
+msgstr "crwdns109318:0crwdne109318:0"
+
+#: setup.py:402
+msgid "Responsibilities"
+msgstr "crwdns109320:0crwdne109320:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Restrict Backdated Leave Application"
+msgstr "crwdns109322:0crwdne109322:0"
+
+#: hr/doctype/interview/interview.js:145
+msgid "Result"
+msgstr "crwdns109324:0crwdne109324:0"
+
+#. Label of a Select field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Result"
+msgstr "crwdns109326:0crwdne109326:0"
+
+#. Label of a Attach field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Resume"
+msgstr "crwdns109328:0crwdne109328:0"
+
+#. Label of a Section Break field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Resume"
+msgstr "crwdns109330:0crwdne109330:0"
+
+#. Label of a Attach field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Resume Attachment"
+msgstr "crwdns109332:0crwdne109332:0"
+
+#. Label of a Data field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Resume Link"
+msgstr "crwdns109334:0crwdne109334:0"
+
+#. Label of a Data field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Resume Link"
+msgstr "crwdns109336:0crwdne109336:0"
+
+#. Label of a Data field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Resume link"
+msgstr "crwdns109338:0crwdne109338:0"
+
+#: hr/report/employee_exits/employee_exits.py:193
+msgid "Retained"
+msgstr "crwdns109340:0crwdne109340:0"
+
+#. Name of a DocType
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgid "Retention Bonus"
+msgstr "crwdns109342:0crwdne109342:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Retention Bonus"
+msgid "Retention Bonus"
+msgstr "crwdns109344:0crwdne109344:0"
+
+#. Label of a Data field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Retirement Age (In Years)"
+msgstr "crwdns109346:0crwdne109346:0"
+
+#: hr/doctype/employee_advance/employee_advance.js:70
+msgid "Return"
+msgstr "crwdns109348:0crwdne109348:0"
+
+#: hr/doctype/employee_advance/employee_advance.py:131
+msgid "Return amount cannot be greater than unclaimed amount"
+msgstr "crwdns109350:0crwdne109350:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Returned"
+msgstr "crwdns109352:0crwdne109352:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Returned"
+msgstr "crwdns109354:0crwdne109354:0"
+
+#. Label of a Currency field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Returned Amount"
+msgstr "crwdns109356:0crwdne109356:0"
+
+#: hr/doctype/hr_settings/hr_settings.js:37
+msgid "Review various other settings related to Employee Leaves and Expense Claim"
+msgstr "crwdns109358:0crwdne109358:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Reviewer"
+msgstr "crwdns109360:0crwdne109360:0"
+
+#. Label of a Data field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Reviewer Name"
+msgstr "crwdns109362:0crwdne109362:0"
+
+#. Label of a Currency field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Revised CTC"
+msgstr "crwdns109364:0crwdne109364:0"
+
+#. Label of a Int field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Right"
+msgstr "crwdns109366:0crwdne109366:0"
+
+#. Label of a Link field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Role"
+msgstr "crwdns109368:0crwdne109368:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Role Allowed to Create Backdated Leave Application"
+msgstr "crwdns109370:0crwdne109370:0"
+
+#. Label of a Data field in DocType 'Interview Round'
+#: hr/doctype/interview_round/interview_round.json
+msgctxt "Interview Round"
+msgid "Round Name"
+msgstr "crwdns109372:0crwdne109372:0"
+
+#. Option for the 'Work Experience Calculation method' (Select) field in
+#. DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Round off Work Experience"
+msgstr "crwdns109374:0crwdne109374:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Round to the Nearest Integer"
+msgstr "crwdns109376:0crwdne109376:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Rounded Total"
+msgstr "crwdns109378:0crwdne109378:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Rounded Total (Company Currency)"
+msgstr "crwdns109380:0crwdne109380:0"
+
+#. Label of a Select field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Rounding"
+msgstr "crwdns109382:0crwdne109382:0"
+
+#. Label of a Data field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Route"
+msgstr "crwdns109384:0crwdne109384:0"
+
+#. Description of the 'Job Application Route' (Data) field in DocType 'Job
+#. Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Route to the custom Job Application Webform"
+msgstr "crwdns109386:0crwdne109386:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:71
+msgid "Row #{0}: Cannot set amount or formula for Salary Component {1} with Variable Based On Taxable Salary"
+msgstr "crwdns109388:0#{0}crwdnd109388:0{1}crwdne109388:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:90
+msgid "Row #{0}: The {1} Component has the options {2} and {3} enabled."
+msgstr "crwdns109390:0#{0}crwdnd109390:0{1}crwdnd109390:0{2}crwdnd109390:0{3}crwdne109390:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:116
+msgid "Row #{0}: Timesheet amount will overwrite the Earning component amount for the Salary Component {1}"
+msgstr "crwdns109392:0#{0}crwdnd109392:0{1}crwdne109392:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:580
+msgid "Row No {0}: Amount cannot be greater than the Outstanding Amount against Expense Claim {1}. Outstanding Amount is {2}"
+msgstr "crwdns109394:0{0}crwdnd109394:0{1}crwdnd109394:0{2}crwdne109394:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:347
+msgid "Row {0}# Allocated amount {1} cannot be greater than unclaimed amount {2}"
+msgstr "crwdns109396:0{0}crwdnd109396:0{1}crwdnd109396:0{2}crwdne109396:0"
+
+#: payroll/doctype/gratuity/gratuity.py:127
+msgid "Row {0}# Paid Amount cannot be greater than Total amount"
+msgstr "crwdns109398:0{0}crwdne109398:0"
+
+#: hr/doctype/employee_advance/employee_advance.py:123
+msgid "Row {0}# Paid Amount cannot be greater than requested advance amount"
+msgstr "crwdns109400:0{0}crwdne109400:0"
+
+#: payroll/doctype/gratuity_rule/gratuity_rule.py:15
+msgid "Row {0}: From (Year) can not be greater than To (Year)"
+msgstr "crwdns109402:0{0}crwdne109402:0"
+
+#: hr/doctype/appraisal/appraisal.py:133
+msgid "Row {0}: Goal Score cannot be greater than 5"
+msgstr "crwdns109404:0{0}crwdne109404:0"
+
+#: payroll/doctype/salary_slip/salary_slip_loan_utils.py:54
+msgid "Row {0}: Paid amount {1} is greater than pending accrued amount {2} against loan {3}"
+msgstr "crwdns109406:0{0}crwdnd109406:0{1}crwdnd109406:0{2}crwdnd109406:0{3}crwdne109406:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:280
+msgid "Row {0}: {1} is required in the expenses table to book an expense claim."
+msgstr "crwdns109408:0{0}crwdnd109408:0{1}crwdne109408:0"
+
+#. Label of a Section Break field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Rules"
+msgstr "crwdns109410:0crwdne109410:0"
+
+#. Label of a Section Break field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Salary"
+msgstr "crwdns109412:0crwdne109412:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_component/salary_component.json
+msgid "Salary Component"
+msgstr "crwdns109414:0crwdne109414:0"
+
+#. Label of a Link field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Salary Component"
+msgstr "crwdns109416:0crwdne109416:0"
+
+#. Label of a Link field in DocType 'Employee Incentive'
+#: payroll/doctype/employee_incentive/employee_incentive.json
+msgctxt "Employee Incentive"
+msgid "Salary Component"
+msgstr "crwdns109418:0crwdne109418:0"
+
+#. Label of a Link field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Salary Component"
+msgstr "crwdns109420:0crwdne109420:0"
+
+#. Label of a Link field in DocType 'Retention Bonus'
+#: payroll/doctype/retention_bonus/retention_bonus.json
+msgctxt "Retention Bonus"
+msgid "Salary Component"
+msgstr "crwdns109422:0crwdne109422:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Salary Component"
+msgid "Salary Component"
+msgstr "crwdns109424:0crwdne109424:0"
+
+#. Label of a Link field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Salary Component"
+msgstr "crwdns109426:0crwdne109426:0"
+
+#. Label of a Link field in DocType 'Gratuity Applicable Component'
+#: payroll/doctype/gratuity_applicable_component/gratuity_applicable_component.json
+msgctxt "Gratuity Applicable Component"
+msgid "Salary Component "
+msgstr "crwdns109428:0crwdne109428:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_component_account/salary_component_account.json
+msgid "Salary Component Account"
+msgstr "crwdns109430:0crwdne109430:0"
+
+#. Label of a Data field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Salary Component Type"
+msgstr "crwdns109432:0crwdne109432:0"
+
+#. Description of the 'Salary Component' (Link) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Salary Component for timesheet based payroll."
+msgstr "crwdns109434:0crwdne109434:0"
+
+#. Label of a Link field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Salary Currency"
+msgstr "crwdns109436:0crwdne109436:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_detail/salary_detail.json
+msgid "Salary Detail"
+msgstr "crwdns109438:0crwdne109438:0"
+
+#. Label of a Section Break field in DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Salary Details"
+msgstr "crwdns109440:0crwdne109440:0"
+
+#. Label of a Section Break field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Salary Expectation"
+msgstr "crwdns109442:0crwdne109442:0"
+
+#. Label of a Select field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Salary Paid Per"
+msgstr "crwdns109444:0crwdne109444:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Salary Payments Based On Payment Mode"
+msgstr "crwdns109446:0crwdne109446:0"
+
+#. Name of a report
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Salary Payments via ECS"
+msgstr "crwdns109448:0crwdne109448:0"
+
+#. Name of a Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Salary Payout"
+msgstr "crwdns109450:0crwdne109450:0"
+
+#: templates/generators/job_opening.html:103
+msgid "Salary Range"
+msgstr "crwdns109452:0crwdne109452:0"
+
+#. Name of a report
+#. Label of a shortcut in the Payroll Workspace
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a shortcut in the Salary Payout Workspace
+#: payroll/report/salary_register/salary_register.json
+#: payroll/workspace/payroll/payroll.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgid "Salary Register"
+msgstr "crwdns109454:0crwdne109454:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_slip/salary_slip.json
+msgid "Salary Slip"
+msgstr "crwdns109456:0crwdne109456:0"
+
+#. Label of a Link field in DocType 'Employee Benefit Claim'
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgctxt "Employee Benefit Claim"
+msgid "Salary Slip"
+msgstr "crwdns109458:0crwdne109458:0"
+
+#. Label of a Link field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Salary Slip"
+msgstr "crwdns109460:0crwdne109460:0"
+
+#. Label of a Section Break field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Salary Slip"
+msgstr "crwdns109462:0crwdne109462:0"
+
+#. Label of a Link in the Payroll Workspace
+#. Label of a Link in the Salary Payout Workspace
+#. Label of a shortcut in the Salary Payout Workspace
+#: payroll/workspace/payroll/payroll.json
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Salary Slip"
+msgid "Salary Slip"
+msgstr "crwdns109464:0crwdne109464:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Salary Slip Based on Timesheet"
+msgstr "crwdns109466:0crwdne109466:0"
+
+#. Label of a Check field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Salary Slip Based on Timesheet"
+msgstr "crwdns109468:0crwdne109468:0"
+
+#. Label of a Check field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Salary Slip Based on Timesheet"
+msgstr "crwdns109470:0crwdne109470:0"
+
+#: payroll/report/salary_register/salary_register.py:109
+msgid "Salary Slip ID"
+msgstr "crwdns109472:0crwdne109472:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Salary Slip Leave"
+msgstr "crwdns109474:0crwdne109474:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Salary Slip Loan"
+msgstr "crwdns109476:0crwdne109476:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_slip_timesheet/salary_slip_timesheet.json
+msgid "Salary Slip Timesheet"
+msgstr "crwdns109478:0crwdne109478:0"
+
+#. Label of a Table field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Salary Slip Timesheet"
+msgstr "crwdns109480:0crwdne109480:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:84
+msgid "Salary Slip already exists for {0} for the given dates"
+msgstr "crwdns109482:0{0}crwdne109482:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:240
+msgid "Salary Slip creation is queued. It may take a few minutes"
+msgstr "crwdns109484:0crwdne109484:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:285
+msgid "Salary Slip of employee {0} already created for this period"
+msgstr "crwdns109486:0{0}crwdne109486:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:291
+msgid "Salary Slip of employee {0} already created for time sheet {1}"
+msgstr "crwdns109488:0{0}crwdnd109488:0{1}crwdne109488:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:285
+msgid "Salary Slip submission is queued. It may take a few minutes"
+msgstr "crwdns109490:0crwdne109490:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1353
+msgid "Salary Slip {0} failed for Payroll Entry {1}"
+msgstr "crwdns109492:0{0}crwdnd109492:0{1}crwdne109492:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:97
+msgid "Salary Slip {0} failed. You can resolve the {1} and retry {0}."
+msgstr "crwdns109494:0{0}crwdnd109494:0{1}crwdnd109494:0{0}crwdne109494:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Salary Slips Created"
+msgstr "crwdns109496:0crwdne109496:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Salary Slips Submitted"
+msgstr "crwdns109498:0crwdne109498:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1395
+msgid "Salary Slips already exist for employees {}, and will not be processed by this payroll."
+msgstr "crwdns109500:0crwdne109500:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1420
+msgid "Salary Slips submitted for period from {0} to {1}"
+msgstr "crwdns109502:0{0}crwdnd109502:0{1}crwdne109502:0"
+
+#. Name of a DocType
+#: payroll/doctype/salary_component/salary_component.js:27
+#: payroll/doctype/salary_structure/salary_structure.json
+msgid "Salary Structure"
+msgstr "crwdns109504:0crwdne109504:0"
+
+#. Label of a Link field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Salary Structure"
+msgstr "crwdns109506:0crwdne109506:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Salary Structure"
+msgid "Salary Structure"
+msgstr "crwdns109508:0crwdne109508:0"
+
+#. Label of a Link field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Salary Structure"
+msgstr "crwdns109510:0crwdne109510:0"
+
+#. Name of a DocType
+#: payroll/doctype/income_tax_slab/income_tax_slab.js:8
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Salary Structure Assignment"
+msgstr "crwdns109512:0crwdne109512:0"
+
+#. Label of a Link in the Salary Payout Workspace
+#: payroll/workspace/salary_payout/salary_payout.json
+msgctxt "Salary Structure Assignment"
+msgid "Salary Structure Assignment"
+msgstr "crwdns109514:0crwdne109514:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:62
+msgid "Salary Structure Assignment for Employee already exists"
+msgstr "crwdns109516:0crwdne109516:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:383
+msgid "Salary Structure Missing"
+msgstr "crwdns109518:0crwdne109518:0"
+
+#: regional/india/utils.py:30
+msgid "Salary Structure must be submitted before submission of {0}"
+msgstr "crwdns109520:0{0}crwdne109520:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:349
+msgid "Salary Structure not found for employee {0} and date {1}"
+msgstr "crwdns109522:0{0}crwdnd109522:0{1}crwdne109522:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:156
+msgid "Salary Structure should have flexible benefit component(s) to dispense benefit amount"
+msgstr "crwdns109524:0crwdne109524:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:85
+msgid "Salary Structure {0} does not belong to company {1}"
+msgstr "crwdns109526:0{0}crwdnd109526:0{1}crwdne109526:0"
+
+#: hr/doctype/leave_application/leave_application.py:330
+msgid "Salary already processed for period between {0} and {1}, Leave application period cannot be between this date range."
+msgstr "crwdns109528:0{0}crwdnd109528:0{1}crwdne109528:0"
+
+#. Description of the 'Earnings & Deductions' (Tab Break) field in DocType
+#. 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Salary breakup based on Earning and Deduction."
+msgstr "crwdns109530:0crwdne109530:0"
+
+#. Description of the 'Applicable Earnings Component' (Table MultiSelect) field
+#. in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Salary components should be part of the Salary Structure."
+msgstr "crwdns109532:0crwdne109532:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:2265
+msgid "Salary slip emails have been enqueued for sending. Check {0} for status."
+msgstr "crwdns109534:0{0}crwdne109534:0"
+
+#. Subtitle of the Module Onboarding 'Payroll'
+#: payroll/module_onboarding/payroll/payroll.json
+msgid "Salary, Compensation, and more."
+msgstr "crwdns109536:0crwdne109536:0"
+
+#: hr/report/project_profitability/project_profitability.py:150
+msgid "Sales Invoice"
+msgstr "crwdns109538:0crwdne109538:0"
+
+#: hr/doctype/expense_claim_type/expense_claim_type.py:22
+msgid "Same Company is entered more than once"
+msgstr "crwdns109540:0crwdne109540:0"
+
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.py:21
+msgid "Sanctioned Amount"
+msgstr "crwdns109542:0crwdne109542:0"
+
+#. Label of a Currency field in DocType 'Expense Claim Detail'
+#: hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgctxt "Expense Claim Detail"
+msgid "Sanctioned Amount"
+msgstr "crwdns109544:0crwdne109544:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:369
+msgid "Sanctioned Amount cannot be greater than Claim Amount in Row {0}."
+msgstr "crwdns109546:0{0}crwdne109546:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:62
+msgid "Saturday"
+msgstr "crwdns109548:0crwdne109548:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Scheduled"
+msgstr "crwdns109550:0crwdne109550:0"
+
+#. Option for the 'Event Status' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Scheduled"
+msgstr "crwdns109552:0crwdne109552:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Scheduled"
+msgstr "crwdns109554:0crwdne109554:0"
+
+#. Label of a Date field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Scheduled On"
+msgstr "crwdns109556:0crwdne109556:0"
+
+#. Label of a Float field in DocType 'Appraisal Goal'
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgctxt "Appraisal Goal"
+msgid "Score (0-5)"
+msgstr "crwdns109558:0crwdne109558:0"
+
+#. Label of a Float field in DocType 'Appraisal Goal'
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgctxt "Appraisal Goal"
+msgid "Score Earned"
+msgstr "crwdns109560:0crwdne109560:0"
+
+#: hr/doctype/appraisal/appraisal.js:124
+msgid "Score must be less than or equal to 5"
+msgstr "crwdns109562:0crwdne109562:0"
+
+#: hr/doctype/appraisal/appraisal.js:96
+msgid "Scores"
+msgstr "crwdns109564:0crwdne109564:0"
+
+#: www/jobs/index.html:64
+msgid "Search for Jobs"
+msgstr "crwdns109566:0crwdne109566:0"
+
+#: public/js/hierarchy_chart/hierarchy_chart_desktop.js:78
+#: public/js/hierarchy_chart/hierarchy_chart_mobile.js:69
+msgid "Select Company"
+msgstr "crwdns109568:0crwdne109568:0"
+
+#. Label of a Section Break field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Select Employees"
+msgstr "crwdns109570:0crwdne109570:0"
+
+#. Label of a Section Break field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Select Employees"
+msgstr "crwdns109572:0crwdne109572:0"
+
+#: hr/doctype/interview/interview.js:206
+msgid "Select Interview Round First"
+msgstr "crwdns109574:0crwdne109574:0"
+
+#: hr/doctype/interview_feedback/interview_feedback.js:50
+msgid "Select Interview first"
+msgstr "crwdns109576:0crwdne109576:0"
+
+#. Description of the 'Payment Account' (Link) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Select Payment Account to make Bank Entry"
+msgstr "crwdns109578:0crwdne109578:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1554
+msgid "Select Payroll Frequency."
+msgstr "crwdns109580:0crwdne109580:0"
+
+#: hr/employee_property_update.js:84
+msgid "Select Property"
+msgstr "crwdns109582:0crwdne109582:0"
+
+#. Label of a Link field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Select Terms and Conditions"
+msgstr "crwdns109584:0crwdne109584:0"
+
+#. Label of a Section Break field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Select Users"
+msgstr "crwdns109586:0crwdne109586:0"
+
+#: hr/doctype/expense_claim/expense_claim.js:370
+msgid "Select an employee to get the employee advance."
+msgstr "crwdns109588:0crwdne109588:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:116
+msgid "Select the Employee for which you want to allocate leaves."
+msgstr "crwdns109590:0crwdne109590:0"
+
+#: hr/doctype/leave_application/leave_application.js:247
+msgid "Select the Employee."
+msgstr "crwdns109592:0crwdne109592:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:121
+msgid "Select the Leave Type like Sick leave, Privilege Leave, Casual Leave, etc."
+msgstr "crwdns109594:0crwdne109594:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:131
+msgid "Select the date after which this Leave Allocation will expire."
+msgstr "crwdns109596:0crwdne109596:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.js:126
+msgid "Select the date from which this Leave Allocation will be valid."
+msgstr "crwdns109598:0crwdne109598:0"
+
+#: hr/doctype/leave_application/leave_application.js:262
+msgid "Select the end date for your Leave Application."
+msgstr "crwdns109600:0crwdne109600:0"
+
+#: hr/doctype/leave_application/leave_application.js:257
+msgid "Select the start date for your Leave Application."
+msgstr "crwdns109602:0crwdne109602:0"
+
+#: hr/doctype/leave_application/leave_application.js:252
+msgid "Select type of leave the employee wants to apply for, like Sick Leave, Privilege Leave, Casual Leave, etc."
+msgstr "crwdns109604:0crwdne109604:0"
+
+#: hr/doctype/leave_application/leave_application.js:272
+msgid "Select your Leave Approver i.e. the person who approves or rejects your leaves."
+msgstr "crwdns109606:0crwdne109606:0"
+
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.py:32
+msgid "Self Appraisal"
+msgstr "crwdns109608:0crwdne109608:0"
+
+#. Label of a Tab Break field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Self Appraisal"
+msgstr "crwdns109610:0crwdne109610:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:114
+msgid "Self Appraisal Pending: {0}"
+msgstr "crwdns109612:0{0}crwdne109612:0"
+
+#: hr/report/appraisal_overview/appraisal_overview.py:56
+#: hr/report/appraisal_overview/appraisal_overview.py:123
+msgid "Self Score"
+msgstr "crwdns109614:0crwdne109614:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Self-Study"
+msgstr "crwdns109616:0crwdne109616:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Seminar"
+msgstr "crwdns109618:0crwdne109618:0"
+
+#. Label of a Select field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Send Emails At"
+msgstr "crwdns109620:0crwdne109620:0"
+
+#: hr/doctype/exit_interview/exit_interview.js:7
+msgid "Send Exit Questionnaire"
+msgstr "crwdns109622:0crwdne109622:0"
+
+#: hr/doctype/exit_interview/exit_interview_list.js:15
+msgid "Send Exit Questionnaires"
+msgstr "crwdns109624:0crwdne109624:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Send Interview Feedback Reminder"
+msgstr "crwdns109626:0crwdne109626:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Send Interview Reminder"
+msgstr "crwdns109628:0crwdne109628:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Send Leave Notification"
+msgstr "crwdns109630:0crwdne109630:0"
+
+#. Label of a Link field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Sender"
+msgstr "crwdns109632:0crwdne109632:0"
+
+#. Label of a Link field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Sender"
+msgstr "crwdns109634:0crwdne109634:0"
+
+#. Label of a Data field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Sender Email"
+msgstr "crwdns109636:0crwdne109636:0"
+
+#. Label of a Data field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Sender Email"
+msgstr "crwdns109638:0crwdne109638:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Daily Work Summary'
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+msgctxt "Daily Work Summary"
+msgid "Sent"
+msgstr "crwdns109640:0crwdne109640:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:21
+#: public/js/salary_slip_deductions_report_filters.js:27
+msgid "Sep"
+msgstr "crwdns109642:0crwdne109642:0"
+
+#. Label of a Section Break field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Separation Activities"
+msgstr "crwdns109644:0crwdne109644:0"
+
+#. Label of a Date field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Separation Begins On"
+msgstr "crwdns109646:0crwdne109646:0"
+
+#. Label of a Select field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "Series"
+msgstr "crwdns109648:0crwdne109648:0"
+
+#. Label of a Select field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Series"
+msgstr "crwdns109650:0crwdne109650:0"
+
+#. Label of a Select field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Series"
+msgstr "crwdns109652:0crwdne109652:0"
+
+#. Label of a Select field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Series"
+msgstr "crwdns109654:0crwdne109654:0"
+
+#. Label of a Select field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Series"
+msgstr "crwdns109656:0crwdne109656:0"
+
+#. Label of a Select field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Series"
+msgstr "crwdns109658:0crwdne109658:0"
+
+#. Label of a Select field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Series"
+msgstr "crwdns109660:0crwdne109660:0"
+
+#. Label of a Select field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Series"
+msgstr "crwdns109662:0crwdne109662:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Service"
+msgstr "crwdns109664:0crwdne109664:0"
+
+#. Label of a Section Break field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Service Details"
+msgstr "crwdns109666:0crwdne109666:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:49
+msgid "Service Expense"
+msgstr "crwdns109668:0crwdne109668:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.py:169
+msgid "Service Expenses"
+msgstr "crwdns109670:0crwdne109670:0"
+
+#. Label of a Link field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Service Item"
+msgstr "crwdns109672:0crwdne109672:0"
+
+#. Label of a Data field in DocType 'Vehicle Service Item'
+#: hr/doctype/vehicle_service_item/vehicle_service_item.json
+msgctxt "Vehicle Service Item"
+msgid "Service Item"
+msgstr "crwdns109674:0crwdne109674:0"
+
+#. Description of the 'Current Work Experience' (Table) field in DocType
+#. 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Set \"From(Year)\" and \"To(Year)\" to 0 for no upper and lower limit."
+msgstr "crwdns109676:0crwdne109676:0"
+
+#. Label of a Section Break field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Set Attendance Details"
+msgstr "crwdns109678:0crwdne109678:0"
+
+#. Label of a Section Break field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "Set Leave Details"
+msgstr "crwdns109680:0crwdne109680:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:54
+msgid "Set Relieving Date for Employee: {0}"
+msgstr "crwdns109682:0{0}crwdne109682:0"
+
+#. Description of the 'Set Attendance Details' (Section Break) field in DocType
+#. 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Set attendance details for the employees select above"
+msgstr "crwdns109684:0crwdne109684:0"
+
+#. Description of the 'Filters' (Section Break) field in DocType 'Employee
+#. Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Set filters to fetch employees"
+msgstr "crwdns109686:0crwdne109686:0"
+
+#. Description of the 'Filters' (Section Break) field in DocType 'Appraisal
+#. Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Set optional filters to fetch employees in the appraisee list"
+msgstr "crwdns109688:0crwdne109688:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:490
+msgid "Set the default account for the {0} {1}"
+msgstr "crwdns109690:0{0}crwdnd109690:0{1}crwdne109690:0"
+
+#. Label of a Select field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Set the frequency for holiday reminders"
+msgstr "crwdns109692:0crwdne109692:0"
+
+#. Description of the 'Employee Promotion Details' (Section Break) field in
+#. DocType 'Employee Promotion'
+#: hr/doctype/employee_promotion/employee_promotion.json
+msgctxt "Employee Promotion"
+msgid "Set the properties that should be updated in the Employee master on promotion submission"
+msgstr "crwdns109694:0crwdne109694:0"
+
+#. Label of a Card Break in the HR Workspace
+#. Label of a Card Break in the Payroll Workspace
+#: hr/workspace/hr/hr.json payroll/workspace/payroll/payroll.json
+msgid "Settings"
+msgstr "crwdns109696:0crwdne109696:0"
+
+#. Label of a Section Break field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Settings"
+msgstr "crwdns109698:0crwdne109698:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:129
+msgid "Settings Missing"
+msgstr "crwdns109700:0crwdne109700:0"
+
+#: hr/doctype/full_and_final_statement/full_and_final_statement.py:35
+msgid "Settle all Payables and Receivables before submission"
+msgstr "crwdns109702:0crwdne109702:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final
+#. Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Settled"
+msgstr "crwdns109704:0crwdne109704:0"
+
+#. Label of a Card Break in the HR Workspace
+#. Label of a Card Break in the Leaves Workspace
+#: hr/workspace/hr/hr.json hr/workspace/leaves/leaves.json
+msgid "Setup"
+msgstr "crwdns109706:0crwdne109706:0"
+
+#: hr/utils.py:656
+msgid "Shared with the user {0} with {1} access"
+msgstr "crwdns109708:0{0}crwdnd109708:0{1}crwdne109708:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:141
+#: hr/report/shift_attendance/shift_attendance.py:36
+#: hr/report/shift_attendance/shift_attendance.py:205
+#: overrides/dashboard_overrides.py:28
+msgid "Shift"
+msgstr "crwdns109710:0crwdne109710:0"
+
+#. Label of a Link field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Shift"
+msgstr "crwdns109712:0crwdne109712:0"
+
+#. Label of a Link field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Shift"
+msgstr "crwdns109714:0crwdne109714:0"
+
+#. Label of a Link field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Shift"
+msgstr "crwdns109716:0crwdne109716:0"
+
+#. Label of a Link field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Shift"
+msgstr "crwdns109718:0crwdne109718:0"
+
+#. Name of a Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift & Attendance"
+msgstr "crwdns109720:0crwdne109720:0"
+
+#. Label of a Datetime field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Shift Actual End"
+msgstr "crwdns109722:0crwdne109722:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:117
+msgid "Shift Actual End Time"
+msgstr "crwdns109724:0crwdne109724:0"
+
+#. Label of a Datetime field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Shift Actual Start"
+msgstr "crwdns109726:0crwdne109726:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:111
+msgid "Shift Actual Start Time"
+msgstr "crwdns109728:0crwdne109728:0"
+
+#. Name of a DocType
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgid "Shift Assignment"
+msgstr "crwdns109730:0crwdne109730:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Shift Assignment"
+msgid "Shift Assignment"
+msgstr "crwdns109732:0crwdne109732:0"
+
+#: hr/doctype/shift_request/shift_request.py:47
+msgid "Shift Assignment: {0} created for Employee: {1}"
+msgstr "crwdns109734:0{0}crwdnd109734:0{1}crwdne109734:0"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/report/shift_attendance/shift_attendance.json
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Attendance"
+msgstr "crwdns109736:0crwdne109736:0"
+
+#. Label of a Datetime field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Shift End"
+msgstr "crwdns109738:0crwdne109738:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:61
+msgid "Shift End Time"
+msgstr "crwdns109740:0crwdne109740:0"
+
+#. Name of a DocType
+#: hr/doctype/shift_request/shift_request.json
+msgid "Shift Request"
+msgstr "crwdns109742:0crwdne109742:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Shift Request"
+msgstr "crwdns109744:0crwdne109744:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#. Label of a shortcut in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Shift Request"
+msgid "Shift Request"
+msgstr "crwdns109746:0crwdne109746:0"
+
+#. Label of a Section Break field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Shift Settings"
+msgstr "crwdns109748:0crwdne109748:0"
+
+#. Label of a Datetime field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Shift Start"
+msgstr "crwdns109750:0crwdne109750:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:55
+msgid "Shift Start Time"
+msgstr "crwdns109752:0crwdne109752:0"
+
+#. Name of a DocType
+#: hr/doctype/shift_type/shift_type.json
+#: hr/report/shift_attendance/shift_attendance.js:28
+msgid "Shift Type"
+msgstr "crwdns109754:0crwdne109754:0"
+
+#. Label of a Link field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Shift Type"
+msgstr "crwdns109756:0crwdne109756:0"
+
+#. Label of a Link field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Shift Type"
+msgstr "crwdns109758:0crwdne109758:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Shift Type"
+msgid "Shift Type"
+msgstr "crwdns109760:0crwdne109760:0"
+
+#. Label of a Card Break in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shifts"
+msgstr "crwdns109762:0crwdne109762:0"
+
+#: hr/doctype/job_offer/job_offer.js:48
+msgid "Show Employee"
+msgstr "crwdns109764:0crwdne109764:0"
+
+#. Label of a Check field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Show Leave Balances in Salary Slip"
+msgstr "crwdns109766:0crwdne109766:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Show Leaves Of All Department Members In Calendar"
+msgstr "crwdns109768:0crwdne109768:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:216
+msgid "Show Salary Slip"
+msgstr "crwdns109770:0crwdne109770:0"
+
+#. Label of an action in the Onboarding Step 'Create Employee'
+#. Label of an action in the Onboarding Step 'Create Holiday List'
+#. Label of an action in the Onboarding Step 'Create Leave Allocation'
+#. Label of an action in the Onboarding Step 'Create Leave Application'
+#. Label of an action in the Onboarding Step 'Create Leave Type'
+#: hr/onboarding_step/create_employee/create_employee.json
+#: hr/onboarding_step/create_holiday_list/create_holiday_list.json
+#: hr/onboarding_step/create_leave_allocation/create_leave_allocation.json
+#: hr/onboarding_step/create_leave_application/create_leave_application.json
+#: hr/onboarding_step/create_leave_type/create_leave_type.json
+msgid "Show Tour"
+msgstr "crwdns109772:0crwdne109772:0"
+
+#: www/jobs/index.html:103
+msgid "Showing"
+msgstr "crwdns109774:0crwdne109774:0"
+
+#: setup.py:356 setup.py:357
+msgid "Sick Leave"
+msgstr "crwdns109776:0crwdne109776:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:99
+msgid "Single Assignment"
+msgstr "crwdns109778:0crwdne109778:0"
+
+#. Name of a DocType
+#: hr/doctype/interview/interview.js:186 hr/doctype/skill/skill.json
+msgid "Skill"
+msgstr "crwdns109780:0crwdne109780:0"
+
+#. Label of a Link field in DocType 'Designation Skill'
+#: hr/doctype/designation_skill/designation_skill.json
+msgctxt "Designation Skill"
+msgid "Skill"
+msgstr "crwdns109782:0crwdne109782:0"
+
+#. Label of a Link field in DocType 'Employee Skill'
+#: hr/doctype/employee_skill/employee_skill.json
+msgctxt "Employee Skill"
+msgid "Skill"
+msgstr "crwdns109784:0crwdne109784:0"
+
+#. Label of a Link field in DocType 'Expected Skill Set'
+#: hr/doctype/expected_skill_set/expected_skill_set.json
+msgctxt "Expected Skill Set"
+msgid "Skill"
+msgstr "crwdns109786:0crwdne109786:0"
+
+#. Label of a Link field in DocType 'Skill Assessment'
+#: hr/doctype/skill_assessment/skill_assessment.json
+msgctxt "Skill Assessment"
+msgid "Skill"
+msgstr "crwdns109788:0crwdne109788:0"
+
+#. Name of a DocType
+#: hr/doctype/interview/interview.js:134
+#: hr/doctype/skill_assessment/skill_assessment.json
+msgid "Skill Assessment"
+msgstr "crwdns109790:0crwdne109790:0"
+
+#. Label of a Section Break field in DocType 'Interview Feedback'
+#: hr/doctype/interview_feedback/interview_feedback.json
+msgctxt "Interview Feedback"
+msgid "Skill Assessment"
+msgstr "crwdns109792:0crwdne109792:0"
+
+#. Label of a Data field in DocType 'Skill'
+#: hr/doctype/skill/skill.json
+msgctxt "Skill"
+msgid "Skill Name"
+msgstr "crwdns109794:0crwdne109794:0"
+
+#. Label of a Section Break field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Skills"
+msgstr "crwdns109796:0crwdne109796:0"
+
+#. Label of a Check field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Skip Auto Attendance"
+msgstr "crwdns109798:0crwdne109798:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:313
+msgid "Skipping Salary Structure Assignment for the following employees, as Salary Structure Assignment records already exists against them. {0}"
+msgstr "crwdns109800:0{0}crwdne109800:0"
+
+#. Label of a Data field in DocType 'Employee Other Income'
+#: payroll/doctype/employee_other_income/employee_other_income.json
+msgctxt "Employee Other Income"
+msgid "Source"
+msgstr "crwdns109802:0crwdne109802:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Source"
+msgstr "crwdns109804:0crwdne109804:0"
+
+#. Label of a Link field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Source Name"
+msgstr "crwdns109806:0crwdne109806:0"
+
+#. Label of a Data field in DocType 'Job Applicant Source'
+#: hr/doctype/job_applicant_source/job_applicant_source.json
+msgctxt "Job Applicant Source"
+msgid "Source Name"
+msgstr "crwdns109808:0crwdne109808:0"
+
+#. Label of a Section Break field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Source and Rating"
+msgstr "crwdns109810:0crwdne109810:0"
+
+#. Label of a Currency field in DocType 'Travel Request Costing'
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgctxt "Travel Request Costing"
+msgid "Sponsored Amount"
+msgstr "crwdns109812:0crwdne109812:0"
+
+#. Label of a Table field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Staffing Details"
+msgstr "crwdns109814:0crwdne109814:0"
+
+#. Name of a DocType
+#: hr/doctype/staffing_plan/staffing_plan.json
+#: hr/report/recruitment_analytics/recruitment_analytics.py:25
+msgid "Staffing Plan"
+msgstr "crwdns109816:0crwdne109816:0"
+
+#. Label of a Link field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Staffing Plan"
+msgstr "crwdns109818:0crwdne109818:0"
+
+#. Label of a Link in the Recruitment Workspace
+#: hr/workspace/recruitment/recruitment.json
+msgctxt "Staffing Plan"
+msgid "Staffing Plan"
+msgstr "crwdns109820:0crwdne109820:0"
+
+#. Name of a DocType
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Staffing Plan Detail"
+msgstr "crwdns109822:0crwdne109822:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:70
+msgid "Staffing Plan {0} already exist for designation {1}"
+msgstr "crwdns109824:0{0}crwdnd109824:0{1}crwdne109824:0"
+
+#. Label of a Currency field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Standard Tax Exemption Amount"
+msgstr "crwdns109826:0crwdne109826:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Standard Tax Exemption Amount"
+msgstr "crwdns109828:0crwdne109828:0"
+
+#. Label of a Float field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Standard Working Hours"
+msgstr "crwdns109830:0crwdne109830:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:43
+#: hr/doctype/attendance/attendance_list.js:46
+msgid "Start"
+msgstr "crwdns109832:0crwdne109832:0"
+
+#: hr/doctype/goal/goal_tree.js:86
+#: hr/report/project_profitability/project_profitability.js:17
+#: hr/report/project_profitability/project_profitability.py:203
+#: payroll/report/salary_register/salary_register.py:163
+msgid "Start Date"
+msgstr "crwdns109834:0crwdne109834:0"
+
+#. Label of a Date field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Start Date"
+msgstr "crwdns109836:0crwdne109836:0"
+
+#. Label of a Date field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Start Date"
+msgstr "crwdns109838:0crwdne109838:0"
+
+#. Label of a Date field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Start Date"
+msgstr "crwdns109840:0crwdne109840:0"
+
+#. Label of a Date field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Start Date"
+msgstr "crwdns109842:0crwdne109842:0"
+
+#. Label of a Date field in DocType 'Payroll Period'
+#: payroll/doctype/payroll_period/payroll_period.json
+msgctxt "Payroll Period"
+msgid "Start Date"
+msgstr "crwdns109844:0crwdne109844:0"
+
+#. Label of a Date field in DocType 'Payroll Period Date'
+#: payroll/doctype/payroll_period_date/payroll_period_date.json
+msgctxt "Payroll Period Date"
+msgid "Start Date"
+msgstr "crwdns109846:0crwdne109846:0"
+
+#. Label of a Date field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Start Date"
+msgstr "crwdns109848:0crwdne109848:0"
+
+#. Label of a Date field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Start Date"
+msgstr "crwdns109850:0crwdne109850:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:32
+#: templates/emails/training_event.html:7
+msgid "Start Time"
+msgstr "crwdns109852:0crwdne109852:0"
+
+#. Label of a Time field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Start Time"
+msgstr "crwdns109854:0crwdne109854:0"
+
+#. Label of a Datetime field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Start Time"
+msgstr "crwdns109856:0crwdne109856:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:263
+msgid "Start and end dates not in a valid Payroll Period, cannot calculate {0}"
+msgstr "crwdns109858:0{0}crwdne109858:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1416
+msgid "Start and end dates not in a valid Payroll Period, cannot calculate {0}."
+msgstr "crwdns109860:0{0}crwdne109860:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:196
+msgid "Start date: {0}"
+msgstr "crwdns109862:0{0}crwdne109862:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Statistical Component"
+msgstr "crwdns109864:0crwdne109864:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Statistical Component"
+msgstr "crwdns109866:0crwdne109866:0"
+
+#: hr/doctype/attendance/attendance_list.js:71
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.js:150
+#: hr/doctype/goal/goal.js:57 hr/doctype/goal/goal.js:64
+#: hr/doctype/goal/goal.js:71 hr/doctype/goal/goal.js:78
+#: hr/report/employee_advance_summary/employee_advance_summary.js:35
+#: hr/report/employee_advance_summary/employee_advance_summary.py:74
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.py:23
+#: hr/report/shift_attendance/shift_attendance.py:49
+msgid "Status"
+msgstr "crwdns109868:0crwdne109868:0"
+
+#. Label of a Select field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Status"
+msgstr "crwdns109870:0crwdne109870:0"
+
+#. Label of a Select field in DocType 'Appraisal Cycle'
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgctxt "Appraisal Cycle"
+msgid "Status"
+msgstr "crwdns109872:0crwdne109872:0"
+
+#. Label of a Select field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Status"
+msgstr "crwdns109874:0crwdne109874:0"
+
+#. Label of a Select field in DocType 'Daily Work Summary'
+#: hr/doctype/daily_work_summary/daily_work_summary.json
+msgctxt "Daily Work Summary"
+msgid "Status"
+msgstr "crwdns109876:0crwdne109876:0"
+
+#. Label of a Select field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Status"
+msgstr "crwdns109878:0crwdne109878:0"
+
+#. Label of a Select field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Status"
+msgstr "crwdns109880:0crwdne109880:0"
+
+#. Label of a Select field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Status"
+msgstr "crwdns109882:0crwdne109882:0"
+
+#. Label of a Select field in DocType 'Employee Onboarding'
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+msgctxt "Employee Onboarding"
+msgid "Status"
+msgstr "crwdns109884:0crwdne109884:0"
+
+#. Label of a Select field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Status"
+msgstr "crwdns109886:0crwdne109886:0"
+
+#. Label of a Select field in DocType 'Employee Separation'
+#: hr/doctype/employee_separation/employee_separation.json
+msgctxt "Employee Separation"
+msgid "Status"
+msgstr "crwdns109888:0crwdne109888:0"
+
+#. Label of a Select field in DocType 'Exit Interview'
+#: hr/doctype/exit_interview/exit_interview.json
+msgctxt "Exit Interview"
+msgid "Status"
+msgstr "crwdns109890:0crwdne109890:0"
+
+#. Label of a Select field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Status"
+msgstr "crwdns109892:0crwdne109892:0"
+
+#. Label of a Select field in DocType 'Full and Final Asset'
+#: hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgctxt "Full and Final Asset"
+msgid "Status"
+msgstr "crwdns109894:0crwdne109894:0"
+
+#. Label of a Select field in DocType 'Full and Final Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Status"
+msgstr "crwdns109896:0crwdne109896:0"
+
+#. Label of a Select field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Status"
+msgstr "crwdns109898:0crwdne109898:0"
+
+#. Label of a Select field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "Status"
+msgstr "crwdns109900:0crwdne109900:0"
+
+#. Label of a Select field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Status"
+msgstr "crwdns109902:0crwdne109902:0"
+
+#. Label of a Select field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Status"
+msgstr "crwdns109904:0crwdne109904:0"
+
+#. Label of a Select field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Status"
+msgstr "crwdns109906:0crwdne109906:0"
+
+#. Label of a Select field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Status"
+msgstr "crwdns109908:0crwdne109908:0"
+
+#. Label of a Select field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Status"
+msgstr "crwdns109910:0crwdne109910:0"
+
+#. Label of a Select field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Status"
+msgstr "crwdns109912:0crwdne109912:0"
+
+#. Label of a Select field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Status"
+msgstr "crwdns109914:0crwdne109914:0"
+
+#. Label of a Select field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Status"
+msgstr "crwdns109916:0crwdne109916:0"
+
+#. Label of a Select field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Status"
+msgstr "crwdns109918:0crwdne109918:0"
+
+#. Label of a Select field in DocType 'Shift Assignment'
+#: hr/doctype/shift_assignment/shift_assignment.json
+msgctxt "Shift Assignment"
+msgid "Status"
+msgstr "crwdns109920:0crwdne109920:0"
+
+#. Label of a Select field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "Status"
+msgstr "crwdns109922:0crwdne109922:0"
+
+#. Label of a Select field in DocType 'Training Event Employee'
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgctxt "Training Event Employee"
+msgid "Status"
+msgstr "crwdns109924:0crwdne109924:0"
+
+#. Label of a Select field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Status"
+msgstr "crwdns109926:0crwdne109926:0"
+
+#: setup.py:399
+msgid "Stock Options"
+msgstr "crwdns109928:0crwdne109928:0"
+
+#. Description of the 'Block Days' (Section Break) field in DocType 'Leave
+#. Block List'
+#: hr/doctype/leave_block_list/leave_block_list.json
+msgctxt "Leave Block List"
+msgid "Stop users from making Leave Applications on following days."
+msgstr "crwdns109930:0crwdne109930:0"
+
+#. Option for the 'Determine Check-in and Check-out' (Select) field in DocType
+#. 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Strictly based on Log Type in Employee Checkin"
+msgstr "crwdns109932:0crwdne109932:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:254
+msgid "Structures have been assigned successfully"
+msgstr "crwdns109934:0crwdne109934:0"
+
+#. Label of a Data field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Subject"
+msgstr "crwdns109936:0crwdne109936:0"
+
+#. Label of a Data field in DocType 'Employee Grievance'
+#: hr/doctype/employee_grievance/employee_grievance.json
+msgctxt "Employee Grievance"
+msgid "Subject"
+msgstr "crwdns109938:0crwdne109938:0"
+
+#. Label of a Date field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Submission Date"
+msgstr "crwdns109940:0crwdne109940:0"
+
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.py:337
+msgid "Submission Failed"
+msgstr "crwdns109942:0crwdne109942:0"
+
+#: hr/doctype/job_requisition/job_requisition.js:59
+#: public/js/performance/performance_feedback.js:97
+msgid "Submit"
+msgstr "crwdns109944:0crwdne109944:0"
+
+#: hr/doctype/interview/interview.js:50 hr/doctype/interview/interview.js:129
+msgid "Submit Feedback"
+msgstr "crwdns109946:0crwdne109946:0"
+
+#: hr/doctype/exit_interview/exit_questionnaire_notification_template.html:15
+msgid "Submit Now"
+msgstr "crwdns109948:0crwdne109948:0"
+
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.js:43
+msgid "Submit Proof"
+msgstr "crwdns109950:0crwdne109950:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:144
+msgid "Submit Salary Slip"
+msgstr "crwdns109952:0crwdne109952:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.py:39
+msgid "Submit this to create the Employee record"
+msgstr "crwdns109954:0crwdne109954:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Submitted"
+msgstr "crwdns109956:0crwdne109956:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Submitted"
+msgstr "crwdns109958:0crwdne109958:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Submitted"
+msgstr "crwdns109960:0crwdne109960:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Submitted"
+msgstr "crwdns109962:0crwdne109962:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Submitted"
+msgstr "crwdns109964:0crwdne109964:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:385
+msgid "Submitting Salary Slips and creating Journal Entry..."
+msgstr "crwdns109966:0crwdne109966:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.py:1470
+msgid "Submitting Salary Slips..."
+msgstr "crwdns109968:0crwdne109968:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:162
+msgid "Subsidiary companies have already planned for {1} vacancies at a budget of {2}. Staffing Plan for {0} should allocate more vacancies and budget for {3} than planned for its subsidiary companies"
+msgstr "crwdns109970:0{1}crwdnd109970:0{2}crwdnd109970:0{0}crwdnd109970:0{3}crwdne109970:0"
+
+#: hr/doctype/employee_referral/employee_referral.py:54
+#: hr/doctype/leave_control_panel/leave_control_panel.py:130
+msgid "Success"
+msgstr "crwdns109972:0crwdne109972:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:133
+msgid "Successfully created {0} records for:"
+msgstr "crwdns109974:0{0}crwdne109974:0"
+
+#. Option for the 'Calculate Gratuity Amount Based On' (Select) field in
+#. DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Sum of all previous slabs"
+msgstr "crwdns109976:0crwdne109976:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:64
+msgid "Summarized View"
+msgstr "crwdns109978:0crwdne109978:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:67
+msgid "Sunday"
+msgstr "crwdns109980:0crwdne109980:0"
+
+#. Label of a Link field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Supplier"
+msgstr "crwdns109982:0crwdne109982:0"
+
+#. Label of a Link field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Supplier"
+msgstr "crwdns109984:0crwdne109984:0"
+
+#. Label of a Link field in DocType 'Vehicle Log'
+#: hr/doctype/vehicle_log/vehicle_log.json
+msgctxt "Vehicle Log"
+msgid "Supplier"
+msgstr "crwdns109986:0crwdne109986:0"
+
+#: hr/report/employee_leave_balance/employee_leave_balance.js:48
+#: hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:42
+msgid "Suspended"
+msgstr "crwdns109988:0crwdne109988:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1170
+msgid "Syntax error"
+msgstr "crwdns109990:0crwdne109990:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:2115
+msgid "Syntax error in condition: {0} in Income Tax Slab"
+msgstr "crwdns109992:0{0}crwdne109992:0"
+
+#. Name of a role
+#: hr/doctype/appointment_letter/appointment_letter.json
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+#: hr/doctype/appraisal/appraisal.json
+#: hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hr/doctype/attendance/attendance.json
+#: hr/doctype/attendance_request/attendance_request.json
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hr/doctype/employee_checkin/employee_checkin.json
+#: hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+#: hr/doctype/employee_grade/employee_grade.json
+#: hr/doctype/employee_grievance/employee_grievance.json
+#: hr/doctype/employee_onboarding/employee_onboarding.json
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hr/doctype/employee_referral/employee_referral.json
+#: hr/doctype/employee_separation/employee_separation.json
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+#: hr/doctype/exit_interview/exit_interview.json
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+#: hr/doctype/goal/goal.json hr/doctype/grievance_type/grievance_type.json
+#: hr/doctype/hr_settings/hr_settings.json
+#: hr/doctype/identification_document_type/identification_document_type.json
+#: hr/doctype/interview/interview.json
+#: hr/doctype/interview_type/interview_type.json
+#: hr/doctype/job_offer_term_template/job_offer_term_template.json
+#: hr/doctype/job_requisition/job_requisition.json hr/doctype/kra/kra.json
+#: hr/doctype/leave_encashment/leave_encashment.json
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hr/doctype/leave_period/leave_period.json
+#: hr/doctype/leave_policy/leave_policy.json
+#: hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hr/doctype/purpose_of_travel/purpose_of_travel.json
+#: hr/doctype/pwa_notification/pwa_notification.json
+#: hr/doctype/skill/skill.json hr/doctype/travel_request/travel_request.json
+#: hr/doctype/vehicle_service_item/vehicle_service_item.json
+#: payroll/doctype/additional_salary/additional_salary.json
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+#: payroll/doctype/payroll_period/payroll_period.json
+#: payroll/doctype/payroll_settings/payroll_settings.json
+#: payroll/doctype/retention_bonus/retention_bonus.json
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "System Manager"
+msgstr "crwdns109994:0crwdne109994:0"
+
+#. Option for the 'Work Experience Calculation method' (Select) field in
+#. DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Take Exact Completed Years"
+msgstr "crwdns109996:0crwdne109996:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.js:34
+#: hr/doctype/employee_separation/employee_separation.js:22
+msgid "Task"
+msgstr "crwdns109998:0crwdne109998:0"
+
+#. Label of a Link field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Task"
+msgstr "crwdns110000:0crwdne110000:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Task"
+msgstr "crwdns110002:0crwdne110002:0"
+
+#. Label of a Float field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "Task Weight"
+msgstr "crwdns110004:0crwdne110004:0"
+
+#. Name of a Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Tax & Benefits"
+msgstr "crwdns110006:0crwdne110006:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:41
+msgid "Tax Deducted Till Date"
+msgstr "crwdns110008:0crwdne110008:0"
+
+#. Label of a Currency field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Tax Deducted Till Date"
+msgstr "crwdns110010:0crwdne110010:0"
+
+#. Label of a Link field in DocType 'Employee Tax Exemption Sub Category'
+#: payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgctxt "Employee Tax Exemption Sub Category"
+msgid "Tax Exemption Category"
+msgstr "crwdns110012:0crwdne110012:0"
+
+#. Label of a Tab Break field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Tax Exemption Declaration"
+msgstr "crwdns110014:0crwdne110014:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Tax Exemption Declaration"
+msgstr "crwdns110016:0crwdne110016:0"
+
+#. Label of a Table field in DocType 'Employee Tax Exemption Proof Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Tax Exemption Proofs"
+msgstr "crwdns110018:0crwdne110018:0"
+
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Tax Setup"
+msgstr "crwdns110020:0crwdne110020:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Tax on additional salary"
+msgstr "crwdns110022:0crwdne110022:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Tax on flexible benefit"
+msgstr "crwdns110024:0crwdne110024:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:40
+msgid "Taxable Earnings Till Date"
+msgstr "crwdns110026:0crwdne110026:0"
+
+#. Label of a Currency field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Taxable Earnings Till Date"
+msgstr "crwdns110028:0crwdne110028:0"
+
+#. Name of a DocType
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid "Taxable Salary Slab"
+msgstr "crwdns110030:0crwdne110030:0"
+
+#. Label of a Section Break field in DocType 'Income Tax Slab'
+#. Label of a Table field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Taxable Salary Slabs"
+msgstr "crwdns110032:0crwdne110032:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Taxes & Charges"
+msgstr "crwdns110034:0crwdne110034:0"
+
+#. Label of a Section Break field in DocType 'Income Tax Slab'
+#: payroll/doctype/income_tax_slab/income_tax_slab.json
+msgctxt "Income Tax Slab"
+msgid "Taxes and Charges on Income Tax"
+msgstr "crwdns110036:0crwdne110036:0"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Taxi"
+msgstr "crwdns110038:0crwdne110038:0"
+
+#. Label of a Link in the HR Workspace
+#: hr/page/team_updates/team_updates.js:4 hr/workspace/hr/hr.json
+msgid "Team Updates"
+msgstr "crwdns110040:0crwdne110040:0"
+
+#. Label of a Data field in DocType 'Appointment Letter Template'
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgctxt "Appointment Letter Template"
+msgid "Template Name"
+msgstr "crwdns110042:0crwdne110042:0"
+
+#. Label of a Table field in DocType 'Appointment Letter'
+#: hr/doctype/appointment_letter/appointment_letter.json
+msgctxt "Appointment Letter"
+msgid "Terms"
+msgstr "crwdns110044:0crwdne110044:0"
+
+#. Label of a Table field in DocType 'Appointment Letter Template'
+#: hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgctxt "Appointment Letter Template"
+msgid "Terms"
+msgstr "crwdns110046:0crwdne110046:0"
+
+#. Label of a Text Editor field in DocType 'Job Offer'
+#: hr/doctype/job_offer/job_offer.json
+msgctxt "Job Offer"
+msgid "Terms and Conditions"
+msgstr "crwdns110048:0crwdne110048:0"
+
+#: templates/emails/training_event.html:20
+msgid "Thank you"
+msgstr "crwdns110050:0crwdne110050:0"
+
+#. Success message of the Module Onboarding 'Human Resource'
+#: hr/module_onboarding/human_resource/human_resource.json
+msgid "The Human Resource Module is all set up!"
+msgstr "crwdns110052:0crwdne110052:0"
+
+#. Success message of the Module Onboarding 'Payroll'
+#: payroll/module_onboarding/payroll/payroll.json
+msgid "The Payroll Module is all set up!"
+msgstr "crwdns110054:0crwdne110054:0"
+
+#. Description of the 'Payroll Date' (Date) field in DocType 'Additional
+#. Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "The date on which Salary Component with Amount will contribute for Earnings/Deduction in Salary Slip. "
+msgstr "crwdns110056:0crwdne110056:0"
+
+#. Description of the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "The day of the month when leaves should be allocated"
+msgstr "crwdns110058:0crwdne110058:0"
+
+#: hr/doctype/leave_application/leave_application.py:368
+msgid "The day(s) on which you are applying for leave are holidays. You need not apply for leave."
+msgstr "crwdns110060:0crwdne110060:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:65
+msgid "The days between {0} to {1} are not valid holidays."
+msgstr "crwdns110062:0{0}crwdnd110062:0{1}crwdne110062:0"
+
+#: hr/doctype/leave_type/leave_type.py:50
+msgid "The fraction of Daily Salary per Leave should be between 0 and 1"
+msgstr "crwdns110064:0crwdne110064:0"
+
+#. Description of the 'Fraction of Daily Salary for Half Day' (Float) field in
+#. DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "The fraction of daily wages to be paid for half-day attendance"
+msgstr "crwdns110066:0crwdne110066:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:35
+#: hr/report/project_profitability/project_profitability.py:101
+msgid "The metrics for this report are calculated based on the Standard Working Hours. Please set {0} in {1}."
+msgstr "crwdns110068:0{0}crwdnd110068:0{1}crwdne110068:0"
+
+#. Description of the 'Encrypt Salary Slips in Emails' (Check) field in DocType
+#. 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "The salary slip emailed to the employee will be password protected, the password will be generated based on the password policy."
+msgstr "crwdns110070:0crwdne110070:0"
+
+#. Description of the 'Late Entry Grace Period' (Int) field in DocType 'Shift
+#. Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "The time after the shift start time when check-in is considered as late (in minutes)."
+msgstr "crwdns110072:0crwdne110072:0"
+
+#. Description of the 'Early Exit Grace Period' (Int) field in DocType 'Shift
+#. Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "The time before the shift end time when check-out is considered as early (in minutes)."
+msgstr "crwdns110074:0crwdne110074:0"
+
+#. Description of the 'Begin check-in before shift start time (in minutes)'
+#. (Int) field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "The time before the shift start time during which Employee Check-in is considered for attendance."
+msgstr "crwdns110076:0crwdne110076:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Theory"
+msgstr "crwdns110078:0crwdne110078:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:441
+msgid "There are more holidays than working days this month."
+msgstr "crwdns110080:0crwdne110080:0"
+
+#: hr/doctype/job_offer/job_offer.py:39
+msgid "There are no vacancies under staffing plan {0}"
+msgstr "crwdns110082:0{0}crwdne110082:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:36
+#: payroll/doctype/employee_incentive/employee_incentive.py:20
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:218
+msgid "There is no Salary Structure assigned to {0}. First assign a Salary Stucture."
+msgstr "crwdns110084:0{0}crwdne110084:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:376
+msgid "There's no Employee with Salary Structure: {0}. Assign {1} to an Employee to preview Salary Slip"
+msgstr "crwdns110086:0{0}crwdnd110086:0{1}crwdne110086:0"
+
+#. Description of the 'Is Optional Leave' (Check) field in DocType 'Leave Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "These leaves are holidays permitted by the company however, availing it is optional for an Employee."
+msgstr "crwdns110088:0crwdne110088:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:85
+msgid "This action will prevent making changes to the linked appraisal feedback/goals."
+msgstr "crwdns110090:0crwdne110090:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:97
+msgid "This compensatory leave will be applicable from {0}."
+msgstr "crwdns110092:0{0}crwdne110092:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:35
+msgid "This employee already has a log with the same timestamp.{0}"
+msgstr "crwdns110094:0{0}crwdne110094:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1178
+msgid "This error can be due to invalid formula or condition."
+msgstr "crwdns110096:0crwdne110096:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1171
+msgid "This error can be due to invalid syntax."
+msgstr "crwdns110098:0crwdne110098:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1164
+msgid "This error can be due to missing or deleted field."
+msgstr "crwdns110100:0crwdne110100:0"
+
+#: hr/doctype/leave_type/leave_type.js:16
+msgid "This field allows you to set the maximum number of consecutive leaves an Employee can apply for."
+msgstr "crwdns110102:0crwdne110102:0"
+
+#: hr/doctype/leave_type/leave_type.js:11
+msgid "This field allows you to set the maximum number of leaves that can be allocated annually for this Leave Type while creating the Leave Policy"
+msgstr "crwdns110104:0crwdne110104:0"
+
+#: overrides/dashboard_overrides.py:57
+msgid "This is based on the attendance of this Employee"
+msgstr "crwdns110106:0crwdne110106:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:378
+msgid "This will submit Salary Slips and create accrual Journal Entry. Do you want to proceed?"
+msgstr "crwdns110108:0crwdne110108:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:52
+msgid "Thursday"
+msgstr "crwdns110110:0crwdne110110:0"
+
+#. Label of a Card Break in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Time"
+msgstr "crwdns110112:0crwdne110112:0"
+
+#. Label of a Datetime field in DocType 'Employee Checkin'
+#: hr/doctype/employee_checkin/employee_checkin.json
+msgctxt "Employee Checkin"
+msgid "Time"
+msgstr "crwdns110114:0crwdne110114:0"
+
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.js:28
+msgid "Time Interval"
+msgstr "crwdns110116:0crwdne110116:0"
+
+#. Label of a Link field in DocType 'Salary Slip Timesheet'
+#: payroll/doctype/salary_slip_timesheet/salary_slip_timesheet.json
+msgctxt "Salary Slip Timesheet"
+msgid "Time Sheet"
+msgstr "crwdns110118:0crwdne110118:0"
+
+#. Description of the 'Allow check-out after shift end time (in minutes)' (Int)
+#. field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Time after the end of shift during which check-out is considered for attendance."
+msgstr "crwdns110120:0crwdne110120:0"
+
+#. Description of the 'Time to Fill' (Duration) field in DocType 'Job
+#. Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Time taken to fill the open positions"
+msgstr "crwdns110122:0crwdne110122:0"
+
+#. Label of a Duration field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Time to Fill"
+msgstr "crwdns110124:0crwdne110124:0"
+
+#. Label of a Section Break field in DocType 'Job Requisition'
+#: hr/doctype/job_requisition/job_requisition.json
+msgctxt "Job Requisition"
+msgid "Timelines"
+msgstr "crwdns110126:0crwdne110126:0"
+
+#: hr/report/project_profitability/project_profitability.py:157
+msgid "Timesheet"
+msgstr "crwdns110128:0crwdne110128:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Timesheet"
+msgid "Timesheet"
+msgstr "crwdns110130:0crwdne110130:0"
+
+#. Label of a Section Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Timesheet Details"
+msgstr "crwdns110132:0crwdne110132:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:29
+msgid "Timing"
+msgstr "crwdns110134:0crwdne110134:0"
+
+#: hr/report/employee_advance_summary/employee_advance_summary.py:40
+msgid "Title"
+msgstr "crwdns110136:0crwdne110136:0"
+
+#. Label of a Data field in DocType 'Appointment Letter content'
+#: hr/doctype/appointment_letter_content/appointment_letter_content.json
+msgctxt "Appointment Letter content"
+msgid "Title"
+msgstr "crwdns110138:0crwdne110138:0"
+
+#. Label of a Data field in DocType 'Employee Onboarding Template'
+#: hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+msgctxt "Employee Onboarding Template"
+msgid "Title"
+msgstr "crwdns110140:0crwdne110140:0"
+
+#. Label of a Data field in DocType 'Employee Separation Template'
+#: hr/doctype/employee_separation_template/employee_separation_template.json
+msgctxt "Employee Separation Template"
+msgid "Title"
+msgstr "crwdns110142:0crwdne110142:0"
+
+#. Label of a Data field in DocType 'Job Offer Term Template'
+#: hr/doctype/job_offer_term_template/job_offer_term_template.json
+msgctxt "Job Offer Term Template"
+msgid "Title"
+msgstr "crwdns110144:0crwdne110144:0"
+
+#. Label of a Data field in DocType 'KRA'
+#: hr/doctype/kra/kra.json
+msgctxt "KRA"
+msgid "Title"
+msgstr "crwdns110146:0crwdne110146:0"
+
+#. Label of a Data field in DocType 'Leave Policy'
+#: hr/doctype/leave_policy/leave_policy.json
+msgctxt "Leave Policy"
+msgid "Title"
+msgstr "crwdns110148:0crwdne110148:0"
+
+#: payroll/report/salary_register/salary_register.js:16
+msgid "To"
+msgstr "crwdns110150:0crwdne110150:0"
+
+#. Label of a Currency field in DocType 'Taxable Salary Slab'
+#: payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgctxt "Taxable Salary Slab"
+msgid "To Amount"
+msgstr "crwdns110152:0crwdne110152:0"
+
+#: hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.js:22
+#: hr/report/employee_advance_summary/employee_advance_summary.js:23
+#: hr/report/employee_exits/employee_exits.js:15
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.js:24
+#: hr/report/employee_leave_balance/employee_leave_balance.js:15
+#: hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.js:15
+#: hr/report/shift_attendance/shift_attendance.js:15
+#: hr/report/vehicle_expenses/vehicle_expenses.js:32
+#: payroll/report/bank_remittance/bank_remittance.js:22
+msgid "To Date"
+msgstr "crwdns110154:0crwdne110154:0"
+
+#. Label of a Date field in DocType 'Additional Salary'
+#: payroll/doctype/additional_salary/additional_salary.json
+msgctxt "Additional Salary"
+msgid "To Date"
+msgstr "crwdns110156:0crwdne110156:0"
+
+#. Label of a Date field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "To Date"
+msgstr "crwdns110158:0crwdne110158:0"
+
+#. Label of a Date field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "To Date"
+msgstr "crwdns110160:0crwdne110160:0"
+
+#. Label of a Date field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "To Date"
+msgstr "crwdns110162:0crwdne110162:0"
+
+#. Label of a Date field in DocType 'Leave Control Panel'
+#: hr/doctype/leave_control_panel/leave_control_panel.json
+msgctxt "Leave Control Panel"
+msgid "To Date"
+msgstr "crwdns110164:0crwdne110164:0"
+
+#. Label of a Date field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "To Date"
+msgstr "crwdns110166:0crwdne110166:0"
+
+#. Label of a Date field in DocType 'Leave Period'
+#: hr/doctype/leave_period/leave_period.json
+msgctxt "Leave Period"
+msgid "To Date"
+msgstr "crwdns110168:0crwdne110168:0"
+
+#. Label of a Date field in DocType 'Shift Request'
+#: hr/doctype/shift_request/shift_request.json
+msgctxt "Shift Request"
+msgid "To Date"
+msgstr "crwdns110170:0crwdne110170:0"
+
+#. Label of a Date field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "To Date"
+msgstr "crwdns110172:0crwdne110172:0"
+
+#: hr/doctype/leave_application/leave_application.js:201
+msgid "To Date cannot be less than From Date"
+msgstr "crwdns110174:0crwdne110174:0"
+
+#: hr/doctype/upload_attendance/upload_attendance.py:30
+msgid "To Date should be greater than From Date"
+msgstr "crwdns110176:0crwdne110176:0"
+
+#. Label of a Time field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "To Time"
+msgstr "crwdns110178:0crwdne110178:0"
+
+#. Label of a Link field in DocType 'PWA Notification'
+#: hr/doctype/pwa_notification/pwa_notification.json
+msgctxt "PWA Notification"
+msgid "To User"
+msgstr "crwdns110180:0crwdne110180:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:59
+msgid "To allow this, enable {0} under {1}."
+msgstr "crwdns110182:0{0}crwdnd110182:0{1}crwdne110182:0"
+
+#: hr/doctype/leave_application/leave_application.js:267
+msgid "To apply for a Half Day check 'Half Day' and select the Half Day Date"
+msgstr "crwdns110184:0crwdne110184:0"
+
+#: hr/doctype/leave_period/leave_period.py:20
+msgid "To date can not be equal or less than from date"
+msgstr "crwdns110186:0crwdne110186:0"
+
+#: payroll/doctype/additional_salary/additional_salary.py:87
+msgid "To date can not be greater than employee's relieving date."
+msgstr "crwdns110188:0crwdne110188:0"
+
+#: hr/utils.py:175
+msgid "To date can not be less than from date"
+msgstr "crwdns110190:0crwdne110190:0"
+
+#: hr/utils.py:181
+msgid "To date can not greater than employee's relieving date"
+msgstr "crwdns110192:0crwdne110192:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:178
+#: hr/doctype/leave_application/leave_application.py:180
+msgid "To date cannot be before from date"
+msgstr "crwdns110194:0crwdne110194:0"
+
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.py:14
+msgid "To date needs to be before from date"
+msgstr "crwdns110196:0crwdne110196:0"
+
+#. Label of a Int field in DocType 'Gratuity Rule Slab'
+#: payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgctxt "Gratuity Rule Slab"
+msgid "To(Year)"
+msgstr "crwdns110198:0crwdne110198:0"
+
+#: payroll/doctype/gratuity_rule/gratuity_rule.js:37
+msgid "To(Year) year can not be less than From(year)"
+msgstr "crwdns110200:0crwdne110200:0"
+
+#: controllers/employee_reminders.py:122
+msgid "Today is {0}'s birthday 🎉"
+msgstr "crwdns110202:0{0}crwdne110202:0"
+
+#: controllers/employee_reminders.py:258
+msgid "Today {0} at our Company! 🎉"
+msgstr "crwdns110204:0{0}crwdne110204:0"
+
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.py:29
+#: payroll/report/provident_fund_deductions/provident_fund_deductions.py:40
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:40
+msgid "Total"
+msgstr "crwdns110206:0crwdne110206:0"
+
+#. Label of a Currency field in DocType 'Expense Taxes and Charges'
+#: hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgctxt "Expense Taxes and Charges"
+msgid "Total"
+msgstr "crwdns110208:0crwdne110208:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:108
+msgid "Total Absent"
+msgstr "crwdns110210:0crwdne110210:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Proof
+#. Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Total Actual Amount"
+msgstr "crwdns110212:0crwdne110212:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Total Advance Amount"
+msgstr "crwdns110214:0crwdne110214:0"
+
+#. Label of a Float field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Total Allocated Leave(s)"
+msgstr "crwdns110216:0crwdne110216:0"
+
+#. Label of a Currency field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Total Amount"
+msgstr "crwdns110218:0crwdne110218:0"
+
+#. Label of a Currency field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Total Amount"
+msgstr "crwdns110220:0crwdne110220:0"
+
+#. Label of a Currency field in DocType 'Travel Request Costing'
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgctxt "Travel Request Costing"
+msgid "Total Amount"
+msgstr "crwdns110222:0crwdne110222:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Total Amount Reimbursed"
+msgstr "crwdns110224:0crwdne110224:0"
+
+#: payroll/doctype/gratuity/gratuity.py:94
+msgid "Total Amount can not be zero"
+msgstr "crwdns110226:0crwdne110226:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:232
+#: hr/report/project_profitability/project_profitability.py:199
+msgid "Total Billed Hours"
+msgstr "crwdns110228:0crwdne110228:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Total Claimed Amount"
+msgstr "crwdns110230:0crwdne110230:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Total Declared Amount"
+msgstr "crwdns110232:0crwdne110232:0"
+
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:151
+#: payroll/report/salary_register/salary_register.py:230
+msgid "Total Deduction"
+msgstr "crwdns110234:0crwdne110234:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total Deduction"
+msgstr "crwdns110236:0crwdne110236:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Total Deduction"
+msgstr "crwdns110238:0crwdne110238:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total Deduction (Company Currency)"
+msgstr "crwdns110240:0crwdne110240:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:133
+msgid "Total Early Exits"
+msgstr "crwdns110242:0crwdne110242:0"
+
+#. Label of a Currency field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Total Earning"
+msgstr "crwdns110244:0crwdne110244:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total Earnings"
+msgstr "crwdns110246:0crwdne110246:0"
+
+#. Label of a Currency field in DocType 'Staffing Plan'
+#: hr/doctype/staffing_plan/staffing_plan.json
+msgctxt "Staffing Plan"
+msgid "Total Estimated Budget"
+msgstr "crwdns110248:0crwdne110248:0"
+
+#. Label of a Currency field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Total Estimated Cost"
+msgstr "crwdns110250:0crwdne110250:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Declaration'
+#: payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgctxt "Employee Tax Exemption Declaration"
+msgid "Total Exemption Amount"
+msgstr "crwdns110252:0crwdne110252:0"
+
+#. Label of a Currency field in DocType 'Employee Tax Exemption Proof
+#. Submission'
+#: payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgctxt "Employee Tax Exemption Proof Submission"
+msgid "Total Exemption Amount"
+msgstr "crwdns110254:0crwdne110254:0"
+
+#. Label of a Float field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Total Goal Score"
+msgstr "crwdns110256:0crwdne110256:0"
+
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:144
+msgid "Total Gross Pay"
+msgstr "crwdns110258:0crwdne110258:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:110
+msgid "Total Holidays"
+msgstr "crwdns110260:0crwdne110260:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:68
+msgid "Total Hours (T)"
+msgstr "crwdns110262:0crwdne110262:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total Income Tax"
+msgstr "crwdns110264:0crwdne110264:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:127
+msgid "Total Late Entries"
+msgstr "crwdns110266:0crwdne110266:0"
+
+#. Label of a Float field in DocType 'Leave Application'
+#: hr/doctype/leave_application/leave_application.json
+msgctxt "Leave Application"
+msgid "Total Leave Days"
+msgstr "crwdns110268:0crwdne110268:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:107
+msgid "Total Leaves"
+msgstr "crwdns110270:0crwdne110270:0"
+
+#. Label of a Float field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Total Leaves Allocated"
+msgstr "crwdns110272:0crwdne110272:0"
+
+#. Label of a Float field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Total Leaves Encashed"
+msgstr "crwdns110274:0crwdne110274:0"
+
+#: payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:158
+msgid "Total Net Pay"
+msgstr "crwdns110276:0crwdne110276:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:233
+msgid "Total Non-Billed Hours"
+msgstr "crwdns110278:0crwdne110278:0"
+
+#. Label of a Currency field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Total Payable Amount"
+msgstr "crwdns110280:0crwdne110280:0"
+
+#. Label of a Currency field in DocType 'Salary Slip Loan'
+#: payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgctxt "Salary Slip Loan"
+msgid "Total Payment"
+msgstr "crwdns110282:0crwdne110282:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:102
+msgid "Total Present"
+msgstr "crwdns110284:0crwdne110284:0"
+
+#. Label of a Currency field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Total Receivable Amount"
+msgstr "crwdns110286:0crwdne110286:0"
+
+#: hr/report/employee_exits/employee_exits.py:215
+msgid "Total Resignations"
+msgstr "crwdns110288:0crwdne110288:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Total Sanctioned Amount"
+msgstr "crwdns110290:0crwdne110290:0"
+
+#. Label of a Float field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "Total Score"
+msgstr "crwdns110292:0crwdne110292:0"
+
+#. Label of a Float field in DocType 'Appraisal'
+#: hr/doctype/appraisal/appraisal.json
+msgctxt "Appraisal"
+msgid "Total Self Score"
+msgstr "crwdns110294:0crwdne110294:0"
+
+#. Label of a Currency field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Total Taxes and Charges"
+msgstr "crwdns110296:0crwdne110296:0"
+
+#: hr/report/shift_attendance/shift_attendance.py:79
+msgid "Total Working Hours"
+msgstr "crwdns110298:0crwdne110298:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total Working Hours"
+msgstr "crwdns110300:0crwdne110300:0"
+
+#: hr/doctype/expense_claim/expense_claim.py:363
+msgid "Total advance amount cannot be greater than total sanctioned amount"
+msgstr "crwdns110302:0crwdne110302:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:71
+msgid "Total allocated leaves are more than maximum allocation allowed for {0} leave type for employee {1} in the period"
+msgstr "crwdns110304:0{0}crwdnd110304:0{1}crwdne110304:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:160
+msgid "Total allocated leaves {0} cannot be less than already approved leaves {1} for the period"
+msgstr "crwdns110306:0{0}crwdnd110306:0{1}crwdne110306:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:150
+msgid "Total flexible benefit component amount {0} should not be less than max benefits {1}"
+msgstr "crwdns110308:0{0}crwdnd110308:0{1}crwdne110308:0"
+
+#. Label of a Data field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total in words"
+msgstr "crwdns110310:0crwdne110310:0"
+
+#. Label of a Data field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total in words (Company Currency)"
+msgstr "crwdns110312:0crwdne110312:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:252
+msgid "Total leaves allocated is mandatory for Leave Type {0}"
+msgstr "crwdns110314:0{0}crwdne110314:0"
+
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:141
+msgid "Total percentage against cost centers should be 100"
+msgstr "crwdns110316:0crwdne110316:0"
+
+#. Description of the 'Year To Date' (Currency) field in DocType 'Salary
+#. Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Total salary booked against this component for this employee from the beginning of the year (payroll period or fiscal year) up to the current salary slip's end date."
+msgstr "crwdns110318:0crwdne110318:0"
+
+#. Description of the 'Month To Date' (Currency) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total salary booked for this employee from the beginning of the month up to the current salary slip's end date."
+msgstr "crwdns110320:0crwdne110320:0"
+
+#. Description of the 'Year To Date' (Currency) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Total salary booked for this employee from the beginning of the year (payroll period or fiscal year) up to the current salary slip's end date."
+msgstr "crwdns110322:0crwdne110322:0"
+
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.py:52
+msgid "Total weightage for all criteria must add up to 100. Currently, it is {0}%"
+msgstr "crwdns110324:0{0}crwdne110324:0"
+
+#: hr/doctype/appraisal/appraisal.py:151
+#: hr/doctype/appraisal_template/appraisal_template.py:25
+msgid "Total weightage for all {0} must add up to 100. Currently, it is {1}%"
+msgstr "crwdns110326:0{0}crwdnd110326:0{1}crwdne110326:0"
+
+#. Label of a Int field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Total working Days Per Year"
+msgstr "crwdns110328:0crwdne110328:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:162
+msgid "Total working hours should not be greater than max working hours {0}"
+msgstr "crwdns110330:0{0}crwdne110330:0"
+
+#. Label of a Section Break field in DocType 'Employee Benefit Application'
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgctxt "Employee Benefit Application"
+msgid "Totals"
+msgstr "crwdns110332:0crwdne110332:0"
+
+#. Label of a Section Break field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Totals"
+msgstr "crwdns110334:0crwdne110334:0"
+
+#. Label of a Section Break field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Totals"
+msgstr "crwdns110336:0crwdne110336:0"
+
+#. Label of a Section Break field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Totals"
+msgstr "crwdns110338:0crwdne110338:0"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Train"
+msgstr "crwdns110340:0crwdne110340:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Trainer Email"
+msgstr "crwdns110342:0crwdne110342:0"
+
+#. Label of a Data field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Trainer Email"
+msgstr "crwdns110344:0crwdne110344:0"
+
+#. Label of a Data field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Trainer Name"
+msgstr "crwdns110346:0crwdne110346:0"
+
+#. Label of a Data field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Trainer Name"
+msgstr "crwdns110348:0crwdne110348:0"
+
+#. Label of a Data field in DocType 'Training Program'
+#: hr/doctype/training_program/training_program.json
+msgctxt "Training Program"
+msgid "Trainer Name"
+msgstr "crwdns110350:0crwdne110350:0"
+
+#. Label of a Card Break in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+#: overrides/dashboard_overrides.py:44
+msgid "Training"
+msgstr "crwdns110352:0crwdne110352:0"
+
+#. Label of a Link field in DocType 'Employee Training'
+#: hr/doctype/employee_training/employee_training.json
+msgctxt "Employee Training"
+msgid "Training"
+msgstr "crwdns110354:0crwdne110354:0"
+
+#. Label of a Date field in DocType 'Employee Training'
+#: hr/doctype/employee_training/employee_training.json
+msgctxt "Employee Training"
+msgid "Training Date"
+msgstr "crwdns110356:0crwdne110356:0"
+
+#. Name of a DocType
+#: hr/doctype/training_event/training_event.json
+#: hr/doctype/training_feedback/training_feedback.py:14
+#: hr/doctype/training_result/training_result.py:16
+#: templates/emails/training_event.html:1
+msgid "Training Event"
+msgstr "crwdns110358:0crwdne110358:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Training Event"
+msgid "Training Event"
+msgstr "crwdns110360:0crwdne110360:0"
+
+#. Label of a Link field in DocType 'Training Feedback'
+#: hr/doctype/training_feedback/training_feedback.json
+msgctxt "Training Feedback"
+msgid "Training Event"
+msgstr "crwdns110362:0crwdne110362:0"
+
+#. Label of a Link field in DocType 'Training Result'
+#: hr/doctype/training_result/training_result.json
+msgctxt "Training Result"
+msgid "Training Event"
+msgstr "crwdns110364:0crwdne110364:0"
+
+#. Name of a DocType
+#: hr/doctype/training_event_employee/training_event_employee.json
+msgid "Training Event Employee"
+msgstr "crwdns110366:0crwdne110366:0"
+
+#: hr/notification/training_scheduled/training_scheduled.html:7
+msgid "Training Event:"
+msgstr "crwdns110368:0crwdne110368:0"
+
+#: hr/doctype/training_program/training_program_dashboard.py:8
+msgid "Training Events"
+msgstr "crwdns110370:0crwdne110370:0"
+
+#. Name of a DocType
+#: hr/doctype/training_event/training_event.js:16
+#: hr/doctype/training_feedback/training_feedback.json
+msgid "Training Feedback"
+msgstr "crwdns110372:0crwdne110372:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Training Feedback"
+msgid "Training Feedback"
+msgstr "crwdns110374:0crwdne110374:0"
+
+#. Name of a DocType
+#: hr/doctype/training_program/training_program.json
+msgid "Training Program"
+msgstr "crwdns110376:0crwdne110376:0"
+
+#. Label of a Link field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Training Program"
+msgstr "crwdns110378:0crwdne110378:0"
+
+#. Label of a Data field in DocType 'Training Program'
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/doctype/training_program/training_program.json
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Training Program"
+msgid "Training Program"
+msgstr "crwdns110380:0crwdne110380:0"
+
+#. Name of a DocType
+#: hr/doctype/training_event/training_event.js:10
+#: hr/doctype/training_result/training_result.json
+msgid "Training Result"
+msgstr "crwdns110382:0crwdne110382:0"
+
+#. Label of a Link in the Employee Lifecycle Workspace
+#: hr/workspace/employee_lifecycle/employee_lifecycle.json
+msgctxt "Training Result"
+msgid "Training Result"
+msgstr "crwdns110384:0crwdne110384:0"
+
+#. Name of a DocType
+#: hr/doctype/training_result_employee/training_result_employee.json
+msgid "Training Result Employee"
+msgstr "crwdns110386:0crwdne110386:0"
+
+#. Label of a Section Break field in DocType 'Employee Skill Map'
+#. Label of a Table field in DocType 'Employee Skill Map'
+#: hr/doctype/employee_skill_map/employee_skill_map.json
+msgctxt "Employee Skill Map"
+msgid "Trainings"
+msgstr "crwdns110388:0crwdne110388:0"
+
+#. Label of a Date field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Transaction Date"
+msgstr "crwdns110390:0crwdne110390:0"
+
+#. Label of a Dynamic Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Transaction Name"
+msgstr "crwdns110392:0crwdne110392:0"
+
+#. Label of a Link field in DocType 'Leave Ledger Entry'
+#: hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+msgctxt "Leave Ledger Entry"
+msgid "Transaction Type"
+msgstr "crwdns110394:0crwdne110394:0"
+
+#: hr/doctype/leave_period/leave_period_dashboard.py:7
+msgid "Transactions"
+msgstr "crwdns110396:0crwdne110396:0"
+
+#: hr/utils.py:679
+msgid "Transactions cannot be created for an Inactive Employee {0}."
+msgstr "crwdns110398:0{0}crwdne110398:0"
+
+#. Label of a Date field in DocType 'Employee Transfer'
+#: hr/doctype/employee_transfer/employee_transfer.json
+msgctxt "Employee Transfer"
+msgid "Transfer Date"
+msgstr "crwdns110400:0crwdne110400:0"
+
+#. Label of a Card Break in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json setup.py:327
+msgid "Travel"
+msgstr "crwdns110402:0crwdne110402:0"
+
+#. Label of a Check field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Travel Advance Required"
+msgstr "crwdns110404:0crwdne110404:0"
+
+#. Label of a Data field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Travel From"
+msgstr "crwdns110406:0crwdne110406:0"
+
+#. Label of a Select field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Travel Funding"
+msgstr "crwdns110408:0crwdne110408:0"
+
+#. Name of a DocType
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Travel Itinerary"
+msgstr "crwdns110410:0crwdne110410:0"
+
+#. Label of a Section Break field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Travel Itinerary"
+msgstr "crwdns110412:0crwdne110412:0"
+
+#. Name of a DocType
+#: hr/doctype/travel_request/travel_request.json
+msgid "Travel Request"
+msgstr "crwdns110414:0crwdne110414:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#. Label of a Link in the HR Workspace
+#: hr/workspace/expense_claims/expense_claims.json hr/workspace/hr/hr.json
+msgctxt "Travel Request"
+msgid "Travel Request"
+msgstr "crwdns110416:0crwdne110416:0"
+
+#. Name of a DocType
+#: hr/doctype/travel_request_costing/travel_request_costing.json
+msgid "Travel Request Costing"
+msgstr "crwdns110418:0crwdne110418:0"
+
+#. Label of a Data field in DocType 'Travel Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Travel To"
+msgstr "crwdns110420:0crwdne110420:0"
+
+#. Label of a Select field in DocType 'Travel Request'
+#: hr/doctype/travel_request/travel_request.json
+msgctxt "Travel Request"
+msgid "Travel Type"
+msgstr "crwdns110422:0crwdne110422:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:42
+msgid "Tuesday"
+msgstr "crwdns110424:0crwdne110424:0"
+
+#: payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.js:10
+msgid "Type"
+msgstr "crwdns110426:0crwdne110426:0"
+
+#. Label of a Select field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Type"
+msgstr "crwdns110428:0crwdne110428:0"
+
+#. Label of a Select field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Type"
+msgstr "crwdns110430:0crwdne110430:0"
+
+#. Label of a Select field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Type"
+msgstr "crwdns110432:0crwdne110432:0"
+
+#. Label of a Data field in DocType 'Employee Tax Exemption Proof Submission
+#. Detail'
+#: payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgctxt "Employee Tax Exemption Proof Submission Detail"
+msgid "Type of Proof"
+msgstr "crwdns110434:0crwdne110434:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:116
+msgid "Unable to find Salary Component {0}"
+msgstr "crwdns110436:0{0}crwdne110436:0"
+
+#: hr/doctype/goal/goal.js:54
+msgid "Unarchive"
+msgstr "crwdns110438:0crwdne110438:0"
+
+#. Label of a Currency field in DocType 'Expense Claim Advance'
+#: hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgctxt "Expense Claim Advance"
+msgid "Unclaimed Amount"
+msgstr "crwdns110440:0crwdne110440:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#: hr/doctype/interview/interview.json
+msgctxt "Interview"
+msgid "Under Review"
+msgstr "crwdns110442:0crwdne110442:0"
+
+#: hr/doctype/attendance/attendance.py:218
+msgid "Unlinked Attendance record from Employee Checkins: {}"
+msgstr "crwdns110444:0crwdne110444:0"
+
+#: hr/doctype/attendance/attendance.py:221
+msgid "Unlinked logs"
+msgstr "crwdns110446:0crwdne110446:0"
+
+#. Description of the 'Select Employees' (Section Break) field in DocType
+#. 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Unmarked Attendance"
+msgstr "crwdns110448:0crwdne110448:0"
+
+#: hr/doctype/attendance/attendance_list.js:84
+msgid "Unmarked Attendance for days"
+msgstr "crwdns110450:0crwdne110450:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:116
+msgid "Unmarked Days"
+msgstr "crwdns110452:0crwdne110452:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Unmarked days"
+msgstr "crwdns110454:0crwdne110454:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: hr/doctype/employee_advance/employee_advance.json
+msgctxt "Employee Advance"
+msgid "Unpaid"
+msgstr "crwdns110456:0crwdne110456:0"
+
+#. Option for the 'Referral Bonus Payment Status' (Select) field in DocType
+#. 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Unpaid"
+msgstr "crwdns110458:0crwdne110458:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Unpaid"
+msgstr "crwdns110460:0crwdne110460:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final Statement'
+#: hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgctxt "Full and Final Statement"
+msgid "Unpaid"
+msgstr "crwdns110462:0crwdne110462:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Gratuity'
+#: payroll/doctype/gratuity/gratuity.json
+msgctxt "Gratuity"
+msgid "Unpaid"
+msgstr "crwdns110464:0crwdne110464:0"
+
+#. Name of a report
+#. Label of a Link in the Expense Claims Workspace
+#: hr/report/unpaid_expense_claim/unpaid_expense_claim.json
+#: hr/workspace/expense_claims/expense_claims.json
+msgid "Unpaid Expense Claim"
+msgstr "crwdns110466:0crwdne110466:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final
+#. Outstanding Statement'
+#: hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgctxt "Full and Final Outstanding Statement"
+msgid "Unsettled"
+msgstr "crwdns110468:0crwdne110468:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:158
+msgid "Unsubmitted Appraisals"
+msgstr "crwdns110470:0crwdne110470:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:256
+msgid "Untracked Hours"
+msgstr "crwdns110472:0crwdne110472:0"
+
+#: hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:82
+msgid "Untracked Hours (U)"
+msgstr "crwdns110474:0crwdne110474:0"
+
+#. Label of a Float field in DocType 'Leave Allocation'
+#: hr/doctype/leave_allocation/leave_allocation.json
+msgctxt "Leave Allocation"
+msgid "Unused leaves"
+msgstr "crwdns110476:0crwdne110476:0"
+
+#: controllers/employee_reminders.py:69
+msgid "Upcoming Holidays Reminder"
+msgstr "crwdns110478:0crwdne110478:0"
+
+#: hr/doctype/goal/goal_tree.js:256
+msgid "Update"
+msgstr "crwdns110480:0crwdne110480:0"
+
+#: hr/doctype/interview/interview.py:73
+msgid "Update Job Applicant"
+msgstr "crwdns110482:0crwdne110482:0"
+
+#: hr/doctype/goal/goal_tree.js:237 hr/doctype/goal/goal_tree.js:243
+msgid "Update Progress"
+msgstr "crwdns110484:0crwdne110484:0"
+
+#: templates/emails/training_event.html:11
+msgid "Update Response"
+msgstr "crwdns110486:0crwdne110486:0"
+
+#: hr/doctype/goal/goal_list.js:36
+msgid "Update Status"
+msgstr "crwdns110488:0crwdne110488:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:99
+msgid "Updated status from {0} to {1} for date {2} in the attendance record {3}"
+msgstr "crwdns110490:0{0}crwdnd110490:0{1}crwdnd110490:0{2}crwdnd110490:0{3}crwdne110490:0"
+
+#: hr/doctype/interview/interview.py:205
+msgid "Updated the Job Applicant status to {0}"
+msgstr "crwdns110492:0{0}crwdne110492:0"
+
+#: overrides/employee_master.py:77
+msgid "Updated the status of Job Offer {0} for the linked Job Applicant {1} to {2}"
+msgstr "crwdns110494:0{0}crwdnd110494:0{1}crwdnd110494:0{2}crwdne110494:0"
+
+#: overrides/employee_master.py:63
+msgid "Updated the status of linked Job Applicant {0} to {1}"
+msgstr "crwdns110496:0{0}crwdnd110496:0{1}crwdne110496:0"
+
+#. Name of a DocType
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgid "Upload Attendance"
+msgstr "crwdns110498:0crwdne110498:0"
+
+#. Label of a Link in the Shift & Attendance Workspace
+#: hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgctxt "Upload Attendance"
+msgid "Upload Attendance"
+msgstr "crwdns110500:0crwdne110500:0"
+
+#. Label of a HTML field in DocType 'Upload Attendance'
+#: hr/doctype/upload_attendance/upload_attendance.json
+msgctxt "Upload Attendance"
+msgid "Upload HTML"
+msgstr "crwdns110502:0crwdne110502:0"
+
+#: public/frontend/assets/InsertVideo-f4f3d0f2.js:2
+msgid "Uploading ${h}%"
+msgstr "crwdns110504:0${h}crwdne110504:0"
+
+#. Label of a Currency field in DocType 'Job Applicant'
+#: hr/doctype/job_applicant/job_applicant.json
+msgctxt "Job Applicant"
+msgid "Upper Range"
+msgstr "crwdns110506:0crwdne110506:0"
+
+#. Label of a Currency field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Upper Range"
+msgstr "crwdns110508:0crwdne110508:0"
+
+#. Label of a Float field in DocType 'Salary Slip Leave'
+#: payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgctxt "Salary Slip Leave"
+msgid "Used Leave(s)"
+msgstr "crwdns110510:0crwdne110510:0"
+
+#: hr/report/daily_work_summary_replies/daily_work_summary_replies.py:20
+msgid "User"
+msgstr "crwdns110512:0crwdne110512:0"
+
+#. Label of a Link field in DocType 'Daily Work Summary Group User'
+#: hr/doctype/daily_work_summary_group_user/daily_work_summary_group_user.json
+msgctxt "Daily Work Summary Group User"
+msgid "User"
+msgstr "crwdns110514:0crwdne110514:0"
+
+#. Label of a Link field in DocType 'Employee Boarding Activity'
+#: hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgctxt "Employee Boarding Activity"
+msgid "User"
+msgstr "crwdns110516:0crwdne110516:0"
+
+#. Label of a Link field in DocType 'Employee Performance Feedback'
+#: hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgctxt "Employee Performance Feedback"
+msgid "User"
+msgstr "crwdns110518:0crwdne110518:0"
+
+#. Label of a Data field in DocType 'Goal'
+#: hr/doctype/goal/goal.json
+msgctxt "Goal"
+msgid "User"
+msgstr "crwdns110520:0crwdne110520:0"
+
+#. Label of a Link field in DocType 'Interviewer'
+#: hr/doctype/interviewer/interviewer.json
+msgctxt "Interviewer"
+msgid "User"
+msgstr "crwdns110522:0crwdne110522:0"
+
+#. Label of a Table field in DocType 'Daily Work Summary Group'
+#: hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgctxt "Daily Work Summary Group"
+msgid "Users"
+msgstr "crwdns110524:0crwdne110524:0"
+
+#: hr/report/project_profitability/project_profitability.py:190
+msgid "Utilization"
+msgstr "crwdns110526:0crwdne110526:0"
+
+#. Label of a Int field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Vacancies"
+msgstr "crwdns110528:0crwdne110528:0"
+
+#. Label of a Int field in DocType 'Staffing Plan Detail'
+#: hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgctxt "Staffing Plan Detail"
+msgid "Vacancies"
+msgstr "crwdns110530:0crwdne110530:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.js:82
+msgid "Vacancies cannot be lower than the current openings"
+msgstr "crwdns110532:0crwdne110532:0"
+
+#: hr/doctype/job_opening/job_opening.py:92
+msgid "Vacancies fulfilled"
+msgstr "crwdns110534:0crwdne110534:0"
+
+#. Label of a Check field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Validate Attendance"
+msgstr "crwdns110536:0crwdne110536:0"
+
+#: payroll/doctype/payroll_entry/payroll_entry.js:362
+msgid "Validating Employee Attendance..."
+msgstr "crwdns110538:0crwdne110538:0"
+
+#. Label of a Small Text field in DocType 'Job Offer Term'
+#: hr/doctype/job_offer_term/job_offer_term.json
+msgctxt "Job Offer Term"
+msgid "Value / Description"
+msgstr "crwdns110540:0crwdne110540:0"
+
+#: hr/employee_property_update.js:166
+msgid "Value missing"
+msgstr "crwdns110542:0crwdne110542:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:153
+msgid "Variable"
+msgstr "crwdns110544:0crwdne110544:0"
+
+#. Label of a Currency field in DocType 'Salary Structure Assignment'
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgctxt "Salary Structure Assignment"
+msgid "Variable"
+msgstr "crwdns110546:0crwdne110546:0"
+
+#. Label of a Check field in DocType 'Salary Component'
+#: payroll/doctype/salary_component/salary_component.json
+msgctxt "Salary Component"
+msgid "Variable Based On Taxable Salary"
+msgstr "crwdns110548:0crwdne110548:0"
+
+#. Label of a Check field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Variable Based On Taxable Salary"
+msgstr "crwdns110550:0crwdne110550:0"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hr/doctype/travel_itinerary/travel_itinerary.json
+msgctxt "Travel Itinerary"
+msgid "Vegetarian"
+msgstr "crwdns110552:0crwdne110552:0"
+
+#: hr/report/vehicle_expenses/vehicle_expenses.js:40
+#: hr/report/vehicle_expenses/vehicle_expenses.py:27
+msgid "Vehicle"
+msgstr "crwdns110554:0crwdne110554:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Vehicle"
+msgid "Vehicle"
+msgstr "crwdns110556:0crwdne110556:0"
+
+#. Name of a report
+#. Label of a Link in the Expense Claims Workspace
+#: hr/doctype/vehicle_log/vehicle_log.py:51
+#: hr/report/vehicle_expenses/vehicle_expenses.json
+#: hr/workspace/expense_claims/expense_claims.json
+msgid "Vehicle Expenses"
+msgstr "crwdns110558:0crwdne110558:0"
+
+#. Name of a DocType
+#: hr/doctype/vehicle_log/vehicle_log.json
+#: hr/report/vehicle_expenses/vehicle_expenses.py:37
+msgid "Vehicle Log"
+msgstr "crwdns110560:0crwdne110560:0"
+
+#. Label of a Link field in DocType 'Expense Claim'
+#: hr/doctype/expense_claim/expense_claim.json
+msgctxt "Expense Claim"
+msgid "Vehicle Log"
+msgstr "crwdns110562:0crwdne110562:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Vehicle Log"
+msgid "Vehicle Log"
+msgstr "crwdns110564:0crwdne110564:0"
+
+#. Name of a DocType
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgid "Vehicle Service"
+msgstr "crwdns110566:0crwdne110566:0"
+
+#. Name of a DocType
+#: hr/doctype/vehicle_service_item/vehicle_service_item.json
+msgid "Vehicle Service Item"
+msgstr "crwdns110568:0crwdne110568:0"
+
+#. Label of a Link in the Expense Claims Workspace
+#: hr/workspace/expense_claims/expense_claims.json
+msgctxt "Vehicle Service Item"
+msgid "Vehicle Service Item"
+msgstr "crwdns110570:0crwdne110570:0"
+
+#: hr/doctype/employee_onboarding/employee_onboarding.js:28
+#: hr/doctype/employee_onboarding/employee_onboarding.js:33
+#: hr/doctype/employee_onboarding/employee_onboarding.js:36
+#: hr/doctype/employee_separation/employee_separation.js:16
+#: hr/doctype/employee_separation/employee_separation.js:21
+#: hr/doctype/employee_separation/employee_separation.js:24
+#: hr/doctype/expense_claim/expense_claim.js:96
+#: hr/doctype/expense_claim/expense_claim.js:226
+#: hr/doctype/job_applicant/job_applicant.js:35
+msgid "View"
+msgstr "crwdns110572:0crwdne110572:0"
+
+#: hr/doctype/appraisal/appraisal.js:48
+#: hr/doctype/appraisal_cycle/appraisal_cycle.js:21
+msgid "View Goals"
+msgstr "crwdns110574:0crwdne110574:0"
+
+#: patches/v15_0/notify_about_loan_app_separation.py:16
+msgid "WARNING: Loan Management module has been separated from ERPNext."
+msgstr "crwdns110576:0crwdne110576:0"
+
+#: setup.py:390
+msgid "Walk In"
+msgstr "crwdns110578:0crwdne110578:0"
+
+#: hr/doctype/leave_application/leave_application.py:407
+#: payroll/doctype/salary_structure/salary_structure.js:321
+#: payroll/doctype/salary_structure/salary_structure.py:37
+#: payroll/doctype/salary_structure/salary_structure.py:119
+#: payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:44
+msgid "Warning"
+msgstr "crwdns110580:0crwdne110580:0"
+
+#: hr/doctype/leave_application/leave_application.py:395
+msgid "Warning: Insufficient leave balance for Leave Type {0} in this allocation."
+msgstr "crwdns110582:0{0}crwdne110582:0"
+
+#: hr/doctype/leave_application/leave_application.py:403
+msgid "Warning: Insufficient leave balance for Leave Type {0}."
+msgstr "crwdns110584:0{0}crwdne110584:0"
+
+#: hr/doctype/leave_application/leave_application.py:348
+msgid "Warning: Leave application contains following block dates"
+msgstr "crwdns110586:0crwdne110586:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:47
+msgid "Warning: {0} already has an active Shift Assignment {1} for some/all of these dates."
+msgstr "crwdns110588:0{0}crwdnd110588:0{1}crwdne110588:0"
+
+#: setup.py:389
+msgid "Website Listing"
+msgstr "crwdns110590:0crwdne110590:0"
+
+#: hr/doctype/leave_block_list/leave_block_list.js:47
+msgid "Wednesday"
+msgstr "crwdns110592:0crwdne110592:0"
+
+#. Option for the 'Set the frequency for holiday reminders' (Select) field in
+#. DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Weekly"
+msgstr "crwdns110594:0crwdne110594:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll Entry'
+#: payroll/doctype/payroll_entry/payroll_entry.json
+msgctxt "Payroll Entry"
+msgid "Weekly"
+msgstr "crwdns110596:0crwdne110596:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Weekly"
+msgstr "crwdns110598:0crwdne110598:0"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Weekly"
+msgstr "crwdns110600:0crwdne110600:0"
+
+#. Label of a Float field in DocType 'Appraisal Goal'
+#: hr/doctype/appraisal_goal/appraisal_goal.json
+msgctxt "Appraisal Goal"
+msgid "Weightage (%)"
+msgstr "crwdns110602:0crwdne110602:0"
+
+#. Label of a Percent field in DocType 'Appraisal KRA'
+#: hr/doctype/appraisal_kra/appraisal_kra.json
+msgctxt "Appraisal KRA"
+msgid "Weightage (%)"
+msgstr "crwdns110604:0crwdne110604:0"
+
+#. Label of a Percent field in DocType 'Appraisal Template Goal'
+#: hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgctxt "Appraisal Template Goal"
+msgid "Weightage (%)"
+msgstr "crwdns110606:0crwdne110606:0"
+
+#. Label of a Percent field in DocType 'Employee Feedback Rating'
+#: hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgctxt "Employee Feedback Rating"
+msgid "Weightage (%)"
+msgstr "crwdns110608:0crwdne110608:0"
+
+#: hr/doctype/leave_type/leave_type.py:35
+msgid "Whereas allocation for Compensatory Leaves is automatically created or updated on submission of Compensatory Leave Request."
+msgstr "crwdns110610:0crwdne110610:0"
+
+#. Label of a Text Editor field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Why is this Candidate Qualified for this Position?"
+msgstr "crwdns110612:0crwdne110612:0"
+
+#. Label of a Check field in DocType 'HR Settings'
+#: hr/doctype/hr_settings/hr_settings.json
+msgctxt "HR Settings"
+msgid "Work Anniversaries "
+msgstr "crwdns110614:0crwdne110614:0"
+
+#: controllers/employee_reminders.py:279 controllers/employee_reminders.py:286
+msgid "Work Anniversary Reminder"
+msgstr "crwdns110616:0crwdne110616:0"
+
+#. Label of a Date field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Work End Date"
+msgstr "crwdns110618:0crwdne110618:0"
+
+#. Label of a Select field in DocType 'Gratuity Rule'
+#: payroll/doctype/gratuity_rule/gratuity_rule.json
+msgctxt "Gratuity Rule"
+msgid "Work Experience Calculation method"
+msgstr "crwdns110620:0crwdne110620:0"
+
+#. Label of a Date field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Work From Date"
+msgstr "crwdns110622:0crwdne110622:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Work From Home"
+msgstr "crwdns110624:0crwdne110624:0"
+
+#. Option for the 'Reason' (Select) field in DocType 'Attendance Request'
+#: hr/doctype/attendance_request/attendance_request.json
+msgctxt "Attendance Request"
+msgid "Work From Home"
+msgstr "crwdns110626:0crwdne110626:0"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance Tool'
+#: hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgctxt "Employee Attendance Tool"
+msgid "Work From Home"
+msgstr "crwdns110628:0crwdne110628:0"
+
+#. Label of a Text Editor field in DocType 'Employee Referral'
+#: hr/doctype/employee_referral/employee_referral.json
+msgctxt "Employee Referral"
+msgid "Work References"
+msgstr "crwdns110630:0crwdne110630:0"
+
+#: hr/doctype/daily_work_summary/daily_work_summary.py:100
+msgid "Work Summary for {0}"
+msgstr "crwdns110632:0{0}crwdne110632:0"
+
+#. Label of a Section Break field in DocType 'Compensatory Leave Request'
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgctxt "Compensatory Leave Request"
+msgid "Worked On Holiday"
+msgstr "crwdns110634:0crwdne110634:0"
+
+#. Label of a Float field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Working Days"
+msgstr "crwdns110636:0crwdne110636:0"
+
+#. Label of a Section Break field in DocType 'Payroll Settings'
+#: payroll/doctype/payroll_settings/payroll_settings.json
+msgctxt "Payroll Settings"
+msgid "Working Days and Hours"
+msgstr "crwdns110638:0crwdne110638:0"
+
+#: setup.py:398
+msgid "Working Hours"
+msgstr "crwdns110640:0crwdne110640:0"
+
+#. Label of a Float field in DocType 'Attendance'
+#: hr/doctype/attendance/attendance.json
+msgctxt "Attendance"
+msgid "Working Hours"
+msgstr "crwdns110642:0crwdne110642:0"
+
+#. Label of a Float field in DocType 'Salary Slip Timesheet'
+#: payroll/doctype/salary_slip_timesheet/salary_slip_timesheet.json
+msgctxt "Salary Slip Timesheet"
+msgid "Working Hours"
+msgstr "crwdns110644:0crwdne110644:0"
+
+#. Label of a Select field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Working Hours Calculation Based On"
+msgstr "crwdns110646:0crwdne110646:0"
+
+#. Label of a Float field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Working Hours Threshold for Absent"
+msgstr "crwdns110648:0crwdne110648:0"
+
+#. Label of a Float field in DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Working Hours Threshold for Half Day"
+msgstr "crwdns110650:0crwdne110650:0"
+
+#. Description of the 'Working Hours Threshold for Absent' (Float) field in
+#. DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Working hours below which Absent is marked. (Zero to disable)"
+msgstr "crwdns110652:0crwdne110652:0"
+
+#. Description of the 'Working Hours Threshold for Half Day' (Float) field in
+#. DocType 'Shift Type'
+#: hr/doctype/shift_type/shift_type.json
+msgctxt "Shift Type"
+msgid "Working hours below which Half Day is marked. (Zero to disable)"
+msgstr "crwdns110654:0crwdne110654:0"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hr/doctype/training_event/training_event.json
+msgctxt "Training Event"
+msgid "Workshop"
+msgstr "crwdns110656:0crwdne110656:0"
+
+#: hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:30
+#: public/js/salary_slip_deductions_report_filters.js:36
+msgid "Year"
+msgstr "crwdns110658:0crwdne110658:0"
+
+#. Option for the 'Salary Paid Per' (Select) field in DocType 'Job Opening'
+#: hr/doctype/job_opening/job_opening.json
+msgctxt "Job Opening"
+msgid "Year"
+msgstr "crwdns110660:0crwdne110660:0"
+
+#. Label of a Currency field in DocType 'Salary Detail'
+#: payroll/doctype/salary_detail/salary_detail.json
+msgctxt "Salary Detail"
+msgid "Year To Date"
+msgstr "crwdns110662:0crwdne110662:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Year To Date"
+msgstr "crwdns110664:0crwdne110664:0"
+
+#. Label of a Currency field in DocType 'Salary Slip'
+#: payroll/doctype/salary_slip/salary_slip.json
+msgctxt "Salary Slip"
+msgid "Year To Date(Company Currency)"
+msgstr "crwdns110666:0crwdne110666:0"
+
+#. Option for the 'Earned Leave Frequency' (Select) field in DocType 'Leave
+#. Type'
+#: hr/doctype/leave_type/leave_type.json
+msgctxt "Leave Type"
+msgid "Yearly"
+msgstr "crwdns110668:0crwdne110668:0"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hr/doctype/vehicle_service/vehicle_service.json
+msgctxt "Vehicle Service"
+msgid "Yearly"
+msgstr "crwdns110670:0crwdne110670:0"
+
+#. Option for the 'Is Active' (Select) field in DocType 'Salary Structure'
+#. Option for the 'Is Default' (Select) field in DocType 'Salary Structure'
+#: payroll/doctype/salary_structure/salary_structure.json
+msgctxt "Salary Structure"
+msgid "Yes"
+msgstr "crwdns110672:0crwdne110672:0"
+
+#: hr/doctype/hr_settings/hr_settings.py:84
+msgid "Yes, Proceed"
+msgstr "crwdns110674:0crwdne110674:0"
+
+#: hr/doctype/leave_application/leave_application.py:358
+msgid "You are not authorized to approve leaves on Block Dates"
+msgstr "crwdns110676:0crwdne110676:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:59
+msgid "You are not present all day(s) between compensatory leave request days"
+msgstr "crwdns110678:0crwdne110678:0"
+
+#: payroll/doctype/employee_benefit_application/employee_benefit_application.py:100
+msgid "You can claim only an amount of {0}, the rest amount {1} should be in the application as pro-rata component"
+msgstr "crwdns110680:0{0}crwdnd110680:0{1}crwdne110680:0"
+
+#: payroll/doctype/gratuity_rule/gratuity_rule.py:22
+msgid "You can not define multiple slabs if you have a slab with no lower and upper limits."
+msgstr "crwdns110682:0crwdne110682:0"
+
+#: hr/doctype/shift_request/shift_request.py:65
+msgid "You can not request for your Default Shift: {0}"
+msgstr "crwdns110684:0{0}crwdne110684:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:93
+msgid "You can only plan for upto {0} vacancies and budget {1} for {2} as per staffing plan {3} for parent company {4}."
+msgstr "crwdns110686:0{0}crwdnd110686:0{1}crwdnd110686:0{2}crwdnd110686:0{3}crwdnd110686:0{4}crwdne110686:0"
+
+#: hr/doctype/leave_encashment/leave_encashment.py:37
+msgid "You can only submit Leave Encashment for a valid encashment amount"
+msgstr "crwdns110688:0crwdne110688:0"
+
+#: api/__init__.py:546
+msgid "You can only upload JPG, PNG, PDF, TXT or Microsoft documents."
+msgstr "crwdns110690:0crwdne110690:0"
+
+#: overrides/employee_master.py:83
+msgid "You may add additional details, if any, and submit the offer."
+msgstr "crwdns110692:0crwdne110692:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:53
+msgid "You were only present for Half Day on {}. Cannot apply for a full day compensatory leave"
+msgstr "crwdns110694:0crwdne110694:0"
+
+#: hr/doctype/interview/interview.py:106
+msgid "Your Interview session is rescheduled from {0} {1} - {2} to {3} {4} - {5}"
+msgstr "crwdns110696:0{0}crwdnd110696:0{1}crwdnd110696:0{2}crwdnd110696:0{3}crwdnd110696:0{4}crwdnd110696:0{5}crwdne110696:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:100
+msgid "active"
+msgstr "crwdns110698:0crwdne110698:0"
+
+#: hr/doctype/attendance_request/attendance_request.py:93
+msgid "changed the status from {0} to {1} via Attendance Request"
+msgstr "crwdns110700:0{0}crwdnd110700:0{1}crwdne110700:0"
+
+#: public/frontend/assets/InsertVideo-f4f3d0f2.js:2
+#: public/frontend/assets/ListView-188fd0bd.js:1
+#: public/frontend/assets/SalarySlipItem-6f5f5571.js:1
+msgid "div"
+msgstr "crwdns110702:0crwdne110702:0"
+
+#. Label of a Read Only field in DocType 'Daily Work Summary Group User'
+#: hr/doctype/daily_work_summary_group_user/daily_work_summary_group_user.json
+msgctxt "Daily Work Summary Group User"
+msgid "email"
+msgstr "crwdns110704:0crwdne110704:0"
+
+#: hr/doctype/department_approver/department_approver.py:90
+msgid "or for Department: {0}"
+msgstr "crwdns110706:0{0}crwdne110706:0"
+
+#: www/jobs/index.html:104
+msgid "result"
+msgstr "crwdns110708:0crwdne110708:0"
+
+#: www/jobs/index.html:104
+msgid "results"
+msgstr "crwdns110710:0crwdne110710:0"
+
+#: hr/doctype/leave_type/leave_type.js:26
+msgid "to know more"
+msgstr "crwdns110712:0crwdne110712:0"
+
+#: public/frontend/assets/InsertVideo-f4f3d0f2.js:2
+msgid "video"
+msgstr "crwdns110714:0crwdne110714:0"
+
+#: controllers/employee_reminders.py:120 controllers/employee_reminders.py:253
+#: controllers/employee_reminders.py:257
+msgid "{0} & {1}"
+msgstr "crwdns110716:0{0}crwdnd110716:0{1}crwdne110716:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:2111
+msgid "{0} <br> This error can be due to missing or deleted field."
+msgstr "crwdns110718:0{0}crwdne110718:0"
+
+#: hr/doctype/appraisal_cycle/appraisal_cycle.py:155
+msgid "{0} Appraisal(s) are not submitted yet"
+msgstr "crwdns110720:0{0}crwdne110720:0"
+
+#: hr/doctype/department_approver/department_approver.py:91
+msgid "{0} Missing"
+msgstr "crwdns110722:0{0}crwdne110722:0"
+
+#: payroll/doctype/salary_structure/salary_structure.py:31
+msgid "{0} Row #{1}: Formula is set but {2} is disabled for the Salary Component {3}."
+msgstr "crwdns110724:0{0}crwdnd110724:0#{1}crwdnd110724:0{2}crwdnd110724:0{3}crwdne110724:0"
+
+#: payroll/doctype/salary_structure/salary_structure.js:320
+msgid "{0} Row #{1}: {2} needs to be enabled for the formula to be considered."
+msgstr "crwdns110726:0{0}crwdnd110726:0#{1}crwdnd110726:0{2}crwdne110726:0"
+
+#: hr/doctype/leave_allocation/leave_allocation.py:201
+msgid "{0} already allocated for Employee {1} for period {2} to {3}"
+msgstr "crwdns110728:0{0}crwdnd110728:0{1}crwdnd110728:0{2}crwdnd110728:0{3}crwdne110728:0"
+
+#: hr/utils.py:251
+msgid "{0} already exists for employee {1} and period {2}"
+msgstr "crwdns110730:0{0}crwdnd110730:0{1}crwdnd110730:0{2}crwdne110730:0"
+
+#: hr/doctype/shift_assignment/shift_assignment.py:54
+msgid "{0} already has an active Shift Assignment {1} for some/all of these dates."
+msgstr "crwdns110732:0{0}crwdnd110732:0{1}crwdne110732:0"
+
+#: hr/doctype/leave_application/leave_application.py:151
+msgid "{0} applicable after {1} working days"
+msgstr "crwdns110734:0{0}crwdnd110734:0{1}crwdne110734:0"
+
+#: overrides/company.py:122
+msgid "{0} currency must be same as company's default currency. Please select another account."
+msgstr "crwdns110736:0{0}crwdne110736:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:140
+msgid "{0} due to missing email information for employee(s): {1}"
+msgstr "crwdns110738:0{0}crwdnd110738:0{1}crwdne110738:0"
+
+#: hr/report/employee_analytics/employee_analytics.py:14
+msgid "{0} is mandatory"
+msgstr "crwdns110740:0{0}crwdne110740:0"
+
+#: hr/doctype/compensatory_leave_request/compensatory_leave_request.py:69
+msgid "{0} is not a holiday."
+msgstr "crwdns110742:0{0}crwdne110742:0"
+
+#: hr/doctype/interview_feedback/interview_feedback.py:29
+msgid "{0} is not allowed to submit Interview Feedback for the Interview: {1}"
+msgstr "crwdns110744:0{0}crwdnd110744:0{1}crwdne110744:0"
+
+#: hr/doctype/leave_application/leave_application.py:566
+msgid "{0} is not in Optional Holiday List"
+msgstr "crwdns110746:0{0}crwdne110746:0"
+
+#: payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:31
+msgid "{0} is not in a valid Payroll Period"
+msgstr "crwdns110748:0{0}crwdne110748:0"
+
+#: hr/doctype/leave_control_panel/leave_control_panel.py:31
+msgid "{0} is required"
+msgstr "crwdns110750:0{0}crwdne110750:0"
+
+#: hr/doctype/training_feedback/training_feedback.py:14
+#: hr/doctype/training_result/training_result.py:16
+msgid "{0} must be submitted"
+msgstr "crwdns110752:0{0}crwdne110752:0"
+
+#: hr/doctype/goal/goal.py:194
+msgid "{0} of {1} Completed"
+msgstr "crwdns110754:0{0}crwdnd110754:0{1}crwdne110754:0"
+
+#: hr/doctype/interview_feedback/interview_feedback.py:39
+msgid "{0} submission before {1} is not allowed"
+msgstr "crwdns110756:0{0}crwdnd110756:0{1}crwdne110756:0"
+
+#: hr/doctype/staffing_plan/staffing_plan.py:129
+msgid "{0} vacancies and {1} budget for {2} already planned for subsidiary companies of {3}. You can only plan for upto {4} vacancies and and budget {5} as per staffing plan {6} for parent company {3}."
+msgstr "crwdns110758:0{0}crwdnd110758:0{1}crwdnd110758:0{2}crwdnd110758:0{3}crwdnd110758:0{4}crwdnd110758:0{5}crwdnd110758:0{6}crwdnd110758:0{3}crwdne110758:0"
+
+#: hr/doctype/goal/goal_list.js:73
+msgid "{0} {1} {2}?"
+msgstr "crwdns110760:0{0}crwdnd110760:0{1}crwdnd110760:0{2}crwdne110760:0"
+
+#: payroll/doctype/salary_slip/salary_slip.py:1823
+msgid "{0}: Employee email not found, hence email not sent"
+msgstr "crwdns110762:0{0}crwdne110762:0"
+
+#: hr/doctype/leave_application/leave_application.py:69
+msgid "{0}: From {0} of type {1}"
+msgstr "crwdns110764:0{0}crwdnd110764:0{0}crwdnd110764:0{1}crwdne110764:0"
+
+#: hr/doctype/exit_interview/exit_interview.py:136
+msgid "{0}: {1}"
+msgstr "crwdns110766:0{0}crwdnd110766:0{1}crwdne110766:0"
+
+#: public/frontend/assets/index-4bb445d5.js:131
+msgid "{|}~.]+@[-a-z0-9]+(.[-a-z0-9]+)*.[a-z]+)(?=$|s)/gmi,w=/<()(?:mailto:)?([-.w]+@[-a-z0-9]+(.[-a-z0-9]+)*.[a-z]+)>/gi,k=function(f){return function(g,m,y,x,_,S,E){y=y.replace(r.helper.regexes.asteriskDashAndColon,r.helper.escapeCharactersCallback);var P=y,$=\"\",L=\"\",I=m||\"\",A=E||\"\";return/^www./i.test(y)&&(y=y.replace(/^www./i,\"http://www.\")),f.excludeTrailingPunctuationFromURLs&&S&&($=S),f.openLinksInNewWindow&&(L=' rel=\"noopener noreferrer\" target=\"¨E95Eblank\"'),I+'<a href=\"'+y+'\"'+L+\">\"+P+\"</a>\"+$+A}},C=function(f,g){return function(m,y,x){var _=\"mailto:\";return y=y||\"\",x=r.subParser(\"unescapeSpecialChars\")(x,f,g),f.encodeEmails?(_=r.helper.encodeEmailAddress(_+x),x=r.helper.encodeEmailAddress(x)):_=_+x,y+'<a href=\"'+_+'\">'+x+\"</a>\"}};r.subParser(\"autoLinks\",function(f,g,m){return f=m.converter._dispatch(\"autoLinks.before\",f,g,m),f=f.replace(v,k(g)),f=f.replace(w,C(g,m)),f=m.converter._dispatch(\"autoLinks.after\",f,g,m),f}),r.subParser(\"simplifiedAutoLinks\",function(f,g,m){return g.simplifiedAutoLink&&(f=m.converter._dispatch(\"simplifiedAutoLinks.before\",f,g,m),g.excludeTrailingPunctuationFromURLs?f=f.replace(p,k(g)):f=f.replace(h,k(g)),f=f.replace(b,C(g,m)),f=m.converter._dispatch(\"simplifiedAutoLinks.after\",f,g,m)),f}),r.subParser(\"blockGamut\",function(f,g,m){return f=m.converter._dispatch(\"blockGamut.before\",f,g,m),f=r.subParser(\"blockQuotes\")(f,g,m),f=r.subParser(\"headers\")(f,g,m),f=r.subParser(\"horizontalRule\")(f,g,m),f=r.subParser(\"lists\")(f,g,m),f=r.subParser(\"codeBlocks\")(f,g,m),f=r.subParser(\"tables\")(f,g,m),f=r.subParser(\"hashHTMLBlocks\")(f,g,m),f=r.subParser(\"paragraphs\")(f,g,m),f=m.converter._dispatch(\"blockGamut.after\",f,g,m),f}),r.subParser(\"blockQuotes\",function(f,g,m){f=m.converter._dispatch(\"blockQuotes.before\",f,g,m),f=f+"
+msgstr "crwdns110768:0{|}crwdnd110768:0:mailto:crwdne110768:0"
+
+#: hr/doctype/employee_checkin/employee_checkin.py:171
+msgid "{} is an invalid Attendance Status."
+msgstr "crwdns110770:0crwdne110770:0"
+
+#: hr/doctype/job_requisition/job_requisition.js:15
+msgid "{} {} open for this position."
+msgstr "crwdns110772:0crwdne110772:0"
+


### PR DESCRIPTION
Allows translation of HRMS strings directly in the UI.
See https://github.com/frappe/frappe/pull/25677