### PR TITLE
fix(Expense Claim): allow editing company and department

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.json
+++ b/hrms/hr/doctype/expense_claim/expense_claim.json
@@ -221,7 +221,6 @@
    "oldfieldname": "company",
    "oldfieldtype": "Link",
    "options": "Company",
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -390,7 +389,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-09 14:16:06.715586",
+ "modified": "2024-12-11 13:04:36.076474",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim",

--- a/hrms/hr/doctype/expense_claim/expense_claim.json
+++ b/hrms/hr/doctype/expense_claim/expense_claim.json
@@ -89,11 +89,11 @@
   },
   {
    "fetch_from": "employee.department",
+   "fetch_if_empty": 1,
    "fieldname": "department",
    "fieldtype": "Link",
    "label": "Department",
-   "options": "Department",
-   "read_only": 1
+   "options": "Department"
   },
   {
    "fieldname": "column_break_5",
@@ -214,6 +214,7 @@
   },
   {
    "fetch_from": "employee.company",
+   "fetch_if_empty": 1,
    "fieldname": "company",
    "fieldtype": "Link",
    "in_standard_filter": 1,
@@ -389,7 +390,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-11 13:04:36.076474",
+ "modified": "2024-12-16 16:16:47.975814",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim",


### PR DESCRIPTION
**Issue:** 
Employee unable to make Expense Claim for other Companies.

**ref:** [26804](https://support.frappe.io/helpdesk/tickets/26804)

**Screenshot:**
![image](https://github.com/user-attachments/assets/92a92e17-0ebf-4d16-8226-39b93c47f3f4)

**Backport needed: Version 15, Version 14**