### PR TITLE
fix: Handle Company deletion

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -170,7 +170,7 @@ doc_events = {
 			"hrms.overrides.company.make_company_fixtures",
 			"hrms.overrides.company.set_default_hr_accounts",
 		],
-		"on_trash": "hrms.overrides.company.clear_company_field_in_linked_docs",
+		"on_trash": "hrms.overrides.company.handle_linked_docs",
 	},
 	"Holiday List": {
 		"on_update": "hrms.utils.holiday_list.invalidate_cache",

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -357,10 +357,8 @@ company_data_to_be_ignored = [
 	"Salary Structure Assignment",
 	"Payroll Period",
 	"Income Tax Slab",
-	"Leave Policy",
 	"Leave Period",
 	"Leave Policy Assignment",
 	"Employee Onboarding Template",
 	"Employee Separation Template",
-	"Job Offer Term Template",
 ]

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -1,3 +1,5 @@
+from hrms.overrides.company import get_company_data_to_be_ignored
+
 app_name = "hrms"
 app_title = "Frappe HR"
 app_publisher = "Frappe Technologies Pvt. Ltd."
@@ -170,6 +172,7 @@ doc_events = {
 			"hrms.overrides.company.make_company_fixtures",
 			"hrms.overrides.company.set_default_hr_accounts",
 		],
+		"on_trash": "hrms.overrides.company.unset_company_field",
 	},
 	"Holiday List": {
 		"on_update": "hrms.utils.holiday_list.invalidate_cache",
@@ -349,3 +352,5 @@ ignore_links_on_delete = ["PWA Notification"]
 # Recommended only for DocTypes which have limited documents with untranslated names
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
+
+company_data_to_be_ignored = get_company_data_to_be_ignored()

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -1,5 +1,3 @@
-from hrms.overrides.company import get_company_data_to_be_ignored
-
 app_name = "hrms"
 app_title = "Frappe HR"
 app_publisher = "Frappe Technologies Pvt. Ltd."
@@ -353,4 +351,16 @@ ignore_links_on_delete = ["PWA Notification"]
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
 
-company_data_to_be_ignored = get_company_data_to_be_ignored()
+company_data_to_be_ignored = [
+	"Salary Component Account",
+	"Salary Structure",
+	"Salary Structure Assignment",
+	"Payroll Period",
+	"Income Tax Slab",
+	"Leave Policy",
+	"Leave Period",
+	"Leave Policy Assignment",
+	"Employee Onboarding Template",
+	"Employee Separation Template",
+	"Job Offer Term Template",
+]

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -170,7 +170,7 @@ doc_events = {
 			"hrms.overrides.company.make_company_fixtures",
 			"hrms.overrides.company.set_default_hr_accounts",
 		],
-		"on_trash": "hrms.overrides.company.unset_company_field",
+		"on_trash": "hrms.overrides.company.clear_company_field_in_linked_docs",
 	},
 	"Holiday List": {
 		"on_update": "hrms.utils.holiday_list.invalidate_cache",

--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -134,24 +134,6 @@ def validate_default_accounts(doc, method=None):
 			)
 
 
-def get_company_data_to_be_ignored():
-	if "erpnext" in frappe.get_installed_apps():
-		return [
-			"Salary Component Account",
-			"Salary Structure",
-			"Salary Structure Assignment",
-			"Payroll Period",
-			"Income Tax Slab",
-			"Leave Policy",
-			"Leave Period",
-			"Leave Policy Assignment",
-			"Employee Onboarding Template",
-			"Employee Separation Template",
-			"Job Offer Term Template",
-		]
-	return []
-
-
 def unset_company_field(doc, method=None):
 	unset_company_field_for_single_doctype(doc)
 	unset_company_field_for_non_single_doctype(doc)
@@ -172,7 +154,8 @@ def unset_company_field_for_single_doctype(doc):
 
 
 def unset_company_field_for_non_single_doctype(doc):
-	for doctype in get_company_data_to_be_ignored():
+	company_data_to_be_ignored = frappe.get_hooks("company_data_to_be_ignored") or []
+	for doctype in company_data_to_be_ignored:
 		company_field = frappe.get_all(
 			"DocField",
 			filters={"parent": doctype, "fieldtype": "Link", "options": "Company"},

--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -132,3 +132,21 @@ def validate_default_accounts(doc, method=None):
 					"The currency of {0} should be same as the company's default currency. Please select another account."
 				).format(frappe.bold(_("Default Payroll Payable Account")))
 			)
+
+
+def get_company_data_to_be_ignored():
+	if "erpnext" in frappe.get_installed_apps():
+		return [
+			"Salary Component Account",
+			"Salary Structure",
+			"Salary Structure Assignment",
+			"Payroll Period",
+			"Income Tax Slab",
+			"Leave Policy",
+			"Leave Period",
+			"Leave Policy Assignment",
+			"Employee Onboarding Template",
+			"Employee Separation Template",
+			"Job Offer Term Template",
+		]
+	return []


### PR DESCRIPTION
- Add `company_data_to_be_ignored` hook to exclude specific doctypes in Transaction Deletion Record  
- Clear field values linked to the Company doctype in single doctypes and masters upon company deletion