### PR TITLE
fix(payroll bank entry): ignore employee with zero payment amount

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1023,6 +1023,9 @@ class PayrollEntry(Document):
 					- (employee_details.get("total_loan_repayment", 0) or 0)
 				)
 
+				if not je_payment_amount:
+					continue
+
 				exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(
 					self.payment_account, je_payment_amount, company_currency, currencies
 				)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -728,7 +728,7 @@ class TestPayrollEntry(FrappeTestCase):
 			"process_payroll_accounting_entry_based_on_employee": 1,
 		},
 	)
-	def test_payroll_entry_with_present_and_absent_employees(self):
+	def test_skip_bank_entry_for_employees_with_zero_amount(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee1 = make_employee("test_employee11@payroll.com", company=company_doc.name)
 		employee2 = make_employee("test_employee12@payroll.com", company=company_doc.name)


### PR DESCRIPTION
**Issue:**
Unable to create bank entry when an employee has 0 payment amount
**ref:** [34459](https://support.frappe.io/helpdesk/tickets/34459)

![image](https://github.com/user-attachments/assets/a793d5e9-e96c-47d0-b139-a722c40b9416)

**Before:**

https://github.com/user-attachments/assets/e22cf303-ffb7-424a-9aa7-61000f04ec19

**After:**

https://github.com/user-attachments/assets/32fc2477-97bd-410c-bf8c-a28498bc7c28


**Backport needed for v15**