### PR TITLE
fix(Payroll): handle empty condition/formula updates from salary components

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.js
+++ b/hrms/payroll/doctype/salary_component/salary_component.js
@@ -125,7 +125,7 @@ frappe.ui.form.on("Salary Component", {
 					args: {
 						structures: structures,
 						field: df.toLowerCase(),
-						value: frm.get_field(df.toLowerCase()).value,
+						value: frm.get_field(df.toLowerCase()).value || "",
 					},
 				})
 				.then((r) => {


### PR DESCRIPTION
1. Creat a new Salary Component, w/o condition or formula defined yet (value is undefined)
2. Use the component in some Salary Structure
3. Attempt to Update Salary Structures with Sync Condition/Formula will show errors.

```
TypeError: SalaryComponent.update_salary_structures() missing 1 required positional argument: 'value'
```

![image](https://github.com/frappe/hrms/assets/1973598/077ac48c-51b0-4f64-b83e-4c11d7e02ae7)
