### PR TITLE
fix: update status of gratuity record referenced in fnf

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
@@ -35,6 +35,10 @@ frappe.ui.form.on("Full and Final Statement", {
 					filters["is_group"] = 0;
 				}
 
+				if (frappe.model.is_submittable(fnf_doc.reference_document_type)) {
+					filters["docstatus"] = ["!=", 2];
+				}
+
 				if (frappe.meta.has_field(fnf_doc.reference_document_type, "company")) {
 					filters["company"] = frm.doc.company;
 				}

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -11,12 +11,13 @@ class FullandFinalStatement(Document):
 	def on_change(self):
 		for payable in self.payables:
 			if payable.component == "Gratuity":
-				gratuity = frappe.get_doc("Gratuity", payable.reference_document)
-				if self.status == "Paid":
-					amount = payable.amount if self.docstatus == 1 else 0
-					gratuity.db_set("paid_amount", amount)
-				if self.docstatus == 2:
-					gratuity.set_status(update=True, cancel=True)
+				if frappe.db.exists("Gratuity", payable.reference_document):
+					gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+					if self.status == "Paid":
+						amount = payable.amount if self.docstatus == 1 else 0
+						gratuity.db_set("paid_amount", amount)
+					if self.docstatus == 2:
+						gratuity.set_status(cancel=True)
 
 	def before_insert(self):
 		self.get_outstanding_statements()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -11,11 +11,12 @@ class FullandFinalStatement(Document):
 	def on_change(self):
 		for payable in self.payables:
 			if payable.component == "Gratuity":
-				frappe.db.set_value(
-					"Gratuity",
-					payable.reference_document,
-					{"status": self.status, "paid_amount": payable.amount},
-				)
+				gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+				if self.status == "Paid":
+					amount = payable.amount if self.docstatus == 1 else 0
+					gratuity.db_set("paid_amount", amount)
+				if self.docstatus == 2:
+					gratuity.set_status(update=True, cancel=True)
 
 	def before_insert(self):
 		self.get_outstanding_statements()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -9,7 +9,13 @@ from frappe.utils import flt, get_link_to_form, today
 
 class FullandFinalStatement(Document):
 	def on_change(self):
-		update_status_of_reference_documents(self, self.status)
+		for payable in self.payables:
+			if payable.component == "Gratuity":
+				frappe.db.set_value(
+					"Gratuity",
+					payable.reference_document,
+					{"status": self.status, "paid_amount": payable.amount},
+				)
 
 	def before_insert(self):
 		self.get_outstanding_statements()
@@ -313,9 +319,3 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
-
-
-def update_status_of_reference_documents(doc, status="Paid"):
-	for payable in doc.payables:
-		if payable.component == "Gratuity":
-			frappe.db.set_value("Gratuity", payable.reference_document, "status", status)

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -8,6 +8,9 @@ from frappe.utils import flt, get_link_to_form, today
 
 
 class FullandFinalStatement(Document):
+	def on_change(self):
+		update_status_of_reference_documents(self, self.status)
+
 	def before_insert(self):
 		self.get_outstanding_statements()
 
@@ -310,3 +313,9 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
+
+
+def update_status_of_reference_documents(doc, status="Paid"):
+	for payable in doc.payables:
+		if payable.component == "Gratuity":
+			frappe.db.set_value("Gratuity", payable.reference_document, "status", status)

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -8,6 +8,17 @@ from frappe.utils import flt, get_link_to_form, today
 
 
 class FullandFinalStatement(Document):
+	def on_change(self):
+		for payable in self.payables:
+			if payable.component == "Gratuity":
+				if frappe.db.exists("Gratuity", payable.reference_document):
+					gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+					if self.status == "Paid":
+						amount = payable.amount if self.docstatus == 1 else 0
+						gratuity.db_set("paid_amount", amount)
+					if self.docstatus == 2:
+						gratuity.set_status(cancel=True)
+
 	def before_insert(self):
 		self.get_outstanding_statements()
 
@@ -24,7 +35,6 @@ class FullandFinalStatement(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry",)
-		self.set_gratuity_status()
 
 	def validate_relieving_date(self):
 		if not self.relieving_date:
@@ -249,18 +259,6 @@ class FullandFinalStatement(Document):
 		)
 		return jv
 
-	def set_gratuity_status(self):
-		for payable in self.payables:
-			if payable.component != "Gratuity":
-				continue
-			gratuity = frappe.get_doc("Gratuity", payable.reference_document)
-			amount = payable.amount if self.docstatus == 1 and self.status == "Paid" else 0
-			gratuity.db_set("paid_amount", amount)
-			if self.docstatus == 2:
-				gratuity.cancel()
-			else:
-				gratuity.set_status(update=True)
-
 
 @frappe.whitelist()
 def get_account_and_amount(ref_doctype, ref_document):
@@ -315,7 +313,6 @@ def get_account_and_amount(ref_doctype, ref_document):
 
 
 def update_full_and_final_statement_status(doc, method=None):
-	print("\n\n at update_full_and_final_statement_status \n\n")
 	"""Updates FnF status on Journal Entry Submission/Cancellation"""
 	status = "Paid" if doc.docstatus == 1 else "Unpaid"
 
@@ -324,4 +321,3 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
-			fnf.set_gratuity_status()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -8,17 +8,6 @@ from frappe.utils import flt, get_link_to_form, today
 
 
 class FullandFinalStatement(Document):
-	def on_change(self):
-		for payable in self.payables:
-			if payable.component == "Gratuity":
-				if frappe.db.exists("Gratuity", payable.reference_document):
-					gratuity = frappe.get_doc("Gratuity", payable.reference_document)
-					if self.status == "Paid":
-						amount = payable.amount if self.docstatus == 1 else 0
-						gratuity.db_set("paid_amount", amount)
-					if self.docstatus == 2:
-						gratuity.set_status(cancel=True)
-
 	def before_insert(self):
 		self.get_outstanding_statements()
 
@@ -35,6 +24,7 @@ class FullandFinalStatement(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry",)
+		self.set_gratuity_status()
 
 	def validate_relieving_date(self):
 		if not self.relieving_date:
@@ -259,6 +249,18 @@ class FullandFinalStatement(Document):
 		)
 		return jv
 
+	def set_gratuity_status(self):
+		for payable in self.payables:
+			if payable.component != "Gratuity":
+				continue
+			gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+			amount = payable.amount if self.docstatus == 1 and self.status == "Paid" else 0
+			gratuity.db_set("paid_amount", amount)
+			if self.docstatus == 2:
+				gratuity.cancel()
+			else:
+				gratuity.set_status(update=True)
+
 
 @frappe.whitelist()
 def get_account_and_amount(ref_doctype, ref_document):
@@ -321,3 +323,4 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
+			fnf.set_gratuity_status()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -8,17 +8,6 @@ from frappe.utils import flt, get_link_to_form, today
 
 
 class FullandFinalStatement(Document):
-	def on_change(self):
-		for payable in self.payables:
-			if payable.component == "Gratuity":
-				if frappe.db.exists("Gratuity", payable.reference_document):
-					gratuity = frappe.get_doc("Gratuity", payable.reference_document)
-					if self.status == "Paid":
-						amount = payable.amount if self.docstatus == 1 else 0
-						gratuity.db_set("paid_amount", amount)
-					if self.docstatus == 2:
-						gratuity.set_status(cancel=True)
-
 	def before_insert(self):
 		self.get_outstanding_statements()
 
@@ -35,6 +24,7 @@ class FullandFinalStatement(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry",)
+		self.set_gratuity_status()
 
 	def validate_relieving_date(self):
 		if not self.relieving_date:
@@ -259,6 +249,18 @@ class FullandFinalStatement(Document):
 		)
 		return jv
 
+	def set_gratuity_status(self):
+		for payable in self.payables:
+			if payable.component != "Gratuity":
+				continue
+			gratuity = frappe.get_doc("Gratuity", payable.reference_document)
+			amount = payable.amount if self.docstatus == 1 and self.status == "Paid" else 0
+			gratuity.db_set("paid_amount", amount)
+			if self.docstatus == 2:
+				gratuity.cancel()
+			else:
+				gratuity.set_status(update=True)
+
 
 @frappe.whitelist()
 def get_account_and_amount(ref_doctype, ref_document):
@@ -313,6 +315,7 @@ def get_account_and_amount(ref_doctype, ref_document):
 
 
 def update_full_and_final_statement_status(doc, method=None):
+	print("\n\n at update_full_and_final_statement_status \n\n")
 	"""Updates FnF status on Journal Entry Submission/Cancellation"""
 	status = "Paid" if doc.docstatus == 1 else "Unpaid"
 
@@ -321,3 +324,4 @@ def update_full_and_final_statement_status(doc, method=None):
 			fnf = frappe.get_doc("Full and Final Statement", entry.reference_name)
 			fnf.db_set("status", status)
 			fnf.notify_update()
+			fnf.set_gratuity_status()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -256,10 +256,7 @@ class FullandFinalStatement(Document):
 			gratuity = frappe.get_doc("Gratuity", payable.reference_document)
 			amount = payable.amount if self.docstatus == 1 and self.status == "Paid" else 0
 			gratuity.db_set("paid_amount", amount)
-			if self.docstatus == 2:
-				gratuity.cancel()
-			else:
-				gratuity.set_status(update=True)
+			gratuity.set_status(update=True)
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -24,7 +24,6 @@ class FullandFinalStatement(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry",)
-		self.set_gratuity_status()
 
 	def validate_relieving_date(self):
 		if not self.relieving_date:

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -205,7 +205,7 @@ class FullandFinalStatement(Document):
 					"debit_in_account_currency": flt(data.amount, precision),
 					"user_remark": data.remark,
 				}
-				if data.reference_document_type == "Expense Claim":
+				if data.reference_document_type in ["Expense Claim", "Gratuity"]:
 					account_dict["party_type"] = "Employee"
 					account_dict["party"] = self.employee
 

--- a/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
@@ -34,7 +34,7 @@ class TestFullandFinalStatement(IntegrationTestCase):
 			"Leave Encashment",
 		]
 
