### PR TITLE
chore: temp workaround to use older lending branch 

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -15,7 +15,7 @@ frappeuser=${FRAPPE_USER:-"frappe"}
 frappebranch=${FRAPPE_BRANCH:-$githubbranch}
 erpnextbranch=${ERPNEXT_BRANCH:-$githubbranch}
 paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
-lendingbranch=${LENDING_BRANCH:-${githubbranch%"-hotfix"}}
+lendingbranch="version-15"
 
 git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench


### PR DESCRIPTION
Because a lot of new changes have been introduced in develop that break the CI. 
This is a workaround so other urgent fixes won't have to wait until the tests are refactored to adapt the lending upgrade.