### PR TITLE
fix: gantt chart view in the attendance

### DIFF
--- a/hrms/hr/doctype/attendance/attendance_calendar.js
+++ b/hrms/hr/doctype/attendance/attendance_calendar.js
@@ -2,8 +2,8 @@
 // For license information, please see license.txt
 frappe.views.calendar["Attendance"] = {
 	field_map: {
-		start: "start",
-		end: "end",
+		start: "attendance_date",
+		end: "attendance_date",
 		id: "name",
 		title: "title",
 		allDay: "allDay",


### PR DESCRIPTION
version 15

fixes: https://discuss.frappe.io/t/server-error-in-gantt-chart-view-in-the-attendance-doctype/128167?u=ncp

**Before:**

![image](https://github.com/user-attachments/assets/1f64d994-bd70-43d7-9adf-8c1a79a135d0)


**After:**

- There is no start and end field for the attendance doctype.

![image](https://github.com/user-attachments/assets/fd060a77-dfbb-4818-bebb-7a6aa8be0c92)



