### PR TITLE
chore: update site urls from frappehr.com to frappe.io/hr

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -10,7 +10,7 @@ body:
         Welcome to Frappe HR issue tracker! Before submitting a request, please consider the following:
 
         1. This tracker should only be used to report bugs and request features / enhancements to Frappe HR
-            - For questions and general support, checkout the [documentation](https://frappehr.com/docs) or use the [forum](https://discuss.frappe.io) to get inputs from the open source community.
+            - For questions and general support, checkout the [documentation](https://docs.frappe.io/hr) or use the [forum](https://discuss.frappe.io) to get inputs from the open source community.
         2. Use the search function before creating a new issue. Duplicates will be closed and directed to
           the original discussion.
         3. When making a feature request, make sure to be as verbose as possible. The better you convey your message, the greater the drive to make it happen.

--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -17,7 +17,7 @@ def docs_link_exists(body):
 					parts = parsed_url.path.split("/")
 					if len(parts) == 5 and parts[1] == "frappe" and parts[2] == "hrms":
 						return True
-				elif parsed_url.netloc == "frappehr.com":
+				elif parsed_url.netloc == "docs.frappe.io":
 					return True
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Frappe HR has everything you need to drive excellence within the company. It's a
 
 ## Learning and Community
 
-1. [Documentation](https://frappehr.com/docs) - Extensive documentation for Frappe HR.
+1. [Documentation](https://docs.frappe.io/hr) - Extensive documentation for Frappe HR.
 2. [User Forum](https://discuss.erpnext.com/) - Engage with the community of ERPNext users and service providers.
 3. [Telegram Group](https://t.me/frappehr) - Get instant help from the community of users.
 

--- a/hrms/hr/doctype/leave_type/leave_type.js
+++ b/hrms/hr/doctype/leave_type/leave_type.js
@@ -30,7 +30,7 @@ frappe.tour["Leave Type"] = [
 		description: __(
 			"Leaves you can avail against a holiday you worked on. You can claim Compensatory Off Leave using Compensatory Leave Request. Click {0} to know more",
 			[
-				`<a href='https://frappehr.com/docs/v14/en/compensatory-leave-request' target='_blank'>${__(
+				`<a href='https://docs.frappe.io/hr/compensatory-leave-request' target='_blank'>${__(
 					"here",
 				)}</a>`,
 			],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/frappe/hrms.git"
   },
-  "homepage": "https://frappehr.com",
+  "homepage": "https://frappe.io/hr",
   "author": "Frappe Technologies Pvt. Ltd.",
   "license": "GPL-3.0",
   "bugs": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ section-order = [
 
 
 [project.urls]
-Homepage = "https://frappehr.com/"
+Homepage = "https://frappe.io/hr"
 Repository = "https://github.com/frappe/hrms.git"
 "Bug Reports" = "https://github.com/frappe/hrms/issues"
 


### PR DESCRIPTION
Also fixes ci documentation validation for new link (docs.frappe.io/hr)