### PR TITLE
test: fix failing tests

### DIFF
--- a/hrms/hr/report/leave_ledger/test_leave_ledger.py
+++ b/hrms/hr/report/leave_ledger/test_leave_ledger.py
@@ -51,6 +51,7 @@ class TestLeaveLedger(IntegrationTestCase):
 		# create leave type
 		self.earned_leave = "Test Earned Leave"
 		self.casual_leave = "_Test Leave Type"
+		create_leave_type(leave_type=self.earned_leave)
 		create_leave_type(leave_type=self.casual_leave)
 
 		self.create_earned_leave_allocation()

--- a/hrms/hr/report/leave_ledger/test_leave_ledger.py
+++ b/hrms/hr/report/leave_ledger/test_leave_ledger.py
@@ -48,6 +48,7 @@ class TestLeaveLedger(IntegrationTestCase):
 		# create leave type
 		self.earned_leave = "Test Earned Leave"
 		self.casual_leave = "_Test Leave Type"
+		create_leave_type(leave_type=self.casual_leave)
 
 		self.create_earned_leave_allocation()
 		self.create_casual_leave_allocation()

--- a/hrms/hr/report/leave_ledger/test_leave_ledger.py
+++ b/hrms/hr/report/leave_ledger/test_leave_ledger.py
@@ -33,16 +33,19 @@ class TestLeaveLedger(IntegrationTestCase):
 		self.year_start = getdate(get_year_start(self.date))
 		self.year_end = getdate(get_year_ending(self.date))
 
-		self.holiday_list = make_holiday_list(
-			"_Test Emp Balance Holiday List", self.year_start, self.year_end
+		holiday_list = make_holiday_list(
+			"_Test Emp Balance Holiday List",
+			self.year_start,
+			self.year_end,
+			add_weekly_offs=False,
 		)
-
-		# create employee 1 & 2
 		self.employee_1 = frappe.get_doc(
-			"Employee", make_employee("test_emp_1@example.com", company="_Test Company")
+			"Employee",
+			make_employee("test_emp_1@example.com", company="_Test Company", holiday_list=holiday_list),
 		)
 		self.employee_2 = frappe.get_doc(
-			"Employee", make_employee("test_emp_2@example.com", company="_Test Company")
+			"Employee",
+			make_employee("test_emp_2@example.com", company="_Test Company", holiday_list=holiday_list),
 		)
 
 		# create leave type

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -372,8 +372,16 @@ class TestSalarySlip(IntegrationTestCase):
 		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 3.75)
 
 	@change_settings("Payroll Settings", {"payroll_based_on": "Leave"})
-	def test_payment_days_calculation_for_varying_leave_ranges(self):
-		emp_id = make_employee("test_payment_days_based_on_leave_application@salary.com")
+	def test_payment_days_calculation_for_lwp_on_month_boundaries(self):
+		"""Tests LWP calculation leave applications created on month boundaries"""
+		holiday_list = make_holiday_list(
+			"Test Holiday List",
+			"2024-01-01",
+			"2024-12-31",
+		)
+		emp_id = make_employee(
+			"test_payment_days_based_on_leave_application@salary.com", holiday_list=holiday_list
+		)
 
 		make_leave_application(emp_id, "2024-06-28", "2024-07-03", "Leave Without Pay")  # 3 days in July
 		make_leave_application(emp_id, "2024-07-10", "2024-07-13", "Leave Without Pay")  # 4 days in July

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -5,6 +5,7 @@ import calendar
 import random
 
 import frappe
