### PR TITLE
fix(Roster): align with copy-html-entry constant

### DIFF
--- a/roster/vite.config.js
+++ b/roster/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
 		},
 	},
 	build: {
-		outDir: `../${path.basename(path.resolve(".."))}/public/roster`,
+		outDir: `../hrms/public/roster`,
 		emptyOutDir: true,
 		target: "es2015",
 		commonjsOptions: {


### PR DESCRIPTION
https://github.com/frappe/hrms/blob/ae828a856cd536e317a75301ab29605176e71bfb/roster/package.json#L9 is hard-coded to `hrms` while this was referencing the name of the folder.

They are not necessarily the same.