### PR TITLE
fix(Employee Grievance): fix perms for Reports To field

### DIFF
--- a/hrms/hr/doctype/employee_grievance/employee_grievance.json
+++ b/hrms/hr/doctype/employee_grievance/employee_grievance.json
@@ -143,6 +143,7 @@
    "fetch_from": "raised_by.reports_to",
    "fieldname": "reports_to",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Reports To",
    "options": "Employee",
    "read_only": 1
@@ -202,7 +203,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:39.125808",
+ "modified": "2024-08-21 15:46:21.711485",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Grievance",


### PR DESCRIPTION
Employee Grievance cannot be created by employees if their **Reports To** has been set in Employee master.

Ignoring User Permission for this field in Employee Grievance fixes the issue.