### PR TITLE
fix: Lending app uninstall error

### DIFF
--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -595,6 +595,7 @@ def remove_lending_docperms_from_ess():
 		if row.document_type in loan_docperms:
 			doc.user_doctypes.remove(row)
 
+	doc.flags.ignore_links = True
 	doc.save(ignore_permissions=True)
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 946, in uninstall
    remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 407, in remove_app
    frappe.get_attr(fn)(app_name)
  File "/home/frappe/frappe-bench/apps/hrms/hrms/setup.py", line 49, in before_app_uninstall
    remove_lending_docperms_from_ess()
  File "/home/frappe/frappe-bench/apps/hrms/hrms/setup.py", line 598, in remove_lending_docperms_from_ess
    doc.save(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 342, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 377, in _save
    self._validate_links()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 942, in _validate_links
    frappe.throw(_("Could not find {0}").format(msg), frappe.LinkValidationError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 603, in throw
    msgprint(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 568, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 519, in _raise_exception
    raise exc
frappe.exceptions.LinkValidationError: Could not find Row #20: Document Type: Loan Category
```