### PR TITLE
fix(Salary Slip): Move lending fields to custom fields

### DIFF
--- a/hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+++ b/hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
@@ -66,22 +66,6 @@
    "in_list_view": 1,
    "label": "Total Payment",
    "options": "Company:company:default_currency"
-  },
-  {
-   "fieldname": "loan_repayment_entry",
-   "fieldtype": "Link",
-   "label": "Loan Repayment Entry",
-   "no_copy": 1,
-   "options": "Loan Repayment",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "loan.loan_product",
-   "fieldname": "loan_product",
-   "fieldtype": "Link",
-   "label": "Loan Product",
-   "options": "Loan Product",
-   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -100,6 +100,22 @@ def get_custom_fields():
 				"options": "Account",
 				"insert_after": "column_break_10",
 			},
+			{
+				"fieldname": "loan_repayment_entry",
+				"fieldtype": "Link",
+				"label": "Loan Repayment Entry",
+				"no_copy": 1,
+				"options": "Loan Repayment",
+				"read_only": 1
+			},
+			{
+				"fetch_from": "loan.loan_product",
+				"fieldname": "loan_product",
+				"fieldtype": "Link",
+				"label": "Loan Product",
+				"options": "Loan Product",
+				"read_only": 1
+			},
 		],
 		"Department": [
 			{


### PR DESCRIPTION
I think these fields are not available if `lending` is not installed.