### PR TITLE
fix(Leave Ledger): Remove DocType Link from Report

### DIFF
--- a/hrms/hr/report/leave_ledger/leave_ledger.py
+++ b/hrms/hr/report/leave_ledger/leave_ledger.py
@@ -71,8 +71,7 @@ def get_columns() -> list[dict]:
 		{
 			"label": _("Transaction Type"),
 			"fieldname": "transaction_type",
-			"fieldtype": "Link",
-			"options": "DocType",
+			"fieldtype": "Data",
 			"width": 130,
 		},
 		{


### PR DESCRIPTION
This caused users who don't have read access to "DocType" (which is most people on an ERP) to be unabe to read this report. The view threw a msgprint that looked like: "No permission to read DocType"

```py
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 116, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1504, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 681, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 228, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 681, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 109, in generate_report_result
    result = get_filtered_data(report.ref_doctype, columns, result, user)
  File "apps/frappe/frappe/desk/query_report.py", line 612, in get_filtered_data
    match_filters_per_doctype = get_user_match_filters(linked_doctypes, user=user)
  File "apps/frappe/frappe/desk/query_report.py", line 800, in get_user_match_filters
    filter_list = frappe.desk.reportview.build_match_conditions(dt, user, False)
  File "apps/frappe/frappe/desk/reportview.py", line 762, in build_match_conditions
    match_conditions = DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
  File "apps/frappe/frappe/model/db_query.py", line 930, in build_match_conditions
    frappe.throw(_("No permission to read {0}").format(_(self.doctype)), frappe.PermissionError)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
    ~~~~~~~~^
        msg,
     ^^^^
    ...<6 lines>...
        primary_action=primary_action,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
    ~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
frappe.exceptions.PermissionError: No permission to read DocType
```

---

Verified on: develop, v15
