### PR TITLE
ci: explicitly stage pot file

### DIFF
--- a/.github/helper/update_pot_file.sh
+++ b/.github/helper/update_pot_file.sh
@@ -30,7 +30,7 @@ branch_name="pot_${BASE_BRANCH}_${isodate}"
 git checkout -b "${branch_name}"
 
 echo "Commiting changes..."
-git add .
+git add hrms/locale/main.pot
 git commit -m "chore: update POT file"
 
 gh auth setup-git


### PR DESCRIPTION
Avoid accidentally adding any other changed files, like yarn.lock, to the commit.

In my test run https://github.com/frappe/hrms/pull/1930/files, `yarn.lock` was committed as well.
