### PR TITLE
fix: set leave encashment amount and payable account in fnf payables

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
@@ -134,6 +134,7 @@ frappe.ui.form.on("Full and Final Outstanding Statement", {
 				args: {
 					ref_doctype: child.reference_document_type,
 					ref_document: child.reference_document,
+					company: frm.doc.company,
 				},
 				callback: function (r) {
 					if (r.message) {

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -259,7 +259,7 @@ class FullandFinalStatement(Document):
 
 
 @frappe.whitelist()
-def get_account_and_amount(ref_doctype, ref_document):
+def get_account_and_amount(ref_doctype, ref_document, company):
 	if not ref_doctype or not ref_document:
 		return None
 
@@ -308,6 +308,11 @@ def get_account_and_amount(ref_doctype, ref_document):
 		payment_account = details.advance_account
 		amount = details.paid_amount - (details.claimed_amount + details.return_amount)
 		return [payment_account, amount]
+
+	if ref_doctype == "Leave Encashment":
+		amount = frappe.db.get_value("Leave Encashment", ref_document, "encashment_amount")
+		payable_account = frappe.get_cached_value("Company", company, "default_payroll_payable_account")
+		return [payable_account, amount]
 
 
 def update_full_and_final_statement_status(doc, method=None):


### PR DESCRIPTION
When Leave Encashment document is selected in FnF payables table, set the respective payable account and encashment amount.

![fnf-encash](https://github.com/user-attachments/assets/267d0e6f-5325-4aab-89c7-8701b91c5404)
