### PR TITLE
fix: submit attendance request for future dates

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -50,18 +50,7 @@ class Attendance(Document):
 	def validate_attendance_date(self):
 		date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
 
-		# leaves can be marked for future dates
-		if (
-			self.status != "On Leave"
-			and not self.leave_application
-			and getdate(self.attendance_date) > getdate(nowdate())
-		):
-			frappe.throw(
-				_("Attendance can not be marked for future dates: {0}").format(
-					frappe.bold(format_date(self.attendance_date)),
-				)
-			)
-		elif date_of_joining and getdate(self.attendance_date) < getdate(date_of_joining):
+		if date_of_joining and getdate(self.attendance_date) < getdate(date_of_joining):
 			frappe.throw(
 				_("Attendance date {0} can not be less than employee {1}'s joining date: {2}").format(
 					frappe.bold(format_date(self.attendance_date)),


### PR DESCRIPTION
Attendance requests for future dates could not be created due to a validation that prevents marking attendance for future dates. The validation has been removed
