### PR TITLE
fix(Expense Claim): update of Outstanding Amount on Payment Entry submission

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -368,13 +368,13 @@ def update_reimbursed_amount(doc):
 
 	doc.set_status(update=True)
 
-	if payment_entry_reference := frappe.db.exists(
-		{"doctype": "Payment Entry Reference", "reference_name": doc.name, "docstatus": 1}
-	):
-		outstanding_amount = get_outstanding_amount_for_claim(doc)
-		frappe.db.set_value(
-			"Payment Entry Reference", payment_entry_reference, "outstanding_amount", outstanding_amount
-		)
+	outstanding_amount = get_outstanding_amount_for_claim(doc)
+	PaymentEntryReference = frappe.qb.DocType("Payment Entry Reference")
+	(
+		frappe.qb.update(PaymentEntryReference)
+		.set(PaymentEntryReference.outstanding_amount, outstanding_amount)
+		.where((PaymentEntryReference.reference_name == doc.name) & (PaymentEntryReference.docstatus == 1))
+	).run()
 
 
 def get_total_reimbursed_amount(doc):

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -368,6 +368,14 @@ def update_reimbursed_amount(doc):
 
 	doc.set_status(update=True)
 
+	if payment_entry_reference := frappe.db.exists(
+		{"doctype": "Payment Entry Reference", "reference_name": doc.name, "docstatus": 1}
+	):
+		outstanding_amount = get_outstanding_amount_for_claim(doc)
+		frappe.db.set_value(
+			"Payment Entry Reference", payment_entry_reference, "outstanding_amount", outstanding_amount
+		)
+
 
 def get_total_reimbursed_amount(doc):
 	if doc.is_paid:
@@ -547,10 +555,7 @@ def update_payment_for_expense_claim(doc, method=None):
 	for d in doc.get(payment_table):
 		if d.get(doctype_field) == "Expense Claim" and d.reference_name:
 			expense_claim = frappe.get_doc("Expense Claim", d.reference_name)
-			if doc.docstatus == 2:
-				update_reimbursed_amount(expense_claim)
-			else:
-				update_reimbursed_amount(expense_claim)
+			update_reimbursed_amount(expense_claim)
 
 
 def validate_expense_claim_in_jv(doc, method=None):

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -10,6 +10,7 @@ from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_paymen
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.expense_claim.expense_claim import (
+	get_outstanding_amount_for_claim,
 	make_bank_entry,
 	make_expense_claim_for_delivery_trip,
 )
@@ -396,39 +397,30 @@ class TestExpenseClaim(FrappeTestCase):
 		pe1.reload()
 		self.assertEqual(pe1.references[0].outstanding_amount, 5000)
 
-		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
-			expense_claim
-		)
+		expense_claim.reload()
+		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 5000)
-		self.assertEqual(total_amount_reimbursed, 500)
+		self.assertEqual(expense_claim.total_amount_reimbursed, 500)
 
-		# Payment entry 1: paying 2000
+		# Payment entry 2: paying 2000
 		pe2 = make_payment_entry(expense_claim, 2000)
 		pe2.reload()
 		self.assertEqual(pe2.references[0].outstanding_amount, 3000)
-		pe1.reload()
-		self.assertEqual(pe1.references[0].outstanding_amount, 3000)
 
-		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
-			expense_claim
-		)
+		expense_claim.reload()
+		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 3000)
-		self.assertEqual(total_amount_reimbursed, 2500)
+		self.assertEqual(expense_claim.total_amount_reimbursed, 2500)
 
-		# Payment entry 1: paying 3000
+		# Payment entry 3: paying 3000
 		pe3 = make_payment_entry(expense_claim, 3000)
 		pe3.reload()
 		self.assertEqual(pe3.references[0].outstanding_amount, 0)
-		pe2.reload()
-		self.assertEqual(pe2.references[0].outstanding_amount, 0)
-		pe1.reload()
-		self.assertEqual(pe1.references[0].outstanding_amount, 0)
 
-		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
-			expense_claim
-		)
+		expense_claim.reload()
+		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 0)
-		self.assertEqual(total_amount_reimbursed, 5500)
+		self.assertEqual(expense_claim.total_amount_reimbursed, 5500)
 
 	def test_expense_claim_against_delivery_trip(self):
 		from erpnext.stock.doctype.delivery_trip.test_delivery_trip import (
@@ -657,17 +649,6 @@ def make_expense_claim(
 		return expense_claim
 	expense_claim.submit()
 	return expense_claim
-
-
-def get_outstanding_and_total_reimbursed_amounts(expense_claim):
-	outstanding_amount = flt(
-		frappe.db.get_value("Expense Claim", expense_claim.name, "total_sanctioned_amount")
-	) - flt(frappe.db.get_value("Expense Claim", expense_claim.name, "total_amount_reimbursed"))
-	total_amount_reimbursed = flt(
-		frappe.db.get_value("Expense Claim", expense_claim.name, "total_amount_reimbursed")
-	)
-
-	return outstanding_amount, total_amount_reimbursed
 
 
 def make_payment_entry(expense_claim, amount):

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -392,7 +392,10 @@ class TestExpenseClaim(FrappeTestCase):
 		expense_claim.submit()
 
 		# Payment entry 1: paying 500
-		make_payment_entry(expense_claim, 500)
+		pe1 = make_payment_entry(expense_claim, 500)
+		pe1.reload()
+		self.assertEqual(pe1.references[0].outstanding_amount, 5000)
+
 		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
 			expense_claim
 		)
@@ -400,7 +403,12 @@ class TestExpenseClaim(FrappeTestCase):
 		self.assertEqual(total_amount_reimbursed, 500)
 
 		# Payment entry 1: paying 2000
-		make_payment_entry(expense_claim, 2000)
+		pe2 = make_payment_entry(expense_claim, 2000)
+		pe2.reload()
+		self.assertEqual(pe2.references[0].outstanding_amount, 3000)
+		pe1.reload()
+		self.assertEqual(pe1.references[0].outstanding_amount, 3000)
+
 		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
 			expense_claim
 		)
@@ -408,7 +416,14 @@ class TestExpenseClaim(FrappeTestCase):
 		self.assertEqual(total_amount_reimbursed, 2500)
 
 		# Payment entry 1: paying 3000
-		make_payment_entry(expense_claim, 3000)
+		pe3 = make_payment_entry(expense_claim, 3000)
+		pe3.reload()
+		self.assertEqual(pe3.references[0].outstanding_amount, 0)
+		pe2.reload()
+		self.assertEqual(pe2.references[0].outstanding_amount, 0)
+		pe1.reload()
+		self.assertEqual(pe1.references[0].outstanding_amount, 0)
+
 		outstanding_amount, total_amount_reimbursed = get_outstanding_and_total_reimbursed_amounts(
 			expense_claim
 		)


### PR DESCRIPTION
Fixes issues where the Outstanding Amount of Payment Entry Reference is not updated on its submission.

<details>

<summary>Screenshots</summary>

### Expense Claim

Paid with Total Amount Reimbursed Rs. 1000

![image](https://github.com/frappe/hrms/assets/61287991/30fbe78a-0b1b-4131-a17e-11abd91d4dcb)

### Payment Entry

Before PR: Outstanding Amount remains Rs. 1000

![image](https://github.com/frappe/hrms/assets/61287991/acc86adc-f7c3-4c5b-8d72-7fb4cc041684)

After PR:  Outstanding Amount updated to Rs. 0

![image](https://github.com/frappe/hrms/assets/61287991/d3ad1d7b-2b04-4793-8877-c87da7c36470)

</details>