### PR TITLE
fix: render correct date in job listing web view

### DIFF
--- a/hrms/templates/generators/job_opening.html
+++ b/hrms/templates/generators/job_opening.html
@@ -187,7 +187,7 @@
 								{{ _("Closes On") if status == "Open" else _("Closed On") }}
 							</div>
 							<div class="font-weight-bold">
-								{{ frappe.utils.formatdate(closes_on if status == "Open" else closed_on, "d MMM, YYYY") }}
+								{{ frappe.utils.format_date(closes_on if status == "Open" else closed_on, "d MMM, YYYY") }}
 							</div>
 						</div>
 					</div>

--- a/hrms/templates/generators/job_opening.html
+++ b/hrms/templates/generators/job_opening.html
@@ -187,7 +187,7 @@
 								{{ _("Closes On") if status == "Open" else _("Closed On") }}
 							</div>
 							<div class="font-weight-bold">
-								{{ frappe.format_date(closes_on if status == "Open" else closed_on, "d MMM, YYYY") }}
+								{{ frappe.utils.formatdate(closes_on if status == "Open" else closed_on, "d MMM, YYYY") }}
 							</div>
 						</div>
 					</div>

--- a/hrms/www/jobs/index.html
+++ b/hrms/www/jobs/index.html
@@ -241,7 +241,7 @@
 							<p class="col-6 text-center mb-0">
 								{%- if jo.closes_on -%}
 									{{ _("Closes on:") + " " }}
-									<b>{{ frappe.format_date(jo.closes_on, "d MMM, YYYY") }}</b>
+									<b>{{ frappe.utils.formatdate(jo.closes_on, "d MMM, YYYY") }}</b>
 								{% endif %}
 							</p>
 						</div>

--- a/hrms/www/jobs/index.html
+++ b/hrms/www/jobs/index.html
@@ -241,7 +241,7 @@
 							<p class="col-6 text-center mb-0">
 								{%- if jo.closes_on -%}
 									{{ _("Closes on:") + " " }}
-									<b>{{ frappe.utils.formatdate(jo.closes_on, "d MMM, YYYY") }}</b>
+									<b>{{ frappe.utils.format_date(jo.closes_on, "d MMM, YYYY") }}</b>
 								{% endif %}
 							</p>
 						</div>


### PR DESCRIPTION
Replaced the format_date function with frappe.utils.format_date to resolve an issue where year-end dates, such as 12-31-2024, were incorrectly rendered with the wrong year (31 Dec, 2025) in the web view. Using frappe.utils.format_date ensures accurate rendering.

**Date Stored:** 
<img width="1235" alt="one-1" src="https://github.com/user-attachments/assets/25fc65f6-2a43-4e82-a2ab-3d28c1cc17c0">

**Date Rendered:**
Before (incorrect year): 
<img width="1354" alt="two-2" src="https://github.com/user-attachments/assets/304cbc41-34a6-4589-a3d4-d3cbe3d47e85">

After:
<img width="1281" alt="three-3" src="https://github.com/user-attachments/assets/6423d855-4e8a-4329-8858-eece855338cc">
