### PR TITLE
fix: year_start_date in Employee Advance Summary

### DIFF
--- a/hrms/hr/report/employee_advance_summary/employee_advance_summary.js
+++ b/hrms/hr/report/employee_advance_summary/employee_advance_summary.js
@@ -15,7 +15,7 @@ frappe.query_reports["Employee Advance Summary"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: frappe.defaults.get_user_default("year_start_date"),
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 			width: "80",
 		},
 		{


### PR DESCRIPTION
Version 15 and 14

**Before:**

![image](https://github.com/user-attachments/assets/1522f26a-5c4d-45e8-887a-dff673e5b813)


**After:**

![image](https://github.com/user-attachments/assets/1f5ffd75-5d9c-4ab7-9555-fbf5110fff32)
