### PR TITLE
refactor(pwa): Reduce visual clutter in form header

### DIFF
--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -15,22 +15,34 @@
 					v-if="id"
 					class="flex flex-row items-center gap-2 overflow-hidden grow"
 				>
-					<h2
-						class="text-xl font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis"
-					>
-						{{ doctype }}
-					</h2>
-					<Badge
-						:label="id"
-						class="whitespace-nowrap text-[8px]"
-						variant="outline"
-					/>
-					<Badge
-						v-if="status"
-						:label="status"
-						:theme="statusColor"
-						class="whitespace-nowrap text-[8px]"
-					/>
+				<div class="flex flex-col items-center overflow-hidden grow">
+					<Popover>
+						<template #target="{ togglePopover }">
+							<div class="flex flex-row gap-2 items-center" @click="togglePopover()">
+								<h2
+									class="text-xl font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis"
+								>
+									{{ doctype }}
+								</h2>
+								<Badge
+								v-if="status"
+								:label="status"
+								:theme="statusColor"
+								class="whitespace-nowrap text-[8px]"
+							/>
+							</div>
+						</template>
+						<template #body-main>
+							<div class="flex place-content-center p-2">
+								<Badge
+									:label="id"
+									class="whitespace-nowrap text-[8px]"
+									variant="outline"
+								/>
+							</div>
+						</template>
+					</Popover>
+				</div>
 
 					<Dropdown
 						class="ml-auto"
@@ -323,6 +335,7 @@ import {
 	Dropdown,
 	Dialog,
 	LoadingIndicator,
+	Popover,
 } from "frappe-ui"
 import FormField from "@/components/FormField.vue"
 import FileUploaderView from "@/components/FileUploaderView.vue"


### PR DESCRIPTION
Hello this is my first contribution, here is a slight visual change to the header which was not fully readable.

-  Changed position of the title in the center of the header.
-  Added a popover for the name on the title.

**Here is the result:**

![popover1](https://github.com/user-attachments/assets/1cce1c6e-15f5-423b-8775-c138819daea3)
![popover2](https://github.com/user-attachments/assets/78c7e425-67b5-44f2-90f0-011c23668541)

> no-docs

re: https://github.com/orgs/frappe/projects/66/views/1?pane=issue&itemId=43852529