### PR TITLE
fix: Fix auto update last sync of checkin

### DIFF
--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -46,7 +46,7 @@ class TestShiftType(IntegrationTestCase):
 		date = getdate()
 		make_shift_assignment(shift_type.name, employee, date)
 
-		# case 1: last sync uodates from none to shift end after the shift end time
+		# case 1: last sync updates from none to shift end after the shift end time
 		frappe.flags.current_datetime = datetime.combine(getdate(), get_time("14:00:00"))
 		update_last_sync_of_checkin()
 		shift_type.reload()


### PR DESCRIPTION
#### Problem

Auto update job updates the last sync of the checkin to the time of the last checkin within the shift. These checkins themselves has their actual shift end time later than the last sync of checkin they just helped set. Only the checkins with actual shift end earlier than last sync of checkin are considered for attendance hence these checkins have to wait till the next day to get their attendance marked. 

#### Solution
Refactored the job to set the last sync of checkin to a minute later than current shifts actual end. 
Modified the test according to the new logic