### PR TITLE
ci: Regenerate POT file (translatable strings)

### DIFF
--- a/.github/helper/update_pot_file.sh
+++ b/.github/helper/update_pot_file.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+cd ~ || exit
+
+echo "Setting Up Bench..."
+
+pip install frappe-bench
+bench -v init frappe-bench --skip-assets --skip-redis-config-generation --python "$(which python)" --frappe-branch "${BASE_BRANCH}"
+cd ./frappe-bench || exit
+
+echo "Get HRMS..."
+bench get-app --skip-assets hrms "${GITHUB_WORKSPACE}"
+
+echo "Generating POT file..."
+bench generate-pot-file --app hrms
+
+cd ./apps/hrms || exit
+
+echo "Configuring git user..."
+git config user.email "developers@erpnext.com"
+git config user.name "frappe-pr-bot"
+
+echo "Setting the correct git remote..."
+# Here, the git remote is a local file path by default. Let's change it to the upstream repo.
+git remote set-url upstream https://github.com/frappe/hrms.git
+
+echo "Creating a new branch..."
+isodate=$(date -u +"%Y-%m-%d")
+branch_name="pot_${BASE_BRANCH}_${isodate}"
+git checkout -b "${branch_name}"
+
+echo "Commiting changes..."
+git add .
+git commit -m "chore: update POT file"
+
+gh auth setup-git
+git push -u upstream "${branch_name}"
+
+echo "Creating a PR..."
+gh pr create --fill --base "${BASE_BRANCH}" --head "${branch_name}" -R frappe/hrms

--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -1,0 +1,35 @@
+name: Regenerate POT file (translatable strings)
+on:
+  schedule:
+    # 9:30 UTC => 3 PM IST Sunday
+    - cron: "30 9 * * 0"
+  workflow_dispatch:
+
+jobs:
+  regenerate-pot-file:
+    name: Regenerate POT file
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ["develop"]
+    permissions:
+      contents: write
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            ref: ${{ matrix.branch }}
+
+        - name: Setup Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.12"
+
+        - name: Run script to update POT file
+          run: |
+            bash ${GITHUB_WORKSPACE}/.github/helper/update_pot_file.sh
+          env:
+            GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+            BASE_BRANCH: ${{ matrix.branch }}


### PR DESCRIPTION
Copy CI configuration from ERPNext for regenerating the file with translatable strings once a week.

This does roughly the following:

- Check out this repo's `develop` branch
- Run `bench generate-pot-file --app hrms`
- Create a PR in the name of Frappe PR Bot

This expects a repository secret named `RELEASE_TOKEN`, which should have permissions to push a branch and create a PR (I think this should be the bot's PAT).

Original Frappe PR for reference: https://github.com/frappe/frappe/pull/24467