### PR TITLE
fix: gratuity - get default amount from earning component

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -56,7 +56,7 @@ class Gratuity(AccountsController):
 			self.create_gl_entries()
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = ["GL Entry"]
+		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry"]
 		self.create_gl_entries(cancel=True)
 		self.set_status(update=True)
 

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -275,7 +275,7 @@ class Gratuity(AccountsController):
 		component_found = False
 		for row in salary_slip.earnings:
 			if row.salary_component in applicable_earning_components:
-				total_amount += flt(row.amount)
+				total_amount += flt(row.default_amount)
 				component_found = True
 
 		if not component_found:


### PR DESCRIPTION
Right now, the gratuity get the `amount` from applicable earning components. But this field will be wrong if the component depends on payment days, or if there is an Additional Salary that overwrites this amount. 

This PR fetches the `default_amount` instead of the `amount` while calculating gratuity.