### PR TITLE
feat(Employee Checkin): add Fetch Shift buttons in form and list view actions

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -18,14 +18,22 @@ frappe.ui.form.on("Employee Checkin", {
 
 	add_fetch_shift_button(frm) {
 		frm.add_custom_button(__("Fetch Shift"), function () {
+			const previous_shift = frm.doc.shift;
 			frappe.call({
 				method: "fetch_shift",
 				doc: frm.doc,
 				freeze: true,
 				freeze_message: __("Fetching Shift"),
 				callback: function () {
+					if (previous_shift === frm.doc.shift) return;
 					frm.dirty();
 					frm.save();
+					frappe.show_alert({
+						message: __("Shift has been successfully updated to {0}.", [
+							frm.doc.shift,
+						]),
+						indicator: "green",
+					});
 				},
 			});
 		});

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -17,6 +17,7 @@ frappe.ui.form.on("Employee Checkin", {
 	},
 
 	add_fetch_shift_button(frm) {
+		if (frm.doc.attendace) return;
 		frm.add_custom_button(__("Fetch Shift"), function () {
 			const previous_shift = frm.doc.shift;
 			frappe.call({

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -2,7 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Employee Checkin", {
-	refresh: async (_frm) => {
+	refresh: async (frm) => {
+		if (!frm.doc.__islocal) frm.trigger("add_fetch_shift_button");
+
 		const allow_geolocation_tracking = await frappe.db.get_single_value(
 			"HR Settings",
 			"allow_geolocation_tracking",
@@ -12,6 +14,21 @@ frappe.ui.form.on("Employee Checkin", {
 			hide_field(["fetch_geolocation", "latitude", "longitude", "geolocation"]);
 			return;
 		}
+	},
+
+	add_fetch_shift_button(frm) {
+		frm.add_custom_button(__("Fetch Shift"), function () {
+			frappe.call({
+				method: "fetch_shift",
+				doc: frm.doc,
+				freeze: true,
+				freeze_message: __("Fetching Shift"),
+				callback: function () {
+					frm.dirty();
+					frm.save();
+				},
+			});
+		});
 	},
 
 	fetch_geolocation: async (frm) => {

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -36,30 +36,33 @@ class EmployeeCheckin(Document):
 				_("This employee already has a log with the same timestamp.{0}").format("<Br>" + doc_link)
 			)
 
+	@frappe.whitelist()
 	def fetch_shift(self):
-		shift_actual_timings = get_actual_start_end_datetime_of_shift(
-			self.employee, get_datetime(self.time), True
-		)
-		if shift_actual_timings:
-			if (
-				shift_actual_timings.shift_type.determine_check_in_and_check_out
-				== "Strictly based on Log Type in Employee Checkin"
-				and not self.log_type
-				and not self.skip_auto_attendance
-			):
-				frappe.throw(
-					_("Log Type is required for check-ins falling in the shift: {0}.").format(
-						shift_actual_timings.shift_type.name
-					)
-				)
-			if not self.attendance:
-				self.shift = shift_actual_timings.shift_type.name
-				self.shift_actual_start = shift_actual_timings.actual_start
-				self.shift_actual_end = shift_actual_timings.actual_end
-				self.shift_start = shift_actual_timings.start_datetime
-				self.shift_end = shift_actual_timings.end_datetime
-		else:
+		if not (
+			shift_actual_timings := get_actual_start_end_datetime_of_shift(
+				self.employee, get_datetime(self.time), True
+			)
+		):
 			self.shift = None
+			return
+
+		if (
+			shift_actual_timings.shift_type.determine_check_in_and_check_out
+			== "Strictly based on Log Type in Employee Checkin"
+			and not self.log_type
+			and not self.skip_auto_attendance
+		):
+			frappe.throw(
+				_("Log Type is required for check-ins falling in the shift: {0}.").format(
+					shift_actual_timings.shift_type.name
+				)
+			)
+		if not self.attendance:
+			self.shift = shift_actual_timings.shift_type.name
+			self.shift_actual_start = shift_actual_timings.actual_start
+			self.shift_actual_end = shift_actual_timings.actual_end
+			self.shift_start = shift_actual_timings.start_datetime
+			self.shift_end = shift_actual_timings.end_datetime
 
 	@frappe.whitelist()
 	def set_geolocation_from_coordinates(self):
@@ -132,6 +135,17 @@ def add_log_based_on_employee_field(
 	doc.insert()
 
 	return doc
+
+
+@frappe.whitelist()
+def bulk_fetch_shift(checkins: list[str] | str) -> None:
+	if isinstance(checkins, str):
+		checkins = frappe.json.loads(checkins)
+	for d in checkins:
+		doc = frappe.get_doc("Employee Checkin", d)
+		doc.fetch_shift()
+		doc.flags.ignore_validate = True
+		doc.save()
 
 
 def mark_attendance_and_link_log(

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -1,0 +1,14 @@
+frappe.listview_settings["Employee Checkin"] = {
+	onload: function (listview) {
+		listview.page.add_action_item(__("Fetch Shifts"), () => {
+			const checkins = listview.get_checked_items().map((checkin) => checkin.name);
+			frappe.call({
+				method: "hrms.hr.doctype.employee_checkin.employee_checkin.bulk_fetch_shift",
+				freeze: true,
+				args: {
+					checkins,
+				},
+			});
+		});
+	},
+};

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -20,6 +20,7 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 
 from hrms.hr.doctype.employee_checkin.employee_checkin import (
 	add_log_based_on_employee_field,
+	bulk_fetch_shift,
 	calculate_working_hours,
 	mark_attendance_and_link_log,
 )
@@ -489,6 +490,40 @@ class TestEmployeeCheckin(FrappeTestCase):
 		timestamp = datetime.combine(date, get_time("12:01:00"))
 		log = make_checkin(employee, timestamp)
 		self.assertEqual(log.shift, shift2.name)
+
+	def test_bulk_fetch_shift(self):
+		emp1 = make_employee("emp1@example.com", company="_Test Company")
+		emp2 = make_employee("emp2@example.com", company="_Test Company")
+
+		# 8 - 12
+		shift1 = setup_shift_type(shift_type="Shift 1")
+		# 12:30 - 16:30
+		shift2 = setup_shift_type(shift_type="Shift 2", start_time="12:30:00", end_time="16:30:00")
+
+		frappe.db.set_value("Employee", emp1, "default_shift", shift1.name)
+		frappe.db.set_value("Employee", emp2, "default_shift", shift1.name)
+
+		date = getdate()
+		timestamp = datetime.combine(date, get_time("12:30:00"))
+
+		log1 = make_checkin(emp1, timestamp)
+		self.assertEqual(log1.shift, shift1.name)
+		log2 = make_checkin(emp2, timestamp)
+		self.assertEqual(log2.shift, shift1.name)
+
+		mark_attendance_and_link_log([log2], "Present", date)
+
+		make_shift_assignment(shift2.name, emp1, date)
+		make_shift_assignment(shift2.name, emp2, date)
+
+		bulk_fetch_shift([log1.name, log2.name])
+
+		log1.reload()
+		# shift changes according to the new assignment
+		self.assertEqual(log1.shift, shift2.name)
+		log2.reload()
+		# shift does not change since attendance is already marked
+		self.assertEqual(log1.shift, shift1.name)
 
 
 def make_n_checkins(employee, n, hours_to_reverse=1):

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -523,7 +523,7 @@ class TestEmployeeCheckin(FrappeTestCase):
 		self.assertEqual(log1.shift, shift2.name)
 		log2.reload()
 		# shift does not change since attendance is already marked
-		self.assertEqual(log1.shift, shift1.name)
+		self.assertEqual(log2.shift, shift1.name)
 
 
 def make_n_checkins(employee, n, hours_to_reverse=1):


### PR DESCRIPTION
For certain cases, such as when a shift is assigned to an employee after the checkin has been created, the shift is not updated in the checkin record. To counter this, users have to perform strange gymnastics like deleting and restoring these records.

This PR adds a Fetch Shift button to the form and list view actions so that this can be achieved more easily.

**Form**: 

![image](https://github.com/user-attachments/assets/081227da-b5fa-4f4c-b1cf-47e34df0e2c2)

**List View**:

![image](https://github.com/user-attachments/assets/03b32772-59fd-486e-8f55-bafd7ecfd7c1)

**Docs**: https://docs.frappe.io/hr/employee-checkin
