### PR TITLE
fix: fetch designation in job applicant from job opening

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.json
+++ b/hrms/hr/doctype/job_applicant/job_applicant.json
@@ -183,6 +183,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "job_title.designation",
    "fetch_if_empty": 1,
    "fieldname": "designation",
    "fieldtype": "Link",
@@ -194,7 +195,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:09:56.340279",
+ "modified": "2025-01-16 13:06:05.312255",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Applicant",


### PR DESCRIPTION
### Issue
Designation remains empty even when a job application is created for a job opening

----
#### Before
<img width="1083" alt="Screenshot 2025-01-16 at 1 00 39 PM" src="https://github.com/user-attachments/assets/8440e55e-5539-4c4c-a62c-5249629b2d1a" />

https://github.com/user-attachments/assets/51e8cb0d-dfa5-40ab-9371-f48f9ab5166d

#### After

https://github.com/user-attachments/assets/55ae0e09-fafc-4a5d-b152-13d10dc6da81

No tests.