### PR TITLE
fix: handle ZeroDivisionError for float division by zero

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1518,10 +1518,11 @@ class SalarySlip(TransactionBase):
 			self.whitelisted_globals,
 			eval_locals,
 		)
-
-		self.current_structured_tax_amount = (
-			self.total_structured_tax_amount - self.previous_total_paid_taxes
-		) / self.remaining_sub_periods
+		self.current_structured_tax_amount=0
+		if self.remaining_sub_periods:
+			self.current_structured_tax_amount = (
+				self.total_structured_tax_amount - self.previous_total_paid_taxes
+			) / self.remaining_sub_periods
 
 		# Total taxable earnings with additional earnings with full tax
 		self.full_tax_on_additional_earnings = 0.0


### PR DESCRIPTION
Fix: ZeroDivisionError in Payroll on "Create Salary Slip" due to remaining_sub_periods = 0

Issue:

This pull request fixes an error in the Payroll module that occurs when creating a salary slip in the following scenario:

- The employee’s relieving date is 01-04-2025  
- The payroll period is from 01-04-2025 to 31-03-2026  
- The payroll frequency is set to Monthly  

In this case, the get_period_factor method in payroll_period.py returns 0 for remaining_sub_periods.

This causes a ZeroDivisionError at the following line in the Salary Slip:


self.current_structured_tax_amount = (
	self.total_structured_tax_amount - self.previous_total_paid_taxes
) / self.remaining_sub_periods


Fix:

A condition has been added to ensure that the division only takes place when remaining_sub_periods is greater than 0. This prevents the division by zero error.