### PR TITLE
fix: add leaves to the correct allocation for compensatory leave request

### DIFF
--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -4,13 +4,26 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import DATE_FORMAT, flt, get_link_to_form, getdate, today
+from frappe.utils import DATE_FORMAT, flt, formatdate, get_link_to_form, getdate, today
+
+
+class InvalidLeaveLedgerEntry(frappe.ValidationError):
+	pass
 
 
 class LeaveLedgerEntry(Document):
 	def validate(self):
 		if getdate(self.from_date) > getdate(self.to_date):
-			frappe.throw(_("To date needs to be before from date"))
+			frappe.throw(
+				_(
+					"Leave Ledger Entry's To date needs to be after From date. Currently, From Date is {0} and To Date is {1}"
+				).format(
+					frappe.bold(formatdate(self.from_date)),
+					frappe.bold(formatdate(self.to_date)),
+				),
+				exc=InvalidLeaveLedgerEntry,
+				title=_("Invalid Leave Ledger Entry"),
+			)
 
 	def on_cancel(self):
 		# allow cancellation of expiry leaves


### PR DESCRIPTION
## Problem

Leave Period: 1st Jan 2024 - 31st Dec 2024
Allocation 1: 1st Nov 2024 - 30 Nov 2024
Allocation 2: 1st Dec 2024 - 31st Dec 2024
Compensatory Leave Request: 1st Dec 2024

On submission of this compensatory leave request, 1 leave should be added applicable from 2nd Dec 2024 - 31st Dec 2024

We are greeted with this validation error from the leave ledger
To Date needs to be **before** From Date 🤡

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/400d56d9-379a-478b-b96b-dfb72bbc40ac" />

This compensatory leave request is trying to update an existing allocation, but it fetches the first allocation from the entire period instead of the exact leave allocation date is falling into

So it's trying to create a ledger entry from 2nd Dec 2024 (comp leave applicable from) to 31st Mar 2024 (Allocation 1's from date)

## Fix

Instead of finding first allocation in the leave period, find the exact allocation in which the compensatory leave falls

Also added more info to the validation and rectified the message

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/8d7399e2-b348-4a27-9adb-cda669cf0afb" />
