### PR TITLE
fix: HR Settings permissions

### DIFF
--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -322,7 +322,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-08 00:40:32.809157",
+ "modified": "2024-06-26 15:20:17.802079",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",
@@ -336,6 +336,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "HR User",
+   "share": 1
   },
   {
    "read": 1,


### PR DESCRIPTION
This PR gives roles HR User and HR Manager 'Read' and 'Read & Write' permissions respectively for the HR Settings DocType.

The lack of these permissions causes users with these roles to get a permission error while [viewing and editing Employee Checkins](https://github.com/frappe/hrms/blob/6a28b718096f437475e931b6a29d466833b83024/hrms/hr/doctype/employee_checkin/employee_checkin.js#L6).