### PR TITLE
fix: skip sending interview reschedule email if interview reminder is disabled in HR Settings

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -105,6 +105,7 @@ class Interview(Document):
 		)
 
 		if not cint(reminder_settings.send_interview_reminder):
+			frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 			return
 
 		try:

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -97,6 +97,16 @@ class Interview(Document):
 
 		recipients = get_recipients(self.name)
 
+		reminder_settings = frappe.db.get_value(
+			"HR Settings",
+			"HR Settings",
+			["send_interview_reminder"],
+			as_dict=True,
+		)
+
+		if not cint(reminder_settings.send_interview_reminder):
+			return
+
 		try:
 			frappe.sendmail(
 				recipients=recipients,

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -97,14 +97,8 @@ class Interview(Document):
 
 		recipients = get_recipients(self.name)
 
-		reminder_settings = frappe.db.get_value(
-			"HR Settings",
-			"HR Settings",
-			["send_interview_reminder"],
-			as_dict=True,
-		)
-
-		if not cint(reminder_settings.send_interview_reminder):
+		if not cint(frappe.db.get_single_value("HR Settings", "send_interview_reminder")):
+			return
 			frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 			return
 

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -95,13 +95,11 @@ class Interview(Document):
 		self.db_set({"scheduled_on": scheduled_on, "from_time": from_time, "to_time": to_time})
 		self.notify_update()
 
-		recipients = get_recipients(self.name)
-
+		
+		frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 		if not cint(frappe.db.get_single_value("HR Settings", "send_interview_reminder")):
 			return
-			frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
-			return
-
+		recipients = get_recipients(self.name)
 		try:
 			frappe.sendmail(
 				recipients=recipients,
@@ -124,7 +122,6 @@ class Interview(Document):
 				)
 			)
 
-		frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
`no-docs`