### PR TITLE
fix: Recruitment Report Company Filter Update

### DIFF
--- a/hrms/hr/report/recruitment_analytics/recruitment_analytics.py
+++ b/hrms/hr/report/recruitment_analytics/recruitment_analytics.py
@@ -119,7 +119,7 @@ def get_child_row(jo, jo_ja_map, ja_joff_map):
 def get_staffing_plan(filters):
 	conditions = f"sp.to_date > '{filters.on_date}'"
 
-	if filters.get("company"):
+	if filters.company:
 		conditions += f" AND sp.company = '{filters.company}'"
 
 	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql

--- a/hrms/hr/report/recruitment_analytics/recruitment_analytics.py
+++ b/hrms/hr/report/recruitment_analytics/recruitment_analytics.py
@@ -70,9 +70,9 @@ def get_data(filters):
 	data = []
 	staffing_plan_details = get_staffing_plan(filters)
 	staffing_plan_list = list(set([details["name"] for details in staffing_plan_details]))
-	sp_jo_map, jo_list = get_job_opening(staffing_plan_list)
+	sp_jo_map, jo_list = get_job_opening(staffing_plan_list, filters)
 	jo_ja_map, ja_list = get_job_applicant(jo_list)
-	ja_joff_map = get_job_offer(ja_list)
+	ja_joff_map = get_job_offer(ja_list, filters)
 
 	for sp in sp_jo_map.keys():
 		parent_row = get_parent_row(sp_jo_map, sp, jo_ja_map, ja_joff_map)
@@ -117,6 +117,11 @@ def get_child_row(jo, jo_ja_map, ja_joff_map):
 
 
 def get_staffing_plan(filters):
+	conditions = f"sp.to_date > '{filters.on_date}'"
+
+	if filters.get("company"):
+		conditions += f" AND sp.company = '{filters.company}'"
+
 	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
 	staffing_plan = frappe.db.sql(
 		f"""
@@ -135,9 +140,16 @@ def get_staffing_plan(filters):
 	return staffing_plan
 
 
-def get_job_opening(sp_list):
+def get_job_opening(sp_list, filters):
+	company = filters.company
+	job_openings_filters = [["staffing_plan", "IN", sp_list]]
+	if company:
+		job_openings_filters.append(["company", "=", company])
+
 	job_openings = frappe.get_all(
-		"Job Opening", filters=[["staffing_plan", "IN", sp_list]], fields=["name", "staffing_plan"]
+		"Job Opening",
+		filters=job_openings_filters,
+		fields=["name", "staffing_plan"]
 	)
 
 	sp_jo_map = {}
@@ -175,12 +187,16 @@ def get_job_applicant(jo_list):
 	return jo_ja_map, ja_list
 
 
-def get_job_offer(ja_list):
+def get_job_offer(ja_list, filters):
 	ja_joff_map = {}
+
+	job_offer_filters = [["job_applicant", "IN", ja_list]]
+	if filters.company:
+		job_offer_filters.append(["company", "=", filters.company])
 
 	offers = frappe.get_all(
 		"Job Offer",
-		filters=[["job_applicant", "IN", ja_list]],
+		filters=job_offer_filters,
 		fields=["name", "job_applicant", "status", "offer_date", "designation"],
 	)
 


### PR DESCRIPTION
Issue: #2883
Fixed the issue where the Company filter in the Recruitment Analytics report was not applying correctly. Updated backend queries to include company filtering, ensuring that the report now displays data relevant to the selected company.
I have added images for reference.
**Before:**
![image](https://github.com/user-attachments/assets/7108a324-d659-4d6b-997f-29a440178b88)
![image](https://github.com/user-attachments/assets/8139903c-fc0f-4f62-b09d-e4121dcda2f3)
**After:**
![image](https://github.com/user-attachments/assets/15585fca-db72-43a1-93a3-5ae34a940493)
![image](https://github.com/user-attachments/assets/45d44a1b-9d09-4712-a097-f6689a926b24)
