### PR TITLE
fix(PWA): broken translation strings

### DIFF
--- a/frontend/src/components/AttendanceCalendar.vue
+++ b/frontend/src/components/AttendanceCalendar.vue
@@ -65,6 +65,7 @@ import { createResource } from "frappe-ui"
 
 const dayjs = inject("$dayjs")
 const employee = inject("$employee")
+const __ = inject("$translate")
 const firstOfMonth = ref(dayjs().date(1).startOf("D"))
 
 const colorMap = {

--- a/frontend/src/components/EmployeeAdvanceItem.vue
+++ b/frontend/src/components/EmployeeAdvanceItem.vue
@@ -41,7 +41,7 @@ import { computed, inject } from "vue"
 
 import ListItem from "@/components/ListItem.vue"
 import EmployeeAdvanceIcon from "@/components/icons/EmployeeAdvanceIcon.vue"
-import { formatCurrency } from "@/utils/formatters";
+import { formatCurrency } from "@/utils/formatters"
 
 const dayjs = inject("$dayjs")
 const props = defineProps({

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -5,7 +5,7 @@
 			props.isTableField ? 'border-2 border-dashed border-gray-300 mt-5' : '',
 		]"
 	>
-		{{ props.message }}
+		{{ __(props.message) }}
 	</div>
 </template>
 

--- a/frontend/src/components/ExpenseAdvancesTable.vue
+++ b/frontend/src/components/ExpenseAdvancesTable.vue
@@ -60,7 +60,7 @@
 		</div>
 	</div>
 
-	<EmptyState v-else :message="__('No advances found')" :isTableField="true" />
+	<EmptyState v-else message="No advances found" :isTableField="true" />
 </template>
 
 <script setup>

--- a/frontend/src/components/ExpenseItems.vue
+++ b/frontend/src/components/ExpenseItems.vue
@@ -18,10 +18,12 @@
 							</div>
 							<div class="text-xs font-normal text-gray-500">
 								<span>
-									{{ __("{0}: {1}", null, [
-										__("Sanctioned"),
-										formatCurrency(item.sanctioned_amount || 0, currency),
-									]) }}
+									{{
+										__("{0}: {1}", [
+											__("Sanctioned"),
+											formatCurrency(item.sanctioned_amount || 0, currency),
+										])
+									}}
 								</span>
 								<span class="whitespace-pre"> &middot; </span>
 								<span class="whitespace-nowrap" v-if="item.expense_date">

--- a/frontend/src/components/ExpenseItems.vue
+++ b/frontend/src/components/ExpenseItems.vue
@@ -45,7 +45,7 @@
 import { computed, inject } from "vue"
 
 import { getCompanyCurrency } from "@/data/currencies"
-import { formatCurrency } from "@/utils/formatters";
+import { formatCurrency } from "@/utils/formatters"
 
 const props = defineProps({
 	doc: {

--- a/frontend/src/components/ExpenseTaxesTable.vue
+++ b/frontend/src/components/ExpenseTaxesTable.vue
@@ -127,7 +127,7 @@
 
 <script setup>
 import { FeatherIcon, createResource } from "frappe-ui"
-import { computed, ref, watch } from "vue"
+import { computed, ref, watch, inject } from "vue"
 
 import FormField from "@/components/FormField.vue"
 import EmptyState from "@/components/EmptyState.vue"
@@ -154,6 +154,7 @@ const emit = defineEmits([
 	"update-expense-tax",
 	"delete-expense-tax",
 ])
+const __ = inject("$translate")
 const expenseTax = ref({})
 const editingIdx = ref(null)
 

--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -37,10 +37,12 @@
 							</div>
 							<div class="text-xs font-normal text-gray-500">
 								<span>
-									{{ __("{0}: {1}", null, [
-										__("Sanctioned"),
-										formatCurrency(item.sanctioned_amount || 0, currency),
-									]) }}
+									{{
+										__("{0}: {1}", [
+											__("Sanctioned"),
+											formatCurrency(item.sanctioned_amount || 0, currency),
+										])
+									}}
 								</span>
 								<span class="whitespace-pre"> &middot; </span>
 								<span class="whitespace-nowrap" v-if="item.expense_date">

--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -133,7 +133,7 @@
 			:disabled="isReadOnly"
 		/>
 
-		<ErrorMessage :message="__(props.errorMessage)" />
+		<ErrorMessage :message="props.errorMessage" />
 	</div>
 </template>
 

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -377,7 +377,9 @@ const props = defineProps({
 })
 const emit = defineEmits(["validateForm", "update:modelValue"])
 const router = useRouter()
+
 const __ = inject("$translate")
+
 let activeTab = ref(props.tabs?.[0].name)
 let fileAttachments = ref([])
 let statusColor = ref("")

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -90,7 +90,7 @@
 					</div>
 				</div>
 				<EmptyState
-					:message="__('No {0} found', [__(props.doctype)])"
+					:message="`No ${props.doctype?.toLowerCase()}s found`"
 					v-else-if="!documents.loading"
 				/>
 

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -276,18 +276,21 @@ const approvalField = computed(() => {
 })
 
 const getSuccessMessage = ({ status = "", docstatus = 0 }) => {
-	if (status) return __([status], __('{0} successfully!'))
-	else if (docstatus)
-		return __('Document {0}', [
+	if (status) {
+		return __("{0} successfully!", [__(status)])
+	} else if (docstatus) {
+		return __("Document {0} successfully!", [
 			docstatus === 1 ? __("submitted") : __("cancelled")]
-			, __('successfully!'))
+		)
+	}
 }
 
 const getFailureMessage = ({ status = "", docstatus = 0 }) => {
-	if (status)
-		return __([status === __("Approved") ? __("Approval") : __("Rejection")], '{0}failed!')
-	else if (docstatus)
+	if (status) {
+		return __("{0} failed!", [status === __("Approved") ? __("Approval") : __("Rejection")])
+	} else if (docstatus) {
 		return __('Document {0} failed!', [docstatus === 1 ? __("submission") : __("cancellation")])
+	}
 }
 
 const updateDocumentStatus = ({ status = "", docstatus = 0 }) => {

--- a/frontend/src/components/RequestList.vue
+++ b/frontend/src/components/RequestList.vue
@@ -28,7 +28,7 @@
 			</Button>
 		</router-link>
 	</div>
-	<EmptyState :message="emptyStateMessage || __('You have no requests')" v-else />
+	<EmptyState :message="emptyStateMessage || 'You have no requests'" v-else />
 
 	<ion-modal
 		ref="modal"

--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -8,10 +8,12 @@
 				</div>
 				<div class="text-xs font-normal text-gray-500">
 					<span>
-						{{ __("{0}: {1}", null, [
+						{{
+							__("{0}: {1}", [
 								__("Gross Pay"),
 								formatCurrency(doc.gross_pay, doc.currency),
-							]) }}
+							])
+						}}
 					</span>
 					<span class="whitespace-pre"> &middot; </span>
 				</div>
@@ -49,9 +51,9 @@ const title = computed(() => {
 		return dayjs(props.doc.start_date).format("MMM YYYY")
 	} else {
 		// quarterly, bimonthly, etc
-		return `${dayjs(props.doc.start_date).format("MMM YYYY")} - ${dayjs(props.doc.end_date).format(
-			"MMM YYYY"
-		)}`
+		return `${dayjs(props.doc.start_date).format("MMM YYYY")} - ${dayjs(
+			props.doc.end_date
+		).format("MMM YYYY")}`
 	}
 })
 </script>

--- a/frontend/src/components/WorkflowActionSheet.vue
+++ b/frontend/src/components/WorkflowActionSheet.vue
@@ -45,8 +45,9 @@
 
 <script setup>
 import { IonActionSheet, modalController } from "@ionic/vue"
-import { computed, ref, onMounted } from "vue"
+import { computed, ref, onMounted, inject } from "vue"
 import { FeatherIcon } from "frappe-ui"
+
 const props = defineProps({
 	doc: {
 		type: Object,
@@ -67,6 +68,8 @@ const emit = defineEmits(["workflow-applied"])
 
 let showActionSheet = ref(false)
 let actions = ref([])
+
+const __ = inject("$translate")
 
 const getTransitions = async () => {
 	const transitions = await props.workflow.getTransitions(props.doc)

--- a/frontend/src/views/attendance/ShiftAssignmentList.vue
+++ b/frontend/src/views/attendance/ShiftAssignmentList.vue
@@ -10,8 +10,11 @@
 </template>
 
 <script setup>
+import { inject } from "vue"
 import { IonPage } from "@ionic/vue"
 import ListView from "@/components/ListView.vue"
+
+const __ = inject("$translate")
 
 const SHIFT_ASSIGNMENT_FIELDS = ["name", "shift_type", "start_date", "end_date", "docstatus"]
 const FILTER_CONFIG = [

--- a/frontend/src/views/attendance/ShiftRequestList.vue
+++ b/frontend/src/views/attendance/ShiftRequestList.vue
@@ -11,9 +11,11 @@
 </template>
 
 <script setup>
+import { inject } from "vue"
 import { IonPage } from "@ionic/vue"
 import ListView from "@/components/ListView.vue"
 
+const __ = inject("$translate")
 const TAB_BUTTONS = ["My Requests", "Team Requests"]
 const SHIFT_REQUEST_FIELDS = [
 	"name",

--- a/frontend/src/views/salary_slip/Dashboard.vue
+++ b/frontend/src/views/salary_slip/Dashboard.vue
@@ -47,7 +47,7 @@
 							</router-link>
 						</div>
 					</div>
-					<EmptyState :message="__('No salary slips found')" v-else />
+					<EmptyState message="No salary slips found" v-else />
 				</div>
 			</div>
 		</template>


### PR DESCRIPTION
Broken after https://github.com/frappe/hrms/pull/1856

- 2nd argument in translation function are the variables, not the context. Here 2nd argument is being passed as null and the variables are being passed as the context

	Incorrect: __("string", context, variables)
	Correct: __("string", variables, context)

- translation function __ was being used without injecting
- simplified some other translation strings