### PR TITLE
fix: validate department based on company

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -64,6 +64,14 @@ frappe.ui.form.on("Expense Claim", {
 				query: "erpnext.controllers.queries.employee_query",
 			};
 		});
+
+		frm.set_query("department", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
 	},
 
 	onload: function (frm) {

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -29,6 +29,10 @@ class ExpenseApproverIdentityError(frappe.ValidationError):
 	pass
 
 
+class CompanyDepartmentMismatchError(frappe.ValidationError):
+	pass
+
+
 class ExpenseClaim(AccountsController, PWANotificationsMixin):
 	def onload(self):
 		self.get("__onload").make_payment_via_journal_entry = frappe.db.get_single_value(
@@ -47,8 +51,17 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		self.set_expense_account(validate=True)
 		self.calculate_taxes()
 		self.set_status()
+		self.validate_company_and_department()
 		if self.task and not self.project:
 			self.project = frappe.db.get_value("Task", self.task, "project")
+
+	def validate_company_and_department(self):
+		if self.department:
+			if self.company != frappe.db.get_value("Department", self.department, "company"):
+				frappe.throw(
+					_("Department {0} does not belong to company: {1}").format(self.department, self.company),
+					exc=CompanyDepartmentMismatchError,
+				)
 
 	def set_status(self, update=False):
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -10,6 +10,7 @@ from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_paymen
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.expense_claim.expense_claim import (
+	CompanyDepartmentMismatchError,
 	get_outstanding_amount_for_claim,
 	make_bank_entry,
 	make_expense_claim_for_delivery_trip,
@@ -567,6 +568,13 @@ class TestExpenseClaim(IntegrationTestCase):
 			fields=["sum(debit) as total_debit", "sum(credit) as total_credit"],
 		)
 		self.assertEqual(ledger_balance, expected_data)
+
+	def test_company_department_validation(self):
+		# validate company and department
+		expense_claim = frappe.new_doc("Expense Claim")
+		expense_claim.company = "_Test Company 3"
+		expense_claim.department = "Accounts - _TC2"
+		self.assertRaises(CompanyDepartmentMismatchError, expense_claim.save)
 
 
 def get_payable_account(company):


### PR DESCRIPTION
**Issue:**
allowing to submit expense claim with different departments with different companies
**ref:** [28450](https://support.frappe.io/helpdesk/tickets/28450)

**Solution:**
added filter for department field and validation for department based on company

**Before:**

[before.webm](https://github.com/user-attachments/assets/edf2d3c1-65c6-4439-9cc5-62dd02b160d6)

**After:**

[after.webm](https://github.com/user-attachments/assets/d1088c13-fc77-44d5-a367-8470255d192e)

**Backport needed for v15**