### PR TITLE
fix: skip patch if previous doctype doesn't exist

### DIFF
--- a/hrms/patches/v15_0/migrate_shift_assignment_schedule_to_shift_schedule.py
+++ b/hrms/patches/v15_0/migrate_shift_assignment_schedule_to_shift_schedule.py
@@ -4,6 +4,9 @@ from hrms.hr.doctype.shift_schedule.shift_schedule import get_or_insert_shift_sc
 
 
 def execute():
+	if not frappe.db.has_table("Shift Assignment Schedule"):
+		return
+
 	fields = ["name", "shift_type", "frequency", "employee", "shift_status", "enabled", "create_shifts_after"]
 	for doc in frappe.get_all("Shift Assignment Schedule", fields=fields):
 		repeat_on_days = frappe.get_all(


### PR DESCRIPTION
**Shift Assignment Schedule** does not exist in `version-14`, so this patch failed when trying to migrate a v14 database.
