### PR TITLE
fix: prevent multiple feedback submissions by checking existing submi…

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -42,12 +42,12 @@ frappe.ui.form.on("Interview", {
 			{
 				interviewer: frappe.session.user,
 				interview: frm.doc.name,
-				docstatus: ("!=", 2),
+				docstatus: ["!=", 2],
 			},
 			"name",
-		)?.message?.name;
+		);
 
-		if (has_submitted_feedback) return;
+		if (has_submitted_feedback?.message?.name) return;
 
 		const allow_feedback_submission = frm.doc.interview_details.some(
 			(interviewer) => interviewer.interviewer === frappe.session.user,


### PR DESCRIPTION
**Issue:**
The Submit Feedback button is still visible after feedback has been submitted.

**ref:** #2758 

**Before:**

![Before](https://github.com/user-attachments/assets/f4b9f462-4f32-4512-aa97-3853518460e8)


**After:**

![After](https://github.com/user-attachments/assets/e617602c-db7a-48b3-9180-a8a7705a401d)


Backport needed: version-15