### PR TITLE
feat(minor): Show option to expire carried forward leaves

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -306,7 +306,7 @@ class LeaveAllocation(Document):
 			)
 			create_leave_ledger_entry(self, args, submit)
 			if submit and getdate(end_date) < getdate():
-				show_expire_leave_dialog(self.unused_leaves)
+				show_expire_leave_dialog(self.unused_leaves, self.leave_type)
 
 		args = dict(
 			leaves=self.new_leaves_allocated,
@@ -482,12 +482,12 @@ def validate_carry_forward(leave_type):
 		frappe.throw(_("Leave Type {0} cannot be carry-forwarded").format(leave_type))
 
 
-def show_expire_leave_dialog(expired_leaves):
+def show_expire_leave_dialog(expired_leaves, leave_type):
 	frappe.msgprint(
 		title=_("Leaves Expired"),
 		msg=_(
-			"{0} leaves from this allocation have expired and will be processed during the next scheduled job. It is recommended to expire them now before creating new leave policy assignments."
-		).format(frappe.bold(expired_leaves)),
+			"{0} leaves from allocation for {1} leave type have expired and will be processed during the next scheduled job. It is recommended to expire them now before creating new leave policy assignments."
+		).format(frappe.bold(expired_leaves), frappe.bold(leave_type)),
 		indicator="orange",
 		primary_action={
 			"label": _("Expire Leaves"),

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -11,6 +11,7 @@ from hrms.hr.doctype.leave_application.leave_application import get_approved_lea
 from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
 	create_leave_ledger_entry,
 	expire_allocation,
+	process_expired_allocation,
 )
 from hrms.hr.utils import create_additional_leave_ledger_entry, get_leave_period, set_employee_name
 from hrms.hr.utils import get_monthly_earned_leave as _get_monthly_earned_leave
@@ -485,8 +486,7 @@ def show_expire_leave_dialog(expired_leaves):
 	frappe.msgprint(
 		title=_("Leaves Expired"),
 		msg=_(
-			"{0} leaves from this allocation have expired and will be processed during the next scheduled job."
-			"It is recommended to expire them now before creating new leave policy assignments."
+			"{0} leaves from this allocation have expired and will be processed during the next scheduled job. It is recommended to expire them now before creating new leave policy assignments."
 		).format(frappe.bold(expired_leaves)),
 		indicator="orange",
 		primary_action={
@@ -500,8 +500,6 @@ def show_expire_leave_dialog(expired_leaves):
 @frappe.whitelist()
 def expire_carried_forward_allocation():
 	if frappe.has_permission(doctype="Leave Allocation", ptype="submit", user=frappe.session.user):
-		from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
-
 		process_expired_allocation()
 	else:
 		frappe.throw(_("You do not have permission to complete this action"), frappe.PermissionError)


### PR DESCRIPTION
### Problem

1. Leave type is configured to carry forward leaves with expiration date set, say 6 months
2. Leave Policy Assignment is created with:

- Year long leave period
- While carry forwarding leaves 
- After the expiration date, i.e. after 6 months

3. Leave Policy assignment for next leave period is created with same the configuration as above before process_expired_allocation job runs

Because ledger does not have expired leave entries from previous allocations incorrect number of leaves are carried forward into the next period

### Solution
Some users may want to create backdated polices, allocations and leaves applications for record keeping, or to set a certain opening balance (coming soon in v-16), so instead of expiring them automatically, give user an option to expire them immediately before creating next policies or let them create backdated applications before leaves expire

----
#### Before
<img width="1004" alt="Screenshot 2025-03-21 at 2 46 10 PM" src="https://github.com/user-attachments/assets/2723029c-5666-457c-a0fa-21a7870a294c" />

https://github.com/user-attachments/assets/1dc67af1-6138-428b-9e28-1fa03b78d867

#### After

https://github.com/user-attachments/assets/5bd12337-d0ae-4f38-acd0-38bfe65cc225

 `no-docs`