### PR TITLE
perf(Roster): improve get_holidays function

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -161,14 +161,18 @@ def insert_shift(
 
 def get_holidays(month_start: str, month_end: str, employee_filters: dict[str, str]) -> dict[str, list[dict]]:
 	holidays = {}
+	holiday_lists = {}
 
 	for employee in frappe.get_list("Employee", filters=employee_filters, pluck="name"):
-		if holiday_list := get_holiday_list_for_employee(employee, raise_exception=False):
-			holidays[employee] = frappe.get_all(
+		if not (holiday_list := get_holiday_list_for_employee(employee, raise_exception=False)):
+			continue
+		if holiday_list not in holiday_lists:
+			holiday_lists[holiday_list] = frappe.get_all(
 				"Holiday",
 				filters={"parent": holiday_list, "holiday_date": ["between", [month_start, month_end]]},
 				fields=["name as holiday", "holiday_date", "description", "weekly_off"],
 			)
+		holidays[employee] = holiday_lists[holiday_list].copy()
 
 	return holidays
 


### PR DESCRIPTION
Fetches each holiday list only once and reuses, instead of fetching repeatedly for each employee.