### PR TITLE
fix(Payroll): multiline condition & formula eval failing

### DIFF
--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1663,7 +1663,7 @@ class TestSalarySlip(FrappeTestCase):
 				"abbr": "DD",
 				"type": "Deduction",
 				"amount_based_on_formula": 1,
-				"formula": "DE / 5",
+				"formula": "DE / 5\nif DE > 0\n else 0",
 			},
 		]
 		make_salary_component(deductions, False, company_list=[])

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -18,6 +18,9 @@ class SalaryStructure(Document):
 	def before_validate(self):
 		self.sanitize_condition_and_formula_fields()
 
+	def before_update_after_submit(self):
+		self.sanitize_condition_and_formula_fields()
+
 	def validate(self):
 		self.set_missing_values()
 		self.validate_amount()
@@ -28,6 +31,9 @@ class SalaryStructure(Document):
 		self.validate_formula_setup()
 
 	def on_update(self):
+		self.reset_condition_and_formula_fields()
+
+	def on_update_after_submit(self):
 		self.reset_condition_and_formula_fields()
 
 	def validate_formula_setup(self):


### PR DESCRIPTION
## Problem

Regression https://github.com/frappe/hrms/pull/2088
Multiline condition & formula eval failing because the last update tries to parse dependent component formulas without the sanitized expression. 

**Multiline formula:**
![image](https://github.com/user-attachments/assets/d946f70b-5d4e-4594-b86f-f2db4c15faf5)

![image](https://github.com/user-attachments/assets/6b7eceab-ddfe-4d7c-98f3-b502f29d664c)


## Fix

Sanitize condition & formula fields in salary structure doc reference to avoid accidental references to unsanitized fields across functions

![image](https://github.com/user-attachments/assets/229e7a97-8b81-4adb-8b90-9dd0f4bd84b1)


Fix in salary structure: Multiline formula updates error out on submitted doc because sanitization was only done on `before_validate`. Sanitize expression fields on `before_update_after_submit` too