### PR TITLE
fix: Show better alert on fetch shift if no shift is found

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -29,14 +29,21 @@ frappe.ui.form.on("Employee Checkin", {
 				freeze: true,
 				freeze_message: __("Fetching Shift"),
 				callback: function () {
-					frm.dirty();
-					frm.save();
-					frappe.show_alert({
-						message: __("Shift has been successfully updated to {0}.", [
-							frm.doc.shift,
-						]),
-						indicator: "green",
-					});
+					if (frm.doc.shift) {
+						frappe.show_alert({
+							message: __("Shift has been successfully updated to {0}.", [
+								frm.doc.shift,
+							]),
+							indicator: "green",
+						});
+						frm.dirty();
+						frm.save();
+					} else {
+						frappe.show_alert({
+							message: __("No valid shift found for log time"),
+							indicator: "orange",
+						});
+					}
 				},
 			});
 		});


### PR DESCRIPTION
#### Before

https://github.com/user-attachments/assets/8b1ed1c5-e0fd-44f7-8216-874b87190014

#### After


https://github.com/user-attachments/assets/73c62367-356d-42fc-845c-bcca18167356


`no-tests`
