### PR TITLE
fix: exclude advances scheduled for deduction when adjusting them aga…

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -138,6 +138,7 @@ frappe.ui.form.on("Employee Advance", {
 				posting_date: frm.doc.posting_date,
 				paid_amount: frm.doc.paid_amount,
 				claimed_amount: frm.doc.claimed_amount,
+				returned_amount: frm.doc.return_amount,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -138,7 +138,7 @@ frappe.ui.form.on("Employee Advance", {
 				posting_date: frm.doc.posting_date,
 				paid_amount: frm.doc.paid_amount,
 				claimed_amount: frm.doc.claimed_amount,
-				returned_amount: frm.doc.return_amount,
+				return_amount: frm.doc.return_amount,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -14,7 +14,7 @@ from hrms.hr.doctype.employee_advance.employee_advance import (
 	make_bank_entry,
 	make_return_entry,
 )
-from hrms.hr.doctype.expense_claim.expense_claim import get_advances
+from hrms.hr.doctype.expense_claim.expense_claim import get_advances, get_allocation_amount
 from hrms.hr.doctype.expense_claim.test_expense_claim import (
 	get_payable_account,
 	make_expense_claim,
@@ -353,7 +353,11 @@ def get_advances_for_claim(claim, advance_name, amount=None):
 		if amount:
 			allocated_amount = amount
 		else:
-			allocated_amount = flt(entry.paid_amount) - flt(entry.claimed_amount)
+			allocated_amount = get_allocation_amount(
+				paid_amount=entry.paid_amount,
+				claimed_amount=entry.claimed_amount,
+				return_amount=entry.return_amount,
+			)
 
 		claim.append(
 			"advances",
@@ -362,7 +366,8 @@ def get_advances_for_claim(claim, advance_name, amount=None):
 				"posting_date": entry.posting_date,
 				"advance_account": entry.advance_account,
 				"advance_paid": entry.paid_amount,
-				"unclaimed_amount": allocated_amount,
+				"return_amount": entry.return_amount,
+				"unclaimed_amount": entry.paid_amount - entry.claimed_amount,
 				"allocated_amount": allocated_amount,
 			},
 		)

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -310,9 +310,11 @@ frappe.ui.form.on("Expense Claim", {
 							row.advance_paid = d.paid_amount;
 							row.unclaimed_amount = flt(d.paid_amount) - flt(d.claimed_amount);
 							row.return_amount = flt(d.return_amount);
-							row.allocated_amount =
-								flt(d.paid_amount) -
-								(flt(d.claimed_amount) + flt(d.return_amount));
+							row.allocated_amount = get_allocation_amount(
+								flt(d.paid_amount),
+								flt(d.claimed_amount),
+								flt(d.return_amount),
+							);
 						});
 						refresh_field("advances");
 					}
@@ -389,9 +391,11 @@ frappe.ui.form.on("Expense Claim Advance", {
 						child.unclaimed_amount =
 							flt(r.message[0].paid_amount) - flt(r.message[0].claimed_amount);
 						child.return_amount = flt(r.message[0].return_amount);
-						child.allocated_amount =
-							flt(r.message[0].paid_amount) -
-							(flt(r.message[0].claimed_amount) + flt(r.message[0].return_amount));
+						child.allocated_amount = get_allocation_amount(
+							flt(r.message[0].paid_amount),
+							flt(r.message[0].claimed_amount),
+							flt(r.message[0].return_amount),
+						);
 						frm.trigger("calculate_grand_total");
 						refresh_field("advances");
 					}
@@ -437,3 +441,7 @@ frappe.ui.form.on("Expense Taxes and Charges", {
 		frm.trigger("calculate_total_tax", cdt, cdn);
 	},
 });
+
+function get_allocation_amount(paid_amount, claimed_amount, return_amount) {
+	return paid_amount - (claimed_amount + return_amount);
+}

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -194,8 +194,9 @@ frappe.ui.form.on("Expense Claim", {
 	update_employee_advance_claimed_amount: function (frm) {
 		let amount_to_be_allocated = frm.doc.grand_total;
 		$.each(frm.doc.advances || [], function (i, advance) {
-			if (amount_to_be_allocated >= advance.unclaimed_amount) {
-				advance.allocated_amount = frm.doc.advances[i].unclaimed_amount;
+			if (amount_to_be_allocated >= advance.unclaimed_amount - advance.return_amount) {
+				advance.allocated_amount =
+					frm.doc.advances[i].unclaimed_amount - frm.doc.advances[i].return_amount;
 				amount_to_be_allocated -= advance.allocated_amount;
 			} else {
 				advance.allocated_amount = amount_to_be_allocated;
@@ -204,7 +205,6 @@ frappe.ui.form.on("Expense Claim", {
 			frm.refresh_field("advances");
 		});
 	},
-
 	make_payment_entry: function (frm) {
 		let method = "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee";
 		if (frm.doc.__onload && frm.doc.__onload.make_payment_via_journal_entry) {
@@ -308,8 +308,8 @@ frappe.ui.form.on("Expense Claim", {
 							row.posting_date = d.posting_date;
 							row.advance_account = d.advance_account;
 							row.advance_paid = d.paid_amount;
-							row.unclaimed_amount =
-								flt(d.paid_amount) - flt(d.claimed_amount) - flt(d.return_amount);
+							row.unclaimed_amount = flt(d.paid_amount) - flt(d.claimed_amount);
+							row.return_amount = flt(d.return_amount);
 							row.allocated_amount = 0;
 						});
 						refresh_field("advances");
@@ -386,8 +386,10 @@ frappe.ui.form.on("Expense Claim Advance", {
 						child.advance_paid = r.message[0].paid_amount;
 						child.unclaimed_amount =
 							flt(r.message[0].paid_amount) - flt(r.message[0].claimed_amount);
+						child.return_amount = flt(r.message[0].return_amount);
 						child.allocated_amount =
-							flt(r.message[0].paid_amount) - flt(r.message[0].claimed_amount);
+							flt(r.message[0].paid_amount) -
+							(flt(r.message[0].claimed_amount) + flt(r.message[0].return_amount));
 						frm.trigger("calculate_grand_total");
 						refresh_field("advances");
 					}

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -308,7 +308,8 @@ frappe.ui.form.on("Expense Claim", {
 							row.posting_date = d.posting_date;
 							row.advance_account = d.advance_account;
 							row.advance_paid = d.paid_amount;
-							row.unclaimed_amount = flt(d.paid_amount) - flt(d.claimed_amount);
+							row.unclaimed_amount =
+								flt(d.paid_amount) - flt(d.claimed_amount) - flt(d.return_amount);
 							row.allocated_amount = 0;
 						});
 						refresh_field("advances");

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -310,7 +310,9 @@ frappe.ui.form.on("Expense Claim", {
 							row.advance_paid = d.paid_amount;
 							row.unclaimed_amount = flt(d.paid_amount) - flt(d.claimed_amount);
 							row.return_amount = flt(d.return_amount);
-							row.allocated_amount = 0;
+							row.allocated_amount =
+								flt(d.paid_amount) -
+								(flt(d.claimed_amount) + flt(d.return_amount));
 						});
 						refresh_field("advances");
 					}

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -536,7 +536,9 @@ def get_expense_claim(
 			"posting_date": posting_date,
 			"advance_paid": flt(paid_amount),
 			"unclaimed_amount": flt(paid_amount) - flt(claimed_amount),
-			"allocated_amount": flt(paid_amount) - (flt(claimed_amount) + flt(return_amount)),
+			"allocated_amount": get_allocation_amount(
+				flt(paid_amount), flt(claimed_amount), flt(return_amount)
+			),
 			"return_amount": flt(return_amount),
 		},
 	)
@@ -594,3 +596,8 @@ def make_expense_claim_for_delivery_trip(source_name, target_doc=None):
 	)
 
 	return doc
+
+
+@frappe.whitelist()
+def get_allocation_amount(paid_amount, claimed_amount, return_amount):
+	return paid_amount - (claimed_amount + return_amount)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -325,7 +325,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			ref_doc = frappe.db.get_value(
 				"Employee Advance",
 				d.employee_advance,
-				["posting_date", "paid_amount", "claimed_amount", "advance_account"],
+				["posting_date", "paid_amount", "claimed_amount", "return_amount", "advance_account"],
 				as_dict=1,
 			)
 			d.posting_date = ref_doc.posting_date
@@ -516,7 +516,7 @@ def get_advances(employee, advance_id=None):
 
 @frappe.whitelist()
 def get_expense_claim(
-	employee_name, company, employee_advance_name, posting_date, paid_amount, claimed_amount, returned_amount
+	employee_name, company, employee_advance_name, posting_date, paid_amount, claimed_amount, return_amount
 ):
 	default_payable_account = frappe.get_cached_value(
 		"Company", company, "default_expense_claim_payable_account"
@@ -535,8 +535,9 @@ def get_expense_claim(
 			"employee_advance": employee_advance_name,
 			"posting_date": posting_date,
 			"advance_paid": flt(paid_amount),
-			"unclaimed_amount": flt(paid_amount) - flt(claimed_amount) - flt(returned_amount),
-			"allocated_amount": flt(paid_amount) - flt(claimed_amount),
+			"unclaimed_amount": flt(paid_amount) - flt(claimed_amount),
+			"allocated_amount": flt(paid_amount) - (flt(claimed_amount) + flt(return_amount)),
+			"return_amount": flt(return_amount),
 		},
 	)
 

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -253,6 +253,54 @@ class TestExpenseClaim(IntegrationTestCase):
 		self.assertEqual(claim.total_amount_reimbursed, 500)
 		self.assertEqual(claim.status, "Paid")
 
+	def test_expense_claim_with_deducted_returned_advance(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			create_return_through_additional_salary,
+			make_employee_advance,
+			make_journal_entry_for_advance,
+		)
+		from hrms.hr.doctype.expense_claim.expense_claim import get_advances
+		from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+
+		employee_name = make_employee("_T@employee.advance", "_Test Company")
+		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
+		journal_entry = make_journal_entry_for_advance(advance)
+		journal_entry.submit()
+
+		args = {"type": "Deduction"}
+		create_salary_component("Advance Salary - Deduction", **args)
+		make_salary_structure(
+			"Test Additional Salary for Advance Return",
+			"Monthly",
+			employee=employee_name,
+			company="_Test Company",
+		)
+
+		advance.reload()
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = "Advance Salary - Deduction"
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = 400
+		additional_salary.insert()
+		additional_salary.submit()
+
+		advance.reload()
+		self.assertEqual(advance.return_amount, 400)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account, 200, 200, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+		)
+		advances = get_advances(claim.employee)
+		for entry in advances:
+			if entry.name == advance.name:
+				self.assertTrue(entry.return_amount, 400)
+				self.assertTrue(
+					entry.allocated_amount,
+					advance.paid_amount - (advance.claimed_amount + advance.return_amount),
+				)
+
 	def test_expense_claim_gl_entry(self):
 		payable_account = get_payable_account(company_name)
 		taxes = generate_taxes()

--- a/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+++ b/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
@@ -88,14 +88,14 @@
   },
   {
    "fieldname": "return_amount",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Returned Amount"
+   "fieldtype": "Currency",
+   "label": "Returned Amount",
+   "options": "Company:company:default_currency"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-11-07 13:00:58.402981",
+ "modified": "2024-11-25 19:53:00.024597",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Advance",

--- a/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+++ b/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
@@ -11,6 +11,7 @@
   "advance_paid",
   "column_break_4",
   "unclaimed_amount",
+  "return_amount",
   "allocated_amount",
   "advance_account"
  ],
@@ -84,11 +85,17 @@
   {
    "fieldname": "column_break_4",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "return_amount",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Returned Amount"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:43.954706",
+ "modified": "2024-11-07 13:00:58.402981",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Advance",


### PR DESCRIPTION
Adjust the calculation of allocation amounts for expense claims against employee advances. Advances scheduled for salary deduction are now excluded, ensuring the allocation amount reflects the accurate claimable advance amount.

**Employee advance:**
<img width="1114" alt="Screenshot 2024-11-29 at 1 21 09 PM" src="https://github.com/user-attachments/assets/643fa822-7ccb-4d7f-88b8-059a97054bb6">

**Creating Expense Claim:**
**Before:**
![before](https://github.com/user-attachments/assets/3d17e354-cd20-453d-97e6-ecc200a20087)

**After:**
![after](https://github.com/user-attachments/assets/11455072-2dd0-4427-ba94-d40878328e79)
