### PR TITLE
fix(Employee Attendance Tool): 'On Leave' status showing as undefined in marked attendance summary

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -162,7 +162,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 						return `<span style="color:red">${__(value)}</span>`;
 					else if (value == "Half Day")
 						return `<span style="color:orange">${__(value)}</span>`;
-					else if (value == "Leave")
+					else if (value == "On Leave")
 						return `<span style="color:#318AD8">${__(value)}</span>`;
 				},
 			},


### PR DESCRIPTION
Employee Attendance Tool Marked Attendance On Leave Status showing in undefined ,
Closes: #1711 
Before:
![Screenshot from 2024-04-25 17-03-22](https://github.com/frappe/hrms/assets/101092028/2a217880-f419-4cab-9d02-ae958cf385ca)
After:
![Screenshot from 2024-04-25 17-13-58](https://github.com/frappe/hrms/assets/101092028/99363270-309c-4f5d-a21c-f89360c47030)