### PR TITLE
fix: prompt user to select company for shift & attendance report creation

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -32,6 +32,9 @@ def execute(filters: Filters | None = None) -> tuple:
 	if not (filters.month and filters.year):
 		frappe.throw(_("Please select month and year."))
 
+	if not (filters.company):
+		frappe.throw(_("Please select company."))
+
 	if filters.company:
 		filters.companies = [filters.company]
 		if filters.include_company_descendants:

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -32,7 +32,7 @@ def execute(filters: Filters | None = None) -> tuple:
 	if not (filters.month and filters.year):
 		frappe.throw(_("Please select month and year."))
 
-	if not (filters.company):
+	if not filters.company:
 		frappe.throw(_("Please select company."))
 
 	if filters.company:


### PR DESCRIPTION
Alert the user to select a company to create and view the Shift & Attendance report. Previously, missing the company filter resulted in an error message since this is a mandatory filter. This is if global default company is not set.

**Before:**
<img width="774" alt="Screenshot 2024-11-29 at 1 08 43 PM" src="https://github.com/user-attachments/assets/c2d6f1ce-9eb2-44af-803a-f9fdcdc279a1">

**After**:
<img width="675" alt="Screenshot 2024-11-29 at 1 08 31 PM" src="https://github.com/user-attachments/assets/d669935a-3848-4568-bc37-ec1994b74f3d">
