### PR TITLE
fix(Payroll): incorrect tax period calculation when payroll period starts after the first day of the month

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import datetime
+
 import frappe
 from frappe import _, qb
 from frappe.model.document import Document
@@ -32,6 +34,8 @@ from erpnext.setup.doctype.employee.employee import (
 from hrms.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
 	calculate_pro_rated_leaves,
 )
+
+DateTimeLikeObject = str | datetime.date | datetime.datetime
 
 
 class DuplicateDeclarationError(frappe.ValidationError):
@@ -854,3 +858,17 @@ def check_app_permission():
 		return True
 
 	return False
+
+
+def get_exact_month_diff(string_ed_date: DateTimeLikeObject, string_st_date: DateTimeLikeObject) -> int:
+	"""Return the difference between given two dates in months."""
+	ed_date = getdate(string_ed_date)
+	st_date = getdate(string_st_date)
+	diff = (ed_date.year - st_date.year) * 12 + ed_date.month - st_date.month
+
+	# count the last month only if end date's day > start date's day
+	# to handle cases like 16th Jul 2024 - 15th Jul 2025
+	# where framework's month_diff will calculate diff as 13 months
+	if ed_date.day > st_date.day:
+		diff += 1
+	return diff

--- a/hrms/payroll/doctype/payroll_period/payroll_period.py
+++ b/hrms/payroll/doctype/payroll_period/payroll_period.py
@@ -5,10 +5,10 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_months, cint, date_diff, flt, formatdate, getdate, month_diff
+from frappe.utils import add_months, cint, date_diff, flt, formatdate, getdate
 from frappe.utils.caching import redis_cache
 
-from hrms.hr.utils import get_holiday_dates_for_employee
+from hrms.hr.utils import get_exact_month_diff, get_holiday_dates_for_employee
 
 
 class PayrollPeriod(Document):
@@ -126,8 +126,8 @@ def get_period_factor(
 	total_sub_periods, remaining_sub_periods = 0.0, 0.0
 
 	if payroll_frequency == "Monthly" and not depends_on_payment_days:
-		total_sub_periods = month_diff(payroll_period.end_date, payroll_period.start_date)
-		remaining_sub_periods = month_diff(period_end, start_date)
+		total_sub_periods = get_exact_month_diff(payroll_period.end_date, payroll_period.start_date)
+		remaining_sub_periods = get_exact_month_diff(period_end, start_date)
 	else:
 		salary_days = date_diff(end_date, start_date) + 1
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1451,6 +1451,30 @@ class TestSalarySlip(FrappeTestCase):
 		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 2), 125439.65)
 		self.assertEqual(flt(salary_slip.total_income_tax, 2), 136843.25)
 
+	def test_tax_period_for_mid_month_payroll_period(self):
+		from hrms.payroll.doctype.payroll_period.payroll_period import get_period_factor
+
+		frappe.db.delete("Payroll Period", {"company": "_Test Company"})
+		payroll_period = create_payroll_period(
+			name="Test Mid Month Payroll Period",
+			company="_Test Company",
+			start_date="2024-07-16",
+			end_date="2025-07-15",
+		)
+		emp_id = make_employee("test_mid_month_payroll@salary.com")
+
+		period_factor = get_period_factor(
+			emp_id,
+			"2024-07-16",
+			"2024-08-15",
+			"Monthly",
+			payroll_period,
+		)[1]
+
+		# count the last month only if end date's day > start date's day
+		# to handle cases like 16th Jul 2024 - 15th Jul 2025
+		self.assertEqual(period_factor, 12)
+
 	@change_settings("Payroll Settings", {"payroll_based_on": "Leave"})
 	def test_lwp_calculation_based_on_relieving_date(self):
 		emp_id = make_employee("test_lwp_based_on_relieving_date@salary.com")
@@ -1675,7 +1699,13 @@ def get_no_of_days():
 	return [no_of_days_in_month[1], no_of_holidays_in_month]
 
 
-def make_employee_salary_slip(emp_id, payroll_frequency, salary_structure=None, posting_date=None):
+def make_employee_salary_slip(
+	emp_id: str,
+	payroll_frequency: str,
+	salary_structure: str | None = None,
+	posting_date: str | None = None,
+	payroll_period: dict | None = None,
+) -> dict:
 	from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 	if not salary_structure:
@@ -1689,6 +1719,7 @@ def make_employee_salary_slip(emp_id, payroll_frequency, salary_structure=None, 
 		employee=employee.name,
 		company=employee.company,
 		from_date=posting_date,
+		payroll_period=payroll_period,
 	)
 	salary_slip_name = frappe.db.get_value("Salary Slip", {"employee": emp_id})
 


### PR DESCRIPTION
Closes https://github.com/frappe/hrms/issues/1992 Closes https://github.com/frappe/hrms/issues/837

If payroll period is from
16th July 2024 - 15th July 2025

Tax period gets calculated as 13 months because of the `month_diff` function in the framework leading to incorrect CTC calculation and thereby incorrect tax breakup

**Before**:

<img width="1063" alt="before" src="https://github.com/user-attachments/assets/b3702cb6-f7a5-4caa-b567-dd6aaf779877">


**After**:

<img width="1063" alt="after" src="https://github.com/user-attachments/assets/f72f1a60-b9c3-4d35-b90c-007b7ad364fd">

There was attempt to fix this in the framework https://github.com/frappe/frappe/pull/10938 but the inclusion of both the months is on purpose and this function doesn't exactly consider the dates. Wrote a custom helper function to handle this case for payroll

