### PR TITLE
fix: Attendance Request as a draft for a future date

### DIFF
--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -19,7 +19,6 @@ class OverlappingAttendanceRequestError(frappe.ValidationError):
 class AttendanceRequest(Document):
 	def validate(self):
 		validate_active_employee(self.employee)
-		validate_dates(self, self.from_date, self.to_date)
 		self.validate_half_day()
 		self.validate_request_overlap()
 


### PR DESCRIPTION
version 15

fixes: #1957


**Before:**

- They can't save the Attendance Request for a future date.

**After:**

- They can now save the Attendance Request as a draft for a future date, but they cannot submit it. Submitting the Attendance Request creates an Attendance record, which has a validation that prevents submissions for future dates.