### PR TITLE
fix(HRA calculation): fetch active salary assignment assigned before payroll period if none in period

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -517,12 +517,23 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 
 def get_salary_assignments(employee, payroll_period):
 	start_date, end_date = frappe.db.get_value("Payroll Period", payroll_period, ["start_date", "end_date"])
-	assignments = frappe.db.get_all(
+	assignments = frappe.get_all(
 		"Salary Structure Assignment",
 		filters={"employee": employee, "docstatus": 1, "from_date": ["between", (start_date, end_date)]},
 		fields=["*"],
 		order_by="from_date",
 	)
+
+	if not assignments:
+		# if no assignments found for the given period
+		# get the last one assigned before the period that is still active
+		assignments = frappe.get_all(
+			"Salary Structure Assignment",
+			filters={"employee": employee, "docstatus": 1, "from_date": ["<=", start_date]},
+			fields=["*"],
+			order_by="from_date desc",
+			limit=1,
+		)
 
 	return assignments
 

--- a/hrms/payroll/doctype/employee_tax_exemption_declaration/test_employee_tax_exemption_declaration.py
+++ b/hrms/payroll/doctype/employee_tax_exemption_declaration/test_employee_tax_exemption_declaration.py
@@ -132,7 +132,8 @@ class TestEmployeeTaxExemptionDeclaration(FrappeTestCase):
 		frappe.flags.country = "India"
 
 		employee = frappe.get_value("Employee", {"user_id": "employee@taxexemption.com"}, "name")
-		setup_hra_exemption_prerequisites("Monthly", employee)
+		# structure assigned before payroll period should still be considered as active
+		setup_hra_exemption_prerequisites("Monthly", employee, from_date=add_months(PAYROLL_PERIOD_START, -1))
 
 		declaration = frappe.get_doc(
 			{
@@ -321,7 +322,7 @@ class TestEmployeeTaxExemptionDeclaration(FrappeTestCase):
 		# reset
 		frappe.flags.country = current_country
 
-	def test_india_hra_exemption_with_multiple_salary_structure_assignments(self):
+	def test_india_hra_exemption_with_multiple_assignments(self):
 		from hrms.payroll.doctype.salary_slip.test_salary_slip import create_tax_slab
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 			create_salary_structure_assignment,
@@ -471,7 +472,7 @@ def create_exemption_category():
 		).insert()
 
 
-def setup_hra_exemption_prerequisites(frequency, employee=None):
+def setup_hra_exemption_prerequisites(frequency, employee=None, from_date=None):
 	from hrms.payroll.doctype.salary_slip.test_salary_slip import create_tax_slab
 	from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
@@ -499,6 +500,7 @@ def setup_hra_exemption_prerequisites(frequency, employee=None):
 		company="_Test Company",
 		currency="INR",
 		payroll_period=payroll_period,
+		from_date=from_date,
 	)
 
 	frappe.db.set_value(

--- a/hrms/regional/india/utils.py
+++ b/hrms/regional/india/utils.py
@@ -28,7 +28,13 @@ def calculate_annual_eligible_hra_exemption(doc):
 		if not assignments and doc.docstatus == 1:
 			frappe.throw(_("Salary Structure must be submitted before submission of {0}").format(doc.doctype))
 
-		assignment_dates = [assignment.from_date for assignment in assignments]
+		period_start_date = frappe.db.get_value("Payroll Period", doc.payroll_period, "start_date")
+
+		assignment_dates = []
+		for assignment in assignments:
+			# if assignment is before payroll period, use period start date to get the correct days
+			assignment.from_date = max(assignment.from_date, period_start_date)
+			assignment_dates.append(assignment.from_date)
 
 		for idx, assignment in enumerate(assignments):
 			if has_hra_component(assignment.salary_structure, hra_component):


### PR DESCRIPTION
## Problem

HRA calculation does not work if there is no new assignment in the latest payroll period

![image](https://github.com/frappe/hrms/assets/24353136/a49fc669-add3-4115-9a87-4ee4b965882c)

Regression from: https://github.com/frappe/erpnext/pull/30898

## Fix

if no assignments found in the given period, get the last one assigned before the period that is still active