### PR TITLE
fix(SalarySlip): use correct end_date variable for calculation

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -482,7 +482,7 @@ class SalarySlip(TransactionBase):
 				days = 0
 				end_date = getdate(end_date)
 				for day in range(no_of_days):
-					date = add_days(self.end_date, -day)
+					date = add_days(end_date, -day)
 					if cstr(date) not in holidays:
 						days += 1
 				return days


### PR DESCRIPTION
Changing the line from date = add_days(self.end_date, -day) to date = add_days(end_date, -day) ensures that the function uses the correct end_date parameter passed to it, rather than an instance variable self.end_date. This change aligns with the function's requirements and ensures that the calculation is based on the correct date values provided as arguments.

By making this change, the function will correctly calculate the days outside the period, preventing negative values in the absent_days field. This leads to accurate payment days and correct salary slip calculations for employees, especially those joining mid-month.

closes #2612 

backport version-14