### PR TITLE
fix: calculations in income tax computation report

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -36,6 +36,7 @@ class IncomeTaxComputationReport:
 		self.get_employee_details()
 		self.get_future_salary_slips()
 		self.get_ctc()
+		self.get_income_from_other_sources()
 		self.get_tax_exempted_earnings_and_deductions()
 		self.get_employee_tax_exemptions()
 		self.get_hra()
@@ -397,11 +398,33 @@ class IncomeTaxComputationReport:
 
 		self.add_column("Total Exemption")
 
+	def get_income_from_other_sources(self):
+		self.add_column("Other Income")
+
+		for employee in list(self.employees.keys()):
+			other_income = (
+				frappe.get_all(
+					"Employee Other Income",
+					filters={
+						"employee": employee,
+						"payroll_period": self.filters.payroll_period,
+						"company": self.filters.company,
+						"docstatus": 1,
+					},
+					fields="SUM(amount) as total_amount",
+				)[0].total_amount
+				or 0.0
+			)
+
+			self.employees[employee].setdefault("other_income", other_income)
+
 	def get_total_taxable_amount(self):
 		self.add_column("Total Taxable Amount")
 		for __, emp_details in self.employees.items():
-			emp_details["total_taxable_amount"] = flt(emp_details.get("ctc")) - flt(
-				emp_details.get("total_exemption")
+			emp_details["total_taxable_amount"] = (
+				flt(emp_details.get("ctc"))
+				+ flt(emp_details.get("other_income"))
+				- flt(emp_details.get("total_exemption"))
 			)
 
 	def get_applicable_tax(self):

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -92,7 +92,13 @@ class IncomeTaxComputationReport:
 				"salary_structure": ["is", "set"],
 				"income_tax_slab": ["is", "set"],
 			},
-			fields=["employee", "income_tax_slab", "salary_structure"],
+			fields=[
+				"employee",
+				"income_tax_slab",
+				"salary_structure",
+				"taxable_earnings_till_date",
+				"tax_deducted_till_date",
+			],
 			order_by="from_date desc",
 		)
 
@@ -110,6 +116,7 @@ class IncomeTaxComputationReport:
 							"salary_structure": d.salary_structure,
 							"income_tax_slab": d.income_tax_slab,
 							"allow_tax_exemption": tax_slab.allow_tax_exemption,
+							"taxable_earnings_till_date": d.taxable_earnings_till_date or 0.0,
 							"tax_deducted_till_date": d.tax_deducted_till_date or 0.0,
 						},
 					)
@@ -184,9 +191,10 @@ class IncomeTaxComputationReport:
 			).run()
 		)
 
-		for employee in list(self.employees.keys()):
+		for employee, employee_details in self.employees.items():
+			opening_taxable_earnings = employee_details["taxable_earnings_till_date"]
 			future_ss_earnings = self.get_future_earnings(employee)
-			ctc = flt(existing_ss.get(employee)) + future_ss_earnings
+			ctc = flt(opening_taxable_earnings) + flt(existing_ss.get(employee)) + future_ss_earnings
 
 			self.employees[employee].setdefault("ctc", ctc)
 

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -110,6 +110,7 @@ class IncomeTaxComputationReport:
 							"salary_structure": d.salary_structure,
 							"income_tax_slab": d.income_tax_slab,
 							"allow_tax_exemption": tax_slab.allow_tax_exemption,
+							"tax_deducted_till_date": d.tax_deducted_till_date or 0.0,
 						},
 					)
 		return employee_ss_assignments
@@ -511,7 +512,8 @@ class IncomeTaxComputationReport:
 		).run(as_dict=True)
 
 		for d in records:
-			self.employees[d.employee].setdefault("total_tax_deducted", d.amount)
+			total_tax_deducted = flt(self.employees[d.employee].get("tax_deducted_till_date", 0)) + d.amount
+			self.employees[d.employee].setdefault("total_tax_deducted", total_tax_deducted)
 
 	def get_payable_tax(self):
 		self.add_column("Payable Tax")

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -222,6 +222,7 @@ class IncomeTaxComputationReport:
 			.select(ss.name, ss.employee, ss_comps.salary_component, Sum(ss_comps.amount).as_("amount"))
 			.where(ss.docstatus == 1)
 			.where(ss.employee.isin(list(self.employees.keys())))
+			.where(ss_comps.do_not_include_in_total == 0)
 			.where(ss_comps.salary_component.isin(tax_exempted_components))
 			.where(ss.start_date >= self.payroll_period_start_date)
 			.where(ss.end_date <= self.payroll_period_end_date)


### PR DESCRIPTION
- Display Employee Other Income in a separate column and include the amount in Total Taxable Income
- Include the  opening balance of tax deducted till date in Total Tax Deducted
- Include opening balance of taxable earnings in CTC and consequently in Total Taxable Amount
- Exclude components with Do Not Include In Total enabled