### PR TITLE
fix: create single leave ledger encashment entry for carry forwarding leave type

### DIFF
--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -205,12 +205,13 @@ class LeaveEncashment(Document):
 
 		to_date = leave_allocation.get("to_date")
 
-		can_expire = not frappe.db.get_value("Leave Type",self.leave_type,"is_carry_forward")
+		can_expire = not frappe.db.get_value("Leave Type", self.leave_type, "is_carry_forward")
 		if to_date < getdate() and can_expire:
 			args = frappe._dict(
 				leaves=self.encashment_days, from_date=to_date, to_date=to_date, is_carry_forward=0
 			)
 			create_leave_ledger_entry(self, args, submit)
+
 
 def create_leave_encashment(leave_allocation):
 	"""Creates leave encashment for the given allocations"""

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -204,12 +204,13 @@ class LeaveEncashment(Document):
 			return
 
 		to_date = leave_allocation.get("to_date")
-		if to_date < getdate():
+
+		can_expire = not frappe.db.get_value("Leave Type",self.leave_type,"is_carry_forward")
+		if to_date < getdate() and can_expire:
 			args = frappe._dict(
 				leaves=self.encashment_days, from_date=to_date, to_date=to_date, is_carry_forward=0
 			)
 			create_leave_ledger_entry(self, args, submit)
-
 
 def create_leave_encashment(leave_allocation):
 	"""Creates leave encashment for the given allocations"""


### PR DESCRIPTION
### Issue
Double ledger entry is created for encashment if leave type is carry forwarding, which doesn't expire normally through expire leave job, leading to extra leaves which could be incorrectly carry forwarded with new allocation

----

#### Before
<img width="1057" alt="Screenshot 2025-01-10 at 2 34 11 PM" src="https://github.com/user-attachments/assets/c53a3d05-eda4-440d-aee1-5fed98c6cb06" />
<img width="1190" alt="Screenshot 2025-01-10 at 2 35 09 PM" src="https://github.com/user-attachments/assets/c9abed81-a537-4f95-a6a6-e3fba350ccc5" />

#### After
<img width="1055" alt="Screenshot 2025-01-10 at 2 36 36 PM" src="https://github.com/user-attachments/assets/8147659a-e872-47d9-bc38-be8f1fa64ce1" />
<img width="1192" alt="Screenshot 2025-01-10 at 2 37 08 PM" src="https://github.com/user-attachments/assets/ad851115-d309-456e-9bce-d3baf1a24269" />

#### Fix
Added a condition to check if leave type is carry forwarding before creating second leave ledger entry