### PR TITLE
fix: allow setting opening tax balance in salary assignment for old employees too

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -172,14 +172,7 @@ class SalaryStructureAssignment(Document):
 		if not get_tax_component(self.salary_structure):
 			return False
 
-		if self.has_emp_joined_after_payroll_period_start() and not self.has_existing_salary_slips():
-			return True
-		else:
-			if not self.docstatus.is_draft() and (
-				self.taxable_earnings_till_date or self.tax_deducted_till_date
-			):
-				return True
-			return False
+		return True
 
 	def has_existing_salary_slips(self) -> bool:
 		return bool(

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -174,21 +174,6 @@ class SalaryStructureAssignment(Document):
 
 		return True
 
-	def has_existing_salary_slips(self) -> bool:
-		return bool(
-			frappe.db.exists(
-				"Salary Slip",
-				{"employee": self.employee, "docstatus": 1},
-			)
-		)
-
-	def has_emp_joined_after_payroll_period_start(self) -> bool:
-		date_of_joining = getdate(frappe.db.get_value("Employee", self.employee, "date_of_joining"))
-		payroll_period = get_payroll_period(self.from_date, self.from_date, self.company)
-		if not payroll_period or date_of_joining > getdate(payroll_period.start_date):
-			return True
-		return False
-
 
 def get_assigned_salary_structure(employee, on_date):
 	if not employee or not on_date:


### PR DESCRIPTION
Allow configuring opening balances for existing employees during salary structure assignment. Previously, this was only possible for new employees or those without existing salary slips.

<img width="1286" alt="Screenshot 2025-01-10 at 3 27 46 PM" src="https://github.com/user-attachments/assets/41d69893-05a8-4f9e-ab99-9852840c42cf" />
