### PR TITLE
fix: correct bank entry calculation with deductions and prevent multiple loan repayment deductions

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -923,10 +923,8 @@ class PayrollEntry(Document):
 
 					salary_slip_total -= salary_detail.amount
 
-		total_loan_repayment = sum(
-			flt(slip.get("total_loan_repayment", 0))
-			for slip in {slip["name"]: slip for slip in salary_slips}.values()
-		)
+		unique_salary_slips = {slip["name"]: slip for slip in salary_slips}.values()
+		total_loan_repayment = sum(flt(slip.get("total_loan_repayment", 0)) for slip in unique_salary_slips)
 		salary_slip_total -= total_loan_repayment
 
 		bank_entry = None

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -923,7 +923,11 @@ class PayrollEntry(Document):
 
 					salary_slip_total -= salary_detail.amount
 
-			salary_slip_total -= flt(salary_detail.get("total_loan_repayment"))
+		total_loan_repayment = sum(
+			flt(slip.get("total_loan_repayment", 0))
+			for slip in {slip["name"]: slip for slip in salary_slips}.values()
+		)
+		salary_slip_total -= total_loan_repayment
 
 		bank_entry = None
 		if salary_slip_total > 0:

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
-from frappe.utils import add_days, add_months, cstr
+from frappe.utils import add_days, add_months, cstr, flt
 
 import erpnext
 from erpnext.accounts.utils import get_fiscal_year, getdate, nowdate
@@ -749,8 +749,19 @@ class TestPayrollEntry(IntegrationTestCase):
 			total_loan_repayment=loan.monthly_repayment_amount,
 		)
 
+		salary_slip_name = frappe.db.get_value("Salary Slip", {"payroll_entry": payroll_entry.name}, "name")
+		salary_slip = frappe.get_doc("Salary Slip", salary_slip_name)
+		payroll_entry.reload()
+
+		initial_gross_pay = flt(salary_slip.gross_pay) - flt(salary_slip.total_deduction)
+		loan_repayment_amount = flt(salary_slip.total_loan_repayment)
+		expected_net_pay = initial_gross_pay - loan_repayment_amount
+
 		payroll_entry.make_bank_entry()
 		submit_bank_entry(payroll_entry.name)
+
+		salary_slip.reload()
+		self.assertEqual(salary_slip.net_pay, expected_net_pay)
 
 
 def get_payroll_entry(**args):


### PR DESCRIPTION
Introduced via #2283 & #2324 and loan flow.

**Issue:**
- When deductions were present, the bank entry calculation did not work as expected.
- `total_loan_repayment` was being subtracted multiple times for each salary detail, leading to an incorrect `salary_slip_total` in the bank entry.

**Resolution:**
- Adjusted the `get_salary_slip_details` function to ensure `total_loan_repayment` is fetched only once per unique salary slip.
- In the `make_bank_entry` function, we separated the `total_loan_repayment` deduction from the main loop, ensuring it’s only subtracted once per salary slip, after calculating the total of earnings and deductions.