### PR TITLE
fix(Salary Assignment): skip warning for missing opening entries in the absence of tax components

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -169,6 +169,10 @@ class SalaryStructureAssignment(Document):
 
 	@frappe.whitelist()
 	def are_opening_entries_required(self) -> bool:
+		tax_component = get_tax_component(self.salary_structure)
+		if not tax_component:
+			return False
+
 		if self.has_emp_joined_after_payroll_period_start() and not self.has_existing_salary_slips():
 			return True
 		else:

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -169,8 +169,7 @@ class SalaryStructureAssignment(Document):
 
 	@frappe.whitelist()
 	def are_opening_entries_required(self) -> bool:
-		tax_component = get_tax_component(self.salary_structure)
-		if not tax_component:
+		if not get_tax_component(self.salary_structure):
 			return False
 
 		if self.has_emp_joined_after_payroll_period_start() and not self.has_existing_salary_slips():


### PR DESCRIPTION
Add a condition to skip the following warning about missing opening tax entries during **Salary Structure Assignment** if the **Salary Structure** does not include any tax-applicable components.
<img width="608" alt="Screenshot 2024-12-03 at 9 32 59 PM" src="https://github.com/user-attachments/assets/aa369db8-ad40-424a-8bcc-ce10d9616b36">
