### PR TITLE
fix(UX): Change label for confusing Leave Type fields - Applicable After & Maximum Leave Allocation Allowed

### DIFF
--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -55,9 +55,10 @@
    "label": "Maximum Leave Allocation Allowed"
   },
   {
+   "description": "Minimum working days required since Date of Joining to apply for this leave",
    "fieldname": "applicable_after",
    "fieldtype": "Int",
-   "label": "Applicable After (Working Days)"
+   "label": "Allow Leave Application After (Working Days)"
   },
   {
    "fieldname": "max_continuous_days_allowed",
@@ -234,7 +235,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:02.014828",
+ "modified": "2024-12-18 19:45:53.190981",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",

--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -52,7 +52,7 @@
   {
    "fieldname": "max_leaves_allowed",
    "fieldtype": "Float",
-   "label": "Maximum Leave Allocation Allowed"
+   "label": "Maximum Leave Allocation Allowed per Leave Period"
   },
   {
    "description": "Minimum working days required since Date of Joining to apply for this leave",
@@ -235,7 +235,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2024-12-18 19:45:53.190981",
+ "modified": "2024-12-18 19:51:44.162375",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",


### PR DESCRIPTION
**Before**:

**Applicable After (Working Days):** Users think this will allocate leaves after the set days. But it allocates leaves immediately, only leave application is restricted until the employee completes these many working days since Date of Joining

**Maximum Leave Allocation Allowed**: No clarity on the period for which this validation applies. All allocations for an employee/single allocation/single leave period? It actually validates per leave period

<img width="1391" alt="relabel-before" src="https://github.com/user-attachments/assets/fba56100-afef-4623-8ec7-a5a354d1e0f4" />


**After:**

Fixed labels for clarity

<img width="1391" alt="relabel" src="https://github.com/user-attachments/assets/80ee6b7f-11ce-469a-a87f-1ef83e31a078" />

Updated docs: https://docs.frappe.io/hr/leave-type
