### PR TITLE
feat: Allow salary slip preview for draft salary structure assignments

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -725,14 +725,14 @@ class SalarySlip(TransactionBase):
 			}
 			doc.append("earnings", wages_row)
 
-	def set_salary_structure_assignment(self):
+	def set_salary_structure_assignment(self,docstatus=1):
 		self._salary_structure_assignment = frappe.db.get_value(
 			"Salary Structure Assignment",
 			{
 				"employee": self.employee,
 				"salary_structure": self.salary_structure,
 				"from_date": ("<=", self.actual_start_date),
-				"docstatus": 1,
+				"docstatus": docstatus,
 			},
 			"*",
 			order_by="from_date desc",
@@ -749,9 +749,9 @@ class SalarySlip(TransactionBase):
 				)
 			)
 
-	def calculate_net_pay(self):
+	def calculate_net_pay(self, docstatus=1):
 		if self.salary_structure:
-			self.calculate_component_amounts("earnings")
+			self.calculate_component_amounts("earnings", docstatus)
 
 		# get remaining numbers of sub-period (period for which one salary is processed)
 		if self.payroll_period:
@@ -771,7 +771,7 @@ class SalarySlip(TransactionBase):
 		)
 
 		if self.salary_structure:
-			self.calculate_component_amounts("deductions")
+			self.calculate_component_amounts("deductions", docstatus)
 
 		set_loan_repayment(self)
 
@@ -1054,19 +1054,19 @@ class SalarySlip(TransactionBase):
 			)
 		return tax_deducted
 
-	def calculate_component_amounts(self, component_type):
+	def calculate_component_amounts(self, component_type, docstatus=1):
 		if not getattr(self, "_salary_structure_doc", None):
 			self._salary_structure_doc = frappe.get_cached_doc("Salary Structure", self.salary_structure)
 
-		self.add_structure_components(component_type)
+		self.add_structure_components(component_type, docstatus)
 		self.add_additional_salary_components(component_type)
 		if component_type == "earnings":
 			self.add_employee_benefits()
 		else:
 			self.add_tax_components()
 
-	def add_structure_components(self, component_type):
-		self.data, self.default_data = self.get_data_for_eval()
+	def add_structure_components(self, component_type, docstatus=1):
+		self.data, self.default_data = self.get_data_for_eval(docstatus)
 		timesheet_component = self._salary_structure_doc.salary_component
 
 		for struct_row in self._salary_structure_doc.get(component_type):
@@ -1111,13 +1111,13 @@ class SalarySlip(TransactionBase):
 						remove_if_zero_valued=remove_if_zero_valued,
 					)
 
-	def get_data_for_eval(self):
+	def get_data_for_eval(self,docstatus=1):
 		"""Returns data for evaluating formula"""
 		data = frappe._dict()
 		employee = frappe.get_cached_doc("Employee", self.employee).as_dict()
 
 		if not hasattr(self, "_salary_structure_assignment"):
-			self.set_salary_structure_assignment()
+			self.set_salary_structure_assignment(docstatus)
 
 		data.update(self._salary_structure_assignment)
 		data.update(self.as_dict())
@@ -1870,13 +1870,13 @@ class SalarySlip(TransactionBase):
 			status = self.get_status()
 		self.db_set("status", status)
 
-	def process_salary_structure(self, for_preview=0):
+	def process_salary_structure(self, for_preview=0, docstatus=1):
 		"""Calculate salary after salary structure details have been updated"""
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
 		self.pull_emp_details()
 		self.get_working_days_details(for_preview=for_preview)
-		self.calculate_net_pay()
+		self.calculate_net_pay(docstatus)
 
 	def pull_emp_details(self):
 		account_details = frappe.get_cached_value(

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -725,7 +725,7 @@ class SalarySlip(TransactionBase):
 			}
 			doc.append("earnings", wages_row)
 
-	def set_salary_structure_assignment(self,salary_structure_assignment=None):
+	def set_salary_structure_assignment(self,salary_structure_assignment=None,docstatus=1):
 		if not salary_structure_assignment:
 			self._salary_structure_assignment = frappe.db.get_value(
 				"Salary Structure Assignment",
@@ -733,7 +733,7 @@ class SalarySlip(TransactionBase):
 					"employee": self.employee,
 					"salary_structure": self.salary_structure,
 					"from_date": ("<=", self.actual_start_date),
-					"docstatus": 1,
+					"docstatus": docstatus,
 				},
 				"*",
 				order_by="from_date desc",