-		receivable_bootstraped_component = ["Employee Advance", "Loan"]
+		receivable_bootstraped_component = self.fnf.get_receivable_component()
 
 		# checking payables and receivables bootstraped value
 		self.assertEqual([payable.component for payable in self.fnf.payables], payables_bootstraped_component)

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -18,7 +18,7 @@ class Gratuity(AccountsController):
 		data = self.calculate_work_experience_and_amount()
 		self.current_work_experience = data["current_work_experience"]
 		self.amount = data["amount"]
-		self.set_status()
+		self.set_status(update=True)
 
 	@property
 	def gratuity_settings(self):
@@ -37,7 +37,7 @@ class Gratuity(AccountsController):
 
 		return self._gratuity_settings
 
-	def set_status(self, update=False, cancel=False):
+	def set_status(self, update=False):
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]
 
 		if self.docstatus == 1:
@@ -48,22 +48,13 @@ class Gratuity(AccountsController):
 				status = "Unpaid"
 
 		if update and self.status != status:
-			if self.status != status:
-				self.db_set("status", status)
-		else:
-			self.status = status
-
-		if cancel and self.docstatus != 2:
-			self.db_set("docstatus", 2)
+			self.db_set("status", status)
 
 	def on_submit(self):
 		if self.pay_via_salary_slip:
 			self.create_additional_salary()
 		else:
 			self.create_gl_entries()
