### PR TITLE
fix(PWA): remove approval status field in expense claim form view

### DIFF
--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -204,6 +204,7 @@ function getFilteredFields(fields) {
 		"task",
 		"taxes_and_charges_sb",
 		"advance_payments_sb",
+		"approval_status"
 	]
 	const extraFields = [
 		"employee",


### PR DESCRIPTION
Before:

Employees can select the approval status to draft, approved or rejected and save the document.

![WhatsApp Image 2024-06-08 at 4 28 42 PM (1)](https://github.com/frappe/hrms/assets/48912196/a06a9cf5-575a-4490-946d-42696b962f33)

After:

Approval status field from expense claim form moved to excluded fields.

![WhatsApp Image 2024-06-10 at 3 50 16 PM](https://github.com/frappe/hrms/assets/48912196/3de51e2d-d602-4c40-b096-7e4f84847f14)


