### PR TITLE
chore: fix deprecated editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 dynamic = ["version"]
 
 [build-system]
-requires = ["flit_core >=3.4,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools >= 64","wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.frappe.testing.function_type_validation]
 max_module_depth = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ dynamic = ["version"]
 requires = ["setuptools >= 64","wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["hrms*", "roster*", "frontend*"]
+exclude = ["docker*"]
+
 [tool.frappe.testing.function_type_validation]
 max_module_depth = 0
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
When Gavin first discovered
https://github.com/frappe/bench/issues/1623

When it was confirmed
https://github.com/frappe/frappe/issues/31991

The deprecation post
https://github.com/pypa/pip/issues/11457

Configured for setuptools as referred here: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html