### PR TITLE
fix: Accomodate `common_filters=None` in Bank Reco API

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -762,21 +762,26 @@ def get_ec_matching_query(
 	filters.append(ec.docstatus == 1)
 	filters.append(ec.is_paid == 1)
 	filters.append(ec.clearance_date.isnull())
-	filters.append(ec.mode_of_payment.isin(mode_of_payments))
-	if exact_match:
-		filters.append(ec.total_sanctioned_amount == common_filters.amount)
+	if mode_of_payments:
+		filters.append(ec.mode_of_payment.isin(mode_of_payments))
+
+	if common_filters:
+		ref_rank = frappe.qb.terms.Case().when(ec.employee == common_filters.party, 1).else_(0) + 1
+
+		if exact_match:
+			filters.append(ec.total_sanctioned_amount == common_filters.amount)
+		else:
+			filters.append(ec.total_sanctioned_amount.gt(common_filters.amount))
 	else:
-		filters.append(ec.total_sanctioned_amount.gt(common_filters.amount))
+		ref_rank = ConstantColumn(1)
 
 	if from_date and to_date:
 		filters.append(ec.posting_date[from_date:to_date])
 
-	ref_rank = frappe.qb.terms.Case().when(ec.employee == common_filters.party, 1).else_(0)
-
 	ec_query = (
 		qb.from_(ec)
 		.select(
-			(ref_rank + 1).as_("rank"),
+			ref_rank.as_("rank"),
 			ec.name,
 			ec.total_sanctioned_amount.as_("paid_amount"),
 			ConstantColumn("").as_("reference_no"),


### PR DESCRIPTION
Ref: https://github.com/frappe/hrms/pull/1510#discussion_r1768871971, https://github.com/alyf-de/banking/issues/108

1. `get_matching_queries` and `get_ec_matching_query` default to `common_filters=None` but do not handle the case where it is None
2. The `IN` Sql Operator does not accept empty lists. If `mode_of_payments` returns an empty list, the query breaks