### PR TITLE
feat: allow fractional values for "Current Work Experience" field in gratuity doctype

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.json
+++ b/hrms/payroll/doctype/gratuity/gratuity.json
@@ -59,7 +59,7 @@
   {
    "default": "0",
    "fieldname": "current_work_experience",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "label": "Current Work Experience"
   },
   {
@@ -199,7 +199,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-15 02:50:10.282517",
+ "modified": "2024-10-25 15:33:11.549493",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Gratuity",


### PR DESCRIPTION
Changed the fieldtype of Current Work Experience in Gratuity doctype from Int to Float, to allow fractional values while creating gratuity.
<img width="700" alt="Screenshot 2024-10-25 at 3 50 36 PM" src="https://github.com/user-attachments/assets/d67e93cc-b394-4a4f-839a-ca41bf0738c7">
no-docs