-
-	def on_change(self):
-		self.set_status(update=True)
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ["GL Entry"]

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -18,7 +18,7 @@ class Gratuity(AccountsController):
 		data = self.calculate_work_experience_and_amount()
 		self.current_work_experience = data["current_work_experience"]
 		self.amount = data["amount"]
-		self.set_status(update=True)
+		self.set_status()
 
 	@property
 	def gratuity_settings(self):
@@ -49,6 +49,8 @@ class Gratuity(AccountsController):
 
 		if update and self.status != status:
 			self.db_set("status", status)
+		else:
+			self.status = status
 
 	def on_submit(self):
 		if self.pay_via_salary_slip:

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -18,7 +18,7 @@ class Gratuity(AccountsController):
 		data = self.calculate_work_experience_and_amount()
 		self.current_work_experience = data["current_work_experience"]
 		self.amount = data["amount"]
-		self.set_status(update=True)
+		self.set_status()
 
 	@property
 	def gratuity_settings(self):
@@ -37,7 +37,7 @@ class Gratuity(AccountsController):
 
 		return self._gratuity_settings
 
-	def set_status(self, update=False):
+	def set_status(self, update=False, cancel=False):
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]
 
 		if self.docstatus == 1:
@@ -48,13 +48,22 @@ class Gratuity(AccountsController):
 				status = "Unpaid"
 
 		if update and self.status != status:
-			self.db_set("status", status)
+			if self.status != status:
+				self.db_set("status", status)
+		else:
+			self.status = status
+
+		if cancel and self.docstatus != 2:
+			self.db_set("docstatus", 2)
 
 	def on_submit(self):
 		if self.pay_via_salary_slip:
 			self.create_additional_salary()
 		else:
 			self.create_gl_entries()
+
+	def on_change(self):
+		self.set_status(update=True)
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ["GL Entry"]

--- a/hrms/payroll/doctype/gratuity/test_gratuity.py
+++ b/hrms/payroll/doctype/gratuity/test_gratuity.py
@@ -10,9 +10,6 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.expense_claim.test_expense_claim import get_payable_account
-from hrms.hr.doctype.full_and_final_statement.full_and_final_statement import (
-	update_full_and_final_statement_status,
-)
 from hrms.payroll.doctype.gratuity.gratuity import get_last_salary_slip
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_deduction_salary_component,
@@ -206,8 +203,14 @@ class TestGratuity(IntegrationTestCase):
 			},
 		)
 		fnf.submit()
+
 		jv = fnf.create_journal_entry()
+		jv.accounts[1].account = frappe.get_cached_value("Company", "_Test Company", "default_bank_account")
+		jv.cheque_no = "123456"
+		jv.cheque_date = getdate()
+		jv.save()
 		jv.submit()
