### PR TITLE
fix: Calculate earned leaves pro-rata if policy assignment is created after the leave period

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils import add_months, get_first_day, get_year_ending, getdate
+from frappe.utils import add_days, add_months, get_first_day, get_year_ending, get_year_start, getdate
 
 from hrms.hr.doctype.leave_application.test_leave_application import get_employee, get_leave_period
 from hrms.hr.doctype.leave_period.test_leave_period import create_leave_period
@@ -32,6 +32,9 @@ class TestLeavePolicyAssignment(IntegrationTestCase):
 		employee = get_employee()
 		self.original_doj = employee.date_of_joining
 		self.employee = employee
+
+	def tearDown(self):
+		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
 
 	def test_grant_leaves(self):
 		leave_period = get_leave_period()
@@ -208,5 +211,29 @@ class TestLeavePolicyAssignment(IntegrationTestCase):
 
 		self.assertGreater(new_leaves_allocated, 0)
 
-	def tearDown(self):
-		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
+	def test_earned_leave_allocation_if_leave_policy_assignment_submitted_after_period(self):
+		year_start_date = get_year_start(getdate())
+		year_end_date = get_year_ending(getdate())
+		leave_period = create_leave_period(year_start_date, year_end_date)
+
+		# assignment 10 days after the leave period
+		frappe.flags.current_date = add_days(year_end_date, 10)
+		leave_type = create_leave_type(
+			leave_type_name="_Test Earned Leave", is_earned_leave=True, allocate_on_day="Last Day"
+		)
+		annual_earned_leaves = 10
+		leave_policy = create_leave_policy(leave_type=leave_type, annual_allocation=annual_earned_leaves)
+		leave_policy.submit()
+
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name,
+		}
+		assignment = create_assignment(self.employee.name, frappe._dict(data))
+		assignment.submit()
+
+		earned_leave_allocation = frappe.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "new_leaves_allocated"
+		)
+		self.assertEqual(earned_leave_allocation, annual_earned_leaves)


### PR DESCRIPTION
### Problem
If leave policy is assigned for a backdated year, earned leaves are still calculated based on the current date at which the assignment is created, this works out if the leave period is shorter than a year, but fails for a period when the months repeat.
For example,
1. Leave Type is set to earned leave with a monthly frequency to be allocated on the last day of the month.
2. Leave period is set to last years start date and end date
3. Annual Leave are set as 12 in the leave policy
4. Leave policy is assigned on this years first month

Then total leave allocated should 12, but 11 leave are assigned, the month in which is assignment is made is excluded because the assignment should be done on the last day, even though the month is outside the leave period

### Solution
If a leave assignment is made outside the leave period that implies that employee _has earned_ all leaves. Hence assign them pro-rata instead.

- Fixed a test
- Added two new tests