### PR TITLE
fix: skip no value fields in formula autocompletions

### DIFF
--- a/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js
+++ b/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js
@@ -93,13 +93,7 @@ frappe.ui.form.on("Appraisal Cycle", {
 		await Promise.all(
 			["Employee", "Appraisal Cycle", "Appraisal"].map((doctype) =>
 				frappe.model.with_doctype(doctype, () => {
-					autocompletions.push(
-						...frappe.get_meta(doctype).fields.map((f) => ({
-							value: f.fieldname,
-							score: 8,
-							meta: __("{0} Field", [doctype]),
-						})),
-					);
+					autocompletions.push(...hrms.get_doctype_fields_for_autocompletion(doctype));
 				}),
 			),
 		);

--- a/hrms/public/js/utils/index.js
+++ b/hrms/public/js/utils/index.js
@@ -178,4 +178,21 @@ $.extend(hrms, {
 			is_minimizable: true,
 		});
 	},
+
+	get_doctype_fields_for_autocompletion: (doctype) => {
+		const fields = frappe.get_meta(doctype).fields;
+		const autocompletions = [];
+
+		fields
+			.filter((df) => !frappe.model.no_value_type.includes(df.fieldtype))
+			.map((df) => {
+				autocompletions.push({
+					value: df.fieldname,
+					score: 8,
+					meta: __("{0} Field", [doctype]),
+				});
+			});
+
+		return autocompletions;
+	},
 });

--- a/hrms/public/js/utils/payroll_utils.js
+++ b/hrms/public/js/utils/payroll_utils.js
@@ -6,11 +6,7 @@ hrms.payroll_utils = {
 				(doctype) =>
 					frappe.model.with_doctype(doctype, () => {
 						autocompletions.push(
-							...frappe.get_meta(doctype).fields.map((f) => ({
-								value: f.fieldname,
-								score: 8,
-								meta: __("{0} Field", [doctype]),
-							})),
+							...hrms.get_doctype_fields_for_autocompletion(doctype),
 						);
 					}),
 			),


### PR DESCRIPTION
## Before

No value fields like section break showing up in autocompletions:

<img width="1102" alt="image" src="https://github.com/frappe/hrms/assets/24353136/eda0aedb-39eb-4688-b33b-fabf105b9537">


## After

<img width="1052" alt="image" src="https://github.com/frappe/hrms/assets/24353136/799b964e-23ec-454f-90ae-5e71e5fa455f">
