### PR TITLE
fix(Monthly Attendance Sheet): consideration of None values while grouping

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -305,7 +305,7 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 	emp_map = {}
 
 	if group_by:
-		group_key = lambda d: d[group_by]  # noqa
+		group_key = lambda d: "" if d[group_by] is None else d[group_by]  # noqa
 		for parameter, employees in groupby(sorted(employee_details, key=group_key), key=group_key):
 			group_by_param_values.append(parameter)
 			emp_map.setdefault(parameter, frappe._dict())

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -205,6 +205,11 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		mark_attendance(self.employee, previous_month_first + relativedelta(days=2), "On Leave")
 		mark_attendance(self.employee, previous_month_first + relativedelta(days=3), "Present")
 
+		departmentless_employee = make_employee(
+			"emp@departmentless.com", company=self.company, department=None
+		)
+		mark_attendance(departmentless_employee, previous_month_first + relativedelta(days=3), "Present")
+
 		filters = frappe._dict(
 			{
 				"month": previous_month_first.month,


### PR DESCRIPTION
Fixes the following error while grouping by some field, for which some records may have `None` values:

`TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
`