### PR TITLE
fix: don't overwrite leave approver while rendering leave summary dashboard

### DIFF
--- a/hrms/hr/doctype/department_approver/department_approver.py
+++ b/hrms/hr/doctype/department_approver/department_approver.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import get_link_to_form
 
 
 class DepartmentApprover(Document):
@@ -81,10 +82,13 @@ def get_approvers(doctype, txt, searchfield, start, page_len, filters):
 
 	if len(approvers) == 0:
 		error_msg = _("Please set {0} for the Employee: {1}").format(
-			_(field_name), frappe.bold(employee.employee_name)
+			frappe.bold(_(field_name)),
+			get_link_to_form("Employee", filters.get("employee"), employee.employee_name),
 		)
 		if department_list:
-			error_msg += " " + _("or for Department: {0}").format(frappe.bold(employee_department))
+			error_msg += " " + _("or for the Employee's Department: {0}").format(
+				get_link_to_form("Department", employee_department)
+			)
 		frappe.throw(error_msg, title=_("{0} Missing").format(_(field_name)))
 
 	return set(tuple(approver) for approver in approvers)

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -63,9 +63,6 @@ frappe.ui.form.on("Leave Application", {
 					if (!r.exc && r.message["leave_allocation"]) {
 						leave_details = r.message["leave_allocation"];
 					}
-					if (!r.exc && r.message["leave_approver"]) {
-						frm.set_value("leave_approver", r.message["leave_approver"]);
-					}
 					lwps = r.message["lwps"];
 				},
 			});


### PR DESCRIPTION
- If there are multiple leave approvers set at the department level and you select the second one for the employee, it gets reset to the first set approver in the table since the `make_dashboard` function overwrites it on refresh. Regression from https://github.com/frappe/hrms/pull/1375
- Fix: decouple dashboard creation from leave approver setting since approver is already set on employee change trigger
- UX fix: link employee & department doc in the error message for missing leave approver 

<img width="1341" alt="image" src="https://github.com/frappe/hrms/assets/24353136/b572da57-cdf0-4d82-a0d9-a5913c16162b">

Closes: https://github.com/frappe/hrms/issues/1764
