### PR TITLE
fix: concurrency issue leading to duplicate attendance insertion

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -95,6 +95,7 @@ class Attendance(Document):
 				& (Attendance.attendance_date == self.attendance_date)
 				& (Attendance.name != self.name)
 			)
+			.for_update()
 		)
 
 		if self.shift:


### PR DESCRIPTION
Duplicate attendance records creation in a matter of milliseconds when 2 users concurrently try marking attendance from different tools.