### PR TITLE
fix: disable 'User Cannot Search' for bulk tools

### DIFF
--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.json
@@ -186,7 +186,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:00.948216",
+ "modified": "2025-01-13 13:47:55.262534",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Control Panel",
@@ -199,7 +199,6 @@
    "write": 1
   }
  ],
- "read_only": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+++ b/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
@@ -209,7 +209,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-13 17:38:45.675004",
+ "modified": "2025-01-13 13:48:33.710186",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Assignment Tool",
@@ -225,7 +225,6 @@
    "write": 1
   }
  ],
- "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+++ b/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
@@ -147,7 +147,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-09 19:33:40.135057",
+ "modified": "2025-01-13 13:48:46.095481",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Bulk Salary Structure Assignment",
@@ -163,7 +163,6 @@
    "write": 1
   }
  ],
- "read_only": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Bulk tools are meant to be searchable. Disable User Cannot Search (`read_only`) flag for:
- Leave Control Panel
- Shift Assignment Tool
- Bulk Salary Structure Assignment Tool