### PR TITLE
fix(Payroll): calculate loan repayment amount based on payroll end date instead of posting date

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -31,7 +31,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 
 	if not doc.get("loans", []):
 		for loan in _get_loan_details(doc):
-			amounts = calculate_amounts(loan.name, doc.posting_date, "Regular Payment")
+			amounts = calculate_amounts(loan.name, doc.end_date, "Regular Payment")
 
 			if amounts["interest_amount"] or amounts["payable_principal_amount"]:
 				doc.append(
@@ -49,7 +49,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.set("loans", [])
 
 	for payment in doc.get("loans", []):
-		amounts = calculate_amounts(payment.loan, doc.posting_date, "Regular Payment")
+		amounts = calculate_amounts(payment.loan, doc.end_date, "Regular Payment")
 		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
 		if payment.total_payment > total_amount:
 			frappe.throw(

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -30,7 +30,11 @@ def set_loan_repayment(doc: "SalarySlip"):
 	doc.total_principal_amount = 0
 
 	if not doc.get("loans", []):
-		for loan in _get_loan_details(doc):
+		loan_details = _get_loan_details(doc)
+		if loan_details:
+			process_loan_interest_accruals(loan_details, doc.end_date)
+
+		for loan in loan_details:
 			amounts = calculate_amounts(loan.name, doc.end_date, "Regular Payment")
 
 			if amounts["interest_amount"] or amounts["payable_principal_amount"]:
@@ -68,11 +72,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.total_loan_repayment += payment.total_payment
 
 
-def _get_loan_details(doc: "SalarySlip"):
-	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-		process_loan_interest_accrual_for_term_loans,
-	)
-
+def _get_loan_details(doc: "SalarySlip") -> dict[str, str | bool]:
 	loan_details = frappe.get_all(
 		"Loan",
 		fields=["name", "interest_income_account", "loan_account", "loan_product", "is_term_loan"],
@@ -84,15 +84,19 @@ def _get_loan_details(doc: "SalarySlip"):
 			"status": ("!=", "Closed"),
 		},
 	)
-
-	if loan_details:
-		for loan in loan_details:
-			if loan.is_term_loan:
-				process_loan_interest_accrual_for_term_loans(
-					posting_date=doc.posting_date, loan_product=loan.loan_product, loan=loan.name
-				)
-
 	return loan_details
+
+
+def process_loan_interest_accruals(loan_details: dict[str, str | bool], posting_date: str):
+	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+		process_loan_interest_accrual_for_term_loans,
+	)
+
+	for loan in loan_details:
+		if loan.is_term_loan:
+			process_loan_interest_accrual_for_term_loans(
+				posting_date=posting_date, loan_product=loan.loan_product, loan=loan.name
+			)
 
 
 @if_lending_app_installed


### PR DESCRIPTION
## Steps to replicate

**Loan Repayment Schedule:**

Monthly repayment amount is 2000

![image](https://github.com/user-attachments/assets/dae980d7-6207-44d4-8d94-56ba50c67e59)

**Backdated salary slip:** 

For April 2024 generated in Sept 2024. Since all loan interest accruals have been processed by sept, loan amount shows up as 10000 for a backdated salary slip:

![loans-before](https://github.com/user-attachments/assets/5749a24f-2f06-4932-8e9d-859ddd9a7db7)

## Fix

Calculate loan repayment amount based on payroll end date instead of posting date
For backdated salary slips fetching loan repayments based on posting date seems incorrect and leads to more deductions than earnings sometimes. Process this relative to the payroll dates instead of posting date

![loans](https://github.com/user-attachments/assets/4f26adf0-a80f-474c-be8a-309660cf5cb3)
