### PR TITLE
fix: gratuity calculation for 'Sum of all previous slabs' option

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -244,6 +244,7 @@ class Gratuity(AccountsController):
 						* total_component_amount
 						* slab.fraction_of_applicable_earnings
 					)
+					years_left -= slab.to_year - slab.from_year
 					slab_found = True
 
 				elif self._is_experience_within_slab(slab, experience):
@@ -251,7 +252,7 @@ class Gratuity(AccountsController):
 						years_left * total_component_amount * slab.fraction_of_applicable_earnings
 					)
 					slab_found = True
-				years_left -= slab.to_year - slab.from_year
+					break
 
 		if not slab_found:
 			frappe.throw(

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -244,7 +244,6 @@ class Gratuity(AccountsController):
 						* total_component_amount
 						* slab.fraction_of_applicable_earnings
 					)
-					years_left -= slab.to_year - slab.from_year
 					slab_found = True
 
 				elif self._is_experience_within_slab(slab, experience):
@@ -252,6 +251,7 @@ class Gratuity(AccountsController):
 						years_left * total_component_amount * slab.fraction_of_applicable_earnings
 					)
 					slab_found = True
+				years_left -= slab.to_year - slab.from_year
 
 		if not slab_found:
 			frappe.throw(
@@ -311,7 +311,7 @@ class Gratuity(AccountsController):
 		)
 
 	def _is_experience_within_slab(self, slab: dict, experience: float) -> bool:
-		return bool(slab.from_year <= experience and (experience < slab.to_year or slab.to_year == 0))
+		return bool(slab.from_year <= experience and (experience <= slab.to_year or slab.to_year == 0))
 
 	def _is_experience_beyond_slab(self, slab: dict, experience: float) -> bool:
 		return bool(slab.from_year < experience and (slab.to_year < experience and slab.to_year != 0))


### PR DESCRIPTION
Employees with experience matching the upper limit of a slab are now correctly applied the appropriate Gratuity Rule Slab for Gratuity calculation. 

**Example:**
For an **Employee** with exactly 5 years of experience and the following **Gratuity Rule Slab**s:
0-5 years: Fraction = 0.7
5-0 years: Fraction = 1.0

The calculation incorrectly placed the employee in the second slab due to the condition in `_is_experience_within_slab`. This caused an amount higher than the correct gratuity amount to be calculated.

Also, the `years_left` calculation was only updated within the if `_is_experience_beyond_slab` block.