### PR TITLE
ci(fix): configure test time type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dynamic = ["version"]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.frappe.testing.function_type_validation]
+max_module_depth = 0
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
CI breaking with weird errors since https://github.com/frappe/frappe/pull/28554.

`flt` handles `NoneType` but this is throwing an error in CI due to type checking

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/dccc1233-06e9-4202-9689-3f4e2542316b">

Referencing this fix: https://github.com/frappe/erpnext/pull/44414