### PR TITLE
fix: Bank Reconciliation tool fails with KeyError: 'payment_doctype'

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -796,6 +796,7 @@ def get_ec_matching_query(
 		qb.from_(ec)
 		.select(
 			ref_rank.as_("rank"),
+			ConstantColumn("Expense Claim").as_("doctype"),
 			ec.name,
 			ec.total_sanctioned_amount.as_("paid_amount"),
 			ConstantColumn("").as_("reference_no"),


### PR DESCRIPTION
Issue: #2591 


What This PR Does
This PR addresses the support issue of an error that is generated when using the bank reconciliation tool to match  on a expense claim.