### PR TITLE
fix: Skip attendance with warning when status is unchanged

### DIFF
--- a/hrms/hr/doctype/attendance_request/test_attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/test_attendance_request.py
@@ -186,7 +186,6 @@ class TestAttendanceRequest(IntegrationTestCase):
 			}
 		)
 		self.assertRaises(frappe.ValidationError, attendance_request.save)
-		attendances = frappe.get_all("Attendance", filters={"employee": self.employee.name})
 
 		# adding an extra day to the attendance request
 		attendance_request.to_date = add_days(today, 1)

--- a/hrms/hr/doctype/attendance_request/test_attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/test_attendance_request.py
@@ -168,6 +168,34 @@ class TestAttendanceRequest(IntegrationTestCase):
 			["status", "docstatus", "attendance_date"],
 		)
 
+	def test_validate_no_attendance_to_create(self):
+		today = getdate()
+		yesterday = add_days(today, -1)
+		# marking absent for two days
+		for day in [yesterday, today]:
+			mark_attendance(self.employee.name, day, "Present")
+		# attendance request with the same status for the same days
+		attendance_request = frappe.get_doc(
+			{
+				"doctype": "Attendance Request",
+				"employee": self.employee.name,
+				"from_date": yesterday,
+				"to_date": today,
+				"reason": "On Duty",
+				"company": "_Test Company",
+			}
+		)
+		self.assertRaises(frappe.ValidationError, attendance_request.save)
+		attendances = frappe.get_all("Attendance", filters={"employee": self.employee.name})
+
+		# adding an extra day to the attendance request
+		attendance_request.to_date = add_days(today, 1)
+		attendance_request.save()
+		attendance_request.submit()
+		# attendance created for the third day
+		records = self.get_attendance_records(attendance_request.name)
+		self.assertEqual(records[0].status, "Present")
+
 
 def get_employee():
 	return frappe.get_doc("Employee", "_T-Employee-00001")


### PR DESCRIPTION
### Problem
Attendance request is used to create attendance or modify status of existing attendance. When status remains unchanged,  "overwrite" warning is shown in the dashboard but the existing record isn't updated or linked because there's no information to update other than status. This could lead to confusion

#### Before

https://github.com/user-attachments/assets/8faee929-5ec0-4b6d-b24f-858b67638029

#### After

https://github.com/user-attachments/assets/278f62da-148d-4610-aeb3-aa8330e60f54


### Fix
- Changed the warning from "Overwrite" to "Skip"
- Added a validation for when submitting a request won't make any new records or update existing ones
- Added a test
