### PR TITLE
fix: add field in non_standard_fieldnames for valid filter

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -93,4 +93,6 @@ def get_dashboard_for_bank_account(data):
 			section["items"].append("Payroll Entry")
 			break
 
+	data["non_standard_fieldnames"].update({"Payroll Entry": "bank_account"})
+
 	return data


### PR DESCRIPTION
Support ticket: [Support Ticket  - 30963](https://support.frappe.io/helpdesk/tickets/30963)

During the change #2369, `non_standard_fieldnames` was not updated. As a result, when loading the Bank Account, `get_external_links` function fetched the default field `party_bank_account` from Payroll Entry, causing an error.