### PR TITLE
fix(Salary Structure Assignment): Preview Salary Slip date

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -118,6 +118,7 @@ frappe.ui.form.on("Salary Structure Assignment", {
 					args: {
 						source_name: frm.doc.salary_structure,
 						employee: frm.doc.employee,
+						posting_date: frm.doc.from_date,
 						as_print: 1,
 						print_format: print_format,
 						for_preview: 1,


### PR DESCRIPTION
### Problem

Clicking on Salary Slip Preview for any Salary Structure Assignment generates it based on the employee's latest (excluding future dates) Salary Structure Assignment.

### Example

Salary Structure Assignment 1:- 
From Date = 01/05/2024

Salary Structure Assignment 2:- 
From Date = 01/06/2024

Salary Structure Assignment 3:- 
From Date = 01/07/2024 (future date)

Previewing Salary Slip based on SSA1 or SSA3 will show that based on SSA2.

### Solution

In this PR, I've edited the `preview_salary_slip` function to pass the `posting_date` param while calling the `make_salary_slip` method to ensure that the correct Salary Structure Assignment is considered.