### PR TITLE
fix(Income Tax Computation): eval locals for Income Tax Slab

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -421,12 +421,16 @@ class IncomeTaxComputationReport:
 			tax_slab = emp_details.get("income_tax_slab")
 			if tax_slab:
 				tax_slab = frappe.get_cached_doc("Income Tax Slab", tax_slab)
-				employee_dict = frappe.get_doc("Employee", emp).as_dict()
+				salary_slip = frappe.new_doc("Salary Slip")
+				salary_slip.employee = emp
+				salary_slip.salary_structure = emp_details.salary_structure
+				salary_slip.process_salary_structure()
+				eval_locals, __ = salary_slip.get_data_for_eval()
 				tax_amount = calculate_tax_by_tax_slab(
 					emp_details["total_taxable_amount"],
 					tax_slab,
 					eval_globals=None,
-					eval_locals=employee_dict,
+					eval_locals=eval_locals,
 				)
 			else:
 				tax_amount = 0.0


### PR DESCRIPTION
All relevant fields are not included in evaluating condition of Income Tax Slab while generating Income Tax Computation report.

Example:

![image](https://github.com/frappe/hrms/assets/61287991/671c30b7-335b-4671-9f70-65795d8a09ca)

This PR fixes that.