### PR TITLE
fix(CTC): `amount_exempted_from_income_tax` only considers last deduction item (exempted from IT), not all

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1678,7 +1678,7 @@ class SalarySlip(TransactionBase):
 
 					taxable_earnings -= flt(amount - additional_amount)
 					additional_income -= additional_amount
-					amount_exempted_from_income_tax = flt(amount - additional_amount)
+					amount_exempted_from_income_tax += flt(amount - additional_amount)
 
 					if additional_amount and ded.is_recurring_additional_salary:
 						additional_income -= self.get_future_recurring_additional_amount(


### PR DESCRIPTION
## **Before**

Gross = ₹ 2,05,000.00
Expected CTC = Gross * 12 (direct formula only applicable when payment days are full and other varying factors per month) = 24,60,000
Actual CTC = ₹ 23,12,964.00

**Gross**
![gross](https://github.com/user-attachments/assets/1a3a432d-23b5-4ce8-b266-8ef45d066750)

**Incorrect CTC**
![ctc-incorrect](https://github.com/user-attachments/assets/ecce92be-58d8-4f9c-9240-533245955a3c)

## **Problem**

### Expected calculation:

CTC formula in the system = (
		self.previous_taxable_earnings_before_exemption (0)
		+ self.current_structured_taxable_earnings_before_exemption ($${\color{green}1,97,800}$$) 
		+ self.future_structured_taxable_earnings_before_exemption ($${\color{green}21,75,800}$$)
		+ self.current_additional_earnings (0)
		+ self.other_incomes (0)
		+ self.unclaimed_taxable_benefits (0)
		+ self.non_taxable_earnings (86,400)
) = 24,60,000

### Actual amounts:

CTC formula in the system = (
		self.previous_taxable_earnings_before_exemption (0)
		+ self.current_structured_taxable_earnings_before_exemption ($${\color{red}1,85,547.0}$$) 
		+ self.future_structured_taxable_earnings_before_exemption ($${\color{red}20,41,017}$$) 
		+ self.current_additional_earnings (0)
		+ self.other_incomes (0)
		+ self.unclaimed_taxable_benefits (0)
		+ self.non_taxable_earnings (86,400)
) = 23,12,964.00

current & future taxable earnings are causing the difference 
this difference is caused because `amount_exempted_from_income_tax` is getting overwritten inside the for loop, not considering cumulative summation
