### PR TITLE
fix:  update payable leave encashment doc handling in full and final statement

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
@@ -46,6 +46,11 @@ frappe.ui.form.on("Full and Final Statement", {
 				if (frappe.meta.has_field(fnf_doc.reference_document_type, "employee")) {
 					filters["employee"] = frm.doc.employee;
 				}
+
+				if (fnf_doc.reference_document_type === "Leave Encashment") {
+					filters["status"] = "Unpaid";
+					filters["pay_via_payment_entry"] = 1;
+				}
 			});
 
 			return {


### PR DESCRIPTION
- Add **Status** and **Pay Via Payment Entry** filters to Leave Encashment payables in Full and Final Statement
- **Update payment status** of Leave Encashment doc based on FnF payment status
- Add test


![fifn-github](https://github.com/user-attachments/assets/8f7f7526-b5e3-49d0-a73b-c399d967dd46)

