### PR TITLE
fix(SalarySlip): get lwp or ppl when payroll calculated based on leave

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2164,6 +2164,8 @@ def get_lwp_or_ppl_for_date_range(employee, start_date, end_date):
 			LeaveType.is_ppl,
 			LeaveType.fraction_of_daily_salary_per_leave,
 			LeaveType.include_holiday,
+			LeaveApplication.from_date,
+			LeaveApplication.to_date,
 			LeaveApplication.half_day,
 			LeaveApplication.half_day_date,
 			Attendance.attendance_date,

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -340,6 +340,24 @@ class TestSalarySlip(FrappeTestCase):
 
 		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 3.75)
 
+	@change_settings("Payroll Settings", {"payroll_based_on": "Leave"})
+	def test_payment_days_calculation_for_spanning_leave(self):
+		emp_id = make_employee("test_payment_days_spanning_leave@salary.com")
+
+		# Leave application spanning from 15-06-2024 to 15-07-2024
+		make_leave_application(emp_id, "2024-06-15", "2024-07-15", "Leave Without Pay")
+
+		# Generate the salary slip for July 2024
+		ss = make_employee_salary_slip(
+			emp_id, "Monthly", "Test Payment Spanning Leave Application", "2024-07-01"
+		)
+
+		# Calculating LWP days: 1-15 July (15 days)
+		# Total days in July: 31
+		# Payment days: 31 - 15 = 16 days
+		self.assertEqual(ss.leave_without_pay, 15)
+		self.assertEqual(ss.payment_days, 16)
+
 	@change_settings("Payroll Settings", {"payroll_based_on": "Attendance"})
 	def test_payment_days_in_salary_slip_based_on_timesheet(self):
 		from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet


### PR DESCRIPTION
Getting Attendance dates that are linked with Leave Application that the Leave Type is lwp or ppl between Salary Slip date range, to solve overlapping dates between Leave Application and Salary Slip.

Closes #1874