### PR TITLE
fix(Salary Structure Assignment: Preview Salary Slip): Calculation of earnings whose formula is dependent on deductions and so on

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import ast
 import unicodedata
 from datetime import date
 
@@ -765,9 +766,6 @@ class SalarySlip(TransactionBase):
 			)
 
 	def calculate_net_pay(self):
-		if self.salary_structure:
-			self.calculate_component_amounts("earnings")
-
 		# get remaining numbers of sub-period (period for which one salary is processed)
 		if self.payroll_period:
 			self.remaining_sub_periods = get_period_factor(
@@ -780,19 +778,39 @@ class SalarySlip(TransactionBase):
 				relieving_date=self.relieving_date,
 			)[1]
 
+		if self.salary_structure:
+			self.calculate_component_amounts("earnings")
+			self.calculate_component_amounts("deductions")
+
+			deductions_abbr = [d.abbr for d in self.deductions]
+			for d in self._salary_structure_doc.earnings:
+				if not d.amount_based_on_formula:
+					continue
+				for var in get_variables_from_formula(d.formula):
+					if var in deductions_abbr:
+						self.add_structure_component(d, "earnings")
+						self.update_dependent_components_recursively("deductions", d.abbr)
+
 		self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
 		self.base_gross_pay = flt(
 			flt(self.gross_pay) * flt(self.exchange_rate), self.precision("base_gross_pay")
 		)
-
-		if self.salary_structure:
-			self.calculate_component_amounts("deductions")
-
 		set_loan_repayment(self)
 
 		self.set_precision_for_component_amounts()
 		self.set_net_pay()
 		self.compute_income_tax_breakup()
+
+	def update_dependent_components_recursively(self, component_type: str, updated_var: str) -> None:
+		other_component_type = "deductions" if component_type == "earnings" else "earnings"
+
+		for d in self._salary_structure_doc.get(component_type):
+			if not d.amount_based_on_formula:
+				continue
+			for var in get_variables_from_formula(d.formula):
+				if var == updated_var:
+					self.add_structure_component(d, component_type)
+					self.update_dependent_components_recursively(other_component_type, d.abbr)
 
 	def set_net_pay(self):
 		self.total_deduction = self.get_component_totals("deductions")
@@ -1082,49 +1100,54 @@ class SalarySlip(TransactionBase):
 
 	def add_structure_components(self, component_type):
 		self.data, self.default_data = self.get_data_for_eval()
-		timesheet_component = self._salary_structure_doc.salary_component
 
 		for struct_row in self._salary_structure_doc.get(component_type):
-			if self.salary_slip_based_on_timesheet and struct_row.salary_component == timesheet_component:
-				continue
+			self.add_structure_component(struct_row, component_type)
 
-			amount = self.eval_condition_and_formula(struct_row, self.data)
-			if struct_row.statistical_component:
-				# update statitical component amount in reference data based on payment days
-				# since row for statistical component is not added to salary slip
+	def add_structure_component(self, struct_row, component_type):
+		if (
+			self.salary_slip_based_on_timesheet
+			and struct_row.salary_component == self._salary_structure_doc.salary_component
+		):
+			return
 
-				self.default_data[struct_row.abbr] = flt(amount)
-				if struct_row.depends_on_payment_days:
-					payment_days_amount = (
-						flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
-						if self.total_working_days
-						else 0
-					)
-					self.data[struct_row.abbr] = flt(payment_days_amount, struct_row.precision("amount"))
+		amount = self.eval_condition_and_formula(struct_row, self.data)
+		if struct_row.statistical_component:
+			# update statitical component amount in reference data based on payment days
+			# since row for statistical component is not added to salary slip
 
