### PR TITLE
fix: HRMS Link value reset on search

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -43,7 +43,8 @@ const searchText = ref("")
 const value = computed({
 	get: () => props.modelValue,
 	set: (val) => {
-		emit("update:modelValue", val?.value || "")
+		const newVal = (val && typeof val === "object" && val.value !== undefined) ? val.value : val
+		emit("update:modelValue", newVal || "")
 	},
 })
 
@@ -77,10 +78,13 @@ const reloadOptions = (searchTextVal) => {
 }
 
 const handleQueryUpdate = debounce((newQuery) => {
-	const val = newQuery || ""
-	if (searchText.value === val) return
-	searchText.value = val
-	reloadOptions(val)
+    const val = newQuery || ""
+
+    if (val === "" && props.modelValue) return
+
+    if (searchText.value === val) return
+    searchText.value = val
+    reloadOptions(val)
 }, 300)
 
 watch(


### PR DESCRIPTION
## Links in HRMS App reset their value after performing a search

This fix modifies the `handleQueryUpdate` function and the value setter for the Link.

---

### Before

#### Value Setter

```js
// Links.vue
set: (val) => {
    emit("update:modelValue", val?.value || "")
},
```

The setter always emitted `val?.value` or an empty string, assuming that the `val` is always an object with a `value` property.

#### Query Handler

```js
const handleQueryUpdate = debounce((newQuery) => {
    const val = newQuery || ""
    if (searchText.value === val) return
    searchText.value = val
    reloadOptions(val)
}, 300)
```

The options would reload on a query change, including when the query was cleared after a selection.

---

### After

#### Value Setter

```js
set: (val) => {
    const newVal = (val && typeof val === 'object' && val.value !== undefined) ? val.value : val
    emit("update:modelValue", newVal || "")
},
```

The setter now checks if `val` is an object with a `value` property, otherwise falls back to using `val`.

#### Query Handler

```js
const handleQueryUpdate = debounce((newQuery) => {
    const val = newQuery || ""

    if (val === "" && props.modelValue) return

    if (searchText.value === val) return
    searchText.value = val
    reloadOptions(val)
}, 300)
```

Now, if the query is cleared (`val === ""`) and a value is directly selected (`props.modelValue`), the options will not be reloaded. This prevents unnecessary reloads.

---

### Summary

- **Old Behaviour:**  
  After selecting a result, the Autocomplete would sometimes trigger the `handleQueryUpdate` function again with an empty value, causing the options to reload and potentially clearing the selection.

- **New Behaviour:**  
  With the added check (`if (val === "" && props.modelValue) return`), the component now ignores these redundant updates, preventing unnecessary reloads and persisting the value after selection.

---

Closes #3037