### PR TITLE
feat: unlink payment on cancelation of employee advance

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -33,7 +33,7 @@ class EmployeeAdvance(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = "GL Entry"
-		self.check_linked_payment_enry()
+		self.check_linked_payment_entry()
 		self.set_status(update=True)
 
 	def on_update(self):
@@ -176,7 +176,7 @@ class EmployeeAdvance(Document):
 			)
 		).run()[0][0] or 0.0
 
-	def check_linked_payment_enry(self):
+	def check_linked_payment_entry(self):
 		from erpnext.accounts.utils import (
 			remove_ref_doc_link_from_pe,
 			update_accounting_ledgers_after_reference_removal,

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -33,6 +33,7 @@ class EmployeeAdvance(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = "GL Entry"
+		self.check_linked_payment_enry()
 		self.set_status(update=True)
 
 	def on_update(self):
@@ -174,6 +175,16 @@ class EmployeeAdvance(Document):
 				& (Advance.status == "Unpaid")
 			)
 		).run()[0][0] or 0.0
+
+	def check_linked_payment_enry(self):
+		from erpnext.accounts.utils import (
+			remove_ref_doc_link_from_pe,
+			update_accounting_ledgers_after_reference_removal,
+		)
+
+		if frappe.db.get_single_value("HR Settings", "unlink_payment_on_cancellation_of_employee_advance"):
+			remove_ref_doc_link_from_pe(self.doctype, self.name)
+			update_accounting_ledgers_after_reference_removal(self.doctype, self.name)
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import flt, now_datetime, nowdate
 
 import erpnext
@@ -277,6 +277,7 @@ class TestEmployeeAdvance(FrappeTestCase):
 		# (1000 - 500) + (1000 - 700)
 		self.assertEqual(advance3.pending_amount, 800)
 
