### PR TITLE
fix: Allocate earned leaves pro-rata if policy assignment is submitted after the effective leave period

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -134,12 +134,12 @@ class LeavePolicyAssignment(Document):
 		from frappe.model.meta import get_field_precision
 
 		precision = get_field_precision(frappe.get_meta("Leave Allocation").get_field("new_leaves_allocated"))
-
+		current_date = getdate(frappe.flags.current_date) or getdate()
 		# Earned Leaves and Compensatory Leaves are allocated by scheduler, initially allocate 0
 		if leave_details.is_compensatory:
 			new_leaves_allocated = 0
-
-		elif leave_details.is_earned_leave:
+		# if earned leave is being allcated after the effective period, then let them be calculated pro-rata
+		elif leave_details.is_earned_leave and current_date < self.effective_to:
 			new_leaves_allocated = self.get_leaves_for_passed_months(
 				annual_allocation, leave_details, date_of_joining
 			)

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -33,6 +33,9 @@ class TestLeavePolicyAssignment(IntegrationTestCase):
 		self.original_doj = employee.date_of_joining
 		self.employee = employee
 
+	def tearDown(self):
+		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
+
 	def test_grant_leaves(self):
 		leave_period = get_leave_period()
 		leave_policy = create_leave_policy(annual_allocation=10)
@@ -208,5 +211,27 @@ class TestLeavePolicyAssignment(IntegrationTestCase):
 
 		self.assertGreater(new_leaves_allocated, 0)
 
-	def tearDown(self):
-		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
+	def test_earned_leave_allocation_if_leave_policy_assignment_submitted_after_period(self):
+		start_date = get_first_day(getdate(), d_months=-3)
+		end_date = get_first_day(getdate(), d_months=-2)
+		leave_period = create_leave_period(start_date, end_date)
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test Earned Leave", is_earned_leave=True, allocate_on_day="First Day"
+		)
+		annual_earned_leaves = 10
+		leave_policy = create_leave_policy(leave_type=leave_type, annual_allocation=annual_earned_leaves)
+		leave_policy.submit()
+
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name,
+		}
+		assignment = create_assignment(self.employee.name, frappe._dict(data))
+		assignment.submit()
+
+		earned_leave_allocation = frappe.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "new_leaves_allocated"
+		)
+		self.assertEqual(earned_leave_allocation, annual_earned_leaves)


### PR DESCRIPTION
### Problem
Because earned leave calculations consider current date of allocation to calculate amount of earned leaves (Yet to write)