### PR TITLE
fix(PWA): site name != host

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -184,6 +184,7 @@
 
 		<script>
 			window.csrf_token = "{{ csrf_token }}"
+			window.site_name = '{{ site_name }}'
 			if (!window.frappe) window.frappe = {}
 			frappe.boot = {{ boot }}
 		</script>

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -6,9 +6,10 @@ import { getCachedResource } from "frappe-ui/src/resources/resources"
 
 export function initSocket() {
 	let host = window.location.hostname
+	let siteName = window.site_name
 	let port = window.location.port ? `:${socketio_port}` : ""
 	let protocol = port ? "http" : "https"
-	let url = `${protocol}://${host}${port}/${host}`
+	let url = `${protocol}://${host}${port}/${siteName}`
 	let socket = io(url, {
 		withCredentials: true,
 		reconnectionAttempts: 5,

--- a/hrms/www/hrms.py
+++ b/hrms/www/hrms.py
@@ -20,4 +20,6 @@ def get_context_for_dev():
 
 
 def get_boot():
-	return frappe._dict({"push_relay_server_url": frappe.conf.get("push_relay_server_url")})
+	return frappe._dict(
+		{"site_name": frappe.local.site, "push_relay_server_url": frappe.conf.get("push_relay_server_url")}
+	)


### PR DESCRIPTION
See `frappe/crm`, `frappe/insights`, `frappe/gameplan`, etc.

Precedent in `frappe/insights`, for example:
- https://github.com/frappe/insights/blob/e10129f4f4d387969ebbcc7f2d23e5bf85855aee/frontend/index.html#L16
- https://github.com/frappe/insights/blob/e10129f4f4d387969ebbcc7f2d23e5bf85855aee/frontend/src/socket.js#L6
- https://github.com/frappe/insights/blob/e10129f4f4d387969ebbcc7f2d23e5bf85855aee/insights/www/insights.py#L58

Please also back-port to `version-15-hotfix`