-			else:
-				# default behavior, the system does not add if component amount is zero
-				# if remove_if_zero_valued is unchecked, then ask system to add component row
-				remove_if_zero_valued = frappe.get_cached_value(
-					"Salary Component", struct_row.salary_component, "remove_if_zero_valued"
+			self.default_data[struct_row.abbr] = flt(amount)
+			if struct_row.depends_on_payment_days:
+				payment_days_amount = (
+					flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
+					if self.total_working_days
+					else 0
 				)
+				self.data[struct_row.abbr] = flt(payment_days_amount, struct_row.precision("amount"))
 
-				default_amount = 0
+		else:
+			# default behavior, the system does not add if component amount is zero
+			# if remove_if_zero_valued is unchecked, then ask system to add component row
+			remove_if_zero_valued = frappe.get_cached_value(
+				"Salary Component", struct_row.salary_component, "remove_if_zero_valued"
+			)
 
-				if (
-					amount
-					or (struct_row.amount_based_on_formula and amount is not None)
-					or (not remove_if_zero_valued and amount is not None and not self.data[struct_row.abbr])
-				):
-					default_amount = self.eval_condition_and_formula(struct_row, self.default_data)
-					self.update_component_row(
-						struct_row,
-						amount,
-						component_type,
-						data=self.data,
-						default_amount=default_amount,
-						remove_if_zero_valued=remove_if_zero_valued,
-					)
+			default_amount = 0
+
+			if (
+				amount
+				or (struct_row.amount_based_on_formula and amount is not None)
+				or (not remove_if_zero_valued and amount is not None and not self.data[struct_row.abbr])
+			):
+				default_amount = self.eval_condition_and_formula(struct_row, self.default_data)
+				self.update_component_row(
+					struct_row,
+					amount,
+					component_type,
+					data=self.data,
+					default_amount=default_amount,
+					remove_if_zero_valued=remove_if_zero_valued,
+				)
 
 	def get_data_for_eval(self):
 		"""Returns data for evaluating formula"""
@@ -2274,8 +2297,6 @@ def _safe_eval(code: str, eval_globals: dict | None = None, eval_locals: dict | 
 
 
 def _check_attributes(code: str) -> None:
-	import ast
-
 	from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES
 
 	unsafe_attrs = set(UNSAFE_ATTRIBUTES).union(["__"]) - {"format"}
@@ -2314,3 +2335,7 @@ def email_salary_slips(names) -> None:
 	for name in names:
 		salary_slip = frappe.get_doc("Salary Slip", name)
 		salary_slip.email_salary_slip()
+
+
+def get_variables_from_formula(formula: str) -> list[str]:
+	return [node.id for node in ast.walk(ast.parse(formula)) if isinstance(node, ast.Name)]

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -796,8 +796,7 @@ class SalarySlip(TransactionBase):
 			self.update_dependent_components_recursively("earnings", deduction_abbrs)
 
 		set_gross_pay_and_base_gross_pay()
-		self.update_dependent_components_recursively("deductions", "gross_pay")
-		self.update_dependent_components_recursively("deductions", "base_gross_pay")
+		self.update_dependent_components_recursively("deductions", ["gross_pay", "base_gross_pay"])
 
 		set_loan_repayment(self)
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1610,6 +1610,69 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(test_tds.accounts[0].company, salary_slip.company)
 		self.assertListEqual(tax_component, ["_Test TDS"])
 
+	def test_circular_dependency_in_formula(self):
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+			create_salary_structure_assignment,
+		)
+
+		earnings = [
+			{
+				"salary_component": "Dependent Earning",
+				"abbr": "DE",
+				"type": "Earning",
+				"depends_on_payment_days": 0,
+				"amount_based_on_formula": 1,
+				"formula": "ID * 10",
+			},
+		]
+		make_salary_component(earnings, False, company_list=[])
+
+		deductions = [
+			{
+				"salary_component": "Independent Deduction",
+				"abbr": "ID",
+				"type": "Deduction",
+				"amount": 500,
+			},
+			{
+				"salary_component": "Dependent Deduction",
+				"abbr": "DD",
+				"type": "Deduction",
+				"amount_based_on_formula": 1,
+				"formula": "DE / 5",
+			},
+		]
+		make_salary_component(deductions, False, company_list=[])
+
+		details = {
+			"doctype": "Salary Structure",
+			"name": "Test Salary Structure for Circular Dependency",
+			"company": "_Test Company",
+			"payroll_frequency": "Monthly",
+			"payment_account": get_random("Account", filters={"account_currency": "USD"}),
+			"currency": "INR",
+		}
+		salary_structure = frappe.get_doc(details)
+
+		for entry in earnings:
+			salary_structure.append("earnings", entry)
+		for entry in deductions:
+			salary_structure.append("deductions", entry)
+
+		salary_structure.insert()
+		salary_structure.submit()
+
+		emp = make_employee("test_circ_dep@salary.com", company="_Test Company")
+
+		create_salary_structure_assignment(emp, salary_structure.name, currency="INR")
+		salary_slip = make_salary_slip(
+			salary_structure.name, employee=emp, posting_date=getdate(), for_preview=1
+		)
+
+		self.assertEqual(salary_slip.gross_pay, 5000)
+		self.assertEqual(salary_slip.earnings[0].amount, 5000)
+		self.assertEqual(salary_slip.deductions[1].amount, 1000)
+
 
 class TestSalarySlipSafeEval(FrappeTestCase):
 	def test_safe_eval_for_salary_slip(self):


### PR DESCRIPTION
Ticket: https://support.frappe.io/helpdesk/tickets/20134

First of all, let it be known that I do not like working on the payroll codebase.

Now that that is out of the way, if the formula of an earning component is dependent on a deduction component, it does not get updated in the salary slip preview. Consequently, other components that are dependent on the _un-updated_ one do not get updated either, and so on.

**Salary Structure**:

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/10bbe332-7098-4528-bcb5-704614b99a77">

**Salary Slip Preview (Base = 4,58,433)**:

<img width="744" alt="image" src="https://github.com/user-attachments/assets/e7fd1d5d-58ea-49fa-be44-0ffda92491f5">

Special Allowance isn't updated, as it does not get Provident Fund and Gratuity values. It should be 3504 - (1800 + 919) =  785

### Solution

- Recursively updating the components whose formulae are dependent on updated components (starting with earnings dependent on deductions)
- Calculating gross and base gross pay twice
	- After calculating earnings
	- After calculating deductions
- Updating deductions after final gross pay calculation in case it is dependent on it