### PR TITLE
fix(UX): Show reason instead of leave type in title

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -1227,6 +1227,7 @@ def add_leaves(events, start, end, filters=None):
 		"docstatus",
 		"employee_name",
 		"leave_type",
+		"reason",
 		"(1) as allDay",
 		"'Leave Application' as doctype",
 	]
@@ -1240,9 +1241,9 @@ def add_leaves(events, start, end, filters=None):
 		leave_applications = frappe.get_list("Leave Application", filters=filters, fields=fields)
 
 	for d in leave_applications:
-		d["title"] = f"{d['employee_name']} ({d['leave_type']})"
+		d["title"] = f"{d['employee_name']} ({d['reason']})"
 		del d["employee_name"]
-		del d["leave_type"]
+		del d["reason"]
 		if d not in events:
 			events.append(d)
 


### PR DESCRIPTION
In calendar view we show leave type which is usually one of 2-3 known
types like privileged leave or sick leave. This information is kinda
useless in most cases (?)

leave type info can be maybe colour-coded if required.
