### PR TITLE
fix(Interview Feedback): type cast user input for "rating" field to float

### DIFF
--- a/hrms/hr/doctype/interview_feedback/interview_feedback.py
+++ b/hrms/hr/doctype/interview_feedback/interview_feedback.py
@@ -58,7 +58,7 @@ class InterviewFeedback(Document):
 		total_rating = 0
 		for d in self.skill_assessment:
 			if d.rating:
-				total_rating += d.rating
+				total_rating += flt(d.rating)
 
 		self.average_rating = flt(
 			total_rating / len(self.skill_assessment) if len(self.skill_assessment) else 0

--- a/hrms/hr/doctype/interview_feedback/test_interview_feedback.py
+++ b/hrms/hr/doctype/interview_feedback/test_interview_feedback.py
@@ -49,7 +49,7 @@ class TestInterviewFeedback(FrappeTestCase):
 		total_rating = 0
 		for d in feedback_1.skill_assessment:
 			if d.rating:
-				total_rating += d.rating
+				total_rating += flt(d.rating)
 
 		avg_rating = flt(
 			total_rating / len(feedback_1.skill_assessment) if len(feedback_1.skill_assessment) else 0


### PR DESCRIPTION
Before: Data imported using CSV, throws "TypeError: unsupported operand type(s) for +=: 'int' and 'str'
" error when calculating average rating in Interview Feedback, because the rating being str.
After: Type cast rating to avoid incompatible user input
 