### PR TITLE
fix: add party and party type in PE

### DIFF
--- a/hrms/public/js/erpnext/payment_entry.js
+++ b/hrms/public/js/erpnext/payment_entry.js
@@ -74,6 +74,8 @@ frappe.ui.form.on("Payment Entry Reference", {
 						frm.doc.payment_type == "Receive"
 							? frm.doc.paid_from_account_currency
 							: frm.doc.paid_to_account_currency,
+					party_type: frm.doc.party_type,
+					party: frm.doc.party,
 				},
 				callback: function (r, rt) {
 					if (r.message) {


### PR DESCRIPTION
fixes: #1831

added `party` and `party_type`. These parameters are necessary for the backend to correctly process transactions. But you should check it your way.