@@ -757,9 +757,9 @@ class SalarySlip(TransactionBase):
 				)
 			)
 
-	def calculate_net_pay(self, salary_structure_assignment=None):
+	def calculate_net_pay(self, salary_structure_assignment=None,docstatus=1):
 		if self.salary_structure:
-			self.calculate_component_amounts("earnings", salary_structure_assignment)
+			self.calculate_component_amounts("earnings", salary_structure_assignment, docstatus)
 
 		# get remaining numbers of sub-period (period for which one salary is processed)
 		if self.payroll_period:
@@ -779,7 +779,7 @@ class SalarySlip(TransactionBase):
 		)
 
 		if self.salary_structure:
-			self.calculate_component_amounts("deductions", salary_structure_assignment)
+			self.calculate_component_amounts("deductions", salary_structure_assignment, docstatus)
 
 		set_loan_repayment(self)
 
@@ -1062,19 +1062,19 @@ class SalarySlip(TransactionBase):
 			)
 		return tax_deducted
 
-	def calculate_component_amounts(self, component_type, salary_structure_assignment=None):
+	def calculate_component_amounts(self, component_type, salary_structure_assignment=None, docstatus=1):
 		if not getattr(self, "_salary_structure_doc", None):
 			self._salary_structure_doc = frappe.get_cached_doc("Salary Structure", self.salary_structure)
 
-		self.add_structure_components(component_type, salary_structure_assignment)
+		self.add_structure_components(component_type, salary_structure_assignment, docstatus)
 		self.add_additional_salary_components(component_type)
 		if component_type == "earnings":
 			self.add_employee_benefits()
 		else:
 			self.add_tax_components()
 
-	def add_structure_components(self, component_type, salary_structure_assignment=None):
-		self.data, self.default_data = self.get_data_for_eval(salary_structure_assignment)
+	def add_structure_components(self, component_type, salary_structure_assignment=None, docstatus=1):
+		self.data, self.default_data = self.get_data_for_eval(salary_structure_assignment, docstatus)
 		timesheet_component = self._salary_structure_doc.salary_component
 
 		for struct_row in self._salary_structure_doc.get(component_type):
@@ -1119,13 +1119,13 @@ class SalarySlip(TransactionBase):
 						remove_if_zero_valued=remove_if_zero_valued,
 					)
 
-	def get_data_for_eval(self, salary_structure_assignment=None):
+	def get_data_for_eval(self, salary_structure_assignment=None, docstatus=1):
 		"""Returns data for evaluating formula"""
 		data = frappe._dict()
 		employee = frappe.get_cached_doc("Employee", self.employee).as_dict()
 
 		if not hasattr(self, "_salary_structure_assignment"):
-			self.set_salary_structure_assignment(salary_structure_assignment)
+			self.set_salary_structure_assignment(salary_structure_assignment, docstatus)
 
 		data.update(self._salary_structure_assignment)
 		data.update(self.as_dict())
@@ -1878,13 +1878,13 @@ class SalarySlip(TransactionBase):
 			status = self.get_status()
 		self.db_set("status", status)
 
-	def process_salary_structure(self, for_preview=0, salary_structure_assignment=None):
+	def process_salary_structure(self, for_preview=0, salary_structure_assignment=None,docstatus=1):
 		"""Calculate salary after salary structure details have been updated"""
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
 		self.pull_emp_details()
 		self.get_working_days_details(for_preview=for_preview)
-		self.calculate_net_pay(salary_structure_assignment)
+		self.calculate_net_pay(salary_structure_assignment,docstatus)
 
 	def pull_emp_details(self):
 		account_details = frappe.get_cached_value(

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -725,7 +725,7 @@ class SalarySlip(TransactionBase):
 			}
 			doc.append("earnings", wages_row)
 
-	def set_salary_structure_assignment(self,salary_structure_assignment=None,docstatus=1):
+	def set_salary_structure_assignment(self, salary_structure_assignment=None, docstatus=1):
 		if not salary_structure_assignment:
 			self._salary_structure_assignment = frappe.db.get_value(
 				"Salary Structure Assignment",
@@ -741,7 +741,8 @@ class SalarySlip(TransactionBase):
 			)
 		else:
 			self._salary_structure_assignment = frappe.db.get_value(
-				"Salary Structure Assignment",salary_structure_assignment,
+				"Salary Structure Assignment",
+				salary_structure_assignment,
 				"*",
 				order_by="from_date desc",
 				as_dict=True,
@@ -757,7 +758,7 @@ class SalarySlip(TransactionBase):
 				)
 			)
 