+	@change_settings("HR Settings", {"unlink_payment_on_cancellation_of_employee_advance": True})
 	def test_unlink_payment_entries(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		self.assertTrue(frappe.db.exists("Employee", employee_name))

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import flt, nowdate
+from frappe.utils import flt, now_datetime, nowdate
 
 import erpnext
 from erpnext.setup.doctype.employee.test_employee import make_employee
@@ -26,9 +26,10 @@ from hrms.payroll.doctype.salary_structure.test_salary_structure import make_sal
 class TestEmployeeAdvance(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Employee Advance")
+		self.update_company_in_fiscal_year()
 
 	def test_paid_amount_and_status(self):
-		employee_name = make_employee("_T@employe.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 
 		journal_entry = make_journal_entry_for_advance(advance)
@@ -44,7 +45,7 @@ class TestEmployeeAdvance(FrappeTestCase):
 		self.assertRaises(EmployeeAdvanceOverPayment, journal_entry1.submit)
 
 	def test_paid_amount_on_pe_cancellation(self):
-		employee_name = make_employee("_T@employe.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 
 		journal_entry = make_journal_entry_for_advance(advance)
@@ -159,14 +160,19 @@ class TestEmployeeAdvance(FrappeTestCase):
 		self.assertTrue(advance.name in advances)
 
 	def test_repay_unclaimed_amount_from_salary(self):
-		employee_name = make_employee("_T@employe.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
 		journal_entry = make_journal_entry_for_advance(advance)
 		journal_entry.submit()
 
 		args = {"type": "Deduction"}
 		create_salary_component("Advance Salary - Deduction", **args)
-		make_salary_structure("Test Additional Salary for Advance Return", "Monthly", employee=employee_name)
+		make_salary_structure(
+			"Test Additional Salary for Advance Return",
+			"Monthly",
+			employee=employee_name,
+			company="_Test Company",
+		)
 
 		# additional salary for 700 first
 		advance.reload()
@@ -199,7 +205,7 @@ class TestEmployeeAdvance(FrappeTestCase):
 		self.assertEqual(advance.status, "Paid")
 
 	def test_payment_entry_against_advance(self):
-		employee_name = make_employee("_T@employee.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 
 		pe = make_payment_entry(advance, 700)
@@ -218,7 +224,7 @@ class TestEmployeeAdvance(FrappeTestCase):
 		self.assertEqual(advance.paid_amount, 700)
 
 	def test_precision(self):
-		employee_name = make_employee("_T@employee.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 		journal_entry = make_journal_entry_for_advance(advance)
 		journal_entry.submit()
@@ -257,7 +263,7 @@ class TestEmployeeAdvance(FrappeTestCase):
 		self.assertEqual(advance.status, "Partly Claimed and Returned")
 
 	def test_pending_amount(self):
-		employee_name = make_employee("_T@employee.advance")
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
 
 		advance1 = make_employee_advance(employee_name)
 		make_payment_entry(advance1, 500)
@@ -270,6 +276,32 @@ class TestEmployeeAdvance(FrappeTestCase):
 		advance3 = make_employee_advance(employee_name)
 		# (1000 - 500) + (1000 - 700)
 		self.assertEqual(advance3.pending_amount, 800)
+
+	def test_unlink_payment_entries(self):
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
+		self.assertTrue(frappe.db.exists("Employee", employee_name))
+
+		advance = make_employee_advance(employee_name)
+		self.assertTrue(advance)
+
+		advance_payment = make_payment_entry(advance, 1000)
+		self.assertTrue(advance_payment)
+		self.assertEqual(advance_payment.total_allocated_amount, 1000)
+
+		advance.reload()
+		advance.cancel()
+		advance_payment.reload()
+		self.assertEqual(advance_payment.unallocated_amount, 1000)
+		self.assertEqual(advance_payment.references, [])
+
+	def update_company_in_fiscal_year(self):
+		fy_entries = frappe.get_all("Fiscal Year")
+		for fy_entry in fy_entries:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy_entry.name)
+			company_list = [fy_c.company for fy_c in fiscal_year.companies if fy_c.company]
+			if "_Test Company" not in company_list:
+				fiscal_year.append("companies", {"company": "_Test Company"})
+				fiscal_year.save()
 
 
 def make_journal_entry_for_advance(advance):

--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -49,7 +49,9 @@
   "exit_questionnaire_notification_template",
   "attendance_settings_section",
   "allow_employee_checkin_from_mobile_app",
-  "allow_geolocation_tracking"
+  "allow_geolocation_tracking",
+  "unlink_payment_section",
+  "unlink_payment_on_cancellation_of_employee_advance"
  ],
  "fields": [
   {
@@ -316,13 +318,24 @@
    "fieldname": "attendance_settings_section",
    "fieldtype": "Section Break",
    "label": "Attendance Settings"
+  },
+  {
+   "fieldname": "unlink_payment_section",
+   "fieldtype": "Section Break",
+   "label": "Unlink Payment"
+  },
+  {
+   "default": "0",
+   "fieldname": "unlink_payment_on_cancellation_of_employee_advance",
+   "fieldtype": "Check",
+   "label": " Unlink Payment on Cancellation of Employee Advance"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-26 15:20:17.802079",
+ "modified": "2024-09-29 12:49:16.175079",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1791,7 +1791,7 @@ def make_salary_component(salary_components, test_tax, company_list=None):
 def set_salary_component_account(sal_comp, company_list=None):
 	company = erpnext.get_default_company()
 
-	if company_list and company not in company_list:
+	if company_list and company and company not in company_list:
 		company_list.append(company)
 
 	if not isinstance(sal_comp, Document):

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -241,7 +241,7 @@ def create_salary_structure_assignment(
 		frappe.db.sql("""delete from `tabSalary Structure Assignment` where employee=%s""", (employee))
 
 	if not payroll_period:
-		payroll_period = create_payroll_period()
+		payroll_period = create_payroll_period(company="_Test Company")
 
 	income_tax_slab = frappe.db.get_value("Income Tax Slab", {"currency": currency})
 


### PR DESCRIPTION
Issue:
Unable to cancel employee advance because of the payment reference in payment entry.
ref:[22530](https://support.frappe.io/helpdesk/tickets/22530)

[Employee Advance Cacellation.webm](https://github.com/user-attachments/assets/4395c063-f84d-4400-9472-1524d3be1036)


Fix:

[HR Setting  to Control Payment Unlink.webm](https://github.com/user-attachments/assets/bbda9881-adfa-4c4b-a327-18bb6d2df61f)

Backport needed: v15
