### PR TITLE
fix: update status of reference documents

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -11,11 +11,12 @@ class FullandFinalStatement(Document):
 	def on_change(self):
 		for payable in self.payables:
 			if payable.component == "Gratuity":
-				frappe.db.set_value(
-					"Gratuity",
-					payable.reference_document,
-					{"status": self.status, "paid_amount": payable.amount},
-				)
+				gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+				if self.status == "Paid":
+					amount = payable.amount if self.docstatus == 1 else 0
+					gratuity.db_set("paid_amount", amount)
+				if self.docstatus == 2:
+					gratuity.set_status(update=True, cancel=True)
 
 	def before_insert(self):
 		self.get_outstanding_statements()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -9,7 +9,13 @@ from frappe.utils import flt, get_link_to_form, today
 
 class FullandFinalStatement(Document):
 	def on_change(self):
-		update_status_of_reference_documents(self, self.status)
+		for payable in self.payables:
+			if payable.component == "Gratuity":
+				frappe.db.set_value(
+					"Gratuity",
+					payable.reference_document,
+					{"status": self.status, "paid_amount": payable.amount},
+				)
 
 	def before_insert(self):
 		self.get_outstanding_statements()
@@ -313,9 +319,3 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
-
-
-def update_status_of_reference_documents(doc, status="Paid"):
-	for payable in doc.payables:
-		if payable.component == "Gratuity":
-			frappe.db.set_value("Gratuity", payable.reference_document, "status", status)

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -8,6 +8,9 @@ from frappe.utils import flt, get_link_to_form, today
 
 
 class FullandFinalStatement(Document):
+	def on_change(self):
+		update_status_of_reference_documents(self, self.status)
+
 	def before_insert(self):
 		self.get_outstanding_statements()
 
@@ -310,3 +313,9 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
+
+
+def update_status_of_reference_documents(doc, status="Paid"):
+	for payable in doc.payables:
+		if payable.component == "Gratuity":
+			frappe.db.set_value("Gratuity", payable.reference_document, "status", status)


### PR DESCRIPTION
Fixes the status issue for gratuity payments. When a Full & Final Statement is marked as 'Paid,' the linked gratuity doc's status updates to 'Paid' too.