### PR TITLE
fix(PWA): allow selecting accounting dimensions in Expense Claim

### DIFF
--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -191,14 +191,6 @@ const taxesTableFields = createResource({
 	params: { doctype: "Expense Taxes and Charges" },
 	transform(data) {
 		const excludeFields = ["description_sb"]
-		const dimensionFields = [
-			"cost_center",
-			"project",
-			"accounting_dimensions_section",
-		]
-
-		if (!props.id) excludeFields.push(...dimensionFields)
-
 		return data
 			.map((field) => {
 				if (field.fieldname === "account_head") {

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -197,15 +197,6 @@ const expensesTableFields = createResource({
 	params: { doctype: "Expense Claim Detail" },
 	transform(data) {
 		const excludeFields = ["description_sb", "amounts_sb"]
-		const dimensionFields = [
-			"cost_center",
-			"project",
-			"branch",
-			"accounting_dimensions_section",
-		]
-
-		if (!props.id) excludeFields.push(...dimensionFields)
-
 		return data.filter((field) => !excludeFields.includes(field.fieldname))
 	},
 })


### PR DESCRIPTION
allow selecting accounting dimensions in Expense Claim

![image](https://github.com/frappe/hrms/assets/24353136/df44cc05-8128-4faa-8eca-3a792ac0c5d8)

Related: https://github.com/frappe/erpnext/pull/41160
