### PR TITLE
fix: payroll bank entry with the loan repayment amount

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -923,6 +923,8 @@ class PayrollEntry(Document):
 
 					salary_slip_total -= salary_detail.amount
 
+			salary_slip_total -= flt(salary_detail.get("total_loan_repayment"))
+
 		bank_entry = None
 		if salary_slip_total > 0:
 			remark = "withheld salaries" if for_withheld_salaries else "salaries"
@@ -946,6 +948,7 @@ class PayrollEntry(Document):
 				SalarySlip.employee,
 				SalarySlip.salary_structure,
 				SalarySlip.salary_withholding_cycle,
+				SalarySlip.total_loan_repayment,
 				SalaryDetail.salary_component,
 				SalaryDetail.amount,
 				SalaryDetail.parentfield,

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -717,6 +717,40 @@ class TestPayrollEntry(FrappeTestCase):
 		employees = payroll_entry.get_employees_with_unmarked_attendance()
 		self.assertFalse(employees)
 
+	@if_lending_app_installed
+	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
+	def test_loan_repayment_from_salary(self):
+		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
+		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+			process_loan_interest_accrual_for_term_loans,
+		)
+
+		frappe.db.delete("Loan")
+		applicant, branch, currency, payroll_payable_account = setup_lending()
+
+		loan = create_loan_for_employee(applicant)
+		loan_doc = frappe.get_doc("Loan", loan.name)
+		loan_doc.repay_from_salary = 1
+		loan_doc.save()
+
+		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
+		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = make_payroll_entry(
+			company="_Test Company",
+			start_date=dates.start_date,
+			payable_account=payroll_payable_account,
+			currency=currency,
+			end_date=dates.end_date,
+			branch=branch,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+			total_loan_repayment=loan.monthly_repayment_amount
+		)
+
+		bank_entry = payroll_entry.make_bank_entry()
+		submit_bank_entry(payroll_entry.name)
 
 def get_payroll_entry(**args):
 	args = frappe._dict(args)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -752,6 +752,7 @@ class TestPayrollEntry(FrappeTestCase):
 		bank_entry = payroll_entry.make_bank_entry()
 		submit_bank_entry(payroll_entry.name)
 
+
 def get_payroll_entry(**args):
 	args = frappe._dict(args)
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -746,7 +746,7 @@ class TestPayrollEntry(FrappeTestCase):
 			branch=branch,
 			cost_center="Main - _TC",
 			payment_account="Cash - _TC",
-			total_loan_repayment=loan.monthly_repayment_amount
+			total_loan_repayment=loan.monthly_repayment_amount,
 		)
 
 		bank_entry = payroll_entry.make_bank_entry()

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -749,7 +749,7 @@ class TestPayrollEntry(FrappeTestCase):
 			total_loan_repayment=loan.monthly_repayment_amount,
 		)
 
-		bank_entry = payroll_entry.make_bank_entry()
+		payroll_entry.make_bank_entry()
 		submit_bank_entry(payroll_entry.name)
 
 


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/app/hd-ticket/23315 & https://support.frappe.io/app/hd-ticket/21676

[before_loan_bank_entry.webm](https://github.com/user-attachments/assets/b0434161-91bc-42f4-b558-a6c42ce8dc15)

Before this change, the payroll entry was not correctly deducting loan repayments from the total salary, so the bank entry and Journal Entry didn’t match the actual pay after loans were taken out. we fixed this issue. Now, the payroll process accurately subtracts loan repayments, which means the Journal Entry shows the correct amount that employees receive after loan deductions.

[after_loan_bank_entry.webm](https://github.com/user-attachments/assets/9e20b348-876f-4273-a533-952284f74781)
