### PR TITLE
fix: Make checkin time readonly if attendance is linked

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.json
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.json
@@ -74,6 +74,7 @@
    "in_list_view": 1,
    "label": "Time",
    "permlevel": 1,
+   "read_only_depends_on": "eval:doc.attendance;",
    "reqd": 1
   },
   {
@@ -176,7 +177,7 @@
   }
  ],
  "links": [],
- "modified": "2025-03-04 14:05:00.729286",
+ "modified": "2025-03-05 15:36:10.014354",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.json
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.json
@@ -171,11 +171,12 @@
    "fieldname": "offshift",
    "fieldtype": "Check",
    "hidden": 1,
-   "label": "Off-shift"
+   "label": "Off-shift",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-02-14 18:44:30.726103",
+ "modified": "2025-03-04 14:05:00.729286",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -26,6 +26,7 @@ class EmployeeCheckin(Document):
 	def validate(self):
 		validate_active_employee(self.employee)
 		self.validate_duplicate_log()
+		self.validate_time_change()
 		self.fetch_shift()
 		self.set_geolocation()
 		self.validate_distance_from_shift_location()
@@ -44,6 +45,15 @@ class EmployeeCheckin(Document):
 			doc_link = frappe.get_desk_link("Employee Checkin", doc)
 			frappe.throw(
 				_("This employee already has a log with the same timestamp.{0}").format("<Br>" + doc_link)
+			)
+
+	def validate_time_change(self):
+		if self.attendance and self.has_value_changed("time"):
+			frappe.throw(
+				title=_("Cannot Modify Time"),
+				msg=_(
+					"An attendance record is linked to this checkin. Please cancel the attendance before modifying time."
+				),
 			)
 
 	@frappe.whitelist()


### PR DESCRIPTION
### Problem
Shift parameters depend on time of checkin but aren't modified if an attendance record is linked, but time still remains editable. Changing time while attendance is still linked results in incorrect shift start which leads to incorrect attendance record.


### Fix
- Made time readonly if attendance is linked
- added a validation for time change in case the readonly is removed using property setter or time is modified through data import
- added a test for validation
 