### PR TITLE
fix: validation for circular shift times

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -51,7 +51,9 @@ class ShiftType(Document):
 				),
 			)
 
-	def get_shift_start_and_shift_end(self, start_time: datetime.time, end_time: datetime.time):
+	def get_shift_start_and_shift_end(
+		self, start_time: datetime.time, end_time: datetime.time
+	) -> tuple[datetime]:
 		shift_start = datetime.combine(getdate(), start_time)
 		if start_time < end_time:
 			shift_end = datetime.combine(getdate(), end_time)
@@ -63,7 +65,7 @@ class ShiftType(Document):
 		self, shift_start: datetime.time, shift_end: datetime.time
 	) -> int:
 		return (
-			(time_diff(shift_end, shift_start).total_seconds() / 60)
+			(round(time_diff(shift_end, shift_start).total_seconds() / 60))
 			+ self.allow_check_out_after_shift_end_time
 			+ self.begin_check_in_before_shift_start_time
 		)

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -46,7 +46,7 @@ class ShiftType(Document):
 			max_label = self.get_max_shift_buffer_label()
 			frappe.throw(
 				title=_("Invalid Shift Times"),
-				msg=_("Please change {0} to avoid shift time overlapping with itself").format(
+				msg=_("Please reduce {0} to avoid shift time overlapping with itself").format(
 					frappe.bold(max_label)
 				),
 			)

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -724,6 +724,44 @@ class TestShiftType(IntegrationTestCase):
 			get_time(frappe.get_value("Shift Type", shift.name, "start_time")), get_time("10:15:00")
 		)
 
+	def test_circular_shift_times(self):
+		# single day shift
+		shift_type = frappe.get_doc(
+			{
+				"doctype": "Shift Type",
+				"__newname": "Test Shift Validation",
+				"start_time": "09:00:00",
+				"end_time": "18:00:00",
+				"enable_auto_attendance": 1,
+				"determine_check_in_and_check_out": "Alternating entries as IN and OUT during the same shift",
+				"working_hours_calculation_based_on": "First Check-in and Last Check-out",
+				"begin_check_in_before_shift_start_time": 500,
+				"allow_check_out_after_shift_end_time": 500,
+				"process_attendance_after": add_days(getdate(), -2),
+				"last_sync_of_checkin": now_datetime() + timedelta(days=1),
+			}
+		)
+
+		self.assertRaises(frappe.ValidationError, shift_type.save)
+
+		# two day shift
+		shift_type = frappe.get_doc(
+			{
+				"doctype": "Shift Type",
+				"__newname": "Test Shift Validation",
+				"start_time": "18:00:00",
+				"end_time": "03:00:00",
+				"enable_auto_attendance": 1,
+				"determine_check_in_and_check_out": "Alternating entries as IN and OUT during the same shift",
+				"working_hours_calculation_based_on": "First Check-in and Last Check-out",
+				"begin_check_in_before_shift_start_time": 500,
+				"allow_check_out_after_shift_end_time": 500,
+				"process_attendance_after": add_days(getdate(), -2),
+				"last_sync_of_checkin": now_datetime() + timedelta(days=1),
+			}
+		)
+		self.assertRaises(frappe.ValidationError, shift_type.save)
+
 
 def setup_shift_type(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
Process Auto attendance breaks for circular overlapping shifts, hence the validation


https://github.com/user-attachments/assets/8584b580-2773-4a14-b070-addc0bd9f84f




- Added test