### PR TITLE
fix: HRA calculation if there are multiple salary structure assignments for the current payroll period

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -542,16 +542,20 @@ def get_salary_assignments(employee, payroll_period):
 		order_by="from_date",
 	)
 
-	if not assignments:
+	if not assignments or getdate(assignments[0].from_date) > getdate(start_date):
 		# if no assignments found for the given period
-		# get the last one assigned before the period that is still active
-		assignments = frappe.get_all(
+		# or the latest assignment hast started in the middle of the period
+		# get the last one assigned before the period start date
+		past_assignment = frappe.get_all(
 			"Salary Structure Assignment",
-			filters={"employee": employee, "docstatus": 1, "from_date": ["<=", start_date]},
+			filters={"employee": employee, "docstatus": 1, "from_date": ["<", start_date]},
 			fields=["*"],
 			order_by="from_date desc",
 			limit=1,
 		)
+
+		if past_assignment:
+			assignments = past_assignment + assignments
 
 	return assignments
 

--- a/hrms/payroll/doctype/employee_tax_exemption_declaration/test_employee_tax_exemption_declaration.py
+++ b/hrms/payroll/doctype/employee_tax_exemption_declaration/test_employee_tax_exemption_declaration.py
@@ -349,6 +349,7 @@ class TestEmployeeTaxExemptionDeclaration(IntegrationTestCase):
 		)
 
 		# salary structure with base 50000, HRA 3000
+		# effective from 3 months before payroll period
 		make_salary_structure(
 			"Monthly Structure for HRA Exemption 1",
 			"Monthly",
@@ -356,7 +357,7 @@ class TestEmployeeTaxExemptionDeclaration(IntegrationTestCase):
 			company="_Test Company",
 			currency="INR",
 			payroll_period=payroll_period.name,
-			from_date=payroll_period.start_date,
+			from_date=add_months(payroll_period.start_date, -3),
 		)
 
 		# salary structure with base 70000, HRA = base * 0.2 = 14000
@@ -379,6 +380,7 @@ class TestEmployeeTaxExemptionDeclaration(IntegrationTestCase):
 
 		salary_structure.submit()
 
+		# effective from 6 months after payroll period
 		create_salary_structure_assignment(
 			employee,
 			salary_structure.name,

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -84,7 +84,7 @@ def get_custom_fields():
 				"fieldname": "hra_section",
 				"label": "HRA Settings",
 				"fieldtype": "Section Break",
-				"insert_after": "asset_received_but_not_billed",
+				"insert_after": "default_payroll_payable_account",
 				"collapsible": 1,
 			},
 			{


### PR DESCRIPTION
HRA calculation was wrong if there were multiple salary structure assignments for the current payroll period and last assignment start date was before the current payroll period start date.

Example:
Payroll Period: 01/04/2024 - 31/03/2025
Assignment 1 Start Date: 01/09/2023
Assignment 2 Start Date: 01/07/2024
