### PR TITLE
fix(Employee Checkin): set the form as dirty on fetching geolocation

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -59,6 +59,7 @@ frappe.ui.form.on("Employee Checkin", {
 				frm.set_value("longitude", position.coords.longitude);
 
 				await frm.call("set_geolocation_from_coordinates");
+				frm.dirty();
 				frappe.dom.unfreeze();
 			},
 			(error) => {


### PR DESCRIPTION
## Before

Unable to save checkin after fetching geolocation post insert

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/fb76f839-300c-4ea2-8f6c-d645b30fbbfe">



## After

Set the form as dirty on fetching geolocation

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/bdc67afa-6c3a-41aa-a8a9-1806ef79d4d2">
