### PR TITLE
feat: allow user to bulk allocate leaves manually 

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -479,6 +479,7 @@ def _bulk_allocate_leaves(allocations, new_leaves):
 	frappe.publish_realtime(
 		"completed_bulk_leave_allocation",
 		message={"success": success, "failure": failure, "for_update": True},
+		doctype="Leave Allocation",
 		after_commit=True,
 	)
 

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -477,3 +477,81 @@ def get_unused_leaves(employee, leave_type, from_date, to_date):
 def validate_carry_forward(leave_type):
 	if not frappe.db.get_value("Leave Type", leave_type, "is_carry_forward"):
 		frappe.throw(_("Leave Type {0} cannot be carry-forwarded").format(leave_type))
+
+
+@frappe.whitelist()
+def bulk_allocate_leaves(allocations, new_leaves):
+	allocations = frappe.parse_json(allocations)
+	if len(allocations) <= 30:
+		return _bulk_allocate_leaves(allocations, new_leaves)
+
+	frappe.enqueue(_bulk_allocate_leaves, timeout=3000, allocations=allocations, new_leaves=new_leaves)
+	frappe.msgprint(
+		_("Allocation of leaves has been queued. It may take a few minutes."),
+		alert=True,
+		indicator="blue",
+	)
+
+
+def _bulk_allocate_leaves(allocations, new_leaves):
+	success, failure = [], []
+
+	for allocation in allocations:
+		doc = frappe.get_doc("Leave Allocation", allocation)
+		new_allocation = flt(doc.total_leaves_allocated) + flt(new_leaves)
+		new_allocation_without_cf = flt(
+			flt(doc.get_existing_leave_count()) + flt(new_leaves),
+			doc.precision("total_leaves_allocated"),
+		)
+		max_leaves_allowed = frappe.db.get_value("Leave Type", doc.leave_type, "max_leaves_allowed")
+
+		if new_allocation > max_leaves_allowed and max_leaves_allowed > 0:
+			new_allocation = max_leaves_allowed
+
+		annual_allocation = 0
+		if doc.leave_policy:
+			annual_allocation = frappe.db.get_value(
+				"Leave Policy Detail",
+				{"parent": doc.leave_policy, "leave_type": doc.leave_type},
+				"annual_allocation",
+			)
+			annual_allocation = flt(annual_allocation, doc.precision("total_leaves_allocated"))
+
+		if new_allocation != doc.total_leaves_allocated and (
+			not doc.leave_policy or new_allocation_without_cf <= annual_allocation
+		):
+			try:
+				doc.db_set("total_leaves_allocated", new_allocation, update_modified=False)
+				date = frappe.flags.current_date or getdate()
+				create_additional_leave_ledger_entry(doc, new_leaves, date)
+
+			except Exception:
+				frappe.log_error(
+					f"Bulk Allocation - Processing failed for Allocation {doc.name}.",
+					reference_doctype="Leave Allocation",
+					reference_name=doc.name,
+				)
+				failure.append(doc.employee)
+			else:
+				text = _("{0} leaves were manually allocated by {1} on {2}").format(
+					frappe.bold(new_leaves), frappe.session.user, frappe.bold(formatdate(date))
+				)
+				doc.add_comment(comment_type="Info", text=text)
+				success.append(
+					{"doc": get_link_to_form("Leave Allocation", doc.name), "employee": doc.employee}
+				)
+		else:
+			frappe.log_error(
+				title=f"Bulk Allocation - Processing failed for Allocation {doc.name}.",
+				message="Total leaves allocated cannot exceed allocation limit.",
+				reference_doctype="Leave Allocation",
+				reference_name=doc.name,
+			)
+			failure.append(doc.employee)
+
+	frappe.clear_messages()
+	frappe.publish_realtime(
+		"completed_bulk_leave_allocation",
+		message={"success": success, "failure": failure},
+		after_commit=True,
+	)

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
@@ -10,7 +10,7 @@ frappe.listview_settings["Leave Allocation"] = {
 	},
 	onload: function (listview) {
 		listview.page.add_action_item(
-			__("Allocate Leaves"),
+			__("Allocate More Leaves"),
 			() => {
 				const allocations = listview
 					.get_checked_items()

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
@@ -8,4 +8,43 @@ frappe.listview_settings["Leave Allocation"] = {
 			return [__("Expired"), "gray", "expired, =, 1"];
 		}
 	},
+	onload: function (listview) {
+		listview.page.add_action_item(
+			__("Allocate Leaves"),
+			() => {
+				const allocations = listview
+					.get_checked_items()
+					.map((allocation) => allocation.name);
+				const dialog = new frappe.ui.Dialog({
+					title: "Manual Leave Allocation",
+					fields: [
+						{
+							label: "New Leaves to be Allocated",
+							fieldname: "new_leaves",
+							fieldtype: "Float",
+						},
+					],
+					primary_action_label: "Allocate",
+					primary_action({ new_leaves }) {
+						frappe.call({
+							method: "hrms.hr.doctype.leave_allocation.leave_allocation.bulk_allocate_leaves",
+							args: { allocations, new_leaves },
+							freeze: true,
+							freeze_message: __("Allocating Leaves"),
+						});
+						dialog.hide();
+					},
+				});
+				dialog.show();
+			},
+			__("Actions"),
+		);
+	},
+	refresh: function (listview) {
+		hrms.handle_realtime_bulk_action_notification(
+			listview,
+			"completed_bulk_leave_allocation",
+			"Leave Allocation",
+		);
+	},
 };

--- a/hrms/public/js/utils/index.js
+++ b/hrms/public/js/utils/index.js
@@ -120,6 +120,7 @@ $.extend(hrms, {
 				message.failure,
 				message.success,
 				message.for_processing,
+				message.for_update,
 			);
 
 			// refresh only on complete/partial success
@@ -127,12 +128,23 @@ $.extend(hrms, {
 		});
 	},
 
-	notify_bulk_action_status: (doctype, failure, success, for_processing = false) => {
+	notify_bulk_action_status: (
+		doctype,
+		failure,
+		success,
+		for_processing = false,
+		for_update = false,
+	) => {
 		let action = __("create/submit");
 		let action_past = __("created");
 		if (for_processing) {
 			action = __("process");
 			action_past = __("processed");
+		}
+
+		if (for_update) {
+			action = __("update");
+			action_past = __("updated");
 		}
 
 		let message = "";


### PR DESCRIPTION
Manually bulk allocate leaves against existing allocations and return results for successful allocations and failures.
![bulk-new](https://github.com/user-attachments/assets/c6d2fa47-93ab-46d6-b5c6-605a3ceb7961)


Error Log for failed allocation:
<img width="1117" alt="Screenshot 2024-12-19 at 12 49 00 PM" src="https://github.com/user-attachments/assets/1287b24b-762e-4dc8-8fed-e933cd58971e" />
