### PR TITLE
fix(Income Tax Computation): include all tax components under Total Tax Deducted

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -456,6 +456,12 @@ class IncomeTaxComputationReport:
 		return salary_slip.whitelisted_globals, eval_locals
 
 	def get_total_deducted_tax(self):
+		tax_components = frappe.get_all(
+			"Salary Component", filters={"is_income_tax_component": 1}, pluck="name"
+		)
+		if not tax_components:
+			return []
+
 		self.add_column("Total Tax Deducted")
 
 		ss = frappe.qb.DocType("Salary Slip")
@@ -468,8 +474,8 @@ class IncomeTaxComputationReport:
 			.select(ss.employee, Sum(ss_ded.amount).as_("amount"))
 			.where(ss.docstatus == 1)
 			.where(ss.employee.isin(list(self.employees.keys())))
+			.where(ss_ded.salary_component.isin(tax_components))
 			.where(ss_ded.parentfield == "deductions")
-			.where(ss_ded.variable_based_on_taxable_salary == 1)
 			.where(ss.start_date >= self.payroll_period_start_date)
 			.where(ss.end_date <= self.payroll_period_end_date)
 			.groupby(ss.employee)

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -457,7 +457,9 @@ class IncomeTaxComputationReport:
 
 	def get_total_deducted_tax(self):
 		tax_components = frappe.get_all(
-			"Salary Component", filters={"is_income_tax_component": 1}, pluck="name"
+			"Salary Component",
+			filters={"is_income_tax_component": 1, "type": "Deduction", "disabled": 0},
+			pluck="name",
 		)
 		if not tax_components:
 			return []

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -456,10 +456,16 @@ class IncomeTaxComputationReport:
 		return salary_slip.whitelisted_globals, eval_locals
 
 	def get_total_deducted_tax(self):
-		tax_components = frappe.get_all(
-			"Salary Component",
-			filters={"is_income_tax_component": 1, "type": "Deduction", "disabled": 0},
-			pluck="name",
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+		tax_components = (
+			frappe.qb.from_(SalaryComponent)
+			.select(SalaryComponent.name)
+			.where(
+				(SalaryComponent.is_income_tax_component == 1)
+				| (SalaryComponent.variable_based_on_taxable_salary == 1)
+			)
+			.where(SalaryComponent.type == "Deduction")
+			.where(SalaryComponent.disabled == 0)
 		)
 		if not tax_components:
 			return []

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -466,7 +466,7 @@ class IncomeTaxComputationReport:
 			)
 			.where(SalaryComponent.type == "Deduction")
 			.where(SalaryComponent.disabled == 0)
-		)
+		).run(pluck="name")
 		if not tax_components:
 			return []
 


### PR DESCRIPTION
The query fetching the **Income Tax Computation Report** has been updated to include all salary deductions marked as "Is Income Tax Component." Previously, deductions were filtered based on the "Variable Based On Taxable Salary" flag.