### PR TITLE
fix: stop leave allocation for left employees

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -483,7 +483,7 @@ def get_leave_allocations(date, leave_type):
 			& (employee.status != "Left")
 		)
 	)
-	return query.run(as_dict=1)
+	return query.run(as_dict=1) or []
 
 
 def get_earned_leaves():

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -461,15 +461,29 @@ def round_earned_leaves(earned_leaves, rounding):
 
 
 def get_leave_allocations(date, leave_type):
-	return frappe.db.sql(
-		"""select name, employee, from_date, to_date, leave_policy_assignment, leave_policy
-		from `tabLeave Allocation`
-		where
-			%s between from_date and to_date and docstatus=1
-			and leave_type=%s""",
-		(date, leave_type),
-		as_dict=1,
+	employee = frappe.qb.DocType("Employee")
+	leave_allocation = frappe.qb.DocType("Leave Allocation")
+	query = (
+		frappe.qb.from_(leave_allocation)
+		.join(employee)
+		.on(leave_allocation.employee == employee.name)
+		.select(
+			leave_allocation.name,
+			leave_allocation.employee,
+			leave_allocation.from_date,
+			leave_allocation.to_date,
+			leave_allocation.leave_policy_assignment,
+			leave_allocation.leave_policy,
+		)
+		.where(
+			(date >= leave_allocation.from_date)
+			& (date <= leave_allocation.to_date)
+			& (leave_allocation.docstatus == 1)
+			& (leave_allocation.leave_type == leave_type)
+			& (employee.status != "Left")
+		)
 	)
+	return query.run(as_dict=1)
 
 
 def get_earned_leaves():

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -345,35 +345,34 @@ def allocate_earned_leaves():
 
 	for e_leave_type in e_leave_types:
 		leave_allocations = get_leave_allocations(today, e_leave_type.name)
-		if leave_allocations:
-			for allocation in leave_allocations:
-				if not allocation.leave_policy_assignment and not allocation.leave_policy:
-					continue
+		for allocation in leave_allocations:
+			if not allocation.leave_policy_assignment and not allocation.leave_policy:
+				continue
 
-				leave_policy = (
-					allocation.leave_policy
-					if allocation.leave_policy
-					else frappe.db.get_value(
-						"Leave Policy Assignment", allocation.leave_policy_assignment, ["leave_policy"]
-					)
+			leave_policy = (
+				allocation.leave_policy
+				if allocation.leave_policy
+				else frappe.db.get_value(
+					"Leave Policy Assignment", allocation.leave_policy_assignment, ["leave_policy"]
 				)
+			)
 
-				annual_allocation = frappe.db.get_value(
-					"Leave Policy Detail",
-					filters={"parent": leave_policy, "leave_type": e_leave_type.name},
-					fieldname=["annual_allocation"],
-				)
-				date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
+			annual_allocation = frappe.db.get_value(
+				"Leave Policy Detail",
+				filters={"parent": leave_policy, "leave_type": e_leave_type.name},
+				fieldname=["annual_allocation"],
+			)
+			date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 
-				from_date = allocation.from_date
+			from_date = allocation.from_date
 
-				if e_leave_type.allocate_on_day == "Date of Joining":
-					from_date = date_of_joining
+			if e_leave_type.allocate_on_day == "Date of Joining":
+				from_date = date_of_joining
 
-				if check_effective_date(
-					from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day
-				):
-					update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining)
+			if check_effective_date(
+				from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day
+			):
+				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining)
 
 
 def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -345,35 +345,35 @@ def allocate_earned_leaves():
 
 	for e_leave_type in e_leave_types:
 		leave_allocations = get_leave_allocations(today, e_leave_type.name)
+		if leave_allocations:
+			for allocation in leave_allocations:
+				if not allocation.leave_policy_assignment and not allocation.leave_policy:
+					continue
 
-		for allocation in leave_allocations:
-			if not allocation.leave_policy_assignment and not allocation.leave_policy:
-				continue
-
-			leave_policy = (
-				allocation.leave_policy
-				if allocation.leave_policy
-				else frappe.db.get_value(
-					"Leave Policy Assignment", allocation.leave_policy_assignment, ["leave_policy"]
+				leave_policy = (
+					allocation.leave_policy
+					if allocation.leave_policy
+					else frappe.db.get_value(
+						"Leave Policy Assignment", allocation.leave_policy_assignment, ["leave_policy"]
+					)
 				)
-			)
 
-			annual_allocation = frappe.db.get_value(
-				"Leave Policy Detail",
-				filters={"parent": leave_policy, "leave_type": e_leave_type.name},
-				fieldname=["annual_allocation"],
-			)
-			date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
+				annual_allocation = frappe.db.get_value(
+					"Leave Policy Detail",
+					filters={"parent": leave_policy, "leave_type": e_leave_type.name},
+					fieldname=["annual_allocation"],
+				)
+				date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 
-			from_date = allocation.from_date
+				from_date = allocation.from_date
 
-			if e_leave_type.allocate_on_day == "Date of Joining":
-				from_date = date_of_joining
+				if e_leave_type.allocate_on_day == "Date of Joining":
+					from_date = date_of_joining
 
-			if check_effective_date(
-				from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day
-			):
-				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining)
+				if check_effective_date(
+					from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day
+				):
+					update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining)
 
 
 def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, date_of_joining):


### PR DESCRIPTION
This pr updates the leave allocation process to exclude employees with the status of 'Left'.