### PR TITLE
feat: show holidays and colour code in attendance calendar

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -207,7 +207,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:36.160893",
+ "modified": "2024-04-05 20:55:02.905452",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",
@@ -254,6 +254,16 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "select": 1,
+   "share": 1
   }
  ],
  "search_fields": "employee,employee_name,attendance_date,status",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -17,7 +17,11 @@ from frappe.utils import (
 )
 
 from hrms.hr.doctype.shift_assignment.shift_assignment import has_overlapping_timings
-from hrms.hr.utils import get_holiday_dates_for_employee, validate_active_employee
+from hrms.hr.utils import (
+	get_holiday_dates_for_employee,
+	get_holidays_for_employee,
+	validate_active_employee,
+)
 
 
 class DuplicateAttendanceError(frappe.ValidationError):
@@ -238,14 +242,16 @@ def get_events(start, end, filters=None):
 
 	conditions = get_filters_cond("Attendance", filters, [])
 	add_attendance(events, start, end, conditions=conditions)
+	add_holidays(events, start, end, employee)
 	return events
 
 
 def add_attendance(events, start, end, conditions=None):
-	query = """select name, attendance_date, status
-		from `tabAttendance` where
-		attendance_date between %(from_date)s and %(to_date)s
-		and docstatus < 2"""
+	query = """select name, attendance_date, status, employee_name
+        from `tabAttendance` where
+        attendance_date between %(from_date)s and %(to_date)s
+        and docstatus < 2"""
+
 	if conditions:
 		query += conditions
 
@@ -255,11 +261,30 @@ def add_attendance(events, start, end, conditions=None):
 			"doctype": "Attendance",
 			"start": d.attendance_date,
 			"end": d.attendance_date,
-			"title": cstr(d.status),
+			"title": f"{d.employee_name}-{cstr(d.status)}",
+			"status": d.status,
 			"docstatus": d.docstatus,
 		}
 		if e not in events:
 			events.append(e)
+
+
+def add_holidays(events, start, end, employee=None):
+	holidays = get_holidays_for_employee(employee, start, end)
+	if not holidays:
+		return
+
+	for holiday in holidays:
+		events.append(
+			{
+				"doctype": "Holiday",
+				"start": holiday.holiday_date,
+				"end": holiday.holiday_date,
+				"title": _("Holiday") + ": " + cstr(holiday.description),
+				"name": holiday.name,
+				"allDay": 1,
+			}
+		)
 
 
 def mark_attendance(

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -2,8 +2,11 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe import _
+from frappe.desk.reportview import get_filters_cond
 from frappe.model.document import Document
 from frappe.utils import (
 	add_days,
@@ -15,6 +18,8 @@ from frappe.utils import (
 	getdate,
 	nowdate,
 )
+
+from erpnext.controllers.status_updater import validate_status
 
 from hrms.hr.doctype.shift_assignment.shift_assignment import has_overlapping_timings
 from hrms.hr.utils import (
@@ -34,7 +39,6 @@ class OverlappingShiftAttendanceError(frappe.ValidationError):
 
 class Attendance(Document):
 	def validate(self):
-		from erpnext.controllers.status_updater import validate_status
 
 		validate_status(self.status, ["Present", "Absent", "On Leave", "Half Day", "Work From Home"])
 		validate_active_employee(self.employee)
@@ -238,8 +242,6 @@ def get_events(start, end, filters=None):
 	if not employee:
 		return events
 
-	from frappe.desk.reportview import get_filters_cond
-
 	conditions = get_filters_cond("Attendance", filters, [])
 	add_attendance(events, start, end, conditions=conditions)
 	add_holidays(events, start, end, employee)
@@ -324,7 +326,6 @@ def mark_attendance(
 
 @frappe.whitelist()
 def mark_bulk_attendance(data):
-	import json
 
 	if isinstance(data, str):
 		data = json.loads(data)

--- a/hrms/hr/doctype/attendance/attendance_calendar.js
+++ b/hrms/hr/doctype/attendance/attendance_calendar.js
@@ -1,12 +1,31 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 frappe.views.calendar["Attendance"] = {
-	options: {
-		header: {
-			left: 'prev,next today',
-			center: 'title',
-			right: 'month'
-		}
-	},
-	get_events_method: "hrms.hr.doctype.attendance.attendance.get_events"
+  field_map: {
+    start: "start",
+    end: "end",
+    id: "name",
+    title: "title",
+    allDay: "allDay",
+    color: "color",
+  },
+  get_css_class: function (data) {
+    console.log("data", data);
+    if (data.doctype === "Holiday") return "default";
+    if (data.doctype === "Attendance") {
+      if (data.status === "Absent" || data.status === "On Leave") {
+        return "danger";
+      }
+      if (data.status === "Half Day") return "warning";
+      return "success";
+    }
+  },
+  options: {
+    header: {
+      left: "prev,next today",
+      center: "title",
+      right: "month",
+    },
+  },
+  get_events_method: "hrms.hr.doctype.attendance.attendance.get_events",
 };

--- a/hrms/hr/doctype/attendance/attendance_calendar.js
+++ b/hrms/hr/doctype/attendance/attendance_calendar.js
@@ -1,31 +1,30 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 frappe.views.calendar["Attendance"] = {
-  field_map: {
-    start: "start",
-    end: "end",
-    id: "name",
-    title: "title",
-    allDay: "allDay",
-    color: "color",
-  },
-  get_css_class: function (data) {
-    console.log("data", data);
-    if (data.doctype === "Holiday") return "default";
-    if (data.doctype === "Attendance") {
-      if (data.status === "Absent" || data.status === "On Leave") {
-        return "danger";
-      }
-      if (data.status === "Half Day") return "warning";
-      return "success";
-    }
-  },
-  options: {
-    header: {
-      left: "prev,next today",
-      center: "title",
-      right: "month",
-    },
-  },
-  get_events_method: "hrms.hr.doctype.attendance.attendance.get_events",
+	field_map: {
+		start: "start",
+		end: "end",
+		id: "name",
+		title: "title",
+		allDay: "allDay",
+		color: "color",
+	},
+	get_css_class: function (data) {
+		if (data.doctype === "Holiday") return "default";
+		else if (data.doctype === "Attendance") {
+			if (data.status === "Absent" || data.status === "On Leave") {
+				return "danger";
+			}
+			if (data.status === "Half Day") return "warning";
+			return "success";
+		}
+	},
+	options: {
+		header: {
+			left: "prev,next today",
+			center: "title",
+			right: "month",
+		},
+	},
+	get_events_method: "hrms.hr.doctype.attendance.attendance.get_events",
 };


### PR DESCRIPTION
Description: Show holidays and colour code for each employee in attendance calendar

Before:
<img width="900" alt="Screenshot 2024-03-28 at 12 39 03 PM" src="https://github.com/frappe/hrms/assets/52369157/d19b5136-7bae-4310-8843-40d55f521c25">

After:
<img width="900" alt="Screenshot 2024-03-28 at 12 34 35 PM" src="https://github.com/frappe/hrms/assets/52369157/5384811a-d09a-4199-9d1c-36b2c7dd6ff4">

Closes https://github.com/frappe/hrms/issues/1311 Closes https://github.com/frappe/hrms/issues/1173
`no-docs` (does not require docs as its just a visual enhancement)
