### PR TITLE
fix(PWA): post login redirection fails due to `default_route` conflict with other app

### DIFF
--- a/frontend/src/data/session.js
+++ b/frontend/src/data/session.js
@@ -19,7 +19,7 @@ function handleLogin(response) {
 		employeeResource.reload()
 
 		session.user = sessionUser()
-		router.replace(response.default_route || "/")
+		router.replace({ path: "/" })
 	}
 }
 

--- a/hrms/www/hrms.py
+++ b/hrms/www/hrms.py
@@ -25,6 +25,7 @@ def get_boot():
 		{
 			"site_name": frappe.local.site,
 			"push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
+			"default_route": get_default_route(),
 		}
 	)
 
@@ -32,3 +33,7 @@ def get_boot():
 	load_translations(bootinfo)
 
 	return bootinfo
+
+
+def get_default_route():
+	return "/hrms"


### PR DESCRIPTION
When hrms and gameplan are installed on the same site, post login redirection fails because gameplan has an `on_login` hook return to navigate to /onboarding

<img width="644" alt="image" src="https://github.com/user-attachments/assets/4a1e76a9-f60a-41da-aa60-6ba9a76a95a4">

and hrms tries to route to default route - so it ends up routing to `/hrms/onboarding`
<img width="440" alt="image" src="https://github.com/user-attachments/assets/a65cd59d-4d11-4126-b0f9-2d59dc38c2bf">
