### PR TITLE
fix(Employee Advance): selection of currency

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -171,18 +171,16 @@ frappe.ui.form.on("Employee Advance", {
 	},
 
 	get_employee_currency: function (frm) {
-		frappe.call({
-			method: "hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment.get_employee_currency",
-			args: {
-				employee: frm.doc.employee,
+		frappe.db.get_value(
+			"Salary Structure Assignment",
+			{ employee: frm.doc.employee, docstatus: 1 },
+			"currency",
+			(r) => {
+				if (r.currency) frm.set_value("currency", r.currency);
+				else frm.set_value("currency", erpnext.get_currency(frm.doc.company));
+				frm.refresh_fields();
 			},
-			callback: function (r) {
-				if (r.message) {
-					frm.set_value("currency", r.message);
-					frm.refresh_fields();
-				}
-			},
-		});
+		);
 	},
 
 	currency: function (frm) {


### PR DESCRIPTION
Currency in an employee advance is set as the currency of the selected employee's latest salary structure assignment. But if the employee does not have any assignments, it uses the currency of the default company, whereas it should be using the currency of the selected company.