### PR TITLE
Fix: Update Docker Compose version and remove unsupported name field

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "15.37"
-name: hrms
+version: "3.8" # Updated version
 services:
   mariadb:
     image: mariadb:10.8


### PR DESCRIPTION
This pull request addresses issue #2597 regarding invalid fields in the `docker-compose.yml` file.

### Changes Made
- Updated the `version` field to `3.8`, a valid Docker Compose version.
- Removed the unsupported `name` field from the configuration.

### Related Issue
Fixes #2597
