### PR TITLE
fix(Income Tax Computation): consideration of new employees without preexisting salary slips

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -442,7 +442,7 @@ class IncomeTaxComputationReport:
 			salary_slip = frappe.new_doc("Salary Slip")
 			salary_slip.employee = emp
 			salary_slip.salary_structure = emp_details.salary_structure
-			salary_slip.start_date = self.payroll_period_start_date
+			salary_slip.start_date = max(self.payroll_period_start_date, emp_details.date_of_joining)
 			salary_slip.payroll_frequency = frappe.db.get_value(
 				"Salary Structure", emp_details.salary_structure, "payroll_frequency"
 			)


### PR DESCRIPTION
While generating the Income Tax Computation report, if an employee does not have pre-existing salary slips, the system looks for salary structure assignments on or before the selected Payroll Period start date. But an employee might not have a salary structure assignment till from when they joined, which could be after the aforementioned Payroll Period start date. In such a case, the system throws an error.

This PR fixes this by looking for assignments on or before the date of joining for such employees.