### PR TITLE
fix: set default value for total_exemption, remove tax exemption elig…

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -389,13 +389,11 @@ class IncomeTaxComputationReport:
 		)
 
 		for emp, emp_details in self.employees.items():
-			if not self.employees[emp]["allow_tax_exemption"]:
-				continue
-
 			income_tax_slab = emp_details.get("income_tax_slab")
 			standard_exemption = standard_exemptions_per_slab.get(income_tax_slab, 0)
 			emp_details["standard_tax_exemption"] = standard_exemption
-			self.employees[emp]["total_exemption"] += standard_exemption
+			emp_details.setdefault("total_exemption", 0)
+			emp_details["total_exemption"] += standard_exemption
 
 		self.add_column("Total Exemption")
 


### PR DESCRIPTION
- Set a default value for `total_exemption`.
- Remove the check for `allow_tax_exemption` when calculating the standard tax exemption, as the exemption applies irrespective of this flag. 