### PR TITLE
feat(minor): allow setting shift location through employee checkin api

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -135,6 +135,8 @@ def add_log_based_on_employee_field(
 	log_type=None,
 	skip_auto_attendance=0,
 	employee_fieldname="attendance_device_id",
+	latitude=None,
+	longitude=None,
 ):
 	"""Finds the relevant Employee using the employee field value and creates a Employee Checkin.
 
@@ -144,6 +146,8 @@ def add_log_based_on_employee_field(
 	:param log_type: (optional)Direction of the Punch if available (IN/OUT).
 	:param skip_auto_attendance: (optional)Skip auto attendance field will be set for this log(0/1).
 	:param employee_fieldname: (Default: attendance_device_id)Name of the field in Employee DocType based on which employee lookup will happen.
+	:latitude: (optional) Latitude of the shift location.
+	:longitude: (optional) Longitude of the shift location.
 	"""
 
 	if not employee_field_value or not timestamp:
@@ -170,6 +174,8 @@ def add_log_based_on_employee_field(
 	doc.time = timestamp
 	doc.device_id = device_id
 	doc.log_type = log_type
+	doc.latitude = latitude
+	doc.longitude = longitude
 	if cint(skip_auto_attendance) == 1:
 		doc.skip_auto_attendance = "1"
 	doc.insert()


### PR DESCRIPTION
#### Problem
When geolocation is turned on, location co-ordinates become mandatory however the api doesn't allow setting the fields.

#### Fix
Now the co-ordinates can be set through the API, so geolocation can be turned for some shifts while also syncing checkin logs from biometric devices.
Updated Docs: https://docs.frappe.io/hr/integrating-frappe-hr-with-biometric-attendance-devices (under review)