### PR TITLE
fix: exclude opening balances if salary structure assignment starts before payroll period

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1583,6 +1583,8 @@ class SalarySlip(TransactionBase):
 		return (taxable_earnings + opening_taxable_earning) - exempted_amount, exempted_amount
 
 	def get_opening_for(self, field_to_select, start_date, end_date):
+		if self._salary_structure_assignment.from_date < self.payroll_period.start_date:
+			return 0
 		return self._salary_structure_assignment.get(field_to_select) or 0
 
 	def get_salary_slip_details(

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1698,6 +1698,7 @@ class TestSalarySlip(IntegrationTestCase):
 		"""tests if opening balances in salary structure assignment are excluded from tax when assignment date is before payroll period"""
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
+		frappe.db.delete("Income Tax Slab", {"currency": "INR"})
 		emp = make_employee(
 			"test_opening_balances@salary.com",
 			company="_Test Company",

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1694,6 +1694,60 @@ class TestSalarySlip(IntegrationTestCase):
 		self.assertEqual(test_tds.accounts[0].company, salary_slip.company)
 		self.assertListEqual(tax_component, ["_Test TDS"])
 
+	def test_opening_balances_excluded_from_tax_calculation(self):
+		"""tests if opening balances in salary structure assignment are excluded from tax when assignment date is before payroll period"""
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+
+		emp = make_employee(
+			"test_opening_balances@salary.com",
+			company="_Test Company",
+			date_of_joining="2022-04-01",
+		)
+
+		payroll_period = create_payroll_period(
+			name="_Test Opening Balance Payroll Period",
+			company="_Test Company",
+			start_date="2023-04-01",
+			end_date="2024-03-31",
+		)
+
+		# create salary structure and assignment with from_date before payroll period
+		salary_structure = make_salary_structure(
+			"Test Opening Balance Structure",
+			"Monthly",
+			company="_Test Company",
+			employee=emp,
+			from_date="2022-04-01",
+			payroll_period=payroll_period,
+			test_tax=True,
+			base=50000,
+		)
+
+		ssa = frappe.get_value(
+			"Salary Structure Assignment",
+			{"employee": emp, "salary_structure": salary_structure.name},
+			"name",
+		)
+		ssa_doc = frappe.get_doc("Salary Structure Assignment", ssa)
+		# Set opening tax balances in assignment
+		ssa_doc.db_set("taxable_earnings_till_date", 600000)
+		ssa_doc.db_set("tax_deducted_till_date", 45500)
+
+		# Create salary slip
+		salary_slip = make_salary_slip(salary_structure.name, employee=emp, posting_date="2023-04-01")
+
+		# calculate expected taxable amount without opening balance
+		# 50000 (base) + 28000 (other earnings from structure)
+		monthly_taxable_earnings = 78000
+		expected_annual_taxable_amount = monthly_taxable_earnings * 12
+
+		# Verify that opening balance is not included in tax calculation
+		self.assertNotEqual(
+			salary_slip.annual_taxable_amount,
+			expected_annual_taxable_amount + ssa_doc.taxable_earnings_till_date,
+		)
+		self.assertEqual(salary_slip.income_tax_deducted_till_date, salary_slip.current_month_income_tax)
+
 
 class TestSalarySlipSafeEval(IntegrationTestCase):
 	def test_safe_eval_for_salary_slip(self):


### PR DESCRIPTION
Exclude opening taxable earnings and deductions from tax calculations if salary structure assignment from_date field is set to before the current payroll period's start date

**Example:**

Salary structure assignment from December 2024:
(Payroll period is April 01 2024 till March 31, 2025)
<img width="1136" alt="Screenshot 2025-03-17 at 10 26 46 AM" src="https://github.com/user-attachments/assets/0457008e-dbfd-4b40-b454-29d04f6cf5b5" />

Income Tax Breakup for March 2025:
<img width="1114" alt="Screenshot 2025-03-17 at 10 29 08 AM" src="https://github.com/user-attachments/assets/296a6fbf-4bae-40e5-a219-0c3aa82328cc" />

Income Tax Breakup for April 2025:
(Payroll period has changed - April 01 2025 till March 31, 2026)

- BEFORE
<img width="1064" alt="Screenshot 2025-03-17 at 10 31 13 AM" src="https://github.com/user-attachments/assets/70df149f-935f-439c-9ce2-25571acbd77c" />



- AFTER
<img width="1107" alt="Screenshot 2025-03-17 at 10 35 44 AM" src="https://github.com/user-attachments/assets/71271a70-8c95-43df-baba-bfb74996f1a9" />
