### PR TITLE
feat: Allow setting From Date while manually allocating extra leaves

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -73,13 +73,26 @@ frappe.ui.form.on("Leave Allocation", {
 							fieldname: "new_leaves",
 							fieldtype: "Float",
 						},
+						{
+							label: "From Date",
+							fieldname: "from_date",
+							fieldtype: "Date",
+							default: frappe.datetime.get_today(),
+						},
+						{
+							label: "To Date",
+							fieldname: "to_date",
+							fieldtype: "Date",
+							read_only: 1,
+							default: frm.doc.to_date,
+						},
 					],
 					primary_action_label: "Allocate",
-					primary_action({ new_leaves }) {
+					primary_action({ new_leaves, from_date }) {
 						frappe.call({
 							method: "allocate_leaves_manually",
 							doc: frm.doc,
-							args: { new_leaves },
+							args: { new_leaves, from_date },
 							callback: function () {
 								frm.reload_doc();
 							},

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -72,6 +72,7 @@ frappe.ui.form.on("Leave Allocation", {
 							label: "New Leaves to be Allocated",
 							fieldname: "new_leaves",
 							fieldtype: "Float",
+							reqd: 1,
 						},
 						{
 							label: "From Date",
@@ -93,14 +94,21 @@ frappe.ui.form.on("Leave Allocation", {
 							method: "allocate_leaves_manually",
 							doc: frm.doc,
 							args: { new_leaves, from_date },
-							callback: function () {
-								frm.reload_doc();
+							callback: function (r) {
+								if (!r.exc) {
+									dialog.hide();
+									frm.reload_doc();
+								}
 							},
 						});
-						dialog.hide();
 					},
 				});
 				dialog.fields_dict.new_leaves.set_value(monthly_earned_leave);
+				dialog.fields_dict.from_date.datepicker?.update({
+					minDate: frappe.datetime.str_to_obj(frm.doc.from_date),
+					maxDate: frappe.datetime.str_to_obj(frm.doc.to_date),
+				});
+
 				dialog.show();
 			},
 			__("Actions"),

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -346,6 +346,11 @@ class LeaveAllocation(Document):
 				frappe.bold(new_leaves), frappe.session.user, frappe.bold(formatdate(date))
 			)
 			self.add_comment(comment_type="Info", text=text)
+			frappe.msgprint(
+				_("{0} leaves allocated successfully").format(frappe.bold(new_leaves)),
+				indicator="green",
+				alert=True,
+			)
 
 		else:
 			msg = _("Total leaves allocated cannot exceed annual allocation of {0}.").format(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -314,7 +314,7 @@ class LeaveAllocation(Document):
 		create_leave_ledger_entry(self, args, submit)
 
 	@frappe.whitelist()
-	def allocate_leaves_manually(self, new_leaves):
+	def allocate_leaves_manually(self, new_leaves, from_date=None):
 		new_allocation = flt(self.total_leaves_allocated) + flt(new_leaves)
 		new_allocation_without_cf = flt(
 			flt(self.get_existing_leave_count()) + flt(new_leaves),
@@ -339,7 +339,7 @@ class LeaveAllocation(Document):
 		):
 			self.db_set("total_leaves_allocated", new_allocation, update_modified=False)
 
-			date = frappe.flags.current_date or getdate()
+			date = from_date or frappe.flags.current_date or getdate()
 			create_additional_leave_ledger_entry(self, new_leaves, date)
 
 			text = _("{0} leaves were manually allocated by {1} on {2}").format(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -315,6 +315,14 @@ class LeaveAllocation(Document):
 
 	@frappe.whitelist()
 	def allocate_leaves_manually(self, new_leaves, from_date=None):
+		if from_date and not (getdate(self.from_date) <= getdate(from_date) <= getdate(self.to_date)):
+			frappe.throw(
+				_("Cannot allocate leaves outside the allocation period {0} - {1}").format(
+					frappe.bold(formatdate(self.from_date)), frappe.bold(formatdate(self.to_date))
+				),
+				title=_("Invalid Dates"),
+			)
+
 		new_allocation = flt(self.total_leaves_allocated) + flt(new_leaves)
 		new_allocation_without_cf = flt(
 			flt(self.get_existing_leave_count()) + flt(new_leaves),

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -495,10 +495,23 @@ class TestLeaveAllocation(IntegrationTestCase):
 			get_leave_balance_on(self.employee.name, self.leave_type, frappe.flags.current_date), 6
 		)
 
-		leave_allocation.allocate_leaves_manually(6)
+		leave_allocation.allocate_leaves_manually(5)
 		self.assertEqual(
-			get_leave_balance_on(self.employee.name, self.leave_type, frappe.flags.current_date), 12
+			get_leave_balance_on(self.employee.name, self.leave_type, frappe.flags.current_date), 11
 		)
+
+		# manually set from_date - applicable from the next day
+		leave_allocation.allocate_leaves_manually(1, add_days(frappe.flags.current_date, 1))
+		# balance should be 11 on the current date
+		self.assertEqual(
+			get_leave_balance_on(self.employee.name, self.leave_type, frappe.flags.current_date), 11
+		)
+		# allocated leave should be applicable from the next day
+		self.assertEqual(
+			get_leave_balance_on(self.employee.name, self.leave_type, add_days(frappe.flags.current_date, 1)),
+			12,
+		)
+
 		self.assertRaises(frappe.ValidationError, leave_allocation.allocate_leaves_manually, 1)
 
 	def tearDown(self):


### PR DESCRIPTION
#### Allow setting From Date while manually allocating extra leaves

Manual earned leave allocation used to only allow setting number of leaves to be allocated and the "**From Date**" for the ledger entry was being considered as the current date. This is now configurable

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/2394cda3-2121-4b2d-83c2-6e5d3c6725cd" />

- Added min & max limits for date selection in the dialog
- Added server-side validation for dates outside allocation period

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/5e83b9f2-1e0d-41a9-94c6-dbfd607ccd12" />

#### Other Fix: User wasn't informed on successful manual allocation

**Before**:

It leaves a comment in the timeline but no visual feedback on success

https://github.com/user-attachments/assets/fded1919-13b0-4d8a-a054-6fbc1b121dc2


**After**:

<img width="1390" alt="Pasted image 20241218133251" src="https://github.com/user-attachments/assets/01f82711-1156-44a1-8eb7-e211227a0f14" />

Added missing docs from https://github.com/frappe/hrms/pull/1950
https://docs.frappe.io/hr/leave-allocation#1-manually-adding-leaves-to-the-current-allocation
