### PR TITLE
fix(PWA): handle password expiry during login

### DIFF
--- a/frontend/src/data/session.js
+++ b/frontend/src/data/session.js
@@ -1,5 +1,5 @@
 import { computed, reactive } from "vue"
-import { createResource } from "frappe-ui"
+import { createResource, call } from "frappe-ui"
 import { userResource } from "./user"
 import { employeeResource } from "./employee"
 import router from "@/router"
@@ -14,23 +14,17 @@ export function sessionUser() {
 }
 
 export const session = reactive({
-	login: createResource({
-		url: "login",
-		makeParams({ email, password }) {
-			return {
-				usr: email,
-				pwd: password,
-			}
-		},
-		onSuccess(data) {
+	login: async (email, password) => {
+		const response = await call("login", { usr: email, pwd: password })
+		if (response.message === "Logged In") {
 			userResource.reload()
 			employeeResource.reload()
 
 			session.user = sessionUser()
-			session.login.reset()
-			router.replace(data.default_route || "/")
-		},
-	}),
+			router.replace(response.default_route || "/")
+		}
+		return response
+	},
 	logout: createResource({
 		url: "logout",
 		onSuccess() {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -107,7 +107,7 @@ router.isReady().then(() => {
 	}
 })
 
-router.beforeEach(async (to, from, next) => {
+router.beforeEach(async (to, _, next) => {
 	let isLoggedIn = session.isLoggedIn
 
 	try {
@@ -116,9 +116,16 @@ router.beforeEach(async (to, from, next) => {
 		isLoggedIn = false
 	}
 
-	if (!isLoggedIn && to.name !== "Login") {
-		next({ name: "Login" })
-	} else if (isLoggedIn && to.name !== "InvalidEmployee") {
+	if (!isLoggedIn) {
+		// password reset page is outside the PWA scope
+		if (to.path === "/update-password") {
+			return next(false)
+		} else if (to.name !== "Login") {
+			next({ name: "Login" })
+		}
+	}
+
+	if (isLoggedIn && to.name !== "InvalidEmployee") {
 		await employeeResource.promise
 		// user should be an employee to access the app
 		// since all views are employee specific

--- a/frontend/src/views/InvalidEmployee.vue
+++ b/frontend/src/views/InvalidEmployee.vue
@@ -31,9 +31,7 @@
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
 import { inject, ref } from "vue"
-import { Input, Button, ErrorMessage, Dialog } from "frappe-ui"
-
-import FrappeHRLogo from "@/components/icons/FrappeHRLogo.vue"
+import { Dialog } from "frappe-ui"
 
 const session = inject("$session")
 const showDialog = ref(true)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -23,7 +23,7 @@
 							placeholder="••••••"
 							v-model="password"
 						/>
-						<ErrorMessage :message="session.login.error" />
+						<ErrorMessage :message="errorMessage" />
 						<Button
 							:loading="session.login.loading"
 							variant="solid"
@@ -34,6 +34,27 @@
 					</form>
 				</div>
 			</div>
+
+			<Dialog v-model="resetPassword">
+				<template #body-title>
+					<h2 class="text-lg font-bold">Reset Password</h2>
+				</template>
+				<template #body-content>
+					<p>
+						Your password has expired. Please reset your password to continue
+					</p>
+				</template>
+				<template #actions>
+					<a
+						class="inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-white bg-gray-900 hover:bg-gray-800 active:bg-gray-700 focus-visible:ring focus-visible:ring-gray-400 h-7 text-base px-2 rounded"
+						:href="resetPasswordLink"
+						target="_blank"
+						onClick
+					>
+						Go to Reset Password page
+					</a>
+				</template>
+			</Dialog>
 		</ion-content>
 	</ion-page>
 </template>
@@ -41,18 +62,30 @@
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
 import { inject, ref } from "vue"
-import { Input, Button, ErrorMessage } from "frappe-ui"
+import { Input, Button, ErrorMessage, Dialog } from "frappe-ui"
 
 import FrappeHRLogo from "@/components/icons/FrappeHRLogo.vue"
 
 const email = ref(null)
 const password = ref(null)
+const errorMessage = ref("")
+const resetPassword = ref(false)
+const resetPasswordLink = ref("")
 
 const session = inject("$session")
-function submit(e) {
-	session.login.submit({
-		email: email.value,
-		password: password.value,
-	})
+
+async function submit(e) {
+	try {
+		const response = await session.login(email.value, password.value)
+		if (response.message === "Password Reset") {
+			resetPassword.value = true
+			resetPasswordLink.value = response.redirect_to
+		} else {
+			resetPassword.value = false
+			resetPasswordLink.value = ""
+		}
+	} catch (error) {
+		errorMessage.value = error.messages.join("\n")
+	}
 }
 </script>


### PR DESCRIPTION
**Problem**:

If the password has expired, the framework's login API doesn't throw an error, it redirects to the link to reset the password. On PWA, there was no feedback on clicking the login button in this case.

**Fix**:

Handle and open the password reset page in a new browser tab in this case

<img width="318" alt="image" src="https://github.com/frappe/hrms/assets/24353136/5a531050-e395-4904-8cc2-bc059b56b5e8">
