### PR TITLE
fix: Exclude carry forwarded leaves from expired leaves

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -207,7 +207,8 @@ def get_allocated_and_expired_leaves(
 				carry_forwarded_leaves += record.leaves
 			else:
 				new_allocation += record.leaves
-
+	# carry forwarded leaves also get counted in expired, hence subtracting them
+	expired_leaves -= carry_forwarded_leaves
 	return new_allocation, expired_leaves, carry_forwarded_leaves
 
 

--- a/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
@@ -241,6 +241,7 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 		)
 		report = execute(filters)
 		self.assertEqual(len(report[1]), 1)
+
 	@set_holiday_list("_Test Emp Balance Holiday List", "_Test Company")
 	def test_closing_balance_considers_carry_forwarded_leaves(self):
 		leave_type = create_leave_type(leave_type_name="_Test_CF_leave_expiry", is_carry_forward=1)
@@ -284,5 +285,3 @@ class TestEmployeeLeaveBalance(IntegrationTestCase):
 			+ allocation2.new_leaves_allocated
 		)
 		self.assertEqual(report[1][0].closing_balance, closing_balance)
-
-


### PR DESCRIPTION
### Issue
Mismatch of closing balance in employee leave balance and employee leave balance summary reports

#### Before
<img width="1247" alt="Screenshot 2024-11-08 at 12 00 52 AM" src="https://github.com/user-attachments/assets/7c5c44cc-baae-4c0d-98a8-da2dd62a4e54">
<img width="1148" alt="Screenshot 2024-11-08 at 12 01 05 AM" src="https://github.com/user-attachments/assets/dc6c3c10-3c72-41fa-97fc-3d8924e52fa5">

#### After
<img width="1237" alt="Screenshot 2024-11-08 at 12 08 49 AM" src="https://github.com/user-attachments/assets/34e7cdca-7baa-4622-a53f-37956bf6f186">
<img width="1023" alt="Screenshot 2024-11-08 at 12 09 06 AM" src="https://github.com/user-attachments/assets/92fb4775-271a-4993-a732-5ac75505c3ab">

#### Fix
Excluded carry forwarded leaves from expired leaves
Added a test case for closing balance