-	def calculate_net_pay(self, salary_structure_assignment=None,docstatus=1):
+	def calculate_net_pay(self, salary_structure_assignment=None, docstatus=1):
 		if self.salary_structure:
 			self.calculate_component_amounts("earnings", salary_structure_assignment, docstatus)
 
@@ -1878,13 +1879,13 @@ class SalarySlip(TransactionBase):
 			status = self.get_status()
 		self.db_set("status", status)
 
-	def process_salary_structure(self, for_preview=0, salary_structure_assignment=None,docstatus=1):
+	def process_salary_structure(self, for_preview=0, salary_structure_assignment=None, docstatus=1):
 		"""Calculate salary after salary structure details have been updated"""
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
 		self.pull_emp_details()
 		self.get_working_days_details(for_preview=for_preview)
-		self.calculate_net_pay(salary_structure_assignment,docstatus)
+		self.calculate_net_pay(salary_structure_assignment, docstatus)
 
 	def pull_emp_details(self):
 		account_details = frappe.get_cached_value(

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -360,7 +360,7 @@ def make_salary_slip(
 	for_preview=0,
 	ignore_permissions=False,
 	salary_structure_assignment=None,
-	docstatus=1
+	docstatus=1,
 ):
 	def postprocess(source, target):
 		if employee:
@@ -368,7 +368,12 @@ def make_salary_slip(
 			if posting_date:
 				target.posting_date = posting_date
 
-		target.run_method("process_salary_structure", for_preview=for_preview, salary_structure_assignment=salary_structure_assignment,docstatus=docstatus)
+		target.run_method(
+			"process_salary_structure",
+			for_preview=for_preview,
+			salary_structure_assignment=salary_structure_assignment,
+			docstatus=docstatus,
+		)
 
 	doc = get_mapped_doc(
 		"Salary Structure",

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -359,7 +359,8 @@ def make_salary_slip(
 	print_format=None,
 	for_preview=0,
 	ignore_permissions=False,
-	salary_structure_assignment=None
+	salary_structure_assignment=None,
+	docstatus=1
 ):
 	def postprocess(source, target):
 		if employee:
@@ -367,7 +368,7 @@ def make_salary_slip(
 			if posting_date:
 				target.posting_date = posting_date
 
-		target.run_method("process_salary_structure", for_preview=for_preview, salary_structure_assignment=salary_structure_assignment)
+		target.run_method("process_salary_structure", for_preview=for_preview, salary_structure_assignment=salary_structure_assignment,docstatus=docstatus)
 
 	doc = get_mapped_doc(
 		"Salary Structure",

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -359,6 +359,7 @@ def make_salary_slip(
 	print_format=None,
 	for_preview=0,
 	ignore_permissions=False,
+	docstatus=1
 ):
 	def postprocess(source, target):
 		if employee:
@@ -366,7 +367,7 @@ def make_salary_slip(
 			if posting_date:
 				target.posting_date = posting_date
 
-		target.run_method("process_salary_structure", for_preview=for_preview)
+		target.run_method("process_salary_structure", for_preview=for_preview, docstatus=docstatus)
 
 	doc = get_mapped_doc(
 		"Salary Structure",

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -359,7 +359,7 @@ def make_salary_slip(
 	print_format=None,
 	for_preview=0,
 	ignore_permissions=False,
-	docstatus=1
+	salary_structure_assignment=None
 ):
 	def postprocess(source, target):
 		if employee:
@@ -367,7 +367,7 @@ def make_salary_slip(
 			if posting_date:
 				target.posting_date = posting_date
 
-		target.run_method("process_salary_structure", for_preview=for_preview, docstatus=docstatus)
+		target.run_method("process_salary_structure", for_preview=for_preview, salary_structure_assignment=salary_structure_assignment)
 
 	doc = get_mapped_doc(
 		"Salary Structure",


### PR DESCRIPTION
 Description:
  This PR introduces functionality to preview salary slips for draft salary structure assignments. It includes the following changes: 

-         Updates the make_salary_slip to fetch and display the file content in an HTML table cell.

-         Implements a feature to allow users to preview salary slips before finalizing the salary structure.

Issue:  #1823 