### PR TITLE
fix(Shift Assignment): overlapping timings validation

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -141,8 +141,10 @@ class Attendance(Document):
 			)
 		).run(as_dict=True)
 
-		if same_date_attendance and has_overlapping_timings(self.shift, same_date_attendance[0].shift):
-			return same_date_attendance[0]
+		for d in same_date_attendance:
+			if has_overlapping_timings(self.shift, d.shift):
+				return d
+
 		return {}
 
 	def validate_employee_status(self):

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -114,7 +114,7 @@ def has_overlapping_timings(shift_1: str, shift_2: str) -> bool:
 		if d.end_time <= d.start_time:
 			d.end_time += timedelta(days=1)
 
-	return s1.end_time >= s2.start_time and s1.start_time <= s2.end_time
+	return s1.end_time > s2.start_time and s1.start_time < s2.end_time
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -35,9 +35,9 @@ class ShiftAssignment(Document):
 		if len(overlapping_dates):
 			self.validate_same_date_multiple_shifts(overlapping_dates)
 			# if dates are overlapping, check if timings are overlapping, else allow
-			overlapping_timings = has_overlapping_timings(self.shift_type, overlapping_dates[0].shift_type)
-			if overlapping_timings:
-				self.throw_overlap_error(overlapping_dates[0])
+			for d in overlapping_dates:
+				if has_overlapping_timings(self.shift_type, d.shift_type):
+					self.throw_overlap_error(d)
 
 	def validate_same_date_multiple_shifts(self, overlapping_dates):
 		if cint(frappe.db.get_single_value("HR Settings", "allow_multiple_shift_assignments")):
@@ -106,25 +106,15 @@ def has_overlapping_timings(shift_1: str, shift_2: str) -> bool:
 	"""
 	Accepts two shift types and checks whether their timings are overlapping
 	"""
-	if shift_1 == shift_2:
-		return True
 
 	s1 = frappe.db.get_value("Shift Type", shift_1, ["start_time", "end_time"], as_dict=True)
 	s2 = frappe.db.get_value("Shift Type", shift_2, ["start_time", "end_time"], as_dict=True)
 
-	if (
-		# shift 1 spans across 2 days
-		(s1.start_time > s1.end_time and s1.start_time < s2.end_time)
-		or (s1.start_time > s1.end_time and s2.start_time < s1.end_time)
-		or (s1.start_time > s1.end_time and s2.start_time > s2.end_time)
-		# both shifts fall on the same day
-		or (s1.start_time < s2.end_time and s2.start_time < s1.end_time)
-		# shift 2 spans across 2 days
-		or (s1.start_time < s2.end_time and s2.start_time > s2.end_time)
-		or (s2.start_time < s1.end_time and s2.start_time > s2.end_time)
-	):
-		return True
-	return False
+	for d in [s1, s2]:
+		if d.end_time <= d.start_time:
+			d.end_time += timedelta(days=1)
+
+	return s1.end_time >= s2.start_time and s1.start_time <= s2.end_time
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/shift_request/shift_request.py
+++ b/hrms/hr/doctype/shift_request/shift_request.py
@@ -81,9 +81,9 @@ class ShiftRequest(Document):
 		overlapping_dates = self.get_overlapping_dates()
 		if len(overlapping_dates):
 			# if dates are overlapping, check if timings are overlapping, else allow
-			overlapping_timings = has_overlapping_timings(self.shift_type, overlapping_dates[0].shift_type)
-			if overlapping_timings:
-				self.throw_overlap_error(overlapping_dates[0])
+			for d in overlapping_dates:
+				if has_overlapping_timings(self.shift_type, d.shift_type):
+					self.throw_overlap_error(d)
 
 	def get_overlapping_dates(self):
 		if not self.name:


### PR DESCRIPTION
This fixes two overlooked cases for overlapping shift timings (for the same date):-

**Case 1**

Shift 1:- 22:00 - 4:00

Shift 2:- 2:00 - 8:00

Shift 2 would be marked as overlapping even though it isn't. (Shift 1 starts 14 hours after Shift 2 ends)

**Case 2**

Shift 1:- 8:00 - 12:00

Shift 2:- 14:00 - 18:00

Shift 3:- 16:00 - 20:00

Shift 3 would **not** be marked as overlapping even though it is, with Shift 2.