### PR TITLE
fix: rendering the email template subject in leave notification

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -597,6 +597,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			frappe.msgprint(_("Please set default template for Leave Status Notification in HR Settings."))
 			return
 		email_template = frappe.get_doc("Email Template", template)
+		subject = frappe.render_template(email_template.subject, args)
 		message = frappe.render_template(email_template.response_, args)
 
 		self.notify(
@@ -605,7 +606,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				"message": message,
 				"message_to": employee_email,
 				# for email
-				"subject": email_template.subject,
+				"subject": subject,
 				"notify": "employee",
 			}
 		)
@@ -622,6 +623,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				)
 				return
 			email_template = frappe.get_doc("Email Template", template)
+			subject = frappe.render_template(email_template.subject, args)
 			message = frappe.render_template(email_template.response_, args)
 
 			self.notify(
@@ -630,7 +632,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 					"message": message,
 					"message_to": self.leave_approver,
 					# for email
-					"subject": email_template.subject,
+					"subject": subject,
 				}
 			)
 


### PR DESCRIPTION
fixes: https://discuss.frappe.io/t/how-can-i-put-name-in-subject-in-email-templatee/129550?u=ncp

**Before:**

![image](https://github.com/user-attachments/assets/e1fb34aa-ba5a-48d5-bf1f-3ba78cc976bd)

**After:**

- fixed for Leave Approval Notification and Leave Status Notification

![image](https://github.com/user-attachments/assets/5569d1c2-8b3a-466a-9c6e-70cb01664e8a)
