### PR TITLE
fix: setup wizard breaks for non-admin user during ERPNext setup on frappehr.com domains

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -97,6 +97,8 @@ jinja = {
 after_install = "hrms.install.after_install"
 after_migrate = "hrms.setup.update_select_perm_after_install"
 
+setup_wizard_complete = "hrms.subscription_utils.update_erpnext_access"
+
 # Uninstallation
 # ------------
 

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -9,7 +9,6 @@ from frappe.desk.page.setup_wizard.setup_wizard import make_records
 from frappe.installer import update_site_config
 
 from hrms.overrides.company import delete_company_fixtures
-from hrms.subscription_utils import update_erpnext_access
 
 
 def after_install():
@@ -20,7 +19,6 @@ def after_install():
 	update_hr_defaults()
 	add_non_standard_user_types()
 	set_single_defaults()
-	update_erpnext_access()
 	create_default_role_profiles()
 	run_post_install_patches()
 

--- a/hrms/subscription_utils.py
+++ b/hrms/subscription_utils.py
@@ -69,10 +69,10 @@ def subscription_updated(app: str, plan: str):
 		update_erpnext_access()
 
 
-def update_erpnext_access():
+def update_erpnext_access(user_input: dict | None):
 	"""
-	ignores if user has no hrms subscription
-	enables erpnext workspaces and roles if user has subscribed to hrms and erpnext
+	Called from hooks after setup wizard completion, ignored if user has no hrms subscription
+	enables erpnext workspaces and roles if user has subscribed to both hrms and erpnext
 	disables erpnext workspaces and roles if user has subscribed to hrms but not erpnext
 	"""
 	if not frappe.utils.get_url().endswith(".frappehr.com"):
@@ -90,8 +90,6 @@ def update_erpnext_workspaces(disable: bool = True):
 		"Accounting",
 		"Buying",
 		"CRM",
-		"ERPNext Integrations",
-		"ERPNext Settings",
 		"Manufacturing",
 		"Quality",
 		"Selling",
@@ -107,7 +105,7 @@ def update_erpnext_workspaces(disable: bool = True):
 			workspace_doc.public = 0 if disable else 1
 			workspace_doc.save()
 		except Exception:
-			pass
+			frappe.clear_messages()
 
 
 def update_erpnext_roles(disable: bool = True):


### PR DESCRIPTION
**Problem**: `hrms` disables erpnext-specific roles after install. 

This used to work fine earlier as FC used to login and run setup wizard as admin. But FC now logs the user in as the system manager and not as an admin, so erpnext setup breaks due to missing roles

![telegram-cloud-photo-size-5-6208774860646235479-y](https://github.com/user-attachments/assets/56ffcbc0-f352-419d-b408-0d4c02381a09)

**Solution**: move disabling roles to `setup_wizard_complete` hook


