### PR TITLE
feat(minor): allow using `rounded` function in salary slip formulae

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -70,6 +70,7 @@ class SalarySlip(TransactionBase):
 			"float": float,
 			"long": int,
 			"round": round,
+			"rounded": rounded,
 			"date": date,
 			"getdate": getdate,
 			"ceil": ceil,


### PR DESCRIPTION
The `round` function in python performs Banker's rounding. Allow usage of `rounded` to respect System Settings & allow Commercial Rounding

Docs updated: https://frappehr.com/docs/v14/en/salary-component#2-1-condition-and-formula