### PR TITLE
feat(poc): holiday assignment

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -362,3 +362,5 @@ company_data_to_be_ignored = [
 	"Employee Onboarding Template",
 	"Employee Separation Template",
 ]
+
+employee_holiday_list = "hrms.utils.holiday_list.get_holiday_list_for_employee"

--- a/hrms/hr/doctype/holiday_assignment/holiday_assignment.js
+++ b/hrms/hr/doctype/holiday_assignment/holiday_assignment.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Holiday Assignment", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hrms/hr/doctype/holiday_assignment/holiday_assignment.json
+++ b/hrms/hr/doctype/holiday_assignment/holiday_assignment.json
@@ -1,0 +1,109 @@
+{
+ "actions": [],
+ "autoname": "HR-HLDY-ASSGN-.#####",
+ "creation": "2025-02-08 18:39:56.893204",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_tpjs",
+  "employee",
+  "employee_name",
+  "holiday_list",
+  "column_break_agfv",
+  "company",
+  "from_date",
+  "to_date",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_tpjs",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Holiday Assignment",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_agfv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "holiday_list",
+   "fieldtype": "Link",
+   "label": "Holiday List",
+   "options": "Holiday List",
+   "reqd": 1
+  },
+  {
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "From Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "To Date",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-02-08 19:03:56.208781",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Holiday Assignment",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/holiday_assignment/holiday_assignment.py
+++ b/hrms/hr/doctype/holiday_assignment/holiday_assignment.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HolidayAssignment(Document):
+	pass

--- a/hrms/hr/doctype/holiday_assignment/test_holiday_assignment.py
+++ b/hrms/hr/doctype/holiday_assignment/test_holiday_assignment.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestHolidayAssignment(UnitTestCase):
+	"""
+	Unit tests for HolidayAssignment.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestHolidayAssignment(IntegrationTestCase):
+	"""
+	Integration tests for HolidayAssignment.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 
 def get_holiday_dates_between(
@@ -25,3 +26,29 @@ def invalidate_cache(doc, method=None):
 	from hrms.payroll.doctype.salary_slip.salary_slip import HOLIDAYS_BETWEEN_DATES
 
 	frappe.cache().delete_value(HOLIDAYS_BETWEEN_DATES)
+
+
+def get_holiday_list_for_employee(
+	employee: str,
+	raise_exception: bool = True,
+	as_on=None
+) -> str:
+	as_on = frappe.utils.getdate(as_on)
+	HolidayList = frappe.qb.DocType("Holiday Assignment")
+	query = (
+		frappe.qb.from_(HolidayList)
+		.select(HolidayList.holiday_list)
+		.where(HolidayList.employee == employee)
+		.where(HolidayList.from_date <= as_on)
+		.where(HolidayList.to_date >= as_on)
+		.where(HolidayList.docstatus == 1)
+		.run()
+	)
+	holiday_list = query[0][0] if query else None
+
+	if not holiday_list and raise_exception:
+		frappe.throw(
+			_("Please assign Holiday List for Employee {0}").format(employee)
+		)
+
+	return holiday_list


### PR DESCRIPTION
This is a PR with bare minimum functionality of holiday list assignment, like shift assignment.
An extra parameter `as_on` is introduced in the existing function with `None` as default.
The existing function is also made to call the new function with the help of a hook.

Related PR on erpnext: https://github.com/frappe/erpnext/pull/45803

I'll work on the validations and rest of the clean up if this approach seems acceptable to the maintainers.