### PR TITLE
fix: none checks for non-mandatory fields in validation

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -66,8 +66,8 @@ class ShiftType(Document):
 	) -> int:
 		return (
 			(round(time_diff(shift_end, shift_start).total_seconds() / 60))
-			+ self.allow_check_out_after_shift_end_time
-			+ self.begin_check_in_before_shift_start_time
+			+ (self.allow_check_out_after_shift_end_time or 0)
+			+ (self.begin_check_in_before_shift_start_time or 0)
 		)
 
 	def get_max_shift_buffer_label(self) -> str:


### PR DESCRIPTION
`allow_check_out_after_shift_end_time` and `begin_check_in_before_shift_start_time` are used in validations but aren't mandatory, put None type checks to avoid getting error if those fields aren't set. 