### PR TITLE
fix(Shift Type): mark Process Attendance After reqd if auto attendance is enabled

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.json
+++ b/hrms/hr/doctype/shift_type/shift_type.json
@@ -3,6 +3,7 @@
  "autoname": "prompt",
  "creation": "2018-04-13 16:22:52.954783",
  "doctype": "DocType",
+ "documentation": "https://docs.frappe.io/hr/shift-type",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
@@ -23,6 +24,7 @@
   "working_hours_threshold_for_absent",
   "process_attendance_after",
   "last_sync_of_checkin",
+  "auto_update_last_sync",
   "grace_period_settings_auto_attendance_section",
   "enable_late_entry_marking",
   "late_entry_grace_period",
@@ -137,16 +139,19 @@
    "label": "Enable Auto Attendance"
   },
   {
+   "default": "Today",
    "description": "Attendance will be marked automatically only after this date.",
    "fieldname": "process_attendance_after",
    "fieldtype": "Date",
-   "label": "Process Attendance After"
+   "label": "Process Attendance After",
+   "mandatory_depends_on": "enable_auto_attendance"
   },
   {
    "description": "Last Known Successful Sync of Employee Checkin. Reset this only if you are sure that all Logs are synced from all the locations. Please don't modify this if you are unsure.",
    "fieldname": "last_sync_of_checkin",
    "fieldtype": "Datetime",
-   "label": "Last Sync of Checkin"
+   "label": "Last Sync of Checkin",
+   "read_only_depends_on": "auto_update_last_sync"
   },
   {
    "default": "0",
@@ -173,10 +178,17 @@
    "fieldtype": "Select",
    "label": "Roster Color",
    "options": "Blue\nCyan\nFuchsia\nGreen\nLime\nOrange\nPink\nRed\nViolet\nYellow"
+  },
+  {
+   "default": "0",
+   "description": "Recommended for a single biometric device / checkins via mobile app",
+   "fieldname": "auto_update_last_sync",
+   "fieldtype": "Check",
+   "label": "Automatically update Last Sync of Checkin"
   }
  ],
  "links": [],
- "modified": "2024-05-17 15:48:27.191003",
+ "modified": "2024-12-18 16:48:10.270409",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Type",


### PR DESCRIPTION
Auto attendance doesn't work if "Process Attendance After" field is not set

- Mark **Process Attendance After** as mandatory if auto attendance is enabled
- Default it to today's date