+
 		gratuity.reload()
 		self.assertEqual(gratuity.status, "Paid")
 

--- a/hrms/payroll/doctype/gratuity/test_gratuity.py
+++ b/hrms/payroll/doctype/gratuity/test_gratuity.py
@@ -171,6 +171,52 @@ class TestGratuity(IntegrationTestCase):
 		)
 		self.assertEqual(gratuity.amount, 190000.0)
 
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_settle_gratuity_via_fnf_statement(self):
+		from hrms.hr.doctype.full_and_final_statement.test_full_and_final_statement import (
+			create_full_and_final_statement,
+		)
+
+		create_salary_slip(self.employee)
+		setup_gratuity_rule("Rule Under Limited Contract (UAE)")
+		set_mode_of_payment_account()
+
+		# create gratuity
+		gratuity = create_gratuity(
+			expense_account="Payment Account - _TC", mode_of_payment="Cash", employee=self.employee
+		)
+		gratuity.reload()
+
+		# create Full and Final Statement and add gratuity as Payables
+		fnf = create_full_and_final_statement(self.employee)
+		fnf.payables = []
+		fnf.receivables = []
+		fnf.append(
+			"payables",
+			{
+				"component": "Gratuity",
+				"reference_document_type": "Gratuity",
+				"reference_document": gratuity.name,
+				"amount": gratuity.amount,
+				"account": gratuity.payable_account,
+				"status": "Settled",
+			},
+		)
+		fnf.save()
+		fnf.create_journal_entry()
+
+		# mark fnf as paid and submit it
+		fnf.status = "Paid"
+		fnf.save()
+		fnf.submit()
+
+		gratuity.reload()
+		self.assertEqual(gratuity.status, "Paid")
+
+		fnf.cancel()
+		gratuity.reload()
+		self.assertEqual(gratuity.status, "Cancelled")
+
 
 def setup_gratuity_rule(name: str) -> dict:
 	from hrms.regional.united_arab_emirates.setup import setup
@@ -201,6 +247,7 @@ def create_gratuity(**args):
 		gratuity.expense_account = args.expense_account or "Payment Account - _TC"
 		gratuity.payable_account = args.payable_account or get_payable_account("_Test Company")
 		gratuity.mode_of_payment = args.mode_of_payment or "Cash"
+		gratuity.cost_center = args.cost_center or "Main - _TC"
 
 	gratuity.save()
 	gratuity.submit()

--- a/hrms/payroll/doctype/gratuity/test_gratuity.py
+++ b/hrms/payroll/doctype/gratuity/test_gratuity.py
@@ -205,17 +205,13 @@ class TestGratuity(IntegrationTestCase):
 				"status": "Settled",
 			},
 		)
-		fnf.create_journal_entry()
-		fnf.status = "Paid"
-		fnf.save()
 		fnf.submit()
-
-		fnf.set_gratuity_status()
-
+		jv = fnf.create_journal_entry()
+		jv.submit()
 		gratuity.reload()
-		self.assertEqual(gratuity.status, fnf.status)
+		self.assertEqual(gratuity.status, "Paid")
 
-		fnf.cancel()
+		jv.cancel()
 		gratuity.reload()
 		self.assertEqual(gratuity.status, "Unpaid")
 

--- a/hrms/payroll/doctype/gratuity/test_gratuity.py
+++ b/hrms/payroll/doctype/gratuity/test_gratuity.py
@@ -10,6 +10,9 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.expense_claim.test_expense_claim import get_payable_account
+from hrms.hr.doctype.full_and_final_statement.full_and_final_statement import (
+	update_full_and_final_statement_status,
+)
 from hrms.payroll.doctype.gratuity.gratuity import get_last_salary_slip
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_deduction_salary_component,
@@ -202,20 +205,19 @@ class TestGratuity(IntegrationTestCase):
 				"status": "Settled",
 			},
 		)
-		fnf.save()
 		fnf.create_journal_entry()
-
-		# mark fnf as paid and submit it
 		fnf.status = "Paid"
 		fnf.save()
 		fnf.submit()
 
+		fnf.set_gratuity_status()
+
 		gratuity.reload()
-		self.assertEqual(gratuity.status, "Paid")
+		self.assertEqual(gratuity.status, fnf.status)
 
 		fnf.cancel()
 		gratuity.reload()
-		self.assertEqual(gratuity.status, "Cancelled")
+		self.assertEqual(gratuity.status, "Unpaid")
 
 
 def setup_gratuity_rule(name: str) -> dict:


### PR DESCRIPTION
When a **Gratuity** record is referenced under **Payables** in a **Full and Final statement**, and the statement is paid, the gratuity record status is updated accordingly. The same update occurs when the Full and Final statement is cancelled.