### PR TITLE
feat: tax relief or rebate configuration

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -273,6 +273,7 @@ regional_overrides = {
 	"India": {
 		"hrms.hr.utils.calculate_annual_eligible_hra_exemption": "hrms.regional.india.utils.calculate_annual_eligible_hra_exemption",
 		"hrms.hr.utils.calculate_hra_exemption_for_period": "hrms.regional.india.utils.calculate_hra_exemption_for_period",
+		"hrms.hr.utils.calculate_tax_with_marginal_relief": "hrms.regional.india.utils.calculate_tax_with_marginal_relief",
 	},
 }
 

--- a/hrms/hr/report/project_profitability/test_project_profitability.py
+++ b/hrms/hr/report/project_profitability/test_project_profitability.py
@@ -18,6 +18,9 @@ class TestProjectProfitability(IntegrationTestCase):
 		frappe.db.delete("Timesheet")
 		emp = make_employee("test_employee_9@salary.com", company="_Test Company")
 
+		frappe.db.set_single_value("HR Settings", "standard_working_hours", 8)
+		frappe.db.set_single_value("Payroll Settings", "include_holidays_in_total_working_days", 0)
+
 		if not frappe.db.exists("Salary Component", "Timesheet Component"):
 			frappe.get_doc(
 				{"doctype": "Salary Component", "salary_component": "Timesheet Component"}
@@ -29,27 +32,19 @@ class TestProjectProfitability(IntegrationTestCase):
 		activity_type = create_activity_type("_Test Employee Timesheet")
 		self.timesheet = make_timesheet(emp, is_billable=1, activity_type=activity_type)
 		self.salary_slip = make_salary_slip_from_timesheet(self.timesheet.name)
-		self.salary_slip.start_date = self.timesheet.start_date
-
-		holidays = self.salary_slip.get_holidays_for_employee(date, date)
-		if holidays:
-			frappe.db.set_single_value("Payroll Settings", "include_holidays_in_total_working_days", 1)
-
 		self.salary_slip.submit()
+
 		self.sales_invoice = make_sales_invoice(
 			self.timesheet.name, "_Test Item", "_Test Customer", currency="INR"
 		)
 		self.sales_invoice.due_date = date
 		self.sales_invoice.submit()
 
-		frappe.db.set_single_value("HR Settings", "standard_working_hours", 8)
-		frappe.db.set_single_value("Payroll Settings", "include_holidays_in_total_working_days", 0)
-
 	def test_project_profitability(self):
 		filters = {
 			"company": "_Test Company",
 			"start_date": add_days(self.timesheet.start_date, -3),
-			"end_date": self.timesheet.start_date,
+			"end_date": add_days(self.timesheet.end_date, 1),
 		}
 
 		report = execute(filters)

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -643,6 +643,13 @@ def calculate_hra_exemption_for_period(doc):
 	return {}
 
 
+@erpnext.allow_regional
+def calculate_tax_with_marginal_relief(tax_slab, tax_amount, annual_taxable_earning):
+	# Don't delete this method, used for localization
+	# Indian TDS Calculation
+	return None
+
+
 def get_previous_claimed_amount(employee, payroll_period, non_pro_rata=False, component=False):
 	total_claimed_amount = 0
 	query = """
@@ -926,6 +933,6 @@ def get_exact_month_diff(string_ed_date: DateTimeLikeObject, string_st_date: Dat
 	# count the last month only if end date's day > start date's day
 	# to handle cases like 16th Jul 2024 - 15th Jul 2025
 	# where framework's month_diff will calculate diff as 13 months
-	if ed_date.day > st_date.day:
+	if ed_date.day == st_date.day:
 		diff += 1
 	return diff

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -933,6 +933,6 @@ def get_exact_month_diff(string_ed_date: DateTimeLikeObject, string_st_date: Dat
 	# count the last month only if end date's day > start date's day
 	# to handle cases like 16th Jul 2024 - 15th Jul 2025
 	# where framework's month_diff will calculate diff as 13 months
-	if ed_date.day == st_date.day:
+	if ed_date.day > st_date.day:
 		diff += 1
 	return diff

--- a/hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+++ b/hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
@@ -113,7 +113,7 @@
    "description": "Maximum annual taxable income eligible for full tax relief. No tax is applied if income does not exceed this limit",
    "fieldname": "tax_relief_limit",
    "fieldtype": "Currency",
-   "label": "Taxable Income Relief Threshold"
+   "label": "Taxable Income Relief Threshold Limit"
   },
   {
    "fieldname": "section_break_cajo",
@@ -126,7 +126,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-02 03:37:39.606769",
+ "modified": "2025-05-05 22:16:48.257971",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Income Tax Slab",

--- a/hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+++ b/hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "autoname": "Prompt",
  "creation": "2020-03-17 16:50:35.564915",
  "doctype": "DocType",
@@ -17,6 +18,9 @@
   "amended_from",
   "taxable_salary_slabs_section",
   "slabs",
+  "section_break_cajo",
+  "tax_relief_limit",
+  "column_break_pdmy",
   "taxes_and_charges_on_income_tax_section",
   "other_taxes_and_charges"
  ],
@@ -104,11 +108,25 @@
   {
    "fieldname": "section_break_2",
    "fieldtype": "Section Break"
+  },
+  {
+   "description": "Maximum annual taxable income eligible for full tax relief. No tax is applied if income does not exceed this limit",
+   "fieldname": "tax_relief_limit",
+   "fieldtype": "Currency",
+   "label": "Taxable Income Relief Threshold"
+  },
+  {
+   "fieldname": "section_break_cajo",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_pdmy",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:50.523690",
+ "modified": "2025-05-02 03:37:39.606769",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Income Tax Slab",
@@ -161,6 +179,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2152,32 +2152,34 @@ def get_payroll_payable_account(company, payroll_entry):
 
 
 def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=None, eval_locals=None):
-	eval_locals.update({"annual_taxable_earning": annual_taxable_earning})
 	tax_amount = 0
 	other_taxes_and_charges = 0
 
-	for slab in tax_slab.slabs:
-		cond = cstr(slab.condition).strip()
-		if cond and not eval_tax_slab_condition(cond, eval_globals, eval_locals):
-			continue
-		if not slab.to_amount and annual_taxable_earning >= slab.from_amount:
-			tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
-			continue
+	if annual_taxable_earning > tax_slab.tax_relief_limit:
+		eval_locals.update({"annual_taxable_earning": annual_taxable_earning})
 
-		if annual_taxable_earning >= slab.from_amount and annual_taxable_earning < slab.to_amount:
-			tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
-		elif annual_taxable_earning >= slab.from_amount and annual_taxable_earning >= slab.to_amount:
-			tax_amount += (slab.to_amount - slab.from_amount + 1) * slab.percent_deduction * 0.01
+		for slab in tax_slab.slabs:
+			cond = cstr(slab.condition).strip()
+			if cond and not eval_tax_slab_condition(cond, eval_globals, eval_locals):
+				continue
+			if not slab.to_amount and annual_taxable_earning >= slab.from_amount:
+				tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
+				continue
 
-	for d in tax_slab.other_taxes_and_charges:
-		if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:
-			continue
+			if annual_taxable_earning >= slab.from_amount and annual_taxable_earning < slab.to_amount:
+				tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
+			elif annual_taxable_earning >= slab.from_amount and annual_taxable_earning >= slab.to_amount:
+				tax_amount += (slab.to_amount - slab.from_amount + 1) * slab.percent_deduction * 0.01
 
-		if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
-			continue
+		for d in tax_slab.other_taxes_and_charges:
+			if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:
+				continue
 
-		other_taxes_and_charges += tax_amount * flt(d.percent) / 100
-		tax_amount += other_taxes_and_charges
+			if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
+				continue
+
+			other_taxes_and_charges += tax_amount * flt(d.percent) / 100
+			tax_amount += other_taxes_and_charges
 
 	return tax_amount, other_taxes_and_charges
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2152,6 +2152,8 @@ def get_payroll_payable_account(company, payroll_entry):
 
 
 def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=None, eval_locals=None):
+	from hrms.hr.utils import calculate_tax_with_marginal_relief
+
 	tax_amount = 0
 	other_taxes_and_charges = 0
 
@@ -2170,6 +2172,12 @@ def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=Non
 				tax_amount += (annual_taxable_earning - slab.from_amount + 1) * slab.percent_deduction * 0.01
 			elif annual_taxable_earning >= slab.from_amount and annual_taxable_earning >= slab.to_amount:
 				tax_amount += (slab.to_amount - slab.from_amount + 1) * slab.percent_deduction * 0.01
+
+		tax_with_marginal_relief = calculate_tax_with_marginal_relief(
+			tax_slab, tax_amount, annual_taxable_earning
+		)
+		if tax_with_marginal_relief is not None:
+			tax_amount = tax_with_marginal_relief
 
 		for d in tax_slab.other_taxes_and_charges:
 			if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:

--- a/hrms/payroll/report/income_tax_deductions/test_income_tax_deductions.py
+++ b/hrms/payroll/report/income_tax_deductions/test_income_tax_deductions.py
@@ -59,7 +59,7 @@ class TestIncomeTaxDeductions(IntegrationTestCase):
 			"employee_name": "test_tax_deductions@example.com",
 			"it_comp": "TDS",
 			"posting_date": posting_date,
-			"it_amount": 6964.0,
+			"it_amount": 7732.0,
 			"gross_pay": 78000.0,
 			"pan_number": None,
 		}

--- a/hrms/payroll/report/income_tax_deductions/test_income_tax_deductions.py
+++ b/hrms/payroll/report/income_tax_deductions/test_income_tax_deductions.py
@@ -36,6 +36,7 @@ class TestIncomeTaxDeductions(IntegrationTestCase):
 		)
 
 		cls.payroll_period = create_payroll_period(name="_Test Payroll Period 1", company="_Test Company")
+		frappe.db.set_single_value("Payroll Settings", "consider_unmarked_attendance_as", "Present")
 		salary_structure = make_salary_structure(
 			"Monthly Salary Structure Test Income Tax Deduction",
 			"Monthly",
@@ -58,7 +59,7 @@ class TestIncomeTaxDeductions(IntegrationTestCase):
 			"employee_name": "test_tax_deductions@example.com",
 			"it_comp": "TDS",
 			"posting_date": posting_date,
-			"it_amount": 7732.0,
+			"it_amount": 6964.0,
 			"gross_pay": 78000.0,
 			"pan_number": None,
 		}

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -230,6 +230,16 @@ def get_custom_fields():
 				"depends_on": "house_rent_payment_amount",
 			},
 		],
+		"Income Tax Slab": [
+			{
+				"fieldname": "marginal_relief_limit",
+				"label": "Marginal Relief Income Threshold",
+				"fieldtype": "Currency",
+				"description": "Maximum taxable income for which marginal relief can be applied. Beyond this limit, normal tax slabs are used for tax calculation.",
+				"insert_after": "column_break_pdmy",
+				"depends_on": "eval:doc.tax_relief_limit > 0",
+			}
+		],
 	}
 
 

--- a/hrms/regional/india/setup.py
+++ b/hrms/regional/india/setup.py
@@ -233,7 +233,7 @@ def get_custom_fields():
 		"Income Tax Slab": [
 			{
 				"fieldname": "marginal_relief_limit",
-				"label": "Marginal Relief Income Threshold",
+				"label": "Marginal Relief Threshold Limit",
 				"fieldtype": "Currency",
 				"description": "Maximum taxable income for which marginal relief can be applied. Beyond this limit, normal tax slabs are used for tax calculation.",
 				"insert_after": "column_break_pdmy",

--- a/hrms/regional/india/utils.py
+++ b/hrms/regional/india/utils.py
@@ -203,3 +203,20 @@ def calculate_hra_exemption_for_period(doc):
 		exemptions["monthly_house_rent"] = monthly_rent
 		exemptions["total_eligible_hra_exemption"] = eligible_hra
 		return exemptions
+
+
+def calculate_tax_with_marginal_relief(tax_slab, tax_amount, annual_taxable_earning):
+	"""
+	Returns the tax payable after applying marginal relief (if applicable).
+	    If taxable income is between tax relief limit and marginal relief limit, and tax payable on income is more than income excess over tax relief, then tax payable is reduced to just the excess income.
+	"""
+	tax_relief_limit = tax_slab.tax_relief_limit or 0
+	marginal_relief_limit = tax_slab.marginal_relief_limit or 0
+
+	if annual_taxable_earning > tax_relief_limit and annual_taxable_earning < marginal_relief_limit:
+		income_excess_over_tax_relief = annual_taxable_earning - tax_slab.tax_relief_limit
+
+		if income_excess_over_tax_relief < tax_amount:
+			return income_excess_over_tax_relief  # marginal relief applies
+
+	return tax_amount


### PR DESCRIPTION
- Add **Taxable Income Relief Threshold** field to Income Tax Slab doctype.
   - This field holds the **maximum annual taxable income eligible for full tax relief.** No tax is applied(tax configured in slab) if the taxable income is less than this.
   - Even if this isn't set, slab specific conditions, if any (eg: annual_taxable_income > X) will be applied
  
  
- Regional change - India
   - Add **Marginal Relief Income Threshold** field to account for marginal tax relief under Section 87A
   - Marginal relief is for those earning slightly more to prevent a situation where a small increase in income leads to a disproportionately large increase in tax liability.
   - Users can configure **Taxable Income Relief Threshold** and **Marginal Relief Income Threshold** and if taxable income is between tax relief limit and marginal relief limit, and tax payable on income is more than income excess over tax relief cap, then tax payable is reduced to just the excess income.
   
**Before:**
<img width="1019" alt="Screenshot 2025-05-02 at 6 02 18 PM" src="https://github.com/user-attachments/assets/65ff6be6-8739-45f6-90db-9dbff18ef12b" />


**After**
<img width="1020" alt="Screenshot 2025-05-02 at 6 03 02 PM" src="https://github.com/user-attachments/assets/8bb1ce78-e64a-4e2b-b972-83c196375817" />


**Configure in Income Tax Slab**
<img width="1010" alt="Screenshot 2025-05-02 at 7 02 47 PM" src="https://github.com/user-attachments/assets/0ad1f52e-08b5-455c-b311-ff43760e105b" />

`no-docs`