### PR TITLE
fix: add company_currency to currencies list to fix issue where multi currency is disabled if company currecy is differnent from component currencies

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -849,6 +849,9 @@ class PayrollEntry(Document):
 
 		if account_currency not in currencies:
 			currencies.append(account_currency)
+		
+		if company_currency not in currencies:
+			currencies.append(company_currency)
 
 		if account_currency == company_currency:
 			conversion_rate = self.exchange_rate

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -849,7 +849,7 @@ class PayrollEntry(Document):
 
 		if account_currency not in currencies:
 			currencies.append(account_currency)
-		
+
 		if company_currency not in currencies:
 			currencies.append(company_currency)
 


### PR DESCRIPTION
Added company_currency to currencies list to fix issue where postings done in multi currency systems get error message as detailed in the issue https://github.com/frappe/hrms/issues/4 #4 

Test case was a multinational company with base currency NGN having salary components in USD and transaction case was USD for all necessary accounts.

This PR closes #4 
Also closes https://github.com/frappe/erpnext/issues/29049

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Page-format-for-ERPNext-docs

- Contribution Guide => https://github.com/frappe/erpnext/wiki/Contribution-Guidelines

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-currency handling for payroll journal entries by ensuring the company currency is always included alongside account currencies. This prevents misclassification of entries, reduces posting errors, and ensures correct exchange rate selection when company and account currencies differ, giving more reliable journal creation and accurate amounts for multi-currency payroll processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->