### PR TITLE
fix(PWA): show dates first in expense claims for consistency with leave items

### DIFF
--- a/frontend/src/components/ExpenseClaimItem.vue
+++ b/frontend/src/components/ExpenseClaimItem.vue
@@ -11,12 +11,12 @@
 					{{ claimTitle }}
 				</div>
 				<div class="text-xs font-normal text-gray-500">
-					<span>
-						{{ formatCurrency(props.doc.total_claimed_amount, currency) }}
-					</span>
-					<span class="whitespace-pre"> &middot; </span>
 					<span class="whitespace-nowrap">
 						{{ claimDates }}
+					</span>
+					<span class="whitespace-pre"> &middot; </span>
+					<span>
+						{{ formatCurrency(props.doc.total_claimed_amount, currency) }}
 					</span>
 				</div>
 			</div>


### PR DESCRIPTION
**Before**:

Expense claim cards show amount first and then the date, while leaves show date first. This breaks consistency while going throw the lists for the user. 

![items-before](https://github.com/user-attachments/assets/6ca11c25-4f23-4a03-bcc7-cf877a0ccfc7)

**After**:

Although amount is more vital info in claims, swapping this for consistency and ease of reading.

![image](https://github.com/user-attachments/assets/b3310021-b795-4600-b90f-b7f1ab669247)
