### PR TITLE
fix: Breadcrumb Label for Non-Logged-In Users in Job Portal

### DIFF
--- a/hrms/www/jobs/index.py
+++ b/hrms/www/jobs/index.py
@@ -9,8 +9,10 @@ from frappe.utils import pretty_date
 
 def get_context(context):
 	context.no_cache = 1
-	breadcrumb = _("Home") if frappe.session.user == "Guest" else _("My Account")
-	context.parents = [{"name": breadcrumb, "route": "/"}]
+	if frappe.session.user == "Guest":
+		context.parents = [{"name": _("Home"), "route": "/"}]
+	else:
+		context.parents = [{"name": _("My Account"), "route": "/me"}]
 	context.body_class = "jobs-page"
 	page_len = 20
 	filters, txt, sort, offset = get_filters_txt_sort_offset(page_len)

--- a/hrms/www/jobs/index.py
+++ b/hrms/www/jobs/index.py
@@ -9,7 +9,8 @@ from frappe.utils import pretty_date
 
 def get_context(context):
 	context.no_cache = 1
-	context.parents = [{"name": _("My Account"), "route": "/"}]
+	breadcrumb = _("Home") if frappe.session.user == "Guest" else _("My Account")
+	context.parents = [{"name": breadcrumb, "route": "/"}]
 	context.body_class = "jobs-page"
 	page_len = 20
 	filters, txt, sort, offset = get_filters_txt_sort_offset(page_len)


### PR DESCRIPTION
fixes: https://github.com/frappe/hrms/issues/2438

Previously, the breadcrumb always displayed "My Account," which could be confusing for users who do not have an account or are not logged in. 

fixes: Now, the breadcrumb dynamically adapts based on the user's login status:
- Non-logged-in users will see "Home" as the breadcrumb label, providing a more intuitive experience.
- Logged-in users will continue to see "My Account," maintaining the existing behavior.