### PR TITLE
fix(income tax computation report): change CTC column label to Gross Earnings and update Total Taxabe Amount column value 

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -454,7 +454,7 @@ class IncomeTaxComputationReport:
 			else:
 				future_salary_slips = self.future_salary_slips.get(employee, [])
 				if future_salary_slips:
-					last_ss = future_salary_slips[-1]
+					last_ss = future_salary_slips[0]
 					annual_taxable_amount = last_ss.get("annual_taxable_amount", 0.0)
 					tax_exemption_declaration = last_ss.get("tax_exemption_declaration", 0.0)
 					standard_tax_exemption_amount = last_ss.get("standard_tax_exemption_amount", 0.0)

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -35,7 +35,7 @@ class IncomeTaxComputationReport:
 	def get_data(self):
 		self.get_employee_details()
 		self.get_future_salary_slips()
-		self.get_ctc()
+		self.get_gross_earnings()
 		self.get_income_from_other_sources()
 		self.get_tax_exempted_earnings_and_deductions()
 		self.get_employee_tax_exemptions()
@@ -176,7 +176,7 @@ class IncomeTaxComputationReport:
 
 		return last_salary_slip
 
-	def get_ctc(self):
+	def get_gross_earnings(self):
 		# Get total earnings from existing salary slip
 		ss = frappe.qb.DocType("Salary Slip")
 		existing_ss = frappe._dict(
@@ -194,9 +194,11 @@ class IncomeTaxComputationReport:
 		for employee, employee_details in self.employees.items():
 			opening_taxable_earnings = employee_details["taxable_earnings_till_date"]
 			future_ss_earnings = self.get_future_earnings(employee)
-			ctc = flt(opening_taxable_earnings) + flt(existing_ss.get(employee)) + future_ss_earnings
+			gross_earnings = (
+				flt(opening_taxable_earnings) + flt(existing_ss.get(employee)) + future_ss_earnings
+			)
 
-			self.employees[employee].setdefault("ctc", ctc)
+			self.employees[employee].setdefault("gross_earnings", gross_earnings)
 
 	def get_future_earnings(self, employee):
 		future_earnings = 0.0
@@ -430,12 +432,19 @@ class IncomeTaxComputationReport:
 
 	def get_total_taxable_amount(self):
 		self.add_column("Total Taxable Amount")
-		for __, emp_details in self.employees.items():
-			emp_details["total_taxable_amount"] = (
-				flt(emp_details.get("ctc"))
-				+ flt(emp_details.get("other_income"))
-				- flt(emp_details.get("total_exemption"))
-			)
+
+		for employee, emp_details in self.employees.items():
+			total_taxable_amount = 0.0
+			last_ss = self.get_last_salary_slip(employee)
+			if last_ss:
+				total_taxable_amount = frappe.db.get_value(
+					"Salary Slip", last_ss.name, "annual_taxable_amount"
+				)
+			else:
+				future_salary_slips = self.future_salary_slips.get(employee, [])
+				if future_salary_slips:
+					total_taxable_amount = future_salary_slips[-1].get("annual_taxable_amount", 0.0)
+			emp_details["total_taxable_amount"] = total_taxable_amount
 
 	def get_applicable_tax(self):
 		self.add_column("Income Tax (Slab Based)", "income_tax_slab_based")
@@ -535,9 +544,10 @@ class IncomeTaxComputationReport:
 		self.add_column("Payable Tax")
 
 		for __, emp_details in self.employees.items():
-			emp_details["payable_tax"] = flt(emp_details.get("applicable_tax")) - flt(
-				emp_details.get("total_tax_deducted")
-			)
+			payable_tax = flt(emp_details.get("applicable_tax")) - flt(emp_details.get("total_tax_deducted"))
+			if payable_tax < 0:
+				payable_tax = 0.0
+			emp_details["payable_tax"] = payable_tax
 
 	def add_column(self, label, fieldname=None, fieldtype=None, options=None, width=None):
 		col = {
@@ -586,5 +596,10 @@ class IncomeTaxComputationReport:
 				"options": "Income Tax Slab",
 				"width": "140px",
 			},
-			{"label": _("CTC"), "fieldname": "ctc", "fieldtype": "Currency", "width": "140px"},
+			{
+				"label": _("Gross Earnings"),
+				"fieldname": "gross_earnings",
+				"fieldtype": "Currency",
+				"width": "140px",
+			},
 		]

--- a/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
@@ -85,10 +85,10 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 			"professional_tax": 2400.0,
 			"standard_tax_exemption": 50000,
 			"total_exemption": 52400.0,
-			"total_taxable_amount": 883600.0,
-			"applicable_tax": 92789.0,
+			"total_taxable_amount": 881200.0,
+			"applicable_tax": 92290.0,
 			"total_tax_deducted": 17997.0,
-			"payable_tax": 74792,
+			"payable_tax": 74293.0,
 		}
 
 		for key, val in expected_data.items():
@@ -103,9 +103,9 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 			{
 				"_test_category": 100000.0,
 				"total_exemption": 152400.0,
-				"total_taxable_amount": 783600.0,
-				"applicable_tax": 71989.0,
-				"payable_tax": 53992.0,
+				"total_taxable_amount": 781200.0,
+				"applicable_tax": 71490.0,
+				"payable_tax": 53493.0,
 			}
 		)
 

--- a/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
@@ -81,7 +81,7 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 			"employee_name": "employee_tax_computation@example.com",
 			"department": "All Departments",
 			"income_tax_slab": self.income_tax_slab,
-			"ctc": 936000.0,
+			"gross_earnings": 936000.0,
 			"professional_tax": 2400.0,
 			"standard_tax_exemption": 50000,
 			"total_exemption": 52400.0,


### PR DESCRIPTION
- Rename the **CTC** column to **Gross Earnings** to reflect the data it represents, which is a **sum of gross pay from salary slips and opening taxable earnings**(if configured in Salary Structure Assignment). 
- Update the **Total Taxable Amount** calculation in the Income Tax Computation Report to use the **annual_taxable_amount** from the last salary slip (since this accounts for tax applicable and exempted components, etc), and deduct any exemptions factored into it (standard + proof/declaration). 
    - This enables the report to reapply exemption logic correctly based on whether declarations or proofs are considered. 
    - When report is accessed mid-year when proof submissions may not yet be available and relying directly on salary slip values would result in missing exemptions as final salary slip only considers proof submissions as exemption.
    - Previously, the report calculated taxable amount by deducting exemptions from gross pay + opening taxable earnings, leading to incorrect taxable amount