### PR TITLE
fix: set correct work experience during gratuity calculation

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.json
+++ b/hrms/payroll/doctype/gratuity/gratuity.json
@@ -60,7 +60,8 @@
    "default": "0",
    "fieldname": "current_work_experience",
    "fieldtype": "Float",
-   "label": "Current Work Experience"
+   "label": "Current Work Experience",
+   "precision": "1"
   },
   {
    "default": "0",
@@ -199,7 +200,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-25 15:33:11.549493",
+ "modified": "2024-12-11 08:46:04.751908",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Gratuity",

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -159,7 +159,7 @@ class Gratuity(AccountsController):
 		if rule.method == "Round off Work Experience":
 			work_experience = round(work_experience)
 		else:
-			work_experience = floor(work_experience)
+			work_experience = flt(work_experience, precision=1)
 
 		if work_experience < rule.minimum_year_for_gratuity:
 			frappe.throw(

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -159,7 +159,7 @@ class Gratuity(AccountsController):
 		if rule.method == "Round off Work Experience":
 			work_experience = round(work_experience)
 		else:
-			work_experience = flt(work_experience, precision=1)
+			work_experience = flt(work_experience, self.precision("current_work_experience"))
 
 		if work_experience < rule.minimum_year_for_gratuity:
 			frappe.throw(

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
-from math import floor
-
 import frappe
 from frappe import _, bold
 from frappe.query_builder.functions import Sum


### PR DESCRIPTION
Fix work experience calculation for gratuity rules using the _**Take Exact Completed Years**_ method. Previously, the experience was rounded to a whole number instead of using the exact decimal value (eg. 1.4 years was incorrectly treated as 1 year).

**Gratuity Rule:** 
<img width="1406" alt="Screenshot 2024-11-29 at 12 59 56 PM" src="https://github.com/user-attachments/assets/825722b2-5213-4f98-9a1e-a7b34ffe9112">

**Before:**
<img width="974" alt="Screenshot 2024-11-29 at 1 12 41 PM" src="https://github.com/user-attachments/assets/da594113-5f15-4b1c-b968-bc34432da08c">

**After:**
<img width="1007" alt="Screenshot 2024-11-29 at 1 15 47 PM" src="https://github.com/user-attachments/assets/ee178183-4bbc-41c6-9083-6908a0de5ac6">


