### PR TITLE
fix: disable overwrite_salary_structure_amount for leave encashment's additional salary component

### DIFF
--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -163,6 +163,7 @@ class LeaveEncashment(AccountsController):
 		additional_salary.salary_component = earning_component
 		additional_salary.payroll_date = self.encashment_date
 		additional_salary.amount = self.encashment_amount
+		additional_salary.overwrite_salary_structure_amount = 0
 		additional_salary.ref_doctype = self.doctype
 		additional_salary.ref_docname = self.name
 		additional_salary.submit()


### PR DESCRIPTION
If the Leave Encashment salary component already exists in the assigned salary structure, avoid overwriting it with the encashment amount.

**Example:**
Salary Structure assigned to employee:
<img width="1192" alt="Screenshot 2025-01-31 at 12 53 16 PM" src="https://github.com/user-attachments/assets/3e0b9ed8-d891-403c-8721-24cb607bde99" />

Additional Salary Component created against Leave Encashment doc:
<img width="1066" alt="Screenshot 2025-01-31 at 1 08 04 PM" src="https://github.com/user-attachments/assets/7907e104-095a-4969-8036-d9472cc170ec" />

**Effect on Salary Slip:**
Before:
<img width="1170" alt="Screenshot 2025-01-31 at 12 52 42 PM" src="https://github.com/user-attachments/assets/1fd8559d-6225-4c5d-876b-4f288abc226b" />

After:
<img width="1174" alt="Screenshot 2025-01-31 at 12 49 35 PM" src="https://github.com/user-attachments/assets/edc20885-31bc-4b3f-bdaa-ab3fb0653b8b" />

