### PR TITLE
fix(UX): validate missing Income Tax Slab in Salary Structure Assignment

### DIFF
--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -264,8 +264,8 @@ def create_salary_structure_assignment(
 	salary_structure_assignment.currency = currency
 	salary_structure_assignment.payroll_payable_account = get_payable_account(company)
 	salary_structure_assignment.company = company or erpnext.get_default_company()
-	salary_structure_assignment.save(ignore_permissions=True)
 	salary_structure_assignment.income_tax_slab = income_tax_slab
+	salary_structure_assignment.save(ignore_permissions=True)
 	salary_structure_assignment.submit()
 	return salary_structure_assignment
 

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, getdate
+from frappe.utils import cint, flt, get_link_to_form, getdate
 
 
 class DuplicateAssignment(frappe.ValidationError):
@@ -90,6 +90,18 @@ class SalaryStructureAssignment(Document):
 			)
 
 	def validate_income_tax_slab(self):
+		tax_component = get_tax_component(self.salary_structure)
+		if tax_component and not self.income_tax_slab:
+			frappe.throw(
+				_(
+					"Income Tax Slab is mandatory since the Salary Structure {0} has a tax component {1}"
+				).format(
+					get_link_to_form("Salary Structure", self.salary_structure), frappe.bold(tax_component)
+				),
+				exc=frappe.MandatoryError,
+				title=_("Missing Mandatory Field"),
+			)
+
 		if not self.income_tax_slab:
 			return
 
@@ -216,3 +228,11 @@ def get_employee_currency(employee):
 			)
 		)
 	return employee_currency
+
+
+def get_tax_component(salary_structure: str) -> str | None:
+	salary_structure = frappe.get_cached_doc("Salary Structure", salary_structure)
+	for d in salary_structure.get("deductions"):
+		if cint(d.variable_based_on_taxable_salary) and not d.formula and not flt(d.amount):
+			return d.salary_component
+	return None

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -232,7 +232,7 @@ def get_employee_currency(employee):
 
 def get_tax_component(salary_structure: str) -> str | None:
 	salary_structure = frappe.get_cached_doc("Salary Structure", salary_structure)
-	for d in salary_structure.get("deductions"):
+	for d in salary_structure.deductions:
 		if cint(d.variable_based_on_taxable_salary) and not d.formula and not flt(d.amount):
 			return d.salary_component
 	return None


### PR DESCRIPTION
Currently, the user only learns about missing income tax slabs in salary structure assignments when they run the payroll. By then the assignment is already submitted and changing it becomes difficult.

Validate this in the assignment itself if any tax component is found

<img width="1334" alt="image" src="https://github.com/frappe/hrms/assets/24353136/dba313c9-95b2-4a77-9cdf-9114ee6c1d8a">

