### PR TITLE
refactor: remove unused "status" field in appraisal

### DIFF
--- a/hrms/hr/doctype/appraisal/appraisal.json
+++ b/hrms/hr/doctype/appraisal/appraisal.json
@@ -15,7 +15,6 @@
   "employee_image",
   "column_break0",
   "company",
-  "status",
   "appraisal_cycle",
   "start_date",
   "end_date",
@@ -82,20 +81,6 @@
    "fieldtype": "Column Break",
    "oldfieldtype": "Column Break",
    "width": "50%"
-  },
-  {
-   "default": "Draft",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_standard_filter": 1,
-   "label": "Status",
-   "no_copy": 1,
-   "oldfieldname": "status",
-   "oldfieldtype": "Select",
-   "options": "\nDraft\nSubmitted\nCompleted\nCancelled",
-   "read_only": 1,
-   "reqd": 1,
-   "search_index": 1
   },
   {
    "fetch_from": "employee.department",
@@ -314,7 +299,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:31.286679",
+ "modified": "2025-02-18 15:03:49.932773",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Appraisal",
@@ -373,7 +358,7 @@
    "write": 1
   }
  ],
- "search_fields": "status, employee, employee_name, appraisal_cycle",
+ "search_fields": "employee, employee_name, appraisal_cycle",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/appraisal/appraisal.py
+++ b/hrms/hr/doctype/appraisal/appraisal.py
@@ -15,9 +15,6 @@ from hrms.payroll.utils import sanitize_expression
 
 class Appraisal(Document, AppraisalMixin):
 	def validate(self):
-		if not self.status:
-			self.status = "Draft"
-
 		self.set_kra_evaluation_method()
 
 		validate_active_employee(self.employee)

--- a/hrms/hr/workspace/performance/performance.json
+++ b/hrms/hr/workspace/performance/performance.json
@@ -174,7 +174,7 @@
    "type": "Link"
   }
  ],
- "modified": "2025-01-15 16:42:54.629038",
+ "modified": "2025-02-18 15:55:42.734793",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Performance",
@@ -192,7 +192,7 @@
    "format": "{} Pending",
    "label": "Appraisal",
    "link_to": "Appraisal",
-   "stats_filter": "{\"status\":[\"=\",\"Draft\"]}",
+   "stats_filter": "[[\"Appraisal\",\"docstatus\",\"=\",\"0\",false]]",
    "type": "DocType"
   },
   {


### PR DESCRIPTION
### Problem
Status field in Appraisal doctype is redundant and doesn't match with docstatus

#### Before 

<img width="1027" alt="Screenshot 2025-02-18 at 3 34 56 PM" src="https://github.com/user-attachments/assets/8cd90a48-7d80-4c73-b0ae-7f2c34275ed3" />


#### After

<img width="1064" alt="Screenshot 2025-02-18 at 3 36 54 PM" src="https://github.com/user-attachments/assets/f077d5f0-881d-4872-82e5-ed6b8a9f891c" />


`no-tests`