### PR TITLE
fix: resolve html rendering issue for holidays in roster view

### DIFF
--- a/roster/src/components/MonthViewTable.vue
+++ b/roster/src/components/MonthViewTable.vue
@@ -112,11 +112,13 @@
 							v-if="events.data?.[employee.name]?.[day.date]?.holiday"
 							class="blocked-cell"
 						>
-							{{
-								events.data[employee.name][day.date].weekly_off
-									? "WO"
-									: events.data[employee.name][day.date].description
-							}}
+							<div
+								v-html="
+									events.data[employee.name][day.date].weekly_off
+										? '<strong>WO</strong>'
+										: events.data[employee.name][day.date].description
+								"
+							></div>
 						</div>
 
 						<!-- Leave -->


### PR DESCRIPTION
### Description
Fixed an issue in the roster where holidays were displayed as raw HTML instead of properly rendered text. This update ensures that holiday descriptions  are displayed correctly.

### Changes
- Updated `MonthViewTable.vue` to handle holiday descriptions with `v-html` for correct rendering.

### Linked Issue
Closes #2589 


### **Before Fix**

![image](https://github.com/user-attachments/assets/432214c0-85b9-4758-987d-78ad8cc47d25)

### **After Fix**

![image](https://github.com/user-attachments/assets/4a21b1bd-5bf7-432c-a1a4-ab6b5d89f4ae)
