### PR TITLE
feat: Show invalid logs

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -3,6 +3,13 @@
 
 frappe.ui.form.on("Employee Checkin", {
 	refresh: async (frm) => {
+		if (frm.doc.is_invalid) {
+			frm.dashboard.set_headline(
+				__(
+					"No valid shift found for this log time. If shift is assigned to the employee, adjust time window of the shift and fetch shift again.",
+				),
+			);
+		}
 		if (!frm.doc.__islocal) frm.trigger("add_fetch_shift_button");
 
 		const allow_geolocation_tracking = await frappe.db.get_single_value(
@@ -43,6 +50,8 @@ frappe.ui.form.on("Employee Checkin", {
 							message: __("No valid shift found for log time"),
 							indicator: "orange",
 						});
+						frm.dirty();
+						frm.save();
 					}
 				},
 			});

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.json
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.json
@@ -25,6 +25,7 @@
   "shift_timings_section",
   "shift_start",
   "shift_end",
+  "is_invalid",
   "column_break_vyyt",
   "shift_actual_start",
   "shift_actual_end"
@@ -164,10 +165,17 @@
    "fieldname": "fetch_geolocation",
    "fieldtype": "Button",
    "label": "Fetch Geolocation"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_invalid",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Invalid"
   }
  ],
  "links": [],
- "modified": "2024-05-29 21:19:11.550766",
+ "modified": "2025-02-12 04:40:24.362987",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -58,6 +58,7 @@ class EmployeeCheckin(Document):
 			)
 		):
 			self.shift = None
+			self.is_invalid = 1
 			return
 
 		if (

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -73,6 +73,7 @@ class EmployeeCheckin(Document):
 				)
 			)
 		if not self.attendance:
+			self.is_invalid = 0
 			self.shift = shift_actual_timings.shift_type.name
 			self.shift_actual_start = shift_actual_timings.actual_start
 			self.shift_actual_end = shift_actual_timings.actual_end

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -1,4 +1,10 @@
 frappe.listview_settings["Employee Checkin"] = {
+	add_fields: ["is_invalid"],
+	get_indicator: function (doc) {
+		if (doc.is_invalid) {
+			return [__("Invalid"), "red", "is_invalid,=,1"];
+		}
+	},
 	onload: function (listview) {
 		listview.page.add_action_item(__("Fetch Shifts"), () => {
 			const checkins = listview.get_checked_items().map((checkin) => checkin.name);

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -611,6 +611,21 @@ class TestEmployeeCheckin(IntegrationTestCase):
 		log2.reload()
 		self.assertEqual(log2.shift_actual_start, datetime.combine(date, get_time("06:00:00")))
 
+	def test_if_logs_are_marked_invalid(self):
+		# time window is 7 to 13
+		shift = setup_shift_type()
+		emp = make_employee("emp_invalid_log@example.com", company="_Test Company", default_shift=shift.name)
+
+		# checkin log outside shift time window
+		timestamp1 = datetime.combine(getdate(), get_time("06:00:00"))
+		log1 = make_checkin(emp, timestamp1)
+		self.assertTrue(log1.is_invalid)
+
+		# checkin log within shift time window
+		timestamp2 = datetime.combine(getdate(), get_time("07:30:00"))
+		log2 = make_checkin(emp, timestamp2)
+		self.assertFalse(log2.is_invalid)
+
 
 def make_n_checkins(employee, n, hours_to_reverse=1):
 	logs = [make_checkin(employee, now_datetime() - timedelta(hours=hours_to_reverse, minutes=n + 1))]

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -626,6 +626,22 @@ class TestEmployeeCheckin(IntegrationTestCase):
 		log2 = make_checkin(emp, timestamp2)
 		self.assertFalse(log2.is_invalid)
 
+	def test_if_logs_are_marked_valid_again(self):
+		# time window is 7 to 13
+		shift = setup_shift_type()
+		emp = make_employee("emp_invalid_log1@example.com", company="_Test Company", default_shift=shift.name)
+
+		# checkin log outside shift time window
+		timestamp = datetime.combine(getdate(), get_time("06:30:00"))
+		log = make_checkin(emp, timestamp)
+		self.assertTrue(log.is_invalid)
+
+		# time window chnaged to 6 to 13, checkin log within shift time window
+		shift.begin_check_in_before_shift_start_time = 120
+		shift.save()
+		log.fetch_shift()
+		self.assertFalse(log.is_invalid)
+
 
 def make_n_checkins(employee, n, hours_to_reverse=1):
 	logs = [make_checkin(employee, now_datetime() - timedelta(hours=hours_to_reverse, minutes=n + 1))]

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -39,7 +39,7 @@ class ShiftType(Document):
 	def unlinked_checkins_exist(self):
 		return frappe.db.exists(
 			"Employee Checkin",
-			{"shift": self.name, "attendance": ["is", "not set"], "skip_auto_attendance": 0},
+			{"shift": self.name, "attendance": ["is", "not set"], "skip_auto_attendance": 0, "is_invalid": 0},
 		)
 
 	@frappe.whitelist()
@@ -116,6 +116,7 @@ class ShiftType(Document):
 				"time": (">=", self.process_attendance_after),
 				"shift_actual_end": ("<", self.last_sync_of_checkin),
 				"shift": self.name,
+				"is_invalid": 0,
 			},
 			order_by="employee,time",
 		)


### PR DESCRIPTION
Let users know upfront that checkin logs outside a shift's time window are invalid and will not be considered for attendance, instead of ending up with an error like this,
<img width="854" alt="Screenshot 2025-02-12 at 8 55 42 AM" src="https://github.com/user-attachments/assets/61b43ec9-b7fe-45a6-9195-ec90804d2d7d" />

#### After

The logs become valid again if either time is modified or shift's time window is changed such that time of checkin falls within the window

https://github.com/user-attachments/assets/1894522e-5db4-42d4-bbd5-99ef5a314372

https://github.com/user-attachments/assets/59daab4f-53e0-4239-91b4-ed2322c03504


- Added tests
- Existing ones passed without any modification

`no-docs`