### PR TITLE
feat: add attachment for each type of proof in income tax proof submission instead of one single attachment

### DIFF
--- a/hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js
+++ b/hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js
@@ -33,6 +33,9 @@ frappe.ui.form.on("Employee Tax Exemption Proof Submission", {
 	},
 
 	refresh: function (frm) {
+		// hide attachments section in new forms in favor of the Attach Proof button against each proof
+		frm.toggle_display("attachments", frm.doc.attachments ? 1 : 0);
+
 		if (frm.doc.docstatus === 0) {
 			let filters = {
 				docstatus: 1,
@@ -53,19 +56,6 @@ frappe.ui.form.on("Employee Tax Exemption Proof Submission", {
 					get_query_filters: filters,
 				});
 			});
-		}
-
-
-		if(frm.doc.attachments)
-			{
-				frm.set_df_property('attachments',  'hidden', 0);
-
-			}
-
-		else 
-		{
-			frm.set_df_property('attachments',  'hidden', 1);
-
 		}
 	},
 

--- a/hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js
+++ b/hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js
@@ -54,6 +54,19 @@ frappe.ui.form.on("Employee Tax Exemption Proof Submission", {
 				});
 			});
 		}
+
+
+		if(frm.doc.attachments)
+			{
+				frm.set_df_property('attachments',  'hidden', 0);
+
+			}
+
+		else 
+		{
+			frm.set_df_property('attachments',  'hidden', 1);
+
+		}
 	},
 
 	currency: function (frm) {

--- a/hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+++ b/hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
@@ -9,7 +9,8 @@
   "exemption_category",
   "max_amount",
   "type_of_proof",
-  "amount"
+  "amount",
+  "proof_attach"
  ],
  "fields": [
   {
@@ -51,7 +52,13 @@
    "in_list_view": 1,
    "label": "Actual Amount",
    "options": "currency"
-  }
+  },
+  {
+    "fieldname": "proof_attach",
+    "fieldtype": "Attach Image",
+    "label": "Proof Attach",
+    "in_list_view": 1
+   }
  ],
  "istable": 1,
  "links": [],

--- a/hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+++ b/hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
@@ -8,12 +8,13 @@
   "exemption_sub_category",
   "exemption_category",
   "max_amount",
-  "type_of_proof",
   "amount",
-  "proof_attach"
+  "type_of_proof",
+  "attach_proof"
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "exemption_sub_category",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -22,6 +23,7 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "fetch_from": "exemption_sub_category.exemption_category",
    "fieldname": "exemption_category",
    "fieldtype": "Read Only",
@@ -30,6 +32,7 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "fetch_from": "exemption_sub_category.max_amount",
    "fieldname": "max_amount",
    "fieldtype": "Currency",
@@ -40,6 +43,7 @@
    "reqd": 1
   },
   {
+   "columns": 1,
    "fieldname": "type_of_proof",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -47,6 +51,7 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "fieldname": "amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -54,15 +59,16 @@
    "options": "currency"
   },
   {
-    "fieldname": "proof_attach",
-    "fieldtype": "Attach Image",
-    "label": "Proof Attach",
-    "in_list_view": 1
-   }
+   "columns": 1,
+   "fieldname": "attach_proof",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Attach Proof"
+  }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:42.297962",
+ "modified": "2024-06-25 19:57:18.490746",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Employee Tax Exemption Proof Submission Detail",


### PR DESCRIPTION
Created the Employee Tax Exmption proof submission attachment option inside the child tabe.So employee can submit seperate proof in each categories.
feat: add attachment for each type of proof in income tax declaration instead of one single attachment
issue:https://github.com/frappe/hrms/issues/1822

Video Link [komododecks.com/recordings/GpvGAtOI98Z9dOT9DK2X?onlyRecording=1](https://komododecks.com/recordings/GpvGAtOI98Z9dOT9DK2X?onlyRecording=1)

`no-docs`