### PR TITLE
Interview changes

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -199,13 +199,11 @@ frappe.ui.form.on("Interview", {
 	},
 
 	interview_round: function (frm) {
-		frm.set_value("job_applicant", "");
 		frm.trigger("set_applicable_interviewers");
 	},
 
 	job_applicant: function (frm) {
 		if (!frm.doc.interview_round) {
-			frm.set_value("job_applicant", "");
 			frappe.throw(__("Select Interview Round First"));
 		}
 
@@ -221,6 +219,7 @@ frappe.ui.form.on("Interview", {
 				interview_round: frm.doc.interview_round || "",
 			},
 			callback: function (r) {
+				frm.doc.interview_details = [];
 				r.message.forEach((interviewer) =>
 					frm.add_child("interview_details", interviewer),
 				);

--- a/hrms/hr/doctype/interview/interview.json
+++ b/hrms/hr/doctype/interview/interview.json
@@ -64,7 +64,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nUnder Review\nCleared\nRejected",
+   "options": "Pending\nRescheduled Interview\nUnder Review\nCleared\nRejected",
    "reqd": 1
   },
   {

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -92,7 +92,14 @@ class Interview(Document):
 		original_from_time = self.from_time
 		original_to_time = self.to_time
 
-		self.db_set({"scheduled_on": scheduled_on, "from_time": from_time, "to_time": to_time,"status":"Rescheduled Interview"})
+		self.db_set(
+			{
+				"scheduled_on": scheduled_on,
+				"from_time": from_time,
+				"to_time": to_time,
+				"status": "Rescheduled Interview",
+			}
+		)
 		self.notify_update()
 
 		recipients = get_recipients(self.name)

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -92,7 +92,7 @@ class Interview(Document):
 		original_from_time = self.from_time
 		original_to_time = self.to_time
 
-		self.db_set({"scheduled_on": scheduled_on, "from_time": from_time, "to_time": to_time})
+		self.db_set({"scheduled_on": scheduled_on, "from_time": from_time, "to_time": to_time,"status":"Rescheduled Interview"})
 		self.notify_update()
 
 		recipients = get_recipients(self.name)

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -90,6 +90,7 @@ frappe.ui.form.on("Job Applicant", {
 					fieldname: "interview_round",
 					fieldtype: "Link",
 					options: "Interview Round",
+					reqd:1,
 				},
 			],
 			primary_action_label: __("Create Interview"),

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -90,7 +90,7 @@ frappe.ui.form.on("Job Applicant", {
 					fieldname: "interview_round",
 					fieldtype: "Link",
 					options: "Interview Round",
-					reqd:1,
+					read: 1,
 				},
 			],
 			primary_action_label: __("Create Interview"),

--- a/hrms/hr/doctype/training_result/training_result.js
+++ b/hrms/hr/doctype/training_result/training_result.js
@@ -12,10 +12,10 @@ frappe.ui.form.on("Training Result", {
 
 	training_event: function (frm) {
 		if (
-+			frm.doc.training_event &&
-+			!frm.doc.docstatus &&
-+			(!frm.doc.employees || frm.doc.employees.length === 0)
-+		) {
+			frm.doc.training_event &&
+			!frm.doc.docstatus &&
+			(!frm.doc.employees || frm.doc.employees.length === 0)
+		) {
 			frappe.call({
 				method: "hrms.hr.doctype.training_result.training_result.get_employees",
 				args: {
@@ -40,3 +40,4 @@ frappe.ui.form.on("Training Result", {
 		}
 	},
 });
+

--- a/hrms/hr/doctype/training_result/training_result.js
+++ b/hrms/hr/doctype/training_result/training_result.js
@@ -40,4 +40,3 @@ frappe.ui.form.on("Training Result", {
 		}
 	},
 });
-

--- a/hrms/hr/doctype/training_result/training_result.js
+++ b/hrms/hr/doctype/training_result/training_result.js
@@ -11,7 +11,11 @@ frappe.ui.form.on("Training Result", {
 	},
 
 	training_event: function (frm) {
-		if (frm.doc.training_event && !frm.doc.docstatus && (!frm.doc.employees || frm.doc.employees.length === 0)) {
+		if (
++			frm.doc.training_event &&
++			!frm.doc.docstatus &&
++			(!frm.doc.employees || frm.doc.employees.length === 0)
++		) {
 			frappe.call({
 				method: "hrms.hr.doctype.training_result.training_result.get_employees",
 				args: {

--- a/hrms/hr/doctype/training_result/training_result.js
+++ b/hrms/hr/doctype/training_result/training_result.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Training Result", {
 	},
 
 	training_event: function (frm) {
-		if (frm.doc.training_event && !frm.doc.docstatus && !frm.doc.employees) {
+		if (frm.doc.training_event && !frm.doc.docstatus && (!frm.doc.employees || frm.doc.employees.length === 0)) {
 			frappe.call({
 				method: "hrms.hr.doctype.training_result.training_result.get_employees",
 				args: {


### PR DESCRIPTION
1. Before There was no status representing rescheduled interviews.
After: A new status has been added for rescheduled interviews.
![image](https://github.com/user-attachments/assets/fbe13f5a-d491-42e5-85b3-24cc76055e36)


2. In Job Applicant to Interview Creation 
Before
[Screencast from 2024-09-05 12-14-28.webm](https://github.com/user-attachments/assets/f25301a6-e618-4af6-bac1-76e147e7645b)

After
[Screencast from 2024-09-05 12-13-25.webm](https://github.com/user-attachments/assets/f6fa7522-b9a5-478e-81d4-87a852b47f93)

3. In the Interview, Interviewer details added to existing interviewer details
Before
[Screencast from 2024-09-26 14-31-07.webm](https://github.com/user-attachments/assets/06d4b49a-dcb5-4f90-bd40-ada5db9c9d7f)

After
[Screencast from 2024-09-26 14-32-02.webm](https://github.com/user-attachments/assets/651ac566-3aae-4aca-b8fd-c3f66a2ec8a7)


fixed: https://github.com/frappe/hrms/issues/2028 Interview Creation issue from dashboard
4. In Interview creation Job applicant and its field were empty during a selection round.
Before
[Screencast from 2024-09-26 14-49-58.webm](https://github.com/user-attachments/assets/0e449eeb-a92f-4e9f-a5c9-71b8dff4b534)

After
[Screencast from 2024-09-26 14-50-52.webm](https://github.com/user-attachments/assets/dcac039f-edc3-4863-ae99-c98445bda5eb)

fixed:#1989
