### PR TITLE
fix: allow creating half attendance from leave application or checkins

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -20,6 +20,7 @@
   "company",
   "department",
   "attendance_request",
+  "half_day_status",
   "details_section",
   "shift",
   "in_time",
@@ -202,13 +203,21 @@
   {
    "fieldname": "column_break_18",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.status==\"Half Day\";",
+   "fieldname": "half_day_status",
+   "fieldtype": "Select",
+   "label": "Status for Other Half",
+   "no_copy": 1,
+   "options": "\nPresent\nAbsent"
   }
  ],
  "icon": "fa fa-ok",
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 11:45:54.846562",
+ "modified": "2025-03-06 15:15:13.866304",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -33,6 +33,10 @@ class OverlappingShiftAttendanceError(frappe.ValidationError):
 
 
 class Attendance(Document):
+	def before_insert(self):
+		if self.half_day_status == "":
+			self.half_day_status = None
+
 	def validate(self):
 		from erpnext.controllers.status_updater import validate_status
 

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -87,7 +87,7 @@ class Attendance(Document):
 				& (Attendance.docstatus < 2)
 				& (Attendance.attendance_date == self.attendance_date)
 				& (Attendance.name != self.name)
-				& (Attendance.half_day_status.isnull())
+				& (Attendance.half_day_status.isnull() | (Attendance.half_day_status == ""))
 			)
 			.for_update()
 		)
@@ -293,6 +293,7 @@ def mark_attendance(
 	leave_type=None,
 	late_entry=False,
 	early_exit=False,
+	half_day_status=None,
 ):
 	savepoint = "attendance_creation"
 
@@ -309,6 +310,7 @@ def mark_attendance(
 				"leave_type": leave_type,
 				"late_entry": late_entry,
 				"early_exit": early_exit,
+				"half_day_status": half_day_status,
 			}
 		)
 		attendance.insert()
@@ -337,6 +339,7 @@ def mark_bulk_attendance(data):
 			"employee": data.employee,
 			"attendance_date": get_datetime(date),
 			"status": data.status,
+			"half_day_status": "Absent" if data.status == "Half Day" else None,
 		}
 		attendance = frappe.get_doc(doc_dict).insert()
 		attendance.submit()

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -87,7 +87,7 @@ class Attendance(Document):
 				& (Attendance.docstatus < 2)
 				& (Attendance.attendance_date == self.attendance_date)
 				& (Attendance.name != self.name)
-				& (Attendance.status == "Half Day" and Attendance.half_day_status != "Absent")
+				& (Attendance.half_day_status.isnull())
 			)
 			.for_update()
 		)

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -83,6 +83,7 @@ class Attendance(Document):
 				& (Attendance.docstatus < 2)
 				& (Attendance.attendance_date == self.attendance_date)
 				& (Attendance.name != self.name)
+				& (Attendance.status == "Half Day" and Attendance.half_day_status != "Absent")
 			)
 			.for_update()
 		)

