### PR TITLE
fix: show validation message before changing shift start time

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -29,10 +29,8 @@ class ShiftType(Document):
 	def validate(self):
 		if self.is_field_modified("start_time") and self.unlinked_checkins_exist():
 			frappe.throw(
-				title=_("Unlinked Logs Found"),
-				msg=_(
-					"Mark attendance for the exsiting check in/out logs before changing important shift settings"
-				),
+				title=_("Unmarked Check-in Logs Found"),
+				msg=_("Mark attendance for exsiting check-in/out logs before changing shift settings"),
 			)
 
 	def is_field_modified(self, fieldname):

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -30,7 +30,7 @@ class ShiftType(Document):
 		if self.is_field_modified("start_time") and self.unlinked_checkins_exist():
 			frappe.throw(
 				title=_("Unmarked Check-in Logs Found"),
-				msg=_("Mark attendance for exsiting check-in/out logs before changing shift settings"),
+				msg=_("Mark attendance for existing check-in/out logs before changing shift settings"),
 			)
 
 	def is_field_modified(self, fieldname):


### PR DESCRIPTION
#### Problem
Shift start time is recorded in the Employee checkins which is then used to sort the logs chronologically to mark attendance. 
If this is time is changed mid shift, check in and check out logs get a different shift start which results in incorrect attendance records

----
#### Before

https://github.com/user-attachments/assets/424cf7a6-5848-4b0c-bbe5-20db7026ea32

#### After

https://github.com/user-attachments/assets/f05f3342-a0b9-4930-a266-7bda9aa194e7


#### Solution
Show a validation before changing start time to mark attendance for unlinked logs.