### PR TITLE
fix: pwa notification logs prevent user deletion

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -309,6 +309,7 @@ override_doctype_dashboards = {
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
 
+ignore_links_on_delete = ["PWA Notification"]
 
 # User Data Protection
 # --------------------


### PR DESCRIPTION
Ignore pwa notification logs when deleting a user.