### PR TITLE
fix: Roster path in Shift & Attendance workspace

### DIFF
--- a/hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+++ b/hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
@@ -259,7 +259,7 @@
    "doc_view": "List",
    "label": "Roster",
    "type": "URL",
-   "url": "/hr/roster/"
+   "url": "/hr/roster"
   },
   {
    "color": "Grey",

--- a/hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+++ b/hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
@@ -242,7 +242,7 @@
    "type": "Link"
   }
  ],
- "modified": "2025-01-15 16:43:18.393364",
+ "modified": "2025-04-11 16:43:18.393364",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift & Attendance",


### PR DESCRIPTION
Fix relative URL to work behind a proxy
I suspect the issue lies with the functions frappe.utils.generate_route or get_route. When operating behind a proxy, shortcut URLs that end with a trailing slash (/) are not correctly converted into fully qualified URLs. If the trailing slash is omitted, the URL is properly interpreted as a relative path.
Before:
![ksnip_20250408-095259](https://github.com/user-attachments/assets/3291f290-d5bd-4915-8b8e-43175ab16cb4)

Change:
![ksnip_20250408-095301](https://github.com/user-attachments/assets/49ca6a55-b62a-46e1-9548-7e795a426c2c)

After:
![ksnip_20250408-095303](https://github.com/user-attachments/assets/2d941367-78fb-407d-b57b-360a0fcb24aa)
