### PR TITLE
fix(job opening): fix job openings validation error

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.py
+++ b/hrms/hr/doctype/job_opening/job_opening.py
@@ -71,18 +71,10 @@ class JobOpening(WebsiteGenerator):
 			)
 
 		if self.staffing_plan and self.planned_vacancies:
-			staffing_plan_company = frappe.db.get_value("Staffing Plan", self.staffing_plan, "company")
-
 			designation_counts = get_designation_counts(self.designation, self.company, self.name)
-			current_count = designation_counts["employee_count"] + designation_counts["job_openings"]
+			current_count = designation_counts["job_openings"]
 
-			number_of_positions = frappe.db.get_value(
-				"Staffing Plan Detail",
-				{"parent": self.staffing_plan, "designation": self.designation},
-				"number_of_positions",
-			)
-
-			if number_of_positions <= current_count:
+			if self.planned_vacancies <= current_count:
 				frappe.throw(
 					_(
 						"Job Openings for the designation {0} are already open or the hiring is complete as per the Staffing Plan {1}"


### PR DESCRIPTION
Description: Validation when creating a new Job Opening compares number of positions for the associated Staff Planning with the current count of employees having the given designation. This throws error, in case there are employees which haven't been onboarded through any job opening, that get counted when comparing.
Error:
![image](https://github.com/frappe/hrms/assets/52369157/c1e9b54a-c97e-496f-b837-4054e7b46429)

Fix: Changed the validation to compare number of vacancies with the number of current open job openings. 
Closes #1575 