--- a/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
@@ -39,6 +39,7 @@ class CompensatoryLeaveRequest(Document):
 			filters={
 				"attendance_date": ["between", (self.work_from_date, self.work_end_date)],
 				"status": ("in", ["Present", "Work From Home", "Half Day"]),
+				"half_day_status": ("!=", "Absent"),
 				"docstatus": 1,
 				"employee": self.employee,
 			},

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -273,7 +273,6 @@ def mark_attendance_and_link_log(
 
 
 def get_existing_half_day_attendance(employee, attendance_date):
-	print("does this even work")
 	attendance_name = frappe.db.exists(
 		"Attendance",
 		{
@@ -283,7 +282,7 @@ def get_existing_half_day_attendance(employee, attendance_date):
 			"half_day_status": "Absent",
 		},
 	)
-	print(attendance_name)
+
 	if attendance_name:
 		attendance_doc = frappe.get_doc("Attendance", attendance_name)
 		return attendance_doc

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -226,7 +226,9 @@ def mark_attendance_and_link_log(
 			if attendance_status == "Half Day" and (
 				attendance := get_existing_half_day_attendance(employee, attendance_date)
 			):
-				attendance.update(
+				frappe.db.set_value(
+					"Attendance",
+					attendance.name,
 					{
 						"half_day_status": "Present",
 						"working_hours": working_hours,
@@ -235,7 +237,7 @@ def mark_attendance_and_link_log(
 						"early_exit": early_exit,
 						"in_time": in_time,
 						"out_time": out_time,
-					}
+					},
 				)
 			else:
 				attendance = frappe.new_doc("Attendance")
@@ -271,6 +273,7 @@ def mark_attendance_and_link_log(
 
 
 def get_existing_half_day_attendance(employee, attendance_date):
+	print("does this even work")
 	attendance_name = frappe.db.exists(
 		"Attendance",
 		{
@@ -280,9 +283,10 @@ def get_existing_half_day_attendance(employee, attendance_date):
 			"half_day_status": "Absent",
 		},
 	)
+	print(attendance_name)
 	if attendance_name:
-		attenadance_doc = frappe.get_doc("Attendance", attendance_name)
-		return attenadance_doc
+		attendance_doc = frappe.get_doc("Attendance", attendance_name)
+		return attendance_doc
 	return None
 
 

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -273,7 +273,7 @@ def mark_attendance_and_link_log(
 def get_existing_half_day_attendance(employee, attendance_date):
 	attendance_name = frappe.db.exists(
 		"Attendance",
-		filters={
+		{
 			"employee": employee,
 			"attendance_date": attendance_date,
 			"status": "Half Day",

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -223,21 +223,37 @@ def mark_attendance_and_link_log(
 	elif attendance_status in ("Present", "Absent", "Half Day"):
 		try:
 			frappe.db.savepoint("attendance_creation")
-			attendance = frappe.new_doc("Attendance")
-			attendance.update(
-				{
-					"doctype": "Attendance",
-					"employee": employee,
-					"attendance_date": attendance_date,
-					"status": attendance_status,
-					"working_hours": working_hours,
-					"shift": shift,
-					"late_entry": late_entry,
-					"early_exit": early_exit,
-					"in_time": in_time,
-					"out_time": out_time,
-				}
-			).submit()
+			if attendance_status == "Half Day" and (
+				attendance := get_existing_half_day_attendance(employee, attendance_date)
+			):
+				attendance.update(
+					{
+						"half_day_status": "Present",
+						"working_hours": working_hours,
+						"shift": shift,
+						"late_entry": late_entry,
+						"early_exit": early_exit,
+						"in_time": in_time,
+						"out_time": out_time,
+					}
+				)
+			else:
+				attendance = frappe.new_doc("Attendance")
+				attendance.update(
+					{
+						"doctype": "Attendance",
+						"employee": employee,
+						"attendance_date": attendance_date,
+						"status": attendance_status,
+						"working_hours": working_hours,
+						"shift": shift,
+						"late_entry": late_entry,
+						"early_exit": early_exit,
+						"in_time": in_time,
+						"out_time": out_time,
+						"half_day_status": "Absent" if attendance_status == "Half Day" else None,
+					}
+				).submit()
 
 			if attendance_status == "Absent":
 				attendance.add_comment(
@@ -252,6 +268,22 @@ def mark_attendance_and_link_log(
 
 	else:
 		frappe.throw(_("{} is an invalid Attendance Status.").format(attendance_status))
+
+
+def get_existing_half_day_attendance(employee, attendance_date):
+	attendance_name = frappe.db.exists(
+		"Attendance",
+		filters={
+			"employee": employee,
+			"attendance_date": attendance_date,
+			"status": "Half Day",
+			"half_day_status": "Absent",
+		},
+	)
+	if attendance_name:
+		attenadance_doc = frappe.get_doc("Attendance", attendance_name)
+		return attenadance_doc
+	return None
 
 
 def calculate_working_hours(logs, check_in_out_type, working_hours_calc_type):

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -556,6 +556,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 				"attendance_date": ("between", [self.from_date, self.to_date]),
 				"status": ("in", ["Present", "Half Day", "Work From Home"]),
 				"docstatus": 1,
+				"half_day_status": ("!=", "Absent"),
 			},
 			fields=["name", "attendance_date"],
 			order_by="attendance_date",

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -263,8 +263,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 					employee=self.employee,
 					attendance_date=date,
 					docstatus=("!=", 2),
-					status=("in", ["Absent", "Half Day"]),
-					half_day_status=("in", ["Absent", "None"]),
 				),
 			)
 			# don't mark attendance for holidays
@@ -290,7 +288,11 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			# update existing attendance, change absent to on leave or half day
 			doc = frappe.get_doc("Attendance", attendance_name)
 			half_day_status = (
-				None if status == "On Leave" else "Absent" if doc.status == "Absent" else "On Leave"
+				None
+				if status == "On Leave"
+				else "Absent"
+				if (doc.status == "Absent" and status == "Half Day")
+				else "Present"
 			)
 			doc.db_set(
 				{

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -107,7 +107,6 @@ class ShiftType(Document):
 			return
 
 		logs = self.get_employee_checkins()
-
 		group_key = lambda x: (x["employee"], x["shift_start"])  # noqa
 		for key, group in groupby(sorted(logs, key=group_key), key=group_key):
 			single_shift_logs = list(group)


### PR DESCRIPTION
### Problem
If a half day attendance already exists from employee checkins, you couldn't create a leave application for the other half day and vice versa and have all the shift related information preserved.

-----

#### Before

https://github.com/user-attachments/assets/4ab4652d-8265-4950-89d4-d9e48a64b3c2

#### After


https://github.com/user-attachments/assets/4392c25e-67c7-4136-9438-0ee6fed3aa29


<img width="1032" alt="Screenshot 2025-04-10 at 12 14 04 PM" src="https://github.com/user-attachments/assets/1ed0f2e5-2f28-4236-bfad-ffb0cd6b4da3" />

