### PR TITLE
fix(Payroll): skip dependent component update if no formula is set

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -813,12 +813,11 @@ class SalarySlip(TransactionBase):
 		other_component_type = "deductions" if component_type == "earnings" else "earnings"
 
 		for d in self._salary_structure_doc.get(component_type):
-			if not d.amount_based_on_formula:
-				continue
-			for var in get_variables_from_formula(d.formula):
-				if is_var_updated(var):
-					self.add_structure_component(d, component_type)
-					self.update_dependent_components_recursively(other_component_type, d.abbr)
+			if d.amount_based_on_formula and d.formula:
+				for var in get_variables_from_formula(d.formula):
+					if is_var_updated(var):
+						self.add_structure_component(d, component_type)
+						self.update_dependent_components_recursively(other_component_type, d.abbr)
 
 	def set_net_pay(self):
 		self.total_deduction = self.get_component_totals("deductions")
@@ -2350,4 +2349,6 @@ def email_salary_slips(names) -> None:
 
 
 def get_variables_from_formula(formula: str) -> list[str]:
+	# compile expects a string
+	formula = cstr(formula)
 	return [node.id for node in ast.walk(ast.parse(formula, mode="eval")) if isinstance(node, ast.Name)]


### PR DESCRIPTION
Fixes in continuation to https://github.com/frappe/hrms/pull/2147, https://github.com/frappe/hrms/pull/2138 🫠
for the change https://github.com/frappe/hrms/pull/2088

If a row has **Amount based on formula** enabled, but formula is not set, it fails because compile expects a string:

![image](https://github.com/user-attachments/assets/f4731ae4-5fdb-4804-be6b-c16e4e85ab27)

Skip dependent component update if no formula is set