### PR TITLE
fix: TypeError in Salary Slip Creation Due to Uninitialized Loans Field

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -104,7 +104,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 
 	if not doc.get("loans"):
 		doc.set("loans", [])
-	
+
 	for loan in doc.get("loans", []):
 		if not loan.total_payment:
 			continue
@@ -133,7 +133,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 def cancel_loan_repayment_entry(doc: "SalarySlip"):
 	if not doc.get("loans"):
 		doc.set("loans", [])
-	
+
 	for loan in doc.get("loans", []):
 		if loan.loan_repayment_entry:
 			repayment_entry = frappe.get_doc("Loan Repayment", loan.loan_repayment_entry)

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -47,7 +47,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 				)
 	if not doc.get("loans"):
 		doc.set("loans", [])
-	
+
 	for payment in doc.get("loans", []):
 		amounts = calculate_amounts(payment.loan, doc.posting_date, "Regular Payment")
 		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -102,6 +102,9 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 		"Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
 	)
 
+	if not doc.get("loans"):
+		doc.set("loans", [])
+	
 	for loan in doc.get("loans", []):
 		if not loan.total_payment:
 			continue

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -131,6 +131,9 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 
 @if_lending_app_installed
 def cancel_loan_repayment_entry(doc: "SalarySlip"):
+	if not doc.get("loans"):
+		doc.set("loans", [])
+	
 	for loan in doc.get("loans", []):
 		if loan.loan_repayment_entry:
 			repayment_entry = frappe.get_doc("Loan Repayment", loan.loan_repayment_entry)

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -45,7 +45,9 @@ def set_loan_repayment(doc: "SalarySlip"):
 						"interest_income_account": loan.interest_income_account,
 					},
 				)
-
+	if not doc.get("loans"):
+		doc.set("loans", [])
+	
 	for payment in doc.get("loans", []):
 		amounts = calculate_amounts(payment.loan, doc.posting_date, "Regular Payment")
 		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]


### PR DESCRIPTION
After migrating to ERPNext v15, creating payroll entries and individual salary slips failed with a TypeError: 'NoneType' object is not iterable. This issue occurs in the set_loan_repayment function when checking for loans associated with salary slips.

Fix:
Added a check to initialize the "loans" field as an empty list if it is None.

This fix ensures that the "loans" field is always iterable, preventing the TypeError and allowing salary slips to be created successfully.