### PR TITLE
fix: separate loan interest accrual processing from set_loan_repayment function

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -50,6 +50,7 @@ from hrms.payroll.doctype.payroll_period.payroll_period import (
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
 	cancel_loan_repayment_entry,
 	make_loan_repayment_entry,
+	process_loan_interest_accruals,
 	set_loan_repayment,
 )
 from hrms.payroll.utils import sanitize_expression
@@ -345,6 +346,8 @@ class SalarySlip(TransactionBase):
 				)
 				self.set_time_sheet()
 				self.pull_sal_struct()
+
+			process_loan_interest_accruals(self)
 
 	def set_time_sheet(self):
 		if self.salary_slip_based_on_timesheet:


### PR DESCRIPTION
- Previously, set_loan_repayment handled both loan repayment and interest accrual.
- Now, interest accrual is processed separately and called within get_emp_and_working_day_details.
- This avoids unnecessary call to process_loan_interest_accruals on Salary Slip Preview
- Previously, calling process_loan_interest_accruals within make_salary_slip → calculate_net_pay → set_loan_repayment could trigger a frappe.exceptions.DatabaseModificationError in cases where accrual submission was required since make_salary_slip runs in read-only mode 
<img width="1414" alt="Screenshot 2025-03-25 at 6 04 21 PM" src="https://github.com/user-attachments/assets/81f67713-5c0a-4926-95a3-6a1a2ed13457" />
