### PR TITLE
fix(Payroll Bank Entry): deduct loan repayments from employee-wise accounting entries

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -28,6 +28,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.utils import get_fiscal_year
 
+from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
 from hrms.payroll.doctype.salary_withholding.salary_withholding import link_bank_entry_in_salary_withholdings
 
 
@@ -871,9 +872,9 @@ class PayrollEntry(Document):
 		)
 
 		salary_slip_total = 0
-		salary_slips = self.get_salary_slip_details(for_withheld_salaries)
+		salary_details = self.get_salary_slip_details(for_withheld_salaries)
 
-		for salary_detail in salary_slips:
+		for salary_detail in salary_details:
 			if salary_detail.parentfield == "earnings":
 				(
 					is_flexible_benefit,
@@ -923,8 +924,7 @@ class PayrollEntry(Document):
 
 					salary_slip_total -= salary_detail.amount
 
-		unique_salary_slips = {slip["name"]: slip for slip in salary_slips}.values()
-		total_loan_repayment = sum(flt(slip.get("total_loan_repayment", 0)) for slip in unique_salary_slips)
+		total_loan_repayment = self.process_loan_repayments_for_bank_entry(salary_details) or 0
 		salary_slip_total -= total_loan_repayment
 
 		bank_entry = None
@@ -933,7 +933,7 @@ class PayrollEntry(Document):
 			bank_entry = self.set_accounting_entries_for_bank_entry(salary_slip_total, remark)
 
 			if for_withheld_salaries:
-				link_bank_entry_in_salary_withholdings(salary_slips, bank_entry.name)
+				link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
 
 		return bank_entry
 
@@ -971,6 +971,23 @@ class PayrollEntry(Document):
 			query = query.where(SalarySlip.status != "Withheld")
 		return query.run(as_dict=True)
 
+	@if_lending_app_installed
+	def process_loan_repayments_for_bank_entry(self, salary_details: list[dict]) -> float:
+		unique_salary_slips = {row["employee"]: row for row in salary_details}.values()
+		total_loan_repayment = sum(flt(slip.get("total_loan_repayment", 0)) for slip in unique_salary_slips)
+
+		if self.employee_based_payroll_payable_entries:
+			for salary_slip in unique_salary_slips:
+				if salary_slip.get("total_loan_repayment"):
+					self.set_employee_based_payroll_payable_entries(
+						"total_loan_repayment",
+						salary_slip.employee,
+						salary_slip.total_loan_repayment,
+						salary_slip.salary_structure,
+					)
+
+		return total_loan_repayment
+
 	def set_accounting_entries_for_bank_entry(self, je_payment_amount, user_remark):
 		payroll_payable_account = self.payroll_payable_account
 		precision = frappe.get_precision("Journal Entry Account", "debit_in_account_currency")
@@ -998,9 +1015,12 @@ class PayrollEntry(Document):
 
 		if self.employee_based_payroll_payable_entries:
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-				je_payment_amount = employee_details.get("earnings", 0) - (
-					employee_details.get("deductions", 0)
+				je_payment_amount = (
+					employee_details.get("earnings", 0)
+					- employee_details.get("deductions", 0)
+					- employee_details.get("total_loan_repayment", 0)
 				)
+
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(
 					self.payment_account, je_payment_amount, company_currency, currencies
 				)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -4,7 +4,7 @@
 from dateutil.relativedelta import relativedelta
 
 import frappe
-from frappe.tests import IntegrationTestCase, change_settings
+from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, add_months, cstr, flt
 
 import erpnext
@@ -42,10 +42,11 @@ from hrms.utils import get_date_range
 test_dependencies = ["Holiday List"]
 
 
-class TestPayrollEntry(IntegrationTestCase):
+class TestPayrollEntry(FrappeTestCase):
 	def setUp(self):
 		for dt in [
 			"Salary Slip",
+			"Salary Detail",
 			"Salary Component",
 			"Salary Component Account",
 			"Payroll Entry",
@@ -720,6 +721,14 @@ class TestPayrollEntry(IntegrationTestCase):
 	@if_lending_app_installed
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
 	def test_loan_repayment_from_salary(self):
+		self.run_test_for_loan_repayment_from_salary()
+
+	@if_lending_app_installed
+	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
+	def test_loan_repayment_from_salary_with_employee_tagging(self):
+		self.run_test_for_loan_repayment_from_salary()
+
+	def run_test_for_loan_repayment_from_salary(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
 		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 			process_loan_interest_accrual_for_term_loans,


### PR DESCRIPTION
## Problem

In continuation to https://github.com/frappe/hrms/pull/2347, #2283 & #2324

#2347 deducts total loan repayments from salary payable but doesn't handle loan repayment deduction when **Process Payroll Accounting Entry based on Employee** is enabled in Payroll Settings.
This leads to difference in total debit and credit amount in Bank Entry

## Before

**Net Pay = 50000 - 2000 (loan repayment)**

![image](https://github.com/user-attachments/assets/a96f6daa-9fd5-4d19-b4af-3ab9314c3aa8)

**Bank Entry failing**

![image](https://github.com/user-attachments/assets/49b42870-ff17-4af4-be40-6231c75222cb)

**This is the bank entry its trying to create**

![image](https://github.com/user-attachments/assets/33f24717-11fb-4786-aff7-556b7f5e5f50)



## After

![image](https://github.com/user-attachments/assets/45617f82-7c11-4738-aef7-386977b46725)

