### PR TITLE
fix: Ensure loan interest accruals run only if Lending app is installed on salary slip

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -85,6 +85,7 @@ def _get_loan_details(doc: "SalarySlip") -> dict[str, Any]:
 	return loan_details
 
 
+@if_lending_app_installed
 def process_loan_interest_accruals(doc: "SalarySlip"):
 	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
 		process_loan_interest_accrual_for_term_loans,


### PR DESCRIPTION
Issue
When creating a Salary Slip, a server error occurs:

No module named 'lending' in hrms
![image](https://github.com/user-attachments/assets/979a0a16-16c5-4119-ae81-d2efd9f96663)


This happens because the function process_loan_interest_accruals in salary_slip_util.py tries to import process_loan_interest_accrual_for_term_loans from the Lending module, which is not available unless the Lending app is installed.

Previously, this function was not being executed, but after [PR #2905](https://github.com/frappe/hrms/pull/2905), it started running without the @if_lending_app_installed decorator. As a result, the system attempts to import a non-existent module when the Lending app is not installed, causing the error.

Fix
Added the @if_lending_app_installed decorator to process_loan_interest_accruals. This ensures that the function only executes when the Lending app is installed, preventing the import error.

Impact
Salary Slip creation now works correctly, even when the Lending app is not installed.

Prevents unnecessary crashes in HRMS for setups that do not include the Lending module.

Ensures smoother handling of loan interest accruals without breaking other functionalities.


[Screencast from 28-03-25 01:06:14 PM IST.webm](https://github.com/user-attachments/assets/c5beda94-c52c-42ac-a8a5-89a93cbf8653)
