### PR TITLE
fix: Update calculations of payable amounts

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -562,9 +562,8 @@ class PayrollEntry(Document):
 				}
 				"""
 				for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-					payable_amount = employee_details.get("earnings", 0) - employee_details.get(
-						"deductions", 0
-					)
+					payable_amount = employee_details.get("earnings", 0) or 0
+					-(employee_details.get("deductions", 0) or 0)
 
 					payable_amount = self.get_accounting_entries_and_payable_amount(
 						payroll_payable_account,
@@ -805,8 +804,8 @@ class PayrollEntry(Document):
 
 		if self.employee_based_payroll_payable_entries:
 			for employee, employee_details in self.employee_based_payroll_payable_entries.items():
-				je_payment_amount = employee_details.get("earnings", 0) - (
-					employee_details.get("deductions", 0)
+				je_payment_amount = (employee_details.get("earnings", 0) or 0) - (
+					employee_details.get("deductions", 0) or 0
 				)
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(
 					self.payment_account, je_payment_amount, company_currency, currencies


### PR DESCRIPTION
Update calculations of payable amount to ensure None values in earnings or deductions default to 0. This prevents TypeError.
