### PR TITLE
fix: loan process in payroll and tests

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -249,19 +249,15 @@ class TestPayrollEntry(FrappeTestCase):
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
 	def test_loan_with_settings_enabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 
 		[applicant, branch, currency, payroll_payable_account] = setup_lending()
 		loan = create_loan_for_employee(applicant)
-
-		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
-
 		dates = get_start_end_dates("Monthly", nowdate())
+
+		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=dates.start_date)
+
 		make_payroll_entry(
 			company="_Test Company",
 			start_date=dates.start_date,
@@ -274,7 +270,6 @@ class TestPayrollEntry(FrappeTestCase):
 		)
 
 		name = frappe.db.get_value("Salary Slip", {"posting_date": nowdate(), "employee": applicant}, "name")
-
 		salary_slip = frappe.get_doc("Salary Slip", name)
 		for row in salary_slip.loans:
 			if row.loan == loan.name:
@@ -293,19 +288,15 @@ class TestPayrollEntry(FrappeTestCase):
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
 	def test_loan_with_settings_disabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 
+		dates = get_start_end_dates("Monthly", nowdate())
 		[applicant, branch, currency, payroll_payable_account] = setup_lending()
 		loan = create_loan_for_employee(applicant)
 
-		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
+		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=dates.start_date)
 
-		dates = get_start_end_dates("Monthly", nowdate())
 		make_payroll_entry(
 			company="_Test Company",
 			start_date=dates.start_date,
@@ -731,22 +722,15 @@ class TestPayrollEntry(FrappeTestCase):
 
 	def run_test_for_loan_repayment_from_salary(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 		applicant, branch, currency, payroll_payable_account = setup_lending()
 
 		loan = create_loan_for_employee(applicant)
-		loan_doc = frappe.get_doc("Loan", loan.name)
-		loan_doc.repay_from_salary = 1
-		loan_doc.save()
-
-		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
-
 		dates = get_start_end_dates("Monthly", nowdate())
+
+		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=dates.end_date)
+
 		payroll_entry = make_payroll_entry(
 			company="_Test Company",
 			start_date=dates.start_date,
@@ -924,13 +908,16 @@ def setup_lending():
 def create_loan_for_employee(applicant):
 	from lending.loan_management.doctype.loan.test_loan import create_loan
 
+	dates = get_start_end_dates("Monthly", nowdate())
+
 	loan = create_loan(
 		applicant,
 		"Car Loan",
 		280000,
 		"Repay Over Number of Periods",
-		20,
-		posting_date=add_months(nowdate(), -1),
+		repayment_periods=20,
+		posting_date=dates.start_date,
+		repayment_start_date=dates.end_date,
 	)
 	loan.repay_from_salary = 1
 	loan.submit()
@@ -959,7 +946,7 @@ def get_repayment_party_type(loan):
 		"GL Entry",
 		{"voucher_no": loan_repayment_entry, "account": payroll_payable_account, "is_cancelled": 0},
 		["party_type", "party"],
-	)
+	) or (None, None)
 
 	return party_type, party
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -60,6 +60,7 @@ class TestPayrollEntry(FrappeTestCase):
 
 		make_earning_salary_component(setup=True, company_list=["_Test Company"])
 		make_deduction_salary_component(setup=True, test_tax=False, company_list=["_Test Company"])
+		set_loan_demand_offset_type("_Test Company")
 
 		frappe.db.set_value("Company", "_Test Company", "default_holiday_list", "_Test Holiday List")
 		frappe.db.set_single_value("Payroll Settings", "email_salary_slip_to_employee", 0)
@@ -935,6 +936,18 @@ def create_loan_for_employee(applicant):
 	loan.submit()
 
 	return loan
