### PR TITLE
feat: toggle self leave approval for employees from HR settings

### DIFF
--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -26,7 +26,7 @@
   "leave_status_notification_template",
   "leave_approver_mandatory_in_leave_application",
   "restrict_backdated_leave_application",
-  "allow_self_leave_approval",
+  "prevent_self_leave_approval",
   "role_allowed_to_create_backdated_leave_application",
   "column_break_29",
   "expense_approver_mandatory_in_expense_claim",
@@ -333,16 +333,16 @@
   },
   {
    "default": "1",
-   "fieldname": "allow_self_leave_approval",
+   "fieldname": "prevent_self_leave_approval",
    "fieldtype": "Check",
-   "label": "Enable Self-Approval For Leaves"
+   "label": "Prevent self approval for leaves even if user has permissions"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-02 13:25:31.843494",
+ "modified": "2024-12-11 12:34:33.019189",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -332,7 +332,7 @@
    "label": " Unlink Payment on Cancellation of Employee Advance"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "prevent_self_leave_approval",
    "fieldtype": "Check",
    "label": "Prevent self approval for leaves even if user has permissions"
@@ -342,7 +342,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-11 12:34:33.019189",
+ "modified": "2025-01-30 12:41:22.594071",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -26,6 +26,7 @@
   "leave_status_notification_template",
   "leave_approver_mandatory_in_leave_application",
   "restrict_backdated_leave_application",
+  "allow_self_leave_approval",
   "role_allowed_to_create_backdated_leave_application",
   "column_break_29",
   "expense_approver_mandatory_in_expense_claim",
@@ -329,13 +330,19 @@
    "fieldname": "unlink_payment_on_cancellation_of_employee_advance",
    "fieldtype": "Check",
    "label": " Unlink Payment on Cancellation of Employee Advance"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_self_leave_approval",
+   "fieldtype": "Check",
+   "label": "Enable Self-Approval For Leaves"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-29 12:49:16.175079",
+ "modified": "2024-12-02 13:25:31.843494",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -285,22 +285,22 @@ frappe.ui.form.on("Leave Application", {
 		frm.disable_save();
 		$(".form-message").prop("hidden", true);
 		frm.add_custom_button(
-			"Approve",
+			__("Approve"),
 			() => {
 				frm.set_value("status", "Approved");
 				frm.save("Submit");
 			},
-			"Actions",
+			__("Actions"),
 		);
 		frm.add_custom_button(
-			"Reject",
+			__("Reject"),
 			() => {
 				frm.set_value("status", "Rejected");
 				frm.save("Submit");
 			},
-			"Actions",
+			__("Actions"),
 		);
-		frm.page.set_inner_btn_group_as_primary("Actions");
+		frm.page.set_inner_btn_group_as_primary(__("Actions"));
 	},
 });
 

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -12,7 +12,6 @@ frappe.ui.form.on("Leave Application", {
 				},
 			};
 		});
-
 		frm.set_query("employee", erpnext.queries.employee);
 	},
 
