### PR TITLE
fix: Fetch shift details and save for all shift types

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -23,14 +23,12 @@ frappe.ui.form.on("Employee Checkin", {
 	add_fetch_shift_button(frm) {
 		if (frm.doc.attendace) return;
 		frm.add_custom_button(__("Fetch Shift"), function () {
-			const previous_shift = frm.doc.shift;
 			frappe.call({
 				method: "fetch_shift",
 				doc: frm.doc,
 				freeze: true,
 				freeze_message: __("Fetching Shift"),
 				callback: function () {
-					if (previous_shift === frm.doc.shift) return;
 					frm.dirty();
 					frm.save();
 					frappe.show_alert({


### PR DESCRIPTION
### Problem
Fetch shift would fetch shift details and save if newly fetched shift was different. This would prevent logs from updating with shift details if the shift settings were changed.

### Fix
- Removed same shift check on fetch shift call
- Added a test

