### PR TITLE
fix: remove employee other income from CTC

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -953,7 +953,6 @@ class SalarySlip(TransactionBase):
 				+ self.current_structured_taxable_earnings_before_exemption
 				+ self.future_structured_taxable_earnings_before_exemption
 				+ self.current_additional_earnings
-				+ self.other_incomes
 				+ self.unclaimed_taxable_benefits
 				+ self.non_taxable_earnings
 			)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1476,14 +1476,14 @@ class TestSalarySlip(IntegrationTestCase):
 
 		monthly_tax_amount = 11403.6
 
-		self.assertEqual(salary_slip.ctc, 1226000.0)
+		self.assertEqual(salary_slip.ctc, 1216000.0)
 		self.assertEqual(salary_slip.income_from_other_sources, 10000.0)
 		self.assertEqual(salary_slip.non_taxable_earnings, 10000.0)
-		self.assertEqual(salary_slip.total_earnings, 1236000.0)
+		self.assertEqual(salary_slip.total_earnings, 1226000.0)
 		self.assertEqual(salary_slip.standard_tax_exemption_amount, 50000.0)
 		self.assertEqual(salary_slip.tax_exemption_declaration, 100000.0)
 		self.assertEqual(salary_slip.deductions_before_tax_calculation, 2400.0)
-		self.assertEqual(salary_slip.annual_taxable_amount, 1073600.0)
+		self.assertEqual(salary_slip.annual_taxable_amount, 1063600.0)
 		self.assertEqual(flt(salary_slip.income_tax_deducted_till_date, 2), monthly_tax_amount)
 		self.assertEqual(flt(salary_slip.current_month_income_tax, 2), monthly_tax_amount)
 		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 2), 125439.65)


### PR DESCRIPTION
**Issue:**
Employee Other Income is included in CTC, then again include the employee other income in total earnings.

**Current Calculation:**

          monthly salary - 1,00,000
          annual salary - 12,00,000
          other income - 1,00,000

          CTC: annual salary +  other income = 13,00,000
          total earning: CTC + other Income = 14,00,000

**Updated Calculation:**

          monthly salary - 1,00,000
          annual salary - 12,00,000
          other income - 1,00,000

          CTC: annual salary = 12,00,000
          total earning: CTC + other Income = 13,00,000

**Salary Structure Assignment:**

![Salary Structure Assignment](https://github.com/user-attachments/assets/0d6825f5-aff7-43b1-bf9d-dd113b6249fa)

**Other Income:**

![Employee Other Income](https://github.com/user-attachments/assets/f9187939-137a-4593-8d14-aa3d3411f1d9)


**Before:**

![Income Tax breakup before](https://github.com/user-attachments/assets/58dd8d7f-fa9c-4fcf-bfba-9bce7dd6b673)

**After:**

![Income Tax breakup after](https://github.com/user-attachments/assets/fc28a29e-6c21-4362-b90e-2e1f59dc2c7f)


**Backport needed for v14 & v15**