### PR TITLE
fix: validation of overlapping shift dates

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -80,33 +80,12 @@ class ShiftAssignment(Document):
 				& (shift.docstatus == 1)
 				& (shift.name != self.name)
 				& (shift.status == "Active")
+				& ((shift.end_date >= self.start_date) | (shift.end_date.isnull()))
 			)
 		)
 
 		if self.end_date:
-			query = query.where(
-				Criterion.any(
-					[
-						Criterion.any(
-							[
-								shift.end_date.isnull(),
-								((self.start_date >= shift.start_date) & (self.start_date <= shift.end_date)),
-							]
-						),
-						Criterion.any(
-							[
-								((self.end_date >= shift.start_date) & (self.end_date <= shift.end_date)),
-								shift.start_date.between(self.start_date, self.end_date),
-							]
-						),
-					]
-				)
-			)
-		else:
-			query = query.where(
-				shift.end_date.isnull()
-				| ((self.start_date >= shift.start_date) & (self.start_date <= shift.end_date))
-			)
+			query = query.where(shift.start_date <= self.end_date)
 
 		return query.run(as_dict=True)
 

--- a/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
@@ -23,21 +23,6 @@ class TestShiftAssignment(FrappeTestCase):
 		frappe.db.delete("Shift Assignment")
 		frappe.db.delete("Shift Type")
 
-	def test_make_shift_assignment(self):
-		setup_shift_type(shift_type="Day Shift")
-		shift_assignment = frappe.get_doc(
-			{
-				"doctype": "Shift Assignment",
-				"shift_type": "Day Shift",
-				"company": "_Test Company",
-				"employee": "_T-Employee-00001",
-				"start_date": nowdate(),
-			}
-		).insert()
-		shift_assignment.submit()
-
-		self.assertEqual(shift_assignment.docstatus, 1)
-
 	def test_overlapping_for_ongoing_shift(self):
 		# shift should be Ongoing if Only start_date is present and status = Active
 		setup_shift_type(shift_type="Day Shift")
@@ -62,18 +47,7 @@ class TestShiftAssignment(FrappeTestCase):
 
 	def test_multiple_shift_assignments_for_same_date(self):
 		setup_shift_type(shift_type="Day Shift")
-		shift_assignment_1 = frappe.get_doc(
-			{
-				"doctype": "Shift Assignment",
-				"shift_type": "Day Shift",
-				"company": "_Test Company",
-				"employee": "_T-Employee-00001",
-				"start_date": nowdate(),
-				"end_date": add_days(nowdate(), 30),
-				"status": "Active",
-			}
-		).insert()
-		shift_assignment_1.submit()
+		make_shift_assignment("Day Shift", "_T-Employee-00001", nowdate(), add_days(nowdate(), 30))
 
 		setup_shift_type(shift_type="Night Shift", start_time="19:00:00", end_time="23:00:00")
 		shift_assignment_2 = frappe.get_doc(
@@ -96,18 +70,7 @@ class TestShiftAssignment(FrappeTestCase):
 	def test_overlapping_for_fixed_period_shift(self):
 		# shift should is for Fixed period if Only start_date and end_date both are present and status = Active
 		setup_shift_type(shift_type="Day Shift")
-		shift_assignment_1 = frappe.get_doc(
-			{
-				"doctype": "Shift Assignment",
-				"shift_type": "Day Shift",
-				"company": "_Test Company",
-				"employee": "_T-Employee-00001",
-				"start_date": nowdate(),
-				"end_date": add_days(nowdate(), 30),
-				"status": "Active",
-			}
-		).insert()
-		shift_assignment_1.submit()
+		make_shift_assignment("Day Shift", "_T-Employee-00001", nowdate(), add_days(nowdate(), 30))
 
 		# it should not allowed within period of any shift.
 		shift_assignment_3 = frappe.get_doc(

--- a/hrms/hr/doctype/shift_request/shift_request.py
+++ b/hrms/hr/doctype/shift_request/shift_request.py
@@ -93,33 +93,16 @@ class ShiftRequest(Document):
 		query = (
 			frappe.qb.from_(shift)
 			.select(shift.name, shift.shift_type)
-			.where((shift.employee == self.employee) & (shift.docstatus < 2) & (shift.name != self.name))
+			.where(
+				(shift.employee == self.employee)
+				& (shift.docstatus < 2)
+				& (shift.name != self.name)
+				& ((shift.to_date >= self.from_date) | (shift.to_date.isnull()))
+			)
 		)
 
 		if self.to_date:
-			query = query.where(
-				Criterion.any(
-					[
-						Criterion.any(
-							[
-								shift.to_date.isnull(),
-								((self.from_date >= shift.from_date) & (self.from_date <= shift.to_date)),
-							]
-						),
-						Criterion.any(
-							[
-								((self.to_date >= shift.from_date) & (self.to_date <= shift.to_date)),
-								shift.from_date.between(self.from_date, self.to_date),
-							]
-						),
-					]
-				)
-			)
-		else:
-			query = query.where(
-				shift.to_date.isnull()
-				| ((self.from_date >= shift.from_date) & (self.from_date <= shift.to_date))
-			)
+			query = query.where(shift.from_date <= self.to_date)
 
 		return query.run(as_dict=True)
 


### PR DESCRIPTION
Fix for a bug that prevents the creation of definite shifts that end before an indefinite one starts.

For example,

Shift 1 -
Start Date: 01/06/2024
End Date: None

Shift 2-
Start Date: 30/05/2024
End Date: 30/05/2024

Trying to create Shift 2 will throw an overlapping error.