### PR TITLE
fix: wrong compute of CTC on salary slip, if employee relieving date before end of payroll period.

### DIFF
--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -122,8 +122,6 @@ def get_period_factor(
 
 	if relieving_date and getdate(relieving_date) < getdate(period_end):
 		period_end = relieving_date
-		if month_diff(period_end, start_date) > 1:
-			start_date = add_months(start_date, -(month_diff(period_end, start_date) + 1))
 
 	total_sub_periods, remaining_sub_periods = 0.0, 0.0
 


### PR DESCRIPTION
Calculation of CTC on Salary Slip is rediculous wrong if Employee's relieving date is set before end of payroll period.
And from the testing, I only find this false commit -> https://github.com/frappe/hrms/commit/4303a9b9d1c41f6e7597de6a168f440809223587
and so, this PR is just removing it.

To explain the problem, I am testing with a simple salary structure with just income and tax.

* Payroll Peirod = 1 Jan 2024 - 31 Dec 2024
* Base Salary = 10,000 (120,000 for CTC of 12 months)
* Employee Relieving Date = 15 Dec 2024 (if change to 31 Dec, or no relieving date, no problem)

Create the Slary Slip for January 2024

![image](https://github.com/frappe/hrms/assets/1973598/40288524-c893-476d-ad68-5d423a90447d)

![image](https://github.com/frappe/hrms/assets/1973598/d7a3dc80-d204-4df3-899c-a4879b6e2be1)

CTC wil be be 250,000 !!!

![image](https://github.com/frappe/hrms/assets/1973598/55963ae0-7382-4b3e-8b4f-b49f0d69a22c)

Looking at the code that I removed

```
if month_diff(period_end, start_date) > 1:
	start_date = add_months(start_date, -(month_diff(period_end, start_date) + 1))
```

As
* month_diff(period_end, start_date) = month_diff( 15 Dec 2024 , 1 Jan 2024 ) = **12 months**
* start_date = add_months(1 Jan 2024, -13) = **1 Dec 2022**

And so, 1 Dec 2022 until 15 Dec 2024 is **25 months**, which compute to **CTC = 10,000 * 25 = 250,000**

Note: even if we use period_end very close to start_date, i.e. 15 Feb, it is still make a very wrong computation. So, I am really don't know the reason of having such code.