+
+
+def set_loan_demand_offset_type(company):
+	if not frappe.db.exists("Loan Demand Offset Order", "Test Loan Demand Offset Order"):
+		order = frappe.new_doc("Loan Demand Offset Order")
+		order.title = "Test Loan Demand Offset Order"
+		order.append("components", {"demand_type": "EMI (Principal + Interest)"})
+		order.insert()
+
+	frappe.db.set_value(
+		"Company", company, "collection_offset_sequence_for_standard_asset", "Test Loan Demand Offset Order"
+	)
 
 
 def get_repayment_party_type(loan):

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -50,6 +50,7 @@ from hrms.payroll.doctype.payroll_period.payroll_period import (
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
 	cancel_loan_repayment_entry,
 	make_loan_repayment_entry,
+	process_loan_demand_and_interest_accruals,
 	set_loan_repayment,
 )
 from hrms.payroll.utils import sanitize_expression
@@ -345,6 +346,8 @@ class SalarySlip(TransactionBase):
 				)
 				self.set_time_sheet()
 				self.pull_sal_struct()
+
+			process_loan_demand_and_interest_accruals(self)
 
 	def set_time_sheet(self):
 		if self.salary_slip_based_on_timesheet:

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import frappe
 from frappe import _
@@ -31,11 +31,9 @@ def set_loan_repayment(doc: "SalarySlip"):
 
 	if not doc.get("loans", []):
 		loan_details = _get_loan_details(doc)
-		if loan_details:
-			process_loan_interest_accruals(loan_details, doc.end_date)
 
 		for loan in loan_details:
-			amounts = calculate_amounts(loan.name, doc.end_date, "Regular Payment")
+			amounts = calculate_amounts(loan.name, doc.end_date, "Normal Repayment")
 
 			if amounts["interest_amount"] or amounts["payable_principal_amount"]:
 				doc.append(
@@ -53,7 +51,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.set("loans", [])
 
 	for payment in doc.get("loans", []):
-		amounts = calculate_amounts(payment.loan, doc.end_date, "Regular Payment")
+		amounts = calculate_amounts(payment.loan, doc.end_date, "Normal Repayment")
 		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
 		if payment.total_payment > total_amount:
 			frappe.throw(
@@ -72,7 +70,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.total_loan_repayment += payment.total_payment
 
 
-def _get_loan_details(doc: "SalarySlip") -> dict[str, str | bool]:
+def _get_loan_details(doc: "SalarySlip") -> dict[str, Any]:
 	loan_details = frappe.get_all(
 		"Loan",
 		fields=["name", "interest_income_account", "loan_account", "loan_product", "is_term_loan"],
@@ -87,16 +85,23 @@ def _get_loan_details(doc: "SalarySlip") -> dict[str, str | bool]:
 	return loan_details
 
 
-def process_loan_interest_accruals(loan_details: dict[str, str | bool], posting_date: str):
+def process_loan_demand_and_interest_accruals(doc: "SalarySlip"):
+	from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
+		process_daily_loan_demands,
+	)
 	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-		process_loan_interest_accrual_for_term_loans,
+		process_loan_interest_accrual_for_loans,
 	)
 
-	for loan in loan_details:
-		if loan.is_term_loan:
-			process_loan_interest_accrual_for_term_loans(
-				posting_date=posting_date, loan_product=loan.loan_product, loan=loan.name
-			)
+	loans = _get_loan_details(doc)
+
+	if not loans:
+		return
+
+	for loan in loans:
+		if loan.get("is_term_loan"):
+			process_loan_interest_accrual_for_loans(doc.end_date, loan.loan_product, loan.name)
+			process_daily_loan_demands(doc.end_date, loan.loan_product, loan.name)
 
 
 @if_lending_app_installed
@@ -121,7 +126,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 			doc.company,
 			doc.posting_date,
 			loan.loan_product,
-			"Regular Payment",
+			"Normal Repayment",
 			loan.interest_amount,
 			loan.principal_amount,
 			loan.total_payment,


### PR DESCRIPTION
- Move loan interest accrual logic out of set_loan_repayment (which is called via calculate_net_pay) to prevent document mapper errors.
- Add Loan Demand Processing: Loan demand is now processed during payroll execution.
- Fix import errors related to the Lending module.\
- Fix lending related tests in Payroll Entry doctype