### PR TITLE
fix: Only fetch active shift assignment locations for geofencing

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -90,6 +90,7 @@ class EmployeeCheckin(Document):
 				"start_date": ["<=", self.time],
 				"shift_location": ["is", "set"],
 				"docstatus": 1,
+				"status": "Active",
 			},
 			or_filters=[["end_date", ">=", self.time], ["end_date", "is", "not set"]],
 			pluck="shift_location",


### PR DESCRIPTION
Filter by active shift assignment to fetch locations for geofencing.
 