### PR TITLE
fix: daily work summary page not found error

### DIFF
--- a/hrms/hr/doctype/daily_work_summary/daily_work_summary.json
+++ b/hrms/hr/doctype/daily_work_summary/daily_work_summary.json
@@ -36,7 +36,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-27 13:06:49.091384",
+ "modified": "2024-09-18 13:30:28.136511",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Daily Work Summary",
@@ -58,7 +58,6 @@
   }
  ],
  "quick_entry": 1,
- "read_only": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Daily Work Summary Doctype Loading Issue
Issue : #2141
Before: 
![image](https://github.com/user-attachments/assets/8bdde4e2-c32e-43da-b9ea-effb9299d66a)
After:
![image](https://github.com/user-attachments/assets/ab8ac157-e299-4e4c-bb63-a1cc6dd834e2)
