### PR TITLE
fix(Monthly Attendance Sheet): show shift for month full of leaves

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -229,7 +229,7 @@ def get_attendance_map(filters: Filters) -> dict:
 
 	for d in attendance_list:
 		if d.status == "On Leave":
-			leave_map.setdefault(d.employee, []).append(d.day_of_month)
+			leave_map.setdefault(d.employee, {}).setdefault(d.shift, []).append(d.day_of_month)
 			continue
 
 		if d.shift is None:
@@ -240,13 +240,14 @@ def get_attendance_map(filters: Filters) -> dict:
 
 	# leave is applicable for the entire day so all shifts should show the leave entry
 	for employee, leave_days in leave_map.items():
-		# no attendance records exist except leaves
-		if employee not in attendance_map:
-			attendance_map.setdefault(employee, {}).setdefault(None, {})
+		for assigned_shift, days in leave_days.items():
+			# no attendance records exist except leaves
+			if employee not in attendance_map:
+				attendance_map.setdefault(employee, {}).setdefault(assigned_shift, {})
 
-		for day in leave_days:
-			for shift in attendance_map[employee].keys():
-				attendance_map[employee][shift][day] = "On Leave"
+			for day in days:
+				for shift in attendance_map[employee].keys():
+					attendance_map[employee][shift][day] = "On Leave"
 
 	return attendance_map
 

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -41,6 +41,9 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		mark_attendance(self.employee, previous_month_first + relativedelta(days=1), "Present")
 		mark_attendance(self.employee, previous_month_first + relativedelta(days=2), "On Leave")
 
+		employee_on_leave_with_shift = make_employee("employee@leave.com", company=self.company)
+		mark_attendance(employee_on_leave_with_shift, previous_month_first, "On Leave", "Day Shift")
+
 		filters = frappe._dict(
 			{
 				"month": previous_month_first.month,
@@ -50,14 +53,14 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 		)
 		report = execute(filters=filters)
 
-		record = report[1][0]
 		datasets = report[3]["data"]["datasets"]
 		absent = datasets[0]["values"]
 		present = datasets[1]["values"]
 		leaves = datasets[2]["values"]
 
 		# ensure correct attendance is reflected on the report
-		self.assertEqual(self.employee, record.get("employee"))
+		self.assertEqual(self.employee, report[1][0].get("employee"))
+		self.assertEqual("Day Shift", report[1][1].get("shift"))
 		self.assertEqual(absent[0], 1)
 		self.assertEqual(present[1], 1)
 		self.assertEqual(leaves[2], 1)


### PR DESCRIPTION
Shift is not shown for an employee who has only been on leave for the entire month. This fixes that.