### PR TITLE
fix: added max height and scroll on expenses drawer

### DIFF
--- a/frontend/src/components/ExpensesTable.vue
+++ b/frontend/src/components/ExpensesTable.vue
@@ -74,8 +74,8 @@
 						{{ modalTitle }}
 					</span>
 				</div>
-				<div class="w-full flex flex-col items-center justify-center gap-5 p-4">
-					<div class="flex flex-col w-full space-y-4">
+				<div class="w-full flex flex-col items-center justify-center gap-5 p-4 max-h-[80vh]">
+					<div class="flex flex-col w-full space-y-4 overflow-y-auto">
 						<FormField
 							v-for="field in expensesTableFields.data"
 							:key="field.fieldname"


### PR DESCRIPTION
For when there are too many custom fields

#### Before

https://github.com/user-attachments/assets/81cd0539-44cc-4d4e-9277-fd90eda2ee6d

#### After

https://github.com/user-attachments/assets/e0b6d2f9-1be2-456e-84cf-0976289924e5

