### PR TITLE
fix: fetch child table schema from meta

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -126,8 +126,8 @@ frappe.ui.form.on("Interview", {
 		d.show();
 	},
 
-	show_feedback_dialog: function (frm, data) {
-		let fields = frm.events.get_fields_for_feedback();
+	show_feedback_dialog: async function (frm, data) {
+		let fields = await frm.events.get_fields_for_feedback();
 
 		let d = new frappe.ui.Dialog({
 			title: __("Submit Feedback"),
@@ -179,23 +179,23 @@ frappe.ui.form.on("Interview", {
 		d.get_close_btn().show();
 	},
 
-	get_fields_for_feedback: function () {
-		return [
-			{
-				fieldtype: "Link",
-				fieldname: "skill",
-				options: "Skill",
-				in_list_view: 1,
-				label: __("Skill"),
-			},
-			{
-				fieldtype: "Rating",
-				fieldname: "rating",
-				label: __("Rating"),
-				in_list_view: 1,
-				reqd: 1,
-			},
-		];
+	get_fields_for_feedback: async function () {
+		return new Promise((resolve, reject) => {
+			frappe.model.with_doctype("Skill Assessment", () => {
+				let meta = frappe.get_meta("Skill Assessment");
+				let fields = meta.fields.map((field) => {
+					return {
+						fieldtype: field.fieldtype,
+						fieldname: field.fieldname,
+						label: field.label,
+						in_list_view: field.in_list_view,
+						reqd: field.reqd,
+						options: field.options,
+					};
+				});
+				resolve(fields);
+			});
+		});
 	},
 
 	interview_round: function (frm) {


### PR DESCRIPTION
Same problem described with #2929, with a better solution: Fetch the fields in child table using frappe.get_meta



