### PR TITLE
fix(PWA):  Autocomplete search functionality in Link component

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -66,7 +66,7 @@ const options = createResource({
 	},
 })
 
-const reloadOptions = debounce((searchTextVal) => {
+const reloadOptions = (searchTextVal) => {
 	options.update({
 		params: {
 			txt: searchTextVal,
@@ -74,6 +74,13 @@ const reloadOptions = debounce((searchTextVal) => {
 		},
 	})
 	options.reload()
+}
+
+const handleQueryUpdate = debounce((newQuery) => {
+	const val = newQuery || ""
+	if (searchText.value === val) return
+	searchText.val = val
+	reloadOptions(val)
 }, 300)
 
 watch(
@@ -84,11 +91,4 @@ watch(
 	},
 	{ immediate: true }
 )
-
-const handleQueryUpdate = (newQuery) => {
-  const val = newQuery || ""
-  if (searchText.value === val) return
-  searchText.value = val
-  reloadOptions(val)
-}
 </script>

--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -7,6 +7,7 @@
 		:options="options.data"
 		:class="disabled ? 'pointer-events-none' : ''"
 		:disabled="disabled"
+		@update:query="handleQueryUpdate"
 	/>
 </template>
 
@@ -84,14 +85,10 @@ watch(
 	{ immediate: true }
 )
 
-watch(
-	() => autocompleteRef.value?.query,
-	(val) => {
-		val = val || ""
-		if (searchText.value === val) return
-		searchText.value = val
-		reloadOptions(val)
-	},
-	{ immediate: true }
-)
+const handleQueryUpdate = (newQuery) => {
+  const val = newQuery || ""
+  if (searchText.value === val) return
+  searchText.value = val
+  reloadOptions(val)
+}
 </script>


### PR DESCRIPTION
**Problem**

The Autocomplete search functionality in the Link component was not properly triggering API calls to frappe.desk.search.search_link when users entered search queries. This resulted in a non-responsive search experience, where users couldn't see updated options based on their input. **The options were limited to 10 and if documents are more than 10 you wont be able to search the rest of the documents.**

![WhatsApp Image 2024-08-20 at 9 33 07 PM (2)](https://github.com/user-attachments/assets/35fde817-a8d0-4c99-87e9-6c28eaed5612)



**Solution**
This PR addresses the issue by restructuring how we handle query changes in the Autocomplete component:

1. Added an @update:query event handler to the Autocomplete component in the template.
2. Implemented a new handleQueryUpdate function to manage query changes efficiently.
3. Removed the problematic watcher for autocompleteRef.value?.query that wasn't reliably detecting changes.
4. Ensured that the reloadOptions function is called with the updated query, triggering the API call to fetch new options.

![Screenshot from 2024-08-28 02-09-00](https://github.com/user-attachments/assets/044a598f-f977-486c-99be-bf1e9c8576d4)



[https://github.com/frappe/hrms/issues/2120](url)
