### PR TITLE
fix(Auto Attendance): incorrect previous shift computation for a timestamp leading to incorrect absent marking

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -459,7 +459,11 @@ def get_prev_or_next_shift(
 		for date_range in shift_dates:
 			# midnight shifts will span more than a day
 			start_date, end_date = date_range[0], add_days(date_range[1], 1)
-			reverse = next_shift_direction == "reverse"
+
+			if reverse := (next_shift_direction == "reverse"):
+				end_date = min(end_date, for_timestamp.date())
+			elif next_shift_direction == "forward":
+				start_date = max(start_date, for_timestamp.date())
 
 			for dt in generate_date_range(start_date, end_date, reverse=reverse):
 				shift_details = get_employee_shift(


### PR DESCRIPTION
2 consecutive day shifts overlapping in timings

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/0c0c7db1-2858-4c65-b6e1-70d9470d3cff">

Assigned to the same employee

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/3f2dc4b9-7bd2-491d-b47d-f9371a8a2971">

## Problem 1

Marks employee as absent even before last sync of check-in due to a bug in fetching previous shifts if there are missing employee checkins

<img width="1440" alt="image" src="https://github.com/frappe/hrms/assets/24353136/c64b32f4-4efd-4038-9e0a-caeb86c0eea8">

## Problem 2

Also if you create a check-in record in the grace ending period of the current shift (General Shift) - let's say 18:30:00
Actual Start would get set as 18:00:00 for this record although start is actually 07:00 so actual start should be 05:00. This only happens when the check-in timestamp falls in a period of current shift which is not valid on previous day's shift. So ideally `prev_shift` should have been None

![image](https://github.com/frappe/hrms/assets/24353136/5b561726-b5dd-41e0-801f-5e73c558d6eb)


This same fix fixes both of these cases. While getting relevant shifts, it resets the end date to not go beyond the `for_timestamp`.
