### PR TITLE
feat(Payroll): allow overwriting tax component through additional salary

### DIFF
--- a/hrms/payroll/doctype/additional_salary/test_additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/test_additional_salary.py
@@ -140,11 +140,8 @@ class TestAdditionalSalary(FrappeTestCase):
 		self.assertEqual(tds_component.additional_salary, additional_salary.name)
 		self.assertEqual(tds_component.amount, 5000)
 
-		# Calculates TDS as per tax slabs since additional salary did not have overwrite enabled
+		# Calculates TDS as per tax slabs
 		additional_salary.cancel()
-		additional_salary = get_additional_salary(
-			emp_id, recurring=False, payroll_date=date, salary_component="TDS", overwrite_salary_structure=0
-		)
 		salary_slip = make_salary_slip(salary_structure.name, employee=emp_id, posting_date=date)
 		tds_component = _get_tds_component(salary_slip)
 		self.assertIsNone(tds_component.additional_salary)

--- a/hrms/payroll/doctype/additional_salary/test_additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/test_additional_salary.py
@@ -119,6 +119,37 @@ class TestAdditionalSalary(FrappeTestCase):
 		salary_slip = make_salary_slip(salary_structure.name, employee=emp_id, posting_date=date)
 		self.assertEqual(salary_slip.earnings[1].amount, 5000)
 
+	def test_overwrite_tax_component(self):
+		def _get_tds_component(doc) -> dict:
+			return next(
+				(d for d in salary_slip.get("deductions") if d.salary_component == "TDS"), frappe._dict()
+			)
+
+		emp_id = make_employee("test_additional@salary.com")
+		salary_structure = make_salary_structure(
+			"Test Salary Structure Additional Salary", "Monthly", employee=emp_id, test_tax=True
+		)
+		date = nowdate()
+
+		# Overwrites TDS Salary Component amount as 5000
+		additional_salary = get_additional_salary(
+			emp_id, recurring=False, payroll_date=date, salary_component="TDS", overwrite_salary_structure=1
+		)
+		salary_slip = make_salary_slip(salary_structure.name, employee=emp_id, posting_date=date)
+		tds_component = _get_tds_component(salary_slip)
+		self.assertEqual(tds_component.additional_salary, additional_salary.name)
+		self.assertEqual(tds_component.amount, 5000)
+
+		# Calculates TDS as per tax slabs since additional salary did not have overwrite enabled
+		additional_salary.cancel()
+		additional_salary = get_additional_salary(
+			emp_id, recurring=False, payroll_date=date, salary_component="TDS", overwrite_salary_structure=0
+		)
+		salary_slip = make_salary_slip(salary_structure.name, employee=emp_id, posting_date=date)
+		tds_component = _get_tds_component(salary_slip)
+		self.assertIsNone(tds_component.additional_salary)
+		self.assertEqual(tds_component.amount, 6042)
+
 
 def get_additional_salary(
 	emp_id, recurring=True, payroll_date=None, salary_component=None, overwrite_salary_structure=0

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1489,8 +1489,9 @@ class SalarySlip(TransactionBase):
 		if not income_tax_slab:
 			frappe.throw(
 				_("Income Tax Slab not set in Salary Structure Assignment: {0}").format(
-					self._salary_structure_assignment
-				)
+					get_link_to_form("Salary Structure Assignment", self._salary_structure_assignment.name)
+				),
+				title=_("Missing Tax Slab"),
 			)
 
 		income_tax_slab_doc = frappe.get_cached_doc("Income Tax Slab", income_tax_slab)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1263,6 +1263,9 @@ class SalarySlip(TransactionBase):
 			else:
 				self.other_deduction_components.append(d.salary_component)
 
+		if has_overwritten_tax := self.handle_additional_salary_tax_component():
+			return
+
 		# consider manually added tax component
 		if not tax_components:
 			tax_components = [
@@ -1334,6 +1337,26 @@ class SalarySlip(TransactionBase):
 			tax_components[key].append(component.name)
 
 		return tax_components
+
+	def handle_additional_salary_tax_component(self) -> bool:
+		component = next(
+			(
+				d for d in self.get("deductions") if d.variable_based_on_taxable_salary and d.additional_salary
+			),
+			None,
+		)
+
+		if not component:
+			return False
+
+		if frappe.db.get_value(
+			"Additional Salary", component.additional_salary, "overwrite_salary_structure_amount"
+		):
+			return True
+		else:
+			# overwriting disabled, remove addtional salary tax component
+			self.get("deductions", []).remove(component)
+			return False
 
 	def update_component_row(
 		self,


### PR DESCRIPTION
In some months, users might want to overwrite the auto-calculated tax amount through additional salary. While overwriting component amount works for other types of components, it was not supported for tax components. Added support for the same

This is only applicable if the additional salary has **Overwrite Salary Structure Amount** enabled

Added validation + warning for both cases:

<img width="1331" alt="image" src="https://github.com/frappe/hrms/assets/24353136/6f3eadfe-e843-4031-a5be-ddbe5dd47170">

<img width="1331" alt="image" src="https://github.com/frappe/hrms/assets/24353136/6187f5b9-2adb-49dc-8151-cdba6450551f">


`no-docs` This works as expected now like overwriting other components. Doesn't require an explicit mention as such