+from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.model.document import Document
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import (
@@ -2168,6 +2169,8 @@ def make_leave_application(
 	half_day_date=None,
 	submit=True,
 ):
+	create_user("test@example.com")
+
 	leave_application = frappe.get_doc(
 		dict(
 			doctype="Leave Application",


### PR DESCRIPTION
Many tests failing due to date changes with the new year - none of them are bugs. Just fixes in the test data


### 1. Leave Ledger tests

Skip weekly offs in the test holiday list created in Leave Ledger tests for deterministic results. Weekly off dates will vary every year, testing against dynamic holiday list isn't necessary for leave ledger


<details>
<summary>Test Failure Traceback</summary>

```python
======================================================================
 FAIL  test_report_with_filters (hrms.hr.report.leave_ledger.test_leave_ledger.TestLeaveLedger)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/hrms/hrms/hr/report/leave_ledger/test_leave_ledger.py", line 141, in test_report_with_filters
    self.assertEqual(actual_result, expected_result)
    actual_result = [{'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 3.0}, {'transaction_type': 'Leave Application', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -1.0}, {'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 1.0}]
    expected_result = [{'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 3}, {'transaction_type': 'Leave Application', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -2}, {'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 1}]
    filters = {'from_date': datetime.date(2025, 1, 1), 'to_date': datetime.date(2025, 12, 31), 'employee': 'EMP-00010', 'leave_type': 'Test Earned Leave'}
    report = ([{'label': 'Leave Ledger Entry', 'fieldname': 'leave_ledger_entry', 'fieldtype': 'Link', 'options': 'Leave Ledger Entry', 'hidden': 1}, {'label': 'Employee', 'fieldname': 'employee', 'fieldtype': 'Link', 'options': 'Employee', 'width': 240}, {'label': 'Employee Name', 'fieldname': 'employee_name', 'fieldtype': 'Data', 'hidden': 1}, {'label': 'Creation Date', 'fieldname': 'date', 'fieldtype': 'Date', 'width': 120}, {'label': 'From Date', 'fieldname': 'from_date', 'fieldtype': 'Date', 'width': 120}, {'label': 'To Date', 'fieldname': 'to_date', 'fieldtype': 'Date', 'width': 120}, {'label': 'Leaves', 'fieldname': 'leaves', 'fieldtype': 'Float', 'width': 80}, {'label': 'Leave Type', 'fieldname': 'leave_type', 'fieldtype': 'Link', 'options': 'Leave Type', 'width': 150}, {'label': 'Transaction Type', 'fieldname': 'transaction_type', 'fieldtype': 'Link', 'options': 'DocType', 'width': 130}, {'label': 'Transaction Name', 'fieldname': 'transaction_name', 'fieldtype': 'Dynamic Link', 'options': 'transaction_type', 'width': 180}, {'label': 'Is Carry Forward', 'fieldname': 'is_carry_forward', 'fieldtype': 'Check', 'width': 80}, {'label': 'Is Expired', 'fieldname': 'is_expired', 'fieldtype': 'Check', 'width': 80}, {'label': 'Is Leave Without Pay', 'fieldname': 'is_lwp', 'fieldtype': 'Check', 'width': 80}, {'label': 'Company', 'fieldname': 'company', 'fieldtype': 'Link', 'options': 'Company', 'width': 150}, {'label': 'Holiday List', 'fieldname': 'holiday_list', 'fieldtype': 'Link', 'options': 'Holiday List', 'width': 150}], [{'leave_ledger_entry': '896iv2lfg3', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 3, 1), 'from_date': datetime.date(2025, 1, 1), 'to_date': datetime.date(2025, 12, 31), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 3.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': None}, {'leave_ledger_entry': 'unrmc1ndcs', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 4, 1), 'from_date': datetime.date(2025, 3, 1), 'to_date': datetime.date(2025, 3, 2), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Application', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -1.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': 'Salary Slip Test Holiday List'}, {'leave_ledger_entry': 'gnepb90ant', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 4, 1), 'from_date': datetime.date(2025, 4, 1), 'to_date': datetime.date(2025, 12, 31), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 1.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': None}, {'employee': 'Total Leaves (Test Earned Leave)', 'leaves': 3.0}])
    result = [{'leave_ledger_entry': '896iv2lfg3', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 3, 1), 'from_date': datetime.date(2025, 1, 1), 'to_date': datetime.date(2025, 12, 31), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 3.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': None}, {'leave_ledger_entry': 'unrmc1ndcs', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 4, 1), 'from_date': datetime.date(2025, 3, 1), 'to_date': datetime.date(2025, 3, 2), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Application', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -1.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': 'Salary Slip Test Holiday List'}, {'leave_ledger_entry': 'gnepb90ant', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 4, 1), 'from_date': datetime.date(2025, 4, 1), 'to_date': datetime.date(2025, 12, 31), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 1.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': None}]
    row = {'leave_ledger_entry': 'gnepb90ant', 'employee': 'EMP-00010', 'employee_name': 'test_emp_1@example.com', 'date': datetime.date(2025, 4, 1), 'from_date': datetime.date(2025, 4, 1), 'to_date': datetime.date(2025, 12, 31), 'leave_type': 'Test Earned Leave', 'transaction_type': 'Leave Allocation', 'transaction_name': 'HR-LAL-2025-00001', 'leaves': 1.0, 'is_carry_forward': 0, 'is_expired': 0, 'is_lwp': 0, 'company': '_Test Company', 'holiday_list': None}
    self = <hrms.hr.report.leave_ledger.test_leave_ledger.TestLeaveLedger testMethod=test_report_with_filters>
AssertionError: Lists differ: [{'tr[84 chars]s': 3.0}, {'transaction_type': 'Leave Applicat[156 chars]1.0}] != [{'tr[84 chars]s': 3}, {'transaction_type': 'Leave Applicatio[150 chars]: 1}]

First differing element 1:
{'tra[30 chars]tion', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -1.0}
{'tra[30 chars]tion', 'transaction_name': 'HR-LAP-2025-00001', 'leaves': -2}

- [{'leaves': 3.0,
?              --

+ [{'leaves': 3,
    'transaction_name': 'HR-LAL-2025-00001',
    'transaction_type': 'Leave Allocation'},
-  {'leaves': -1.0,
?              ^^^

+  {'leaves': -2,
?              ^

    'transaction_name': 'HR-LAP-2025-00001',
    'transaction_type': 'Leave Application'},
-  {'leaves': 1.0,
?              --

+  {'leaves': 1,
    'transaction_name': 'HR-LAL-2025-00001',
    'transaction_type': 'Leave Allocation'}]

======================================================================
 FAIL  test_totals (hrms.hr.report.leave_ledger.test_leave_ledger.TestLeaveLedger)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/hrms/hrms/hr/report/leave_ledger/test_leave_ledger.py", line 171, in test_totals
    self.assertEqual(total_row.leaves, 2)
    filters = {'from_date': datetime.date(2025, 1, 1), 'to_date': datetime.date(2025, 12, 31), 'employee': 'EMP-00013'}
    get_total_row = <function TestLeaveLedger.test_totals.<locals>.get_total_row at 0x7f0b1958f2e0>
    self = <hrms.hr.report.leave_ledger.test_leave_ledger.TestLeaveLedger testMethod=test_totals>
    total_row = {'employee': 'Total Leaves (Test Earned Leave)', 'leaves': 3.0}
AssertionError: 3.0 != 2

```
</details>

### 2. Salary Slip test - `test_payment_days_calculation_for_varying_leave_ranges`

Renamed for clarity - `test_payment_days_calculation_for_varying_leave_ranges` -> `test_payment_days_calculation_for_lwp_on_month_boundaries`

fix: set correct holiday list
- tests generate holiday list as per current year. Tests that assert against hardcoded dates from previous years fail as holidays from prev year aren't applicable anymore
- set that year's holiday list for tests that check against exact dates

<details>
<summary>Test Failure Traceback</summary>

```python
======================================================================
 FAIL  test_payment_days_calculation_for_varying_leave_ranges (hrms.payroll.doctype.salary_slip.test_salary_slip.TestSalarySlip)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
    args = (<hrms.payroll.doctype.salary_slip.test_salary_slip.TestSalarySlip testMethod=test_payment_days_calculation_for_varying_leave_ranges>,)
    func = <function TestSalarySlip.test_payment_days_calculation_for_varying_leave_ranges at 0x7f0b19042d40>
    kwds = {}
    self = <contextlib._GeneratorContextManager object at 0x7f0b1950f670>
  File "/home/runner/frappe-bench/apps/hrms/hrms/payroll/doctype/salary_slip/test_salary_slip.py", line 385, in test_payment_days_calculation_for_varying_leave_ranges
    self.assertEqual(ss.leave_without_pay, 10)
    emp_id = 'EMP-00039'
    self = <hrms.payroll.doctype.salary_slip.test_salary_slip.TestSalarySlip testMethod=test_payment_days_calculation_for_varying_leave_ranges>
    ss = <SalarySlip: doctype=Salary Slip Sal Slip/None/00016>
AssertionError: 11 != 10
```

</details>


### 3. Salary Withholding test - `test_set_withholding_cycles_and_to_date`

refactor: use consistent dates in all salary withholding tests
- currently 1 test uses hardcoded dates from 2024, while others use dynamic dates from current year, leading to missing salary structure assignment validations
- use the same dates in all tests, no need to test this against dynamic data

<details>
<summary>Test Failure Traceback</summary>

```python

======================================================================
 ERROR  test_set_withholding_cycles_and_to_date (hrms.payroll.doctype.salary_withholding.test_salary_withholding.TestSalaryWithholding)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/hrms/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py", line 41, in test_set_withholding_cycles_and_to_date
    withholding = create_salary_withholding(self.employee1, from_date, 2)
    from_date = datetime.date(2024, 6, 1)
    self = <hrms.payroll.doctype.salary_withholding.test_salary_withholding.TestSalaryWithholding testMethod=test_set_withholding_cycles_and_to_date>
    to_date = datetime.date(2024, 7, 31)
  File "/home/runner/frappe-bench/apps/hrms/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py", line 137, in create_salary_withholding
    doc.insert()
    doc = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
    employee = 'EMP-00011'
    from_date = datetime.date(2024, 6, 1)
    number_of_withholding_cycles = 2
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
    args = ()
    func = <function Document.insert at 0x7f0b20211510>
    kwargs = {}
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 399, in insert
    self.run_before_save_methods()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1246, in run_before_save_methods
    self.run_method("validate")
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1095, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7f0b17a369e0>
    kwargs = {}
    method = 'validate'
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1482, in composer
    return composed(self, method, *args, **kwargs)
    args = ()
    compose = <function Document.hook.<locals>.compose at 0x7f0b17a37d90>
    composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x7f0b17a376d0>
    doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type', 'frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.file.utils.attach_files_to_document'], 'on_change': ['frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points', 'frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone'], 'after_delete': ['frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'validate': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.apply', 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job']}, 'Event': {'after_insert': ['frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar', 'erpnext.crm.utils.link_events_with_prospect'], 'on_update': ['frappe.integrations.doctype.google_calendar.google_calendar.update_event_in_google_calendar'], 'on_trash': ['frappe.integrations.doctype.google_calendar.google_calendar.delete_event_from_google_calendar']}, 'Contact': {'after_insert': ['frappe.integrations.doctype.google_contacts.google_contacts.insert_contacts_to_google_contacts', 'erpnext.telephony.doctype.call_log.call_log.link_existing_conversations'], 'on_update': ['frappe.integrations.doctype.google_contacts.google_contacts.update_contacts_to_google_contacts'], 'on_trash': ['erpnext.support.doctype.issue.issue.update_issue'], 'validate': ['erpnext.crm.utils.update_lead_phone_numbers']}, 'DocType': {'on_update': ['frappe.cache_manager.build_domain_restricted_doctype_cache']}, 'Page': {'on_update': ['frappe.cache_manager.build_domain_restricted_page_cache']}, 'Sales Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.regional.italy.utils.sales_invoice_on_submit'], 'on_cancel': ['erpnext.regional.italy.utils.sales_invoice_on_cancel'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Purchase Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm', 'erpnext.regional.united_arab_emirates.utils.validate_returns']}, 'Journal Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'hrms.hr.doctype.expense_claim.expense_claim.validate_expense_claim_in_jv'], 'on_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim', 'hrms.hr.doctype.full_and_final_statement.full_and_final_statement.update_full_and_final_statement_status', 'hrms.payroll.doctype.salary_withholding.salary_withholding.update_salary_withholding_payment_status'], 'on_update_after_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim'], 'on_cancel': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim', 'hrms.payroll.doctype.salary_slip.salary_slip.unlink_ref_doc_from_salary_slip', 'hrms.hr.doctype.full_and_final_statement.full_and_final_statement.update_full_and_final_statement_status', 'hrms.payroll.doctype.salary_withholding.salary_withholding.update_salary_withholding_payment_status']}, 'Bank Clearance': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty'], 'on_cancel': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty']}, 'Dunning': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Invoice Discounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Payment Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.accounts.doctype.dunning.dunning.resolve_dunning', 'hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim'], 'on_cancel': ['erpnext.accounts.doctype.dunning.dunning.resolve_dunning', 'hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim'], 'on_trash': ['erpnext.regional.check_deletion_permission'], 'on_update_after_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim']}, 'Period Closing Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Process Deferred Accounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Capitalization': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Repair': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Delivery Note': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Landed Cost Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Purchase Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Reconciliation': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Subcontracting Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'User': {'after_insert': ['frappe.contacts.doctype.contact.contact.update_contact'], 'validate': ['erpnext.setup.doctype.employee.employee.validate_employee_role', 'erpnext.setup.doctype.employee.employee.validate_employee_role'], 'on_update': ['erpnext.setup.doctype.employee.employee.update_user_permissions', 'erpnext.portal.utils.set_default_role', 'erpnext.setup.doctype.employee.employee.update_user_permissions']}, 'Communication': {'on_update': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update', 'erpnext.support.doctype.issue.issue.set_first_response_time'], 'after_insert': ['erpnext.crm.utils.link_communications_with_prospect']}, 'Address': {'validate': ['erpnext.regional.italy.utils.set_state_code']}, 'Email Unsubscribe': {'after_insert': ['erpnext.crm.doctype.email_campaign.email_campaign.unsubscribe_recipient']}, 'Integration Request': {'validate': ['erpnext.accounts.doctype.payment_request.payment_request.validate_payment']}, 'Company': {'validate': ['lending.overrides.company.validate_loan_tables', 'hrms.overrides.company.validate_default_accounts'], 'on_update': ['hrms.overrides.company.make_company_fixtures', 'hrms.overrides.company.set_default_hr_accounts']}, 'Holiday List': {'on_update': ['hrms.utils.holiday_list.invalidate_cache'], 'on_trash': ['hrms.utils.holiday_list.invalidate_cache']}, 'Timesheet': {'validate': ['hrms.hr.utils.validate_active_employee']}, 'Loan': {'validate': ['hrms.hr.utils.validate_loan_repay_from_salary']}, 'Employee': {'validate': ['hrms.overrides.employee_master.validate_onboarding_process'], 'on_update': ['hrms.overrides.employee_master.update_approver_role', 'hrms.overrides.employee_master.publish_update'], 'after_insert': ['hrms.overrides.employee_master.update_job_applicant_and_offer'], 'on_trash': ['hrms.overrides.employee_master.update_employee_transfer'], 'after_delete': ['hrms.overrides.employee_master.publish_update']}, 'Project': {'validate': ['hrms.controllers.employee_boarding_controller.update_employee_boarding_status']}, 'Task': {'on_update': ['hrms.controllers.employee_boarding_controller.update_task']}}
    f = <function Document.run_method.<locals>.fn at 0x7f0b17a369e0>
    handler = 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job'
    hooks = [<function apply at 0x7f0b1bf0fac0>, <function check_for_running_deletion_job at 0x7f0b1bf2d630>]
    kwargs = {}
    method = 'validate'
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1460, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7f0b17a36950>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7f0b17a369e0>
    hooks = (<function apply at 0x7f0b1bf0fac0>, <function check_for_running_deletion_job at 0x7f0b1bf2d630>)
    kwargs = {}
    method = 'validate'
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1092, in fn
    return method_object(*args, **kwargs)
    args = ()
    kwargs = {}
    method = 'validate'
    method_object = <bound method SalaryWithholding.validate of <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>>
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/hrms/hrms/payroll/doctype/salary_withholding/salary_withholding.py", line 17, in validate
    self.payroll_frequency = get_payroll_frequency(self.employee, self.from_date)
    self = <SalaryWithholding: doctype=Salary Withholding SAL-WTH-00003>
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
    apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x7f0b1b144790>
    args = ['EMP-00011', datetime.date(2024, 6, 1)]
    func = <function get_payroll_frequency at 0x7f0b1b1448b0>
    kwargs = {}
  File "/home/runner/frappe-bench/apps/hrms/hrms/payroll/doctype/salary_withholding/salary_withholding.py", line 115, in get_payroll_frequency
    frappe.throw(
    employee = 'EMP-00011'
    posting_date = datetime.date(2024, 6, 1)
    salary_structure = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 584, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = 'No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01'
    primary_action = None
    title = 'Error'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 545, in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7f0b17a36440>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/inspect.py'>
    is_minimizable = False
    msg = 'No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01'
    out = {'message': 'No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01', 'title': 'Error', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'cf33d73c6b34892d5d6feaa3da1eb1c9244699cc5d7a405d1c5ba0da'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = 'Error'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 496, in _raise_exception
    raise exc
    exc = ValidationError('No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01')
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/inspect.py'>
    msg = 'No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01'
    out = {'message': 'No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01', 'title': 'Error', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'cf33d73c6b34892d5d6feaa3da1eb1c9244699cc5d7a405d1c5ba0da'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: No Salary Structure Assignment found for employee EMP-00011 on or before 2024-06-01
```

</details>

### 4. Loan tests

Loan tests failing with error `Party Type and Party can only be set for Receivable / Payable account<br><br>Loan Account - _TC` after a recent validation in erpnext core.

Can't find the source of this fixture creation in ERPNext. Fix needed in lending/erpnext