### PR TITLE
fix: cannot cancel gratuity when payment ledger entry exists

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -56,7 +56,7 @@ class Gratuity(AccountsController):
 			self.create_gl_entries()
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = ["GL Entry"]
+		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry"]
 		self.create_gl_entries(cancel=True)
 		self.set_status(update=True)
 


### PR DESCRIPTION
Right now, we cannot cancel the Gratuity because new Payment Ledger Entries are created when cancelling the Gratuity and a `LinkExistsError` is being thrown. 

This PR fixes it by adding "Payment Ledger Entry" to the `ignore_linked_doctypes`