### PR TITLE
fix(Salary Slip): remove company filter from employee

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.js
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.js
@@ -37,9 +37,6 @@ frappe.ui.form.on("Salary Slip", {
 		frm.set_query("employee", function () {
 			return {
 				query: "erpnext.controllers.queries.employee_query",
-				filters: {
-					company: frm.doc.company,
-				},
 			};
 		});
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -195,7 +195,6 @@
    "in_standard_filter": 1,
    "label": "Company",
    "options": "Company",
-   "remember_last_selected_value": 1,
    "reqd": 1
   },
   {
@@ -727,7 +726,7 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:34.358893",
+ "modified": "2024-06-11 10:00:16.606996",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",


### PR DESCRIPTION
Dont set company filter on employee field, and remove "Remember last" property for company field.  