### PR TITLE
fix(PWA): remove approval status field from expense claim form view

### DIFF
--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -204,6 +204,7 @@ function getFilteredFields(fields) {
 		"task",
 		"taxes_and_charges_sb",
 		"advance_payments_sb",
+		"approval_status"
 	]
 	const extraFields = [
 		"employee",


### PR DESCRIPTION
Before:

Employees can select approval status as draft, approved or rejected and save the form.

![WhatsApp Image 2024-06-08 at 4 28 42 PM (1)](https://github.com/frappe/hrms/assets/48912196/f397c269-eed4-43d8-b10b-40119bbaaab4)

After:

Moved the approval status to excluded fields.

```
function getFilteredFields(fields) {
	// reduce noise from the form view by excluding unnecessary fields
	// eg: employee and other details can be fetched from the session user
	const excludeFields = [
		"naming_series",
		"task",
		"taxes_and_charges_sb",
		"advance_payments_sb",
		"approval_status"
	]
	const extraFields = [
		"employee",
		"employee_name",
		"department",
		"company",
		"remark",
		"is_paid",
		"mode_of_payment",
		"clearance_date",
	]

	if (!props.id) excludeFields.push(...extraFields)

	return fields.filter((field) => !excludeFields.includes(field.fieldname))
}
```

![WhatsApp Image 2024-06-10 at 3 50 16 PM](https://github.com/frappe/hrms/assets/48912196/91371846-e024-4284-9e36-0c2ce270ec48)


