### PR TITLE
fix: missing mapping of all_day parameter

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application_calendar.js
+++ b/hrms/hr/doctype/leave_application/leave_application_calendar.js
@@ -9,6 +9,7 @@ frappe.views.calendar["Leave Application"] = {
 		"title": "title",
 		"docstatus": 1,
 		"color": "color",
+		"allDay": "all_day",
 	},
 	options: {
 		header: {


### PR DESCRIPTION
Adds missing mapping of 'all_day' parameter for leave application doctype.

Fixes incorrect display of the leave application period, for calendar view, where the last day is not shown.