### PR TITLE
fix: remove default from Employee Leave Balance report

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -8,14 +8,14 @@ frappe.query_reports["Employee Leave Balance"] = {
 			label: __("From Date"),
 			fieldtype: "Date",
 			reqd: 1,
-			default: frappe.defaults.get_default("year_start_date"),
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 		},
 		{
 			fieldname: "to_date",
 			label: __("To Date"),
 			fieldtype: "Date",
 			reqd: 1,
-			default: frappe.defaults.get_default("year_end_date"),
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 		},
 		{
 			label: __("Company"),

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -8,14 +8,12 @@ frappe.query_reports["Employee Leave Balance"] = {
 			label: __("From Date"),
 			fieldtype: "Date",
 			reqd: 1,
-			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 		},
 		{
 			fieldname: "to_date",
 			label: __("To Date"),
 			fieldtype: "Date",
 			reqd: 1,
-			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 		},
 		{
 			label: __("Company"),
@@ -23,7 +21,6 @@ frappe.query_reports["Employee Leave Balance"] = {
 			fieldtype: "Link",
 			options: "Company",
 			reqd: 1,
-			default: frappe.defaults.get_user_default("Company"),
 		},
 		{
 			fieldname: "department",

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -21,6 +21,7 @@ frappe.query_reports["Employee Leave Balance"] = {
 			fieldtype: "Link",
 			options: "Company",
 			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
 		},
 		{
 			fieldname: "department",


### PR DESCRIPTION
Version 15 and 14

- There's no need to define the default value because it won’t work that way. Remove it, and if a leave period is created, it will be set in the onload event, which is already defined. So, remove the line below:
```py
default: frappe.defaults.get_default("year_start_date"),
```