### PR TITLE
refactor: submit Interview Feedback using the Interview Feedback form

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -69,15 +69,9 @@ frappe.ui.form.on("Interview", {
 	},
 
 	submit_feedback: function (frm) {
-		frappe.call({
-			method: "hrms.hr.doctype.interview.interview.get_expected_skill_set",
-			args: {
-				interview_round: frm.doc.interview_round,
-			},
-			callback: function (r) {
-				frm.events.show_feedback_dialog(frm, r.message);
-				frm.refresh();
-			},
+		frappe.model.open_mapped_doc({
+			method: "hrms.hr.doctype.interview.interview.set_interview_feedback",
+			frm: frm,
 		});
 	},
 
@@ -124,78 +118,6 @@ frappe.ui.form.on("Interview", {
 			},
 		});
 		d.show();
-	},
-
-	show_feedback_dialog: function (frm, data) {
-		let fields = frm.events.get_fields_for_feedback();
-
-		let d = new frappe.ui.Dialog({
-			title: __("Submit Feedback"),
-			fields: [
-				{
-					fieldname: "skill_set",
-					fieldtype: "Table",
-					label: __("Skill Assessment"),
-					cannot_add_rows: false,
-					in_editable_grid: true,
-					reqd: 1,
-					fields: fields,
-					data: data,
-				},
-				{
-					fieldname: "result",
-					fieldtype: "Select",
-					options: ["", "Cleared", "Rejected"],
-					label: __("Result"),
-					reqd: 1,
-				},
-				{
-					fieldname: "feedback",
-					fieldtype: "Small Text",
-					label: __("Feedback"),
-				},
-			],
-			size: "large",
-			minimizable: true,
-			static: true,
-			primary_action: function (values) {
-				frappe
-					.call({
-						method: "hrms.hr.doctype.interview.interview.create_interview_feedback",
-						args: {
-							data: values,
-							interview_name: frm.doc.name,
-							interviewer: frappe.session.user,
-							job_applicant: frm.doc.job_applicant,
-						},
-					})
-					.then(() => {
-						frm.refresh();
-					});
-				d.hide();
-			},
-		});
-		d.show();
-		d.get_close_btn().show();
-	},
-
-	get_fields_for_feedback: function () {
-		return [
-			{
-				fieldtype: "Link",
-				fieldname: "skill",
-				options: "Skill",
-				in_list_view: 1,
-				label: __("Skill"),
-			},
-			{
-				fieldtype: "Rating",
-				fieldname: "rating",
-				label: __("Rating"),
-				in_list_view: 1,
-				reqd: 1,
-			},
-		];
 	},
 
 	interview_round: function (frm) {

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -7,6 +7,7 @@ import datetime
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Avg
 from frappe.utils import cint, cstr, get_datetime, get_link_to_form, getdate, nowtime
 
@@ -341,6 +342,33 @@ def create_interview_feedback(data, interview_name, interviewer, job_applicant):
 			get_link_to_form("Interview Feedback", interview_feedback.name)
 		)
 	)
+
+
+@frappe.whitelist()
+def set_interview_feedback(source, target=None):
+	def set_missing_values(source, target):
+		target.interviewer = frappe.session.user
+		skill_set = get_expected_skill_set(frappe.get_value("Interview", source, ["interview_round"]))
+		for skill in skill_set:
+			target.append("skill_assessment", skill)
+
+	interview_feedback = get_mapped_doc(
+		from_doctype="Interview",
+		from_docname=source,
+		table_maps={
+			"Interview": {
+				"doctype": "Interview Feedback",
+				"field_map": {
+					"interview": "name",
+					"interview_round": "interview_round",
+					"job_applicant": "job_applicant",
+				},
+			}
+		},
+		postprocess=set_missing_values,
+	)
+
+	return interview_feedback
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### Problem

Child tables aren't configurable in dialogs because the schema is hardcoded, so users can't add any custom fields to such child tables.
We'll figure out a way to handle this in framework for now, refactoring the submit feedback button to direct to Interview feedback form instead of opening a dialog

#### Before

https://github.com/user-attachments/assets/70322f6a-5ef9-4d54-bca4-b033a6d34d83

#### After

https://github.com/user-attachments/assets/b3ba91b8-add4-47cf-8fda-4b1674402b24

