### PR TITLE
test: fixed failing tests due to implicitly set dates

### DIFF
--- a/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
@@ -349,6 +349,7 @@ class TestLeaveEncashment(IntegrationTestCase):
 			"Salary Structure for Encashment",
 			"Monthly",
 			employee,
+			from_date=start_date,
 			other_details={"leave_encashment_amount_per_day": 50},
 		)
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1331,7 +1331,9 @@ class TestSalarySlip(IntegrationTestCase):
 				precision = entry.precision("amount")
 				break
 
-		self.assertEqual(amount, flt((1000 * ss.payment_days / ss.total_working_days) * 0.5, precision))
+		self.assertEqual(
+			amount, flt(flt((1000 * ss.payment_days / ss.total_working_days), precision) * 0.5, precision)
+		)
 
 	def make_activity_for_employee(self):
 		activity_type = frappe.get_doc("Activity Type", "_Test Activity Type")


### PR DESCRIPTION
Today's lesson: Always set explicit test data, don't assume the functions you're using to create data will make it the way the test scene requires.