### PR TITLE
fix: Correct PostgreSQL SQL generation for string literals and boolean conditions

### DIFF
--- a/hrms/patches/post_install/move_payroll_setting_separately_from_hr_settings.py
+++ b/hrms/patches/post_install/move_payroll_setting_separately_from_hr_settings.py
@@ -10,17 +10,17 @@ def execute():
 		"""SELECT *
         FROM `tabSingles`
         WHERE
-            doctype = "HR Settings"
+            doctype = 'HR Settings'
         AND
             field in (
-                "encrypt_salary_slips_in_emails",
-                "email_salary_slip_to_employee",
-                "daily_wages_fraction_for_half_day",
-                "disable_rounded_total",
-                "include_holidays_in_total_working_days",
-                "max_working_hours_against_timesheet",
-                "payroll_based_on",
-                "password_policy"
+                'encrypt_salary_slips_in_emails',
+                'email_salary_slip_to_employee',
+                'daily_wages_fraction_for_half_day',
+                'disable_rounded_total',
+                'include_holidays_in_total_working_days',
+                'max_working_hours_against_timesheet',
+                'payroll_based_on',
+                'password_policy'
             )
             """,
 		as_dict=1,

--- a/hrms/patches/post_install/update_employee_advance_status.py
+++ b/hrms/patches/post_install/update_employee_advance_status.py
@@ -10,7 +10,7 @@ def execute():
 		.set(advance.status, "Returned")
 		.where(
 			(advance.docstatus == 1)
-			& ((advance.return_amount) & (advance.paid_amount == advance.return_amount))
+			& ((advance.return_amount.notnull() & advance.return_amount > 0) & (advance.paid_amount == advance.return_amount))
 			& (advance.status == "Paid")
 		)
 	).run()
@@ -21,7 +21,7 @@ def execute():
 		.where(
 			(advance.docstatus == 1)
 			& (
-				(advance.claimed_amount & advance.return_amount)
+				((advance.claimed_amount.notnull() & advance.claimed_amount > 0) & (advance.return_amount.notnull() & advance.return_amount > 0))
 				& (advance.paid_amount == (advance.return_amount + advance.claimed_amount))
 			)
 			& (advance.status == "Paid")


### PR DESCRIPTION
#### **Issue 1: Incorrect String Literals**
**Problem**: Using `""` for values (e.g., `some_col = "some_val"`) causes PostgreSQL to interpret `"some_val"` as a column identifier, not a string value.

**Solution**:
- Replace double quotes (`"`) with single quotes (`'`) for string literals in SQL queries.


#### **Issue 2: Invalid Boolean Logic**
**Problem**: SQL clauses like `WHERE ... AND "return_amount"` are invalid because `return_amount` is not a boolean expression.

**Solution**:
- Explicitly define boolean conditions (e.g., check for non-null values or comparisons).
- Replace ambiguous bitwise operations (`&`) with explicit boolean logic.

Closes #1814 