### PR TITLE
fix: use reference name while updating exc rate

### DIFF
--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -31,7 +31,7 @@ class EmployeePaymentEntry(PaymentEntry):
 		self,
 		force: bool = False,
 		update_ref_details_only_for: list | None = None,
-		ref_exchange_rate: float | None = None,
+		reference_exchange_details: dict | None = None,
 	) -> None:
 		for d in self.get("references"):
 			if d.allocated_amount:
@@ -45,8 +45,12 @@ class EmployeePaymentEntry(PaymentEntry):
 				)
 
 				# Only update exchange rate when the reference is Journal Entry
-				if ref_exchange_rate and d.reference_doctype == "Journal Entry":
-					ref_details.update({"exchange_rate": ref_exchange_rate})
+				if (
+					reference_exchange_details
+					and d.reference_doctype == reference_exchange_details.reference_doctype
+					and d.reference_name == reference_exchange_details.reference_name
+				):
+					ref_details.update({"exchange_rate": reference_exchange_details.exchange_rate})
 
 				for field, value in ref_details.items():
 					if d.exchange_gain_loss:


### PR DESCRIPTION
continues: https://github.com/frappe/hrms/pull/1553
parent change in ERPNext: https://github.com/frappe/erpnext/pull/40856
Previous fix wasn't working as expected.