### PR TITLE
Fix income tax report

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -244,6 +244,7 @@ class Gratuity(AccountsController):
 						* total_component_amount
 						* slab.fraction_of_applicable_earnings
 					)
+					years_left -= slab.to_year - slab.from_year
 					slab_found = True
 
 				elif self._is_experience_within_slab(slab, experience):
@@ -251,7 +252,7 @@ class Gratuity(AccountsController):
 						years_left * total_component_amount * slab.fraction_of_applicable_earnings
 					)
 					slab_found = True
-				years_left -= slab.to_year - slab.from_year
+					break
 
 		if not slab_found:
 			frappe.throw(

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -244,7 +244,6 @@ class Gratuity(AccountsController):
 						* total_component_amount
 						* slab.fraction_of_applicable_earnings
 					)
-					years_left -= slab.to_year - slab.from_year
 					slab_found = True
 
 				elif self._is_experience_within_slab(slab, experience):
@@ -252,6 +251,7 @@ class Gratuity(AccountsController):
 						years_left * total_component_amount * slab.fraction_of_applicable_earnings
 					)
 					slab_found = True
+				years_left -= slab.to_year - slab.from_year
 
 		if not slab_found:
 			frappe.throw(
@@ -311,7 +311,7 @@ class Gratuity(AccountsController):
 		)
 
 	def _is_experience_within_slab(self, slab: dict, experience: float) -> bool:
-		return bool(slab.from_year <= experience and (experience < slab.to_year or slab.to_year == 0))
+		return bool(slab.from_year <= experience and (experience <= slab.to_year or slab.to_year == 0))
 
 	def _is_experience_beyond_slab(self, slab: dict, experience: float) -> bool:
 		return bool(slab.from_year < experience and (slab.to_year < experience and slab.to_year != 0))

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -456,6 +456,12 @@ class IncomeTaxComputationReport:
 		return salary_slip.whitelisted_globals, eval_locals
 
 	def get_total_deducted_tax(self):
+		tax_components = frappe.get_all(
+			"Salary Component", filters={"is_income_tax_component": 1}, pluck="name"
+		)
+		if not tax_components:
+			return []
+
 		self.add_column("Total Tax Deducted")
 
 		ss = frappe.qb.DocType("Salary Slip")
@@ -468,8 +474,8 @@ class IncomeTaxComputationReport:
 			.select(ss.employee, Sum(ss_ded.amount).as_("amount"))
 			.where(ss.docstatus == 1)
 			.where(ss.employee.isin(list(self.employees.keys())))
+			.where(ss_ded.salary_component.isin(tax_components))
 			.where(ss_ded.parentfield == "deductions")
-			.where(ss_ded.variable_based_on_taxable_salary == 1)
 			.where(ss.start_date >= self.payroll_period_start_date)
 			.where(ss.end_date <= self.payroll_period_end_date)
 			.groupby(ss.employee)


### PR DESCRIPTION
The query fetching the Income Tax Computation Report has been updated to include all salary deductions marked as "Is Income Tax Component." Previously, deductions were filtered based on the "Variable Based On Taxable Salary" flag.

