### PR TITLE
fix: skip components marked as 'Do not include in total' from payroll accounting entries

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -322,6 +322,7 @@ class PayrollEntry(Document):
 		return account
 
 	def get_salary_components(self, component_type):
+		"""Get Salary Components based For Accrual JV"""
 		salary_slips = self.get_sal_slip_list(ss_status=1, as_dict=True)
 
 		if salary_slips:
@@ -339,7 +340,11 @@ class PayrollEntry(Document):
 					ss.salary_structure,
 					ss.employee,
 				)
-				.where((ssd.parentfield == component_type) & (ss.name.isin([d.name for d in salary_slips])))
+				.where(
+					(ssd.parentfield == component_type)
+					& (ss.name.isin([d.name for d in salary_slips]))
+					& (ssd.do_not_include_in_total == 0)
+				)
 			).run(as_dict=True)
 
 			return salary_components
@@ -349,6 +354,7 @@ class PayrollEntry(Document):
 		component_type=None,
 		employee_wise_accounting_enabled=False,
 	):
+		"""Get Salary Component total for Accrual JV"""
 		salary_components = self.get_salary_components(component_type)
 		if salary_components:
 			component_dict = {}
@@ -938,6 +944,7 @@ class PayrollEntry(Document):
 		return bank_entry
 
 	def get_salary_slip_details(self, for_withheld_salaries=False):
+		"""Get salary slip details for bank entry"""
 		SalarySlip = frappe.qb.DocType("Salary Slip")
 		SalaryDetail = frappe.qb.DocType("Salary Detail")
 
@@ -959,6 +966,7 @@ class PayrollEntry(Document):
 				& (SalarySlip.start_date >= self.start_date)
 				& (SalarySlip.end_date <= self.end_date)
 				& (SalarySlip.payroll_entry == self.name)
+				& (SalaryDetail.do_not_include_in_total == 0)
 			)
 		)
 


### PR DESCRIPTION
## Problem

Components marked as 'Do not include in total' are excluded from employee's gross pay and net pay but still considered in Payroll Accrual JV and Bank Entry

Still unsure of what the actual need for this feature was. Originated here: https://github.com/frappe/erpnext/pull/10900
Sometimes earnings are not directly deposited in employee's account: Ref https://github.com/frappe/erpnext/issues/7389
Should accrual entry still be made for this to book expenses but bank entry should be skipped?

## Before

**Component marked as 'Do not include in total'**

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/fa80e5dc-aea0-4c78-ad2c-52eec74c92e8">

**Gross Pay**

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/1b547c6c-9eb5-458f-b3e5-c34b8f28c902">

**Accrual JV considers 50k too**

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/77fb38e4-88af-42db-99bc-c9b978a44025">

**Bank Entry considers 50k too**

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/fb7862ef-0b47-45ce-8bd8-7f2f04d94222">


## After

Accrual JV - Payroll payable matches net pay for employee (50k not considered)

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/2238c8fb-6c5f-43b2-8266-35cffe6d6558">


Bank Entry - Actual payment matches net pay for employee (50k not considered)

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/cbe1957f-f845-4dcf-800b-fa6c0433279b">

