### PR TITLE
fix: set payroll date to none before validating if additional salary is recurring

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -11,6 +11,10 @@ from hrms.hr.utils import validate_active_employee
 
 
 class AdditionalSalary(Document):
+	def before_validate(self):
+		if self.payroll_date and self.is_recurring:
+			self.payroll_date = None
+
 	def on_submit(self):
 		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral()


### PR DESCRIPTION
#### Problem
Duplicate salary validation on payroll date is not required for recurring additional salary.
If payroll date was set in additional salary and changed to recurring or if recurring salary is duplicated from a salary that had payroll date set, it incorrectly throws a validation error.

#### Fix
Set payroll date to None is salary is recurring before validating