### PR TITLE
fix: consider payment days = total working days in the last salary slip while calculating Gratuity

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -212,7 +212,7 @@ class Gratuity(AccountsController):
 		calculate_amount_based_on = self.gratuity_settings.calculate_gratuity_amount_based_on
 
 		gratuity_amount = 0
-		slabs = get_gratuity_rule_slabs(self.gratuity_rule)
+		slabs = self.get_gratuity_rule_slabs()
 		slab_found = False
 		years_left = experience
 
@@ -302,17 +302,19 @@ class Gratuity(AccountsController):
 
 		return applicable_earning_components
 
+	def get_gratuity_rule_slabs(self) -> list[dict]:
+		return frappe.get_all(
+			"Gratuity Rule Slab",
+			filters={"parent": self.gratuity_rule},
+			fields=["from_year", "to_year", "fraction_of_applicable_earnings"],
+			order_by="idx",
+		)
+
 	def _is_experience_within_slab(self, slab: dict, experience: float) -> bool:
 		return bool(slab.from_year <= experience and (experience < slab.to_year or slab.to_year == 0))
 
 	def _is_experience_beyond_slab(self, slab: dict, experience: float) -> bool:
 		return bool(slab.from_year < experience and (slab.to_year < experience and slab.to_year != 0))
-
-
-def get_gratuity_rule_slabs(gratuity_rule):
-	return frappe.get_all(
-		"Gratuity Rule Slab", filters={"parent": gratuity_rule}, fields=["*"], order_by="idx"
-	)
 
 
 def get_last_salary_slip(employee: str) -> dict | None:

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -271,7 +271,7 @@ class Gratuity(AccountsController):
 		# consider full payment days for calculation as last month's salary slip
 		# might have less payment days as per attendance, making it non-deterministic
 		salary_slip.payment_days = salary_slip.total_working_days
-		salary_slip.process_salary_structure()
+		salary_slip.calculate_net_pay()
 
 		total_amount = 0
 		component_found = False


### PR DESCRIPTION
Gratuity is calculated based on last drawn salary but if the employee worked for less number of days in the last payroll cycle, gratuity amount gets affected. 

Always keep payment days = total working days irrespective of attendance making it non-deterministic