### PR TITLE
fix: don't access db unnecessarily

### DIFF
--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -65,7 +65,10 @@ class EmployeePaymentEntry(PaymentEntry):
 						continue
 
 					if field == "exchange_rate" or not d.get(field) or force:
-						d.db_set(field, value)
+						if self.get("_action") in ("submit", "cancel"):
+							d.db_set(field, value)
+						else:
+							d.set(field, value)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Companion to https://github.com/frappe/erpnext/pull/43301

This just created a major outage in producton (no payments could be processed by Guest in a restricted whitelisted permission scope - see Frappe PR linked in that ERPNext PR for details)
