### PR TITLE
fix: allow creating two half day leave applications

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -574,7 +574,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			filters={
 				"employee": self.employee,
 				"attendance_date": ("between", [self.from_date, self.to_date]),
-				"status": ("in", ["Present", "Half Day", "Work From Home"]),
+				"status": ("in", ["Present", "Work From Home"]),
 				"docstatus": 1,
 				"half_day_status": ("!=", "Absent"),
 			},


### PR DESCRIPTION
Reverts this behaviour for half day #2863, since a lot of people create two half day leave applications.