### PR TITLE
chore: Upgrade artifact actions from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           CAPTURE_COVERAGE: ${{ github.event_name != 'pull_request' }}
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: github.event_name != 'pull_request'
         with:
           name: coverage-${{ matrix.container }}
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Upload coverage data
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Because Github Deprecated V3 : https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

