### PR TITLE
fix(Additional Salary): amount gets overwritten by salary component amount even if mapped from a reference document

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.js
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.js
@@ -86,4 +86,28 @@ frappe.ui.form.on("Additional Salary", {
 			},
 		});
 	},
+
+	salary_component: function (frm) {
+		if (!frm.doc.ref_doctype) {
+			frm.trigger("get_salary_component_amount");
+		}
+	},
+
+	get_salary_component_amount: function (frm) {
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Salary Component",
+				fieldname: "amount",
+				filters: {
+					name: frm.doc.salary_component,
+				},
+			},
+			callback: function (data) {
+				if (data.message) {
+					frm.set_value("amount", data.message.amount);
+				}
+			},
+		});
+	},
 });

--- a/hrms/payroll/doctype/additional_salary/additional_salary.json
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.json
@@ -60,8 +60,6 @@
    "search_index": 1
   },
   {
-   "fetch_from": "salary_component.amount",
-   "fetch_if_empty": 1,
    "fieldname": "amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -205,7 +203,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:05:58.117102",
+ "modified": "2024-11-14 16:51:17.594568",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Additional Salary",


### PR DESCRIPTION
### Issue
Amount field in New Additional Salary Doctype gets overwritten by amount field in Salary Component after selecting salary component. This behaviour is ideal except for scenarios like creating a "deduction from salary" from "employee advance"

#### Before
While creating new additional salary
<img width="697" alt="Screenshot 2024-11-14 at 6 42 03 PM" src="https://github.com/user-attachments/assets/4608ba50-34e4-4592-9a19-2deac02c14e7">
While creating deduction from salary
<img width="522" alt="Screenshot 2024-11-14 at 6 44 31 PM" src="https://github.com/user-attachments/assets/956ba6ba-d326-4c6b-82b1-8aece8435d51">

#### After
While creating new additional salary (same as before)
<img width="697" alt="Screenshot 2024-11-14 at 6 48 28 PM" src="https://github.com/user-attachments/assets/92cf8c96-0e4d-4e3c-86d3-ed4df8fdb543">
While creating deduction from salary: Deduction amount referencing the employee advance doctype isn't overweritten
<img width="524" alt="Screenshot 2024-11-14 at 6 48 09 PM" src="https://github.com/user-attachments/assets/8be7c5d5-2de2-4673-a7b4-a1770d4b2ce6">

### Fix
Removed "fetch from" "Salary Component" Setting on amount field in Additional Salary Doctype
Added conditional fetching and setting based on referenced doctype

no-tests