### PR TITLE
fix(Expense Claim): get_taxes condition

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -274,17 +274,18 @@ frappe.ui.form.on("Expense Claim", {
 			}
 		});
 	},
+
 	get_taxes: function (frm) {
-		if (frm.doc.taxes) {
-			frappe.call({
-				method: "calculate_taxes",
-				doc: frm.doc,
-				callback: () => {
-					refresh_field("taxes");
-					frm.trigger("update_employee_advance_claimed_amount");
-				},
-			});
-		}
+		if (!frm.doc.taxes.length) return;
+
+		frappe.call({
+			method: "calculate_taxes",
+			doc: frm.doc,
+			callback: () => {
+				refresh_field("taxes");
+				frm.trigger("update_employee_advance_claimed_amount");
+			},
+		});
 	},
 
 	get_advances: function (frm) {


### PR DESCRIPTION
### Issue

After adding a few rows in the expenses table, new ones _randomly_ become uneditable.

![a20um1Z](https://github.com/user-attachments/assets/a083404d-a566-43d4-a0b8-60a63300c2c1)

### Investigation

It seems to occur because of the [following code](https://github.com/frappe/hrms/blob/03d5b85f73c5b64d5d7f0633408d1a5808d4e983/hrms/hr/doctype/expense_claim/expense_claim.js#L277), which is executed every time the sanctioned amount in an expense is updated. Not entirely sure why, but turns out that making any server side call causes this to happen.

```
	get_taxes: function (frm) {
		if (frm.doc.taxes) {
			frappe.call({
				method: "calculate_taxes",
				doc: frm.doc,
				callback: () => {
					refresh_field("taxes");
					frm.trigger("update_employee_advance_claimed_amount");
				},
			});
		}
	},
```

### Temporary Solution

The `get_taxes` function is meant to run only if there are taxes added in the expense claim document. However, an empty array being a truthy value, `frm.doc.taxes` in `if (frm.doc.taxes)` always returns `true` and this call is made for every expense. 

Fixing this condition, at the very least, prevents this issue from occurring for most users (who I'm guessing add their taxes after their expenses). However, a more universal fix, involving business logic refactoring, may be in order.