### PR TITLE
fix: Only show permitted attendance records in calendar view

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -122,7 +122,8 @@
    "label": "Attendance Date",
    "oldfieldname": "attendance_date",
    "oldfieldtype": "Date",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fetch_from": "employee.company",
@@ -207,7 +208,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-05 20:55:02.905452",
+ "modified": "2025-01-31 11:45:54.846562",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -228,42 +228,36 @@ class Attendance(Document):
 
 @frappe.whitelist()
 def get_events(start, end, filters=None):
-	from frappe.desk.reportview import get_filters_cond
+	if isinstance(filters, str):
+		import json
 
-	events = []
+		filters = json.loads(filters)
+	if filters:
+		filters.append(["attendance_date", "between", [get_datetime(start).date(), get_datetime(end).date()]])
 
+	attendance_records = add_attendance(filters)
 	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
-
-	if not employee:
-		return events
-
-	conditions = get_filters_cond("Attendance", filters, [])
-	add_attendance(events, start, end, conditions=conditions)
-	add_holidays(events, start, end, employee)
-	return events
+	add_holidays(attendance_records, start, end, employee)
+	return attendance_records
 
 
-def add_attendance(events, start, end, conditions=None):
-	query = """select name, attendance_date, status, employee_name
-		from `tabAttendance` where
-		attendance_date between %(from_date)s and %(to_date)s
-		and docstatus < 2"""
-
-	if conditions:
-		query += conditions
-
-	for d in frappe.db.sql(query, {"from_date": start, "to_date": end}, as_dict=True):
-		e = {
-			"name": d.name,
-			"doctype": "Attendance",
-			"start": d.attendance_date,
-			"end": d.attendance_date,
-			"title": f"{d.employee_name}: {cstr(d.status)}",
-			"status": d.status,
-			"docstatus": d.docstatus,
-		}
-		if e not in events:
-			events.append(e)
+def add_attendance(filters):
+	attendance = frappe.get_list(
+		"Attendance",
+		fields=[
+			"name",
+			"'Attendance' as doctype",
+			"attendance_date as start",
+			"attendance_date as end",
+			"employee_name",
+			"status",
+			"docstatus",
+		],
+		filters=filters,
+	)
+	for record in attendance:
+		record["title"] = f"{record.employee_name} : {record.status}"
+	return attendance
 
 
 def add_holidays(events, start, end, employee=None):

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -235,9 +235,9 @@ def get_events(start, end, filters=None):
 		import json
 
 		filters = json.loads(filters)
-	if filters:
-		filters.append(["attendance_date", "between", [get_datetime(start).date(), get_datetime(end).date()]])
-
+	if not filters:
+		filters = []
+	filters.append(["attendance_date", "between", [get_datetime(start).date(), get_datetime(end).date()]])
 	attendance_records = add_attendance(filters)
 	add_holidays(attendance_records, start, end, employee)
 	return attendance_records

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -228,6 +228,9 @@ class Attendance(Document):
 
 @frappe.whitelist()
 def get_events(start, end, filters=None):
+	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
+	if not employee:
+		return []
 	if isinstance(filters, str):
 		import json
 
@@ -236,7 +239,6 @@ def get_events(start, end, filters=None):
 		filters.append(["attendance_date", "between", [get_datetime(start).date(), get_datetime(end).date()]])
 
 	attendance_records = add_attendance(filters)
-	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
 	add_holidays(attendance_records, start, end, employee)
 	return attendance_records
 


### PR DESCRIPTION
#### Problem

Employee's could see other employee's attendance records in calendar view on clearing filters.


#### Fix:
Apply permissions while fetching records instead of using filters.
Added attendance date as search index to fetch records faster
`no-tests`

Closes #2466