### PR TITLE
fix: autofill skills on entering designation in Interview Round

### DIFF
--- a/hrms/hr/doctype/interview_round/interview_round.js
+++ b/hrms/hr/doctype/interview_round/interview_round.js
@@ -9,6 +9,22 @@ frappe.ui.form.on("Interview Round", {
 			});
 		}
 	},
+	designation: function (frm) {
+		frm.set_value("expected_skill_set", null);
+		if (frm.doc.designation) {
+			frappe.db.get_doc("Designation", frm.doc.designation).then((designation) => {
+				designation.skills.forEach((designation_skill) => {
+					let row = frappe.model.add_child(
+						frm.doc,
+						"Expected Skill Set",
+						"expected_skill_set",
+					);
+					row.skill = designation_skill.skill;
+				});
+				refresh_field("expected_skill_set");
+			});
+		}
+	},
 	create_interview: function (frm) {
 		frappe.call({
 			method: "hrms.hr.doctype.interview_round.interview_round.create_interview",

--- a/hrms/hr/doctype/interview_round/interview_round.js
+++ b/hrms/hr/doctype/interview_round/interview_round.js
@@ -10,17 +10,15 @@ frappe.ui.form.on("Interview Round", {
 		}
 	},
 	designation: function (frm) {
-		frm.set_value("expected_skill_set", null);
 		if (frm.doc.designation) {
 			frappe.db.get_doc("Designation", frm.doc.designation).then((designation) => {
+				frappe.model.clear_table(frm.doc, "expected_skill_set");
+
 				designation.skills.forEach((designation_skill) => {
-					let row = frappe.model.add_child(
-						frm.doc,
-						"Expected Skill Set",
-						"expected_skill_set",
-					);
+					const row = frm.add_child("expected_skill_set");
 					row.skill = designation_skill.skill;
 				});
+
 				refresh_field("expected_skill_set");
 			});
 		}

--- a/hrms/hr/doctype/interview_round/interview_round.json
+++ b/hrms/hr/doctype/interview_round/interview_round.json
@@ -11,9 +11,9 @@
   "interview_type",
   "interviewers",
   "column_break_3",
-  "designation",
   "expected_average_rating",
   "expected_skills_section",
+  "designation",
   "expected_skill_set"
  ],
  "fields": [
@@ -33,12 +33,12 @@
   },
   {
    "fieldname": "expected_skills_section",
-   "fieldtype": "Section Break",
-   "label": "Expected Skillset"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "expected_skill_set",
    "fieldtype": "Table",
+   "label": "Expected Skillset",
    "options": "Expected Skill Set",
    "reqd": 1
   },
@@ -66,7 +66,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:09:52.135039",
+ "modified": "2024-05-01 11:57:32.754037",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Interview Round",


### PR DESCRIPTION
Before: Selecting designation didn't fetch skills for Interview Round.
After: Resets and autofills skills on entering designation.
![designation](https://github.com/frappe/hrms/assets/52369157/3ac1cb01-b026-4147-b8a7-bb905858b480)
closes: #1671 