### PR TITLE
fix: create job applicant from employee referral

### DIFF
--- a/hrms/hr/doctype/employee_referral/employee_referral.js
+++ b/hrms/hr/doctype/employee_referral/employee_referral.js
@@ -45,9 +45,11 @@ frappe.ui.form.on("Employee Referral", {
 		}
 	},
 	create_job_applicant: function (frm) {
-		frappe.model.open_mapped_doc({
+		frappe.call({
 			method: "hrms.hr.doctype.employee_referral.employee_referral.create_job_applicant",
-			frm: frm,
+			args: {
+				source_name: frm.docname,
+			},
 		});
 	},
 


### PR DESCRIPTION
### Problem
Source and target documents cannot be saved while using open_mapped_doc, broken by frappe/frappe#27955


### Fix
Used frappe.call instead of open_mapped_doc while creating job applicant, could have refactored create_job_applicant method to use get_mapped_doc, but saving directly seems better since user doesn't have to enter any new information to save job applicant

-------
#### Before

https://github.com/user-attachments/assets/8be53e88-cc51-4413-acb1-dda31904c912

#### After

https://github.com/user-attachments/assets/f98ef31a-f022-4140-9bbd-39be6034bb65


