### PR TITLE
fix: disable leave application against expired allocations

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -953,7 +953,6 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 			& (Ledger.docstatus == 1)
 			& (Ledger.transaction_type == "Leave Allocation")
 			& (Ledger.employee == employee)
-			& (LeaveAllocation.expired == 0)
 			& (Ledger.is_lwp == 0)
 			& (
 				# newly allocated leave's end date is same as the leave allocation's to date

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -953,7 +953,7 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 			& (Ledger.docstatus == 1)
 			& (Ledger.transaction_type == "Leave Allocation")
 			& (Ledger.employee == employee)
-			& (Ledger.is_expired == 0)
+			& (LeaveAllocation.expired == 0)
 			& (Ledger.is_lwp == 0)
 			& (
 				# newly allocated leave's end date is same as the leave allocation's to date


### PR DESCRIPTION
Fixes an issue where employees could apply for leaves marked as expired. Updated the condition to exclude expired leave allocations when fetching available leaves.

**Before:**
![before](https://github.com/user-attachments/assets/d22dd50e-8838-46fb-9668-f6165d5b1b0d)

**After:**
![after-2](https://github.com/user-attachments/assets/6f8a523d-e074-427a-b991-1bb4a79fb8cb)

