### PR TITLE
ci(fix): remove version specification for mariadb-client

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -6,7 +6,7 @@ cd ~ || exit
 
 sudo apt update
 sudo apt remove mysql-server mysql-client
-sudo apt install libcups2-dev redis-server mariadb-client-10.6
+sudo apt install libcups2-dev redis-server mariadb-client
 
 pip install frappe-bench
 


### PR DESCRIPTION
CI breaking:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/c464e5b8-d06c-4559-acc4-2ddca8f379e4" />
