### PR TITLE
fix: clear loans on employee and salary slip date change

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -324,6 +324,7 @@ class SalarySlip(TransactionBase):
 	def get_emp_and_working_day_details(self):
 		"""First time, load all the components from salary structure"""
 		if self.employee:
+			self.set("loans", [])
 			self.set("earnings", [])
 			self.set("deductions", [])
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -324,9 +324,10 @@ class SalarySlip(TransactionBase):
 	def get_emp_and_working_day_details(self):
 		"""First time, load all the components from salary structure"""
 		if self.employee:
-			self.set("loans", [])
 			self.set("earnings", [])
 			self.set("deductions", [])
+			if hasattr(self, "loans"):
+				self.set("loans", [])
 
 			if self.payroll_frequency:
 				self.get_date_details()


### PR DESCRIPTION
the `set_loan_repayment` function in `salary_slip_loan_utils.py` doesn't update loans field if it is already populated.
this can create a bug that the loans field is not updated if employee or date of salary slip is changes.
this will create another bug that the loan is repaid with another employees salary if the employee field is changed.
this fix clears the loans field if employee or end date of salary slip is changed.


Please
backport version-15-hotfix
backport version-14-hotfix