### PR TITLE
fix: display slab based tax and additional tax amount separately in income tax computation report

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1106,6 +1106,7 @@ class SalarySlip(TransactionBase):
 
 		self.add_structure_components(component_type)
 		self.add_additional_salary_components(component_type)
+
 		if component_type == "earnings":
 			self.add_employee_benefits()
 		else:
@@ -1511,7 +1512,7 @@ class SalarySlip(TransactionBase):
 
 		# Structured tax amount
 		eval_locals, default_data = self.get_data_for_eval()
-		self.total_structured_tax_amount = calculate_tax_by_tax_slab(
+		self.total_structured_tax_amount, __ = calculate_tax_by_tax_slab(
 			self.total_taxable_earnings_without_full_tax_addl_components,
 			self.tax_slab,
 			self.whitelisted_globals,
@@ -1525,7 +1526,7 @@ class SalarySlip(TransactionBase):
 		# Total taxable earnings with additional earnings with full tax
 		self.full_tax_on_additional_earnings = 0.0
 		if self.current_additional_earnings_with_full_tax:
-			self.total_tax_amount = calculate_tax_by_tax_slab(
+			self.total_tax_amount, __ = calculate_tax_by_tax_slab(
 				self.total_taxable_earnings, self.tax_slab, self.whitelisted_globals, eval_locals
 			)
 			self.full_tax_on_additional_earnings = self.total_tax_amount - self.total_structured_tax_amount
@@ -2153,6 +2154,8 @@ def get_payroll_payable_account(company, payroll_entry):
 def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=None, eval_locals=None):
 	eval_locals.update({"annual_taxable_earning": annual_taxable_earning})
 	tax_amount = 0
+	other_taxes_and_charges = 0
+
 	for slab in tax_slab.slabs:
 		cond = cstr(slab.condition).strip()
 		if cond and not eval_tax_slab_condition(cond, eval_globals, eval_locals):
@@ -2166,7 +2169,6 @@ def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=Non
 		elif annual_taxable_earning >= slab.from_amount and annual_taxable_earning >= slab.to_amount:
 			tax_amount += (slab.to_amount - slab.from_amount + 1) * slab.percent_deduction * 0.01
 
-	# other taxes and charges on income tax
 	for d in tax_slab.other_taxes_and_charges:
 		if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:
 			continue
@@ -2174,9 +2176,10 @@ def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=Non
 		if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
 			continue
 
-		tax_amount += tax_amount * flt(d.percent) / 100
+		other_taxes_and_charges += tax_amount * flt(d.percent) / 100
+		tax_amount += other_taxes_and_charges
 
-	return tax_amount
+	return tax_amount, other_taxes_and_charges
 
 
 def eval_tax_slab_condition(condition, eval_globals=None, eval_locals=None):

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -438,7 +438,9 @@ class IncomeTaxComputationReport:
 			)
 
 	def get_applicable_tax(self):
-		self.add_column("Applicable Tax")
+		self.add_column("Income Tax (Slab Based)", "income_tax_slab_based")
+		self.add_column("Other Taxes and Charges")
+		self.add_column("Total Applicable Tax", "applicable_tax")
 
 		is_tax_rounded = frappe.db.get_value(
 			"Salary Component",
@@ -451,7 +453,7 @@ class IncomeTaxComputationReport:
 			if tax_slab:
 				tax_slab = frappe.get_cached_doc("Income Tax Slab", tax_slab)
 				eval_globals, eval_locals = self.get_data_for_eval(emp, emp_details)
-				tax_amount = calculate_tax_by_tax_slab(
+				tax_amount, other_taxes_and_charges = calculate_tax_by_tax_slab(
 					emp_details["total_taxable_amount"],
 					tax_slab,
 					eval_globals=eval_globals,
@@ -459,9 +461,14 @@ class IncomeTaxComputationReport:
 				)
 			else:
 				tax_amount = 0.0
+				other_taxes_and_charges = 0.0
 
 			if is_tax_rounded:
 				tax_amount = rounded(tax_amount)
+				other_taxes_and_charges = rounded(other_taxes_and_charges)
+
+			emp_details["income_tax_slab_based"] = tax_amount - other_taxes_and_charges
+			emp_details["other_taxes_and_charges"] = other_taxes_and_charges
 			emp_details["applicable_tax"] = tax_amount
 
 	def get_data_for_eval(self, emp: str, emp_details: dict) -> tuple:


### PR DESCRIPTION
- Previously, the "Applicable Tax" column included both slab-based tax and additional charges combined.
- Now, these amounts are displayed in separate columns to help users clearly distinguish base tax liability from additional taxes and charges.
- No change to tax calculations—only affects how the data is displayed.

**Before:**
<img width="1421" alt="Screenshot 2025-03-26 at 1 39 23 PM" src="https://github.com/user-attachments/assets/62277296-c35e-4611-aa9b-60ab76fcdaaf" />

After:
<img width="1416" alt="Screenshot 2025-03-26 at 1 36 19 PM" src="https://github.com/user-attachments/assets/33db3df5-8dea-41a0-9ee3-771df502b2b4" />