@@ -114,7 +113,7 @@ frappe.ui.form.on("Leave Application", {
 		if (frm.doc.docstatus === 0) {
 			frm.trigger("make_dashboard");
 		}
-		frm.trigger("prevent_self_leave_approval");
+		frm.trigger("set_form_buttons");
 	},
 
 	async set_employee(frm) {
@@ -136,7 +135,6 @@ frappe.ui.form.on("Leave Application", {
 		if (frm.doc.leave_approver) {
 			frm.set_value("leave_approver_name", frappe.user.full_name(frm.doc.leave_approver));
 		}
-		frm.trigger("prevent_self_leave_approval");
 	},
 
 	leave_type: function (frm) {
@@ -258,37 +256,53 @@ frappe.ui.form.on("Leave Application", {
 		}
 	},
 
-	prevent_self_leave_approval: async function (frm) {
-		let is_invalid_leave_approver = invalid_leave_approver(
-			frm.doc.employee,
-			await hrms.get_current_employee(),
-			await self_approval_not_allowed(),
-		);
-
+	set_form_buttons: async function (frm) {
+		let self_approval_not_allowed = frm.doc.__onload
+			? frm.doc.__onload.self_leave_approval_not_allowed
+			: 0;
+		let current_employee = await hrms.get_current_employee();
 		if (
 			frm.doc.docstatus === 0 &&
-			is_invalid_leave_approver &&
 			!frm.is_dirty() &&
 			!frappe.model.has_workflow(frm.doctype)
 		) {
-			frm.page.clear_primary_action();
-			$(".form-message").prop("hidden", true);
+			if (current_employee != frm.doc.employee) {
+				frm.trigger("show_grouped_buttons");
+			} else if (self_approval_not_allowed) {
+				frm.set_df_property("status", "read_only", 1);
+				frm.trigger("show_save_button");
+			}
 		}
 	},
+	show_save_button: function (frm) {
+		frm.page.set_primary_action("Save", () => {
+			frm.save();
+		});
+		$(".form-message").prop("hidden", true);
+	},
+
+	show_grouped_buttons: function (frm) {
+		frm.disable_save();
+		$(".form-message").prop("hidden", true);
+		frm.add_custom_button(
+			"Approve",
+			() => {
+				frm.set_value("status", "Approved");
+				frm.save("Submit");
+			},
+			"Actions",
+		);
+		frm.add_custom_button(
+			"Reject",
+			() => {
+				frm.set_value("status", "Rejected");
+				frm.save("Submit");
+			},
+			"Actions",
+		);
+		frm.page.set_inner_btn_group_as_primary("Actions");
+	},
 });
-
-function invalid_leave_approver(leave_applicant, current_employee, self_approval_not_allowed) {
-	const invalid_leave_approver =
-		self_approval_not_allowed && leave_applicant == current_employee ? 1 : 0;
-	return invalid_leave_approver;
-}
-
-async function self_approval_not_allowed() {
-	allow_self_leave_approval = cint(
-		await frappe.db.get_single_value("HR Settings", "allow_self_leave_approval"),
-	);
-	return !allow_self_leave_approval;
-}
 
 frappe.tour["Leave Application"] = [
 	{

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -90,7 +90,6 @@ frappe.ui.form.on("Leave Application", {
 
 	refresh: function (frm) {
 		hrms.leave_utils.add_view_ledger_button(frm);
-
 		if (frm.is_new()) {
 			frm.trigger("calculate_total_days");
 		}
@@ -266,9 +265,7 @@ frappe.ui.form.on("Leave Application", {
 			!frm.is_dirty() &&
 			!frappe.model.has_workflow(frm.doctype)
 		) {
-			if (current_employee != frm.doc.employee) {
-				frm.trigger("show_grouped_buttons");
-			} else if (self_approval_not_allowed) {
+			if (self_approval_not_allowed && current_employee == frm.doc.employee) {
 				frm.set_df_property("status", "read_only", 1);
 				frm.trigger("show_save_button");
 			}
@@ -279,28 +276,6 @@ frappe.ui.form.on("Leave Application", {
 			frm.save();
 		});
 		$(".form-message").prop("hidden", true);
-	},
-
-	show_grouped_buttons: function (frm) {
-		frm.disable_save();
-		$(".form-message").prop("hidden", true);
-		frm.add_custom_button(
-			__("Approve"),
-			() => {
-				frm.set_value("status", "Approved");
-				frm.save("Submit");
-			},
-			__("Actions"),
-		);
-		frm.add_custom_button(
-			__("Reject"),
-			() => {
-				frm.set_value("status", "Rejected");
-				frm.save("Submit");
-			},
-			__("Actions"),
-		);
-		frm.page.set_inner_btn_group_as_primary(__("Actions"));
 	},
 });
 

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -136,6 +136,7 @@ frappe.ui.form.on("Leave Application", {
 		if (frm.doc.leave_approver) {
 			frm.set_value("leave_approver_name", frappe.user.full_name(frm.doc.leave_approver));
 		}
+		frm.trigger("prevent_self_leave_approval");
 	},
 
 	leave_type: function (frm) {
@@ -257,9 +258,6 @@ frappe.ui.form.on("Leave Application", {
 		}
 	},
 
-	leave_approver: function (frm) {
-		frm.trigger("prevent_self_leave_approval");
-	},
 	prevent_self_leave_approval: async function (frm) {
 		let is_invalid_leave_approver = invalid_leave_approver(
 			frm.doc.employee,
@@ -267,7 +265,12 @@ frappe.ui.form.on("Leave Application", {
 			await self_approval_not_allowed(),
 		);
 
-		if (frm.doc.docstatus === 0 && is_invalid_leave_approver && !frm.is_dirty()) {
+		if (
+			frm.doc.docstatus === 0 &&
+			is_invalid_leave_approver &&
+			!frm.is_dirty() &&
+			!frappe.model.has_workflow(frm.doctype)
+		) {
 			frm.page.clear_primary_action();
 			$(".form-message").prop("hidden", true);
 		}

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -5,6 +5,7 @@ import datetime
 
 import frappe
 from frappe import _
+from frappe.model.workflow import get_workflow_name
 from frappe.query_builder.functions import Max, Min, Sum
 from frappe.utils import (
 	add_days,
@@ -797,7 +798,10 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 	def validate_for_self_approval(self):
 		self_leave_approval_allowed = frappe.db.get_single_value("HR Settings", "allow_self_leave_approval")
-		if (not self_leave_approval_allowed) and (self.employee == get_current_employee_info()["name"]):
+		if (not self_leave_approval_allowed) and (
+			self.employee == get_current_employee_info()["name"]
+			and not get_workflow_name("Leave Application")
+		):
 			frappe.throw(_("Self approval for leaves is not allowed"), frappe.ValidationError)
 
 

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -23,6 +23,7 @@ from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import dateran
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 
 import hrms
+from hrms.api import get_current_employee_info
 from hrms.hr.doctype.leave_block_list.leave_block_list import get_applicable_block_dates
 from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import create_leave_ledger_entry
 from hrms.hr.utils import (
@@ -102,6 +103,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 		self.validate_back_dated_application()
 		self.update_attendance()
+		self.validate_for_self_approval()
 
 		# notify leave applier about approval
 		if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
@@ -792,6 +794,11 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			if leaves:
 				args.update(dict(from_date=start_date, to_date=self.to_date, leaves=leaves * -1))
 				create_leave_ledger_entry(self, args, submit)
+
+	def validate_for_self_approval(self):
+		self_leave_approval_allowed = frappe.db.get_single_value("HR Settings", "allow_self_leave_approval")
+		if (not self_leave_approval_allowed) and (self.employee == get_current_employee_info()["name"]):
+			frappe.throw(_("Self approval for leaves is not allowed"))
 
 
 def get_allocation_expiry_for_cf_leaves(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -798,7 +798,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 	def validate_for_self_approval(self):
 		self_leave_approval_allowed = frappe.db.get_single_value("HR Settings", "allow_self_leave_approval")
 		if (not self_leave_approval_allowed) and (self.employee == get_current_employee_info()["name"]):
-			frappe.throw(_("Self approval for leaves is not allowed"))
+			frappe.throw(_("Self approval for leaves is not allowed"), frappe.ValidationError)
 
 
 def get_allocation_expiry_for_cf_leaves(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -798,11 +798,13 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 	def validate_for_self_approval(self):
 		self_leave_approval_allowed = frappe.db.get_single_value("HR Settings", "allow_self_leave_approval")
+
 		if (not self_leave_approval_allowed) and (
-			self.employee == get_current_employee_info()["name"]
-			and not get_workflow_name("Leave Application")
+			self.employee == get_current_employee_info().get("name")
+			if get_current_employee_info()
+			else None and not get_workflow_name("Leave Application")
 		):
-			frappe.throw(_("Self approval for leaves is not allowed"), frappe.ValidationError)
+			frappe.throw(_("Self-approval for leaves is not allowed"), frappe.ValidationError)
 
 
 def get_allocation_expiry_for_cf_leaves(

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -968,7 +968,6 @@ class TestLeaveApplication(IntegrationTestCase):
 		employee.save()
 
 	def test_self_leave_approval_allowed(self):
-		print("test self approval started")
 		leave_approver = "test_leave_approver@example.com"
 		employee = get_employee()
 		make_employee(leave_approver, "_Test Company")
@@ -987,7 +986,6 @@ class TestLeaveApplication(IntegrationTestCase):
 		self.assertEqual(1, application.docstatus)
 
 	def test_self_leave_approval_not_allowed(self):
-		print("test self deniel started")
 		leave_approver = "test_leave_approver@example.com"
 		employee = get_employee()
 		make_employee(leave_approver, "_Test Company")

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -968,7 +968,7 @@ class TestLeaveApplication(IntegrationTestCase):
 		employee.save()
 
 	def test_self_leave_approval_allowed(self):
-		frappe.db.set_single_value("HR Settings", "allow_self_leave_approval", 1)
+		frappe.db.set_single_value("HR Settings", "prevent_self_leave_approval", 0)
 
 		leave_approver = "test_leave_approver@example.com"
 		make_employee(leave_approver, "_Test Company")
@@ -1006,7 +1006,7 @@ class TestLeaveApplication(IntegrationTestCase):
 		frappe.set_user("Administrator")
 
 	def test_self_leave_approval_not_allowed(self):
-		frappe.db.set_single_value("HR Settings", "allow_self_leave_approval", 0)
+		frappe.db.set_single_value("HR Settings", "prevent_self_leave_approval", 1)
 
 		leave_approver = "test_leave_approver@example.com"
 		make_employee(leave_approver, "_Test Company")

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -985,17 +985,15 @@ class TestLeaveApplication(IntegrationTestCase):
 
 		make_allocation_record(employee.name)
 		application = frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type="_Test Leave Type",
-				from_date="2014-06-01",
-				to_date="2014-06-02",
-				posting_date="2014-05-30",
-				description="_Test Reason",
-				company="_Test Company",
-				leave_approver=leave_approver,
-			)
+			doctype="Leave Application",
+			employee=employee.name,
+			leave_type="_Test Leave Type",
+			from_date="2014-06-01",
+			to_date="2014-06-02",
+			posting_date="2014-05-30",
+			description="_Test Reason",
+			company="_Test Company",
+			leave_approver=leave_approver,
 		)
 		application.insert()
 		application.status = "Approved"
@@ -1025,17 +1023,15 @@ class TestLeaveApplication(IntegrationTestCase):
 
 		make_allocation_record(employee.name)
 		application = application = frappe.get_doc(
-			dict(
-				doctype="Leave Application",
-				employee=employee.name,
-				leave_type="_Test Leave Type",
-				from_date="2014-06-03",
-				to_date="2014-06-04",
-				posting_date="2014-05-30",
-				description="_Test Reason",
-				company="_Test Company",
-				leave_approver=leave_approver,
-			)
+			doctype="Leave Application",
+			employee=employee.name,
+			leave_type="_Test Leave Type",
+			from_date="2014-06-03",
+			to_date="2014-06-04",
+			posting_date="2014-05-30",
+			description="_Test Reason",
+			company="_Test Company",
+			leave_approver=leave_approver,
 		)
 		application.insert()
 		application.status = "Approved"


### PR DESCRIPTION
### Issue

Immediately after employees create and save leave application they see the document with "submit" as primary action that can lead to confusion as to clicking submit is part of the leave application process. So the employees ended up submitting their own leaves even if a different leave approver was already set in the application.
Role permission do not help in case one employee is leave approver for another employee.

----

### Before
https://github.com/user-attachments/assets/fbaed5b7-6e20-45e5-be64-e1a69778a3dc

### After
https://github.com/user-attachments/assets/e4286f49-bc3f-4476-b053-2e18e54ec7f8


https://github.com/user-attachments/assets/d8e1875b-9fcf-4eae-886a-f5186aaabc43



### Fix
Added a new setting in HR Settings called **Prevent self-approval for leaves even if user has permissions** which is disabled by default to retain current behaviour.
The submit action is removed on leave application if the settings is checked. Setting is ignored if the leave application doctype has a workflow.
Added tests for when self approval is enabled/disabled
I'll update the documentation once this is merged, no-docs for now 