### PR TITLE
fix: handle None values in earnings and deductions to avoid TypeError

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -710,7 +710,9 @@ class PayrollEntry(Document):
 			}
 			"""
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-				payable_amount = employee_details.get("earnings", 0) - employee_details.get("deductions", 0)
+				payable_amount = (employee_details.get("earnings", 0) or 0) - (
+					employee_details.get("deductions", 0) or 0
+				)
 
 				payable_amount = self.get_accounting_entries_and_payable_amount(
 					payroll_payable_account,
@@ -1016,9 +1018,9 @@ class PayrollEntry(Document):
 		if self.employee_based_payroll_payable_entries:
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
 				je_payment_amount = (
-					employee_details.get("earnings", 0)
-					- employee_details.get("deductions", 0)
-					- employee_details.get("total_loan_repayment", 0)
+					(employee_details.get("earnings", 0) or 0)
+					- (employee_details.get("deductions", 0) or 0)
+					- (employee_details.get("total_loan_repayment", 0) or 0)
 				)
 
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(


### PR DESCRIPTION
Update calculations of payable amount to ensure None values in earnings or deductions default to 0. This prevents TypeError.