### PR TITLE
fix: Sort lists before calling itertools.groupby

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -2,8 +2,8 @@
 # For license information, please see license.txt
 
 
-import itertools
 from datetime import datetime, timedelta
+from itertools import groupby
 
 import frappe
 from frappe.model.document import Document
@@ -36,7 +36,8 @@ class ShiftType(Document):
 
 		logs = self.get_employee_checkins()
 
-		for key, group in itertools.groupby(logs, key=lambda x: (x["employee"], x["shift_start"])):
+		group_key = lambda x: (x["employee"], x["shift_start"])  # noqa
+		for key, group in groupby(sorted(logs, key=group_key), key=group_key):
 			single_shift_logs = list(group)
 			attendance_date = key[1].date()
 			employee = key[0]

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -305,7 +305,8 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 	emp_map = {}
 
 	if group_by:
-		for parameter, employees in groupby(employee_details, key=lambda d: d[group_by]):
+		group_key = lambda d: d[group_by]  # noqa
+		for parameter, employees in groupby(sorted(employee_details, key=group_key), key=group_key):
 			group_by_param_values.append(parameter)
 			emp_map.setdefault(parameter, frappe._dict())
 


### PR DESCRIPTION
`itertools.groupby` returns consecutive groups only when the keys are consecutive. An input of `aBaB` will create 4 groups, not 2.

https://docs.python.org/3/library/itertools.html#itertools.groupby
https://stackoverflow.com/a/7286