### PR TITLE
fix(ux): Set from_date or to_date automatically in Leave Application if to_date < from_date

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -154,14 +154,14 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	from_date: function (frm) {
-		frm.events.validate_from_to_date(frm, "to_date");
+		frm.events.validate_from_to_date(frm, "from_date");
 		frm.trigger("make_dashboard");
 		frm.trigger("half_day_datepicker");
 		frm.trigger("calculate_total_days");
 	},
 
 	to_date: function (frm) {
-		frm.events.validate_from_to_date(frm, "from_date");
+		frm.events.validate_from_to_date(frm, "to_date");
 		frm.trigger("make_dashboard");
 		frm.trigger("half_day_datepicker");
 		frm.trigger("calculate_total_days");
@@ -171,10 +171,21 @@ frappe.ui.form.on("Leave Application", {
 		frm.trigger("calculate_total_days");
 	},
 
-	validate_from_to_date: function (frm, null_date) {
+	validate_from_to_date: function (frm, updated_field) {
+		if (!frm.doc.from_date || !frm.doc.to_date) return;
+
 		const from_date = Date.parse(frm.doc.from_date);
 		const to_date = Date.parse(frm.doc.to_date);
-		if (to_date < from_date) frm.set_value(null_date, "");
+
+		if (to_date < from_date) {
+			const other_field = updated_field === "from_date" ? "to_date" : "from_date";
+
+			frm.set_value(other_field, frm.doc[updated_field]);
+			frappe.show_alert({
+				message: __("To Date cannot be before From Date."),
+				indicator: "red",
+			});
+		}
 	},
 
 	half_day_datepicker: function (frm) {

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -184,7 +184,7 @@ frappe.ui.form.on("Leave Application", {
 			frappe.show_alert({
 				message: __("Changing '{0}' to {1}.", [
 					__(frm.fields_dict[other_field].df.label),
-					frm.doc[updated_field],
+					frappe.datetime.str_to_user(frm.doc[updated_field]),
 				]),
 				indicator: "blue",
 			});

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -182,8 +182,11 @@ frappe.ui.form.on("Leave Application", {
 
 			frm.set_value(other_field, frm.doc[updated_field]);
 			frappe.show_alert({
-				message: __("To Date cannot be before From Date."),
-				indicator: "red",
+				message: __("Changing '{0}' to {1}.", [
+					__(frm.fields_dict[other_field].df.label),
+					frm.doc[updated_field],
+				]),
+				indicator: "blue",
 			});
 		}
 	},


### PR DESCRIPTION
In case the from_date is later than the to_date, or the other way around - set the least-value instead of simply unsetting it. Show an alert for the same.


![Screenshot from 2025-03-14 15-51-09](https://github.com/user-attachments/assets/eea041f2-54dd-4d8f-983e-2271216321d8)


![image](https://github.com/user-attachments/assets/8401fe24-5a49-4a59-aa5c-5f42662da6af)
