### PR TITLE
feat: show In and Out Time in Attendance even if there is only one log

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -241,8 +241,9 @@ def calculate_working_hours(logs, check_in_out_type, working_hours_calc_type):
 				if last_out_log_index or last_out_log_index == 0
 				else None
 			)
+			in_time = getattr(first_in_log, "time", None)
+			out_time = getattr(last_out_log, "time", None)
 			if first_in_log and last_out_log:
-				in_time, out_time = first_in_log.time, last_out_log.time
 				total_hours = time_diff_in_hours(in_time, out_time)
 		elif working_hours_calc_type == "Every Valid Check-in and Check-out":
 			in_log = out_log = None


### PR DESCRIPTION
For Shift Types where **Determine Check-in and Check-out** is "Strictly based on Log Type in Employee Checkin" and **Working Hours Calculation Based On** is "First Check-in and Last Check-out", `in_time `and `out_time` is not set for Attendance records when there is only one log. Now, it sets whatever log is available.

`no-docs`