### PR TITLE
feat: Added mandatory fields in dialog box for create interview

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -82,36 +82,104 @@ frappe.ui.form.on("Job Applicant", {
 	},
 
 	create_dialog: function (frm) {
-		let d = new frappe.ui.Dialog({
-			title: "Enter Interview Round",
-			fields: [
-				{
-					label: "Interview Round",
-					fieldname: "interview_round",
-					fieldtype: "Link",
-					options: "Interview Round",
-				},
-			],
-			primary_action_label: __("Create Interview"),
-			primary_action(values) {
-				frm.events.create_interview(frm, values);
-				d.hide();
-			},
-		});
-		d.show();
-	},
-
-	create_interview: function (frm, values) {
-		frappe.call({
-			method: "hrms.hr.doctype.job_applicant.job_applicant.create_interview",
-			args: {
-				doc: frm.doc,
-				interview_round: values.interview_round,
-			},
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			},
-		});
-	},
+        let d = new frappe.ui.Dialog({
+            title: "Enter Interview Round",
+            fields: [
+                {
+                    label: "Interview Round",
+                    fieldname: "interview_round",
+                    fieldtype: "Link",
+                    options: "Interview Round",
+                    reqd: 1,
+                    in_list_view: 1,
+                    in_standard_filter: 1
+                },
+                {
+                    label: "Scheduled On",
+                    fieldname: "scheduled_on",
+                    fieldtype: "Date",
+                    reqd: 1,
+                    in_list_view: 1,
+                    in_standard_filter: 1,
+                },
+                {
+                    label: "Interview Start Time",
+                    fieldname: "from_time",
+                    fieldtype: "Time",
+                    reqd: 1
+                },
+                {
+                    label: "Interview End Time",
+                    fieldname: "to_time",
+                    fieldtype: "Time",
+                    reqd: 1
+                },
+                {
+                    label: "Interviewer",
+                    fieldname: "interviewer",
+                    fieldtype: "Link",
+                    options: "User",
+                    reqd: 0
+                },
+            ],
+            primary_action_label: __("Create Interview"),
+            primary_action(values) {
+                // console.log("Dialog Values:", values); // Debugging line to check values
+                frm.events.create_interview(frm, values);
+                d.hide();
+            },
+        });
+        d.show();
+    },
+    create_interview: function (frm, values) {
+        console.log("Create Interview Values:", values);
+        if (!values.scheduled_on || !values.from_time || !values.to_time) {
+            frappe.show_alert({message: __('Scheduled date or interview time is required'), indicator: 'red'});
+            return;
+        }
+        let scheduledDate = new Date(values.scheduled_on);
+        frappe.call({
+            method: "hrms.hr.doctype.job_applicant.job_applicant.create_interview",
+            type: "POST",
+            args: {
+                doc: frm.doc,
+                interview_round: values.interview_round,
+                scheduled_on: scheduledDate.toISOString().split('T')[0],
+                from_time: values.from_time,
+                to_time: values.to_time,
+                interviewer: values.interviewer  // Add this line to include the interviewer
+            },
+            callback: function (r) {
+                if (r.message) {
+                    var doclist = frappe.model.sync(r.message);
+                    var doc = doclist[0];
+                    // Update the document with the values from the dialog
+                    frappe.model.set_value(doc.doctype, doc.name, 'scheduled_on', values.scheduled_on);
+                    frappe.model.set_value(doc.doctype, doc.name, 'from_time', values.from_time);
+                    frappe.model.set_value(doc.doctype, doc.name, 'to_time', values.to_time);
+                    let child = frappe.model.add_child(doc, 'interview_details', 'interview_details');
+                    frappe.model.set_value(child.doctype, child.name, 'interviewer', values.interviewer);
+                    // Save the document
+                    frappe.call({
+                        method: 'frappe.desk.form.save.savedocs',
+                        args: {
+                            doc: doc,
+                            action: 'Save'
+                        },
+                        callback: function(r) {
+                            if (r.exc) {
+                                frappe.msgprint(__("There were errors while saving. Please try again."));
+                            } else {
+                                frappe.show_alert({message: __('Interview created and saved successfully'), indicator: 'green'});
+                                frm.refresh();
+                            }
+                        }
+                    });
+                } else {
+                    console.error("Failed to create interview:", r);
+                    frappe.show_alert({message: __('Failed to create interview'), indicator: 'red'});
+                }
+            },
+        });
+    }
 });


### PR DESCRIPTION
closes #2015 
Adding a way to create job interviews directly from job applicant doctype to save time and make the process smoother
![image](https://github.com/user-attachments/assets/5782c9d6-c29a-48f7-9a0b-b29b1c60ea12)

