### PR TITLE
feat: update half day attendance from employee tool

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -24,7 +24,15 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	company(frm) {
 		frm.trigger("load_employees");
 	},
-
+	employement_type(frm) {
+		frm.trigger("load_employees");
+	},
+	designation(frm) {
+		frm.trigger("load_employees");
+	},
+	employee_grade(frm) {
+		frm.trigger("load_employees");
+	},
 	status(frm) {
 		frm.trigger("set_primary_action");
 	},
@@ -38,7 +46,6 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
 	load_employees(frm) {
 		if (!frm.doc.date) return;
-
 		frappe
 			.call({
 				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
@@ -47,11 +54,18 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					department: frm.doc.department,
 					branch: frm.doc.branch,
 					company: frm.doc.company,
+					employment_type: frm.employement_type,
+					designation: frm.doc.designation,
+					employee_grade: frm.doc.employee_grade,
 				},
+				freeze: true,
+				freeze_message: __("...Feching Employees"),
 			})
 			.then((r) => {
-				frm.employees = r.message["unmarked"];
-
+				frm.no_employees_to_mark =
+					r.message["unmarked"].length > 0 || r.message["half_day_marked"].length > 0
+						? false
+						: true;
 				if (r.message["unmarked"].length > 0) {
 					unhide_field("unmarked_attendance_section");
 					unhide_field("attendance_details_section");
@@ -60,7 +74,13 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					hide_field("unmarked_attendance_section");
 					hide_field("attendance_details_section");
 				}
-
+				if (r.message["half_day_marked"].length > 0) {
+					unhide_field("half_day_attendance_section");
+					unhide_field("attendance_details_section");
+					frm.events.show_half_marked_employees(frm, r.message["half_day_marked"]);
+				} else {
+					hide_field("half_day_attendance_section");
+				}
 				if (r.message["marked"].length > 0) {
 					unhide_field("marked_attendance_html");
 					frm.events.show_marked_employees(frm, r.message["marked"]);
@@ -71,54 +91,151 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	},
 
 	show_unmarked_employees(frm, unmarked_employees) {
-		const $wrapper = frm.get_field("employees_html").$wrapper;
-		$wrapper.empty();
-		const employee_wrapper = $(`<div class="employee_wrapper">`).appendTo($wrapper);
-
-		frm.employees_multicheck = frappe.ui.form.make_control({
-			parent: employee_wrapper,
-			df: {
-				fieldname: "employees_multicheck",
-				fieldtype: "MultiCheck",
-				select_all: true,
-				columns: 4,
-				get_data: () => {
-					return unmarked_employees.map((employee) => {
-						return {
-							label: `${employee.employee} : ${employee.employee_name}`,
-							value: employee.employee,
-							checked: 0,
-						};
-					});
-				},
-			},
-			render_input: true,
-		});
-
-		frm.employees_multicheck.refresh_input();
+		no_data_message = __(
+			"Attendance for all the employees under this criteria has been marked already.",
+		);
+		frm.events.render_employees_datatable(
+			frm,
+			unmarked_employees,
+			"unmarked_employees_html",
+			"unmarked_employees_table",
+			no_data_message,
+			frm.events.get_columns_for_unmarked_employees_table,
+		);
 	},
-
+	show_half_marked_employees(frm, half_marked_employees) {
+		no_data_message = __(
+			"Half Day Status for all the employees under this criteria has been marked already.",
+		);
+		frm.events.render_employees_datatable(
+			frm,
+			half_marked_employees,
+			"half_marked_employees_html",
+			"half_marked_employees_table",
+			no_data_message,
+			frm.events.get_columns_for_half_marked_employees_table,
+		);
+	},
+	render_employees_datatable(
+		frm,
+		employees,
+		html_field_name,
+		datatable_name,
+		no_data_message,
+		get_columns_callback,
+	) {
+		const $wrapper = frm.get_field(html_field_name).$wrapper;
+		const employee_wrapper = $(`<div class="employee_wrapper">`).appendTo($wrapper);
+		const columns = get_columns_callback();
+		const data = employees.map((entry) => {
+			return Object.values(entry);
+		});
+		if (!frm.get_field(datatable_name)) {
+			const datatable_options = {
+				columns: columns,
+				data: data,
+				checkboxColumn: true,
+				serialNoColumn: false,
+				checkedRowStatus: false,
+				dynamicRowHeight: true,
+				inlineFilters: true,
+				layout: "fixed",
+				cellHeight: 35,
+				noDataMessage: __(no_data_message),
+				disableReorderColumn: true,
+			};
+			frm.fields_dict[datatable_name] = new frappe.DataTable(
+				employee_wrapper.get(0),
+				datatable_options,
+			);
+		} else {
+			frm.get_field(datatable_name).rowmanager.checkMap = [];
+			frm.get_field(datatable_name).refresh(data, columns);
+		}
+	},
 	show_marked_employees(frm, marked_employees) {
 		const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
 		const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
-
+		const columns = frm.events.get_columns_for_marked_attendance_table(frm);
 		const data = marked_employees.map((entry) => {
 			return [`${entry.employee} : ${entry.employee_name}`, entry.status];
 		});
-
-		frm.events.render_datatable(frm, data, summary_wrapper);
+		frm.events.render_marked_employee_datatable(frm, data, summary_wrapper, columns);
 	},
 
-	render_datatable(frm, data, summary_wrapper) {
-		const columns = frm.events.get_columns_for_marked_attendance_table(frm);
-
+	get_columns_for_unmarked_employees_table() {
+		return [
+			{
+				name: "employee",
+				id: "employee",
+				content: __("Employee"),
+			},
+			{
+				name: "employee_name",
+				id: "employee_name",
+				content: __("Employee Name"),
+			},
+			{
+				name: "company",
+				id: "company",
+				content: __("Company"),
+			},
+			{
+				name: "department",
+				id: "department",
+				content: __("Department"),
+			},
+		].map((x) => ({
+			...x,
+			editable: false,
+			focusable: false,
+			dropdown: false,
+			align: "left",
+			width: 200,
+		}));
+	},
+	get_columns_for_half_marked_employees_table() {
+		return [
+			{
+				name: "employee",
+				id: "employee",
+				content: __("Employee"),
+			},
+			{
+				name: "employee_name",
+				id: "employee_name",
+				content: __("Name"),
+			},
+			{
+				name: "status",
+				id: "status",
+				content: __("Status"),
+				format: (value) => {
+					return `<span style="color:orange">${__(value)}</span>`;
+				},
+			},
+			{
+				name: "leave_type",
+				id: "leave_type",
+				content: __("Leave Type"),
+			},
+		].map((x) => ({
+			...x,
+			editable: false,
+			focusable: false,
+			dropdown: false,
+			align: "left",
+			width: 200,
+		}));
+	},
+	render_marked_employee_datatable(frm, data, summary_wrapper, columns) {
 		if (!frm.marked_emp_datatable) {
 			const datatable_options = {
 				columns: columns,
 				data: data,
 				dynamicRowHeight: true,
 				inlineFilters: true,
-				layout: "fluid",
+				layout: "fixed",
 				cellHeight: 35,
 				noDataMessage: __("No Data"),
 				disableReorderColumn: true,
@@ -131,29 +248,18 @@ frappe.ui.form.on("Employee Attendance Tool", {
 			frm.marked_emp_datatable.refresh(data, columns);
 		}
 	},
-
-	get_columns_for_marked_attendance_table(frm) {
+	get_columns_for_marked_attendance_table() {
 		return [
 			{
 				name: "employee",
 				id: "employee",
 				content: __("Employee"),
-				editable: false,
-				sortable: false,
-				focusable: false,
-				dropdown: false,
-				align: "left",
 				width: 350,
 			},
 			{
 				name: "status",
 				id: "status",
 				content: __("Status"),
-				editable: false,
-				sortable: false,
-				focusable: false,
-				dropdown: false,
-				align: "left",
 				width: 150,
 				format: (value) => {
 					if (value == "Present" || value == "Work From Home")
@@ -166,13 +272,20 @@ frappe.ui.form.on("Employee Attendance Tool", {
 						return `<span style="color:#318AD8">${__(value)}</span>`;
 				},
 			},
-		];
+		].map((x) => ({
+			...x,
+			editable: false,
+			sortable: false,
+			focusable: false,
+			dropdown: false,
+			align: "left",
+		}));
 	},
 
 	set_primary_action(frm) {
 		frm.disable_save();
 		frm.page.set_primary_action(__("Mark Attendance"), () => {
-			if (frm.employees.length === 0) {
+			if (frm.no_employees_to_mark) {
 				frappe.msgprint({
 					message: __(
 						"Attendance for all the employees under this criteria has been marked already.",
@@ -182,33 +295,61 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				});
 				return;
 			}
+			const unmarked_employees_check_map = frm.get_field("unmarked_employees_table")
+				.rowmanager.checkMap;
+			const half_day_employees_check_map = frm.get_field("half_marked_employees_table")
+				.rowmanager.checkMap;
+			const selected_employees_to_mark_full_day = [];
+			const selected_employees_to_mark_half_day = [];
+			unmarked_employees_check_map.forEach((is_checked, idx) => {
+				if (is_checked)
+					selected_employees_to_mark_full_day.push(
+						frm.get_field("unmarked_employees_table").datamanager.data[idx][0],
+					);
+			});
+			half_day_employees_check_map.forEach((is_checked, idx) => {
+				if (is_checked)
+					selected_employees_to_mark_half_day.push(
+						frm.get_field("half_marked_employees_table").datamanager.data[idx][0],
+					);
+			});
 
-			if (frm.employees_multicheck.get_checked_options().length === 0) {
+			if (
+				selected_employees_to_mark_full_day.length === 0 &&
+				selected_employees_to_mark_half_day.length === 0
+			) {
 				frappe.throw({
 					message: __("Please select the employees you want to mark attendance for."),
 					title: __("Mandatory"),
 				});
 			}
 
-			if (!frm.doc.status) {
+			if (selected_employees_to_mark_full_day.length > 0 && !frm.doc.status) {
 				frappe.throw({
 					message: __("Please select the attendance status."),
 					title: __("Mandatory"),
 				});
 			}
-
-			frm.trigger("mark_attendance");
+			if (selected_employees_to_mark_half_day.length > 0 && !frm.doc.half_day_status) {
+				frappe.throw({
+					message: __("Please select half day attendance status."),
+					title: __("Mandatory"),
+				});
+			}
+			if (selected_employees_to_mark_full_day.length > 0) {
+				frm.events.mark_full_day_attendance(frm, selected_employees_to_mark_full_day);
+			}
+			if (selected_employees_to_mark_half_day.length > 0)
+				frm.events.update_half_day_attendance(frm, selected_employees_to_mark_half_day);
 		});
 	},
 
-	mark_attendance(frm) {
-		const marked_employees = frm.employees_multicheck.get_checked_options();
-
+	mark_full_day_attendance(frm, employees_to_mark_full_day) {
 		frappe
 			.call({
 				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.mark_employee_attendance",
 				args: {
-					employee_list: marked_employees,
+					employee_list: employees_to_mark_full_day,
 					status: frm.doc.status,
 					date: frm.doc.date,
 					late_entry: frm.doc.late_entry,
@@ -222,6 +363,31 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				if (!r.exc) {
 					frappe.show_alert({
 						message: __("Attendance marked successfully"),
+						indicator: "green",
+					});
+					frm.refresh();
+				}
+			});
+	},
+	update_half_day_attendance(frm, employees_to_mark_half_day) {
+		frappe
+			.call({
+				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.update_half_day_attendance",
+				args: {
+					employee_list: employees_to_mark_half_day,
+					date: frm.doc.date,
+					late_entry: frm.doc.late_entry,
+					early_exit: frm.doc.early_exit,
+					shift: frm.doc.shift,
+					half_day_status: frm.doc.half_day_status,
+				},
+				freeze: true,
+				freeze_message: __("Marking Attendance"),
+			})
+			.then((r) => {
+				if (!r.exc) {
+					frappe.show_alert({
+						message: __("Attendance Updated successfully"),
 						indicator: "green",
 					});
 					frm.refresh();

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -336,15 +336,20 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					title: __("Mandatory"),
 				});
 			}
-			if (selected_employees_to_mark_full_day.length > 0) {
-				frm.events.mark_full_day_attendance(frm, selected_employees_to_mark_full_day);
+			if (
+				selected_employees_to_mark_full_day.length > 0 ||
+				selected_employees_to_mark_half_day > 0
+			) {
+				frm.events.mark_full_day_attendance(
+					frm,
+					selected_employees_to_mark_full_day,
+					selected_employees_to_mark_half_day,
+				);
 			}
-			if (selected_employees_to_mark_half_day.length > 0)
-				frm.events.update_half_day_attendance(frm, selected_employees_to_mark_half_day);
 		});
 	},
 
-	mark_full_day_attendance(frm, employees_to_mark_full_day) {
+	mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day) {
 		frappe
 			.call({
 				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.mark_employee_attendance",
@@ -355,6 +360,9 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					late_entry: frm.doc.late_entry,
 					early_exit: frm.doc.early_exit,
 					shift: frm.doc.shift,
+					mark_half_day: employees_to_mark_half_day.length ? true : false,
+					half_day_status: frm.doc.half_day_status,
+					half_day_employee_list: employees_to_mark_half_day,
 				},
 				freeze: true,
 				freeze_message: __("Marking Attendance"),
@@ -363,31 +371,6 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				if (!r.exc) {
 					frappe.show_alert({
 						message: __("Attendance marked successfully"),
-						indicator: "green",
-					});
-					frm.refresh();
-				}
-			});
-	},
-	update_half_day_attendance(frm, employees_to_mark_half_day) {
-		frappe
-			.call({
-				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.update_half_day_attendance",
-				args: {
-					employee_list: employees_to_mark_half_day,
-					date: frm.doc.date,
-					late_entry: frm.doc.late_entry,
-					early_exit: frm.doc.early_exit,
-					shift: frm.doc.shift,
-					half_day_status: frm.doc.half_day_status,
-				},
-				freeze: true,
-				freeze_message: __("Marking Attendance"),
-			})
-			.then((r) => {
-				if (!r.exc) {
-					frappe.show_alert({
-						message: __("Attendance Updated successfully"),
 						indicator: "green",
 					});
 					frm.refresh();

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -8,21 +8,24 @@
   "date",
   "section_break_ackd",
   "company",
-  "column_break_bhny",
-  "department",
-  "column_break_3",
   "branch",
-  "unmarked_attendance_section",
-  "employees_html",
+  "department",
+  "column_break_bhny",
+  "employment_type",
+  "designation",
+  "employee_grade",
   "attendance_details_section",
-  "status",
+  "shift",
   "late_entry",
   "early_exit",
-  "column_break_kecn",
-  "shift",
+  "unmarked_attendance_section",
+  "status",
+  "unmarked_employees_html",
+  "half_day_attendance_section",
+  "half_day_status",
+  "half_marked_employees_html",
   "marked_attendance_section",
-  "marked_attendance_html",
-  "column_break_khjs"
+  "marked_attendance_html"
  ],
  "fields": [
   {
@@ -38,10 +41,6 @@
    "options": "Department"
   },
   {
-   "fieldname": "column_break_3",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "branch",
    "fieldtype": "Link",
    "label": "Branch",
@@ -54,19 +53,15 @@
    "options": "Company"
   },
   {
-   "depends_on": "date",
-   "description": "Unmarked Attendance",
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:false",
+   "description": "Select employees and attendance status",
    "fieldname": "unmarked_attendance_section",
    "fieldtype": "Section Break",
-   "label": "Select Employees"
+   "label": "Unmarked Employees"
   },
   {
-   "fieldname": "employees_html",
-   "fieldtype": "HTML",
-   "label": "Employees HTML",
-   "read_only": 1
-  },
-  {
+   "collapsible": 1,
    "depends_on": "date",
    "fieldname": "marked_attendance_section",
    "fieldtype": "Section Break",
@@ -94,10 +89,8 @@
   },
   {
    "depends_on": "date",
-   "description": "Set attendance details for the employees select above",
    "fieldname": "attendance_details_section",
    "fieldtype": "Section Break",
-   "hide_border": 1,
    "label": "Set Attendance Details"
   },
   {
@@ -117,24 +110,61 @@
    "label": "Early Exit"
   },
   {
-   "fieldname": "column_break_kecn",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
    "options": "Shift Type"
   },
   {
-   "fieldname": "column_break_khjs",
-   "fieldtype": "Column Break"
+   "fieldname": "employment_type",
+   "fieldtype": "Link",
+   "label": "Employment Type",
+   "options": "Employment Type"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation"
+  },
+  {
+   "fieldname": "employee_grade",
+   "fieldtype": "Link",
+   "label": "Employee Grade",
+   "options": "Employee Grade"
+  },
+  {
+   "fieldname": "unmarked_employees_html",
+   "fieldtype": "HTML",
+   "label": "Unmarked Employees HTML",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:false",
+   "description": "Select employees and status for other half (attendance status is \"Half Day\" as created from leave application)",
+   "fieldname": "half_day_attendance_section",
+   "fieldtype": "Section Break",
+   "label": "Employees on Half Day"
+  },
+  {
+   "fieldname": "half_marked_employees_html",
+   "fieldtype": "HTML",
+   "label": "Employees on Half Day HTML"
+  },
+  {
+   "fieldname": "half_day_status",
+   "fieldtype": "Select",
+   "label": "Status for Other Half",
+   "options": "Present\nAbsent",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-08 20:02:36.408240",
+ "modified": "2025-05-05 10:44:35.922422",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Attendance Tool",
@@ -147,6 +177,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -96,9 +96,9 @@ def mark_employee_attendance(
 	late_entry: int | None = None,
 	early_exit: int | None = None,
 	shift: str | None = None,
-	mark_half_day=False,
-	half_day_status=None,
-	half_day_employee_list=None,
+	mark_half_day: bool | None = False,
+	half_day_status: str | None = None,
+	half_day_employee_list: list | str | None = None,
 ) -> None:
 	if isinstance(employee_list, str):
 		employee_list = json.loads(employee_list)

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -96,6 +96,9 @@ def mark_employee_attendance(
 	late_entry: int | None = None,
 	early_exit: int | None = None,
 	shift: str | None = None,
+	mark_half_day=False,
+	half_day_status=None,
+	half_day_employee_list=None,
 ) -> None:
 	if isinstance(employee_list, str):
 		employee_list = json.loads(employee_list)
@@ -119,28 +122,21 @@ def mark_employee_attendance(
 		)
 		attendance.insert()
 		attendance.submit()
+	if mark_half_day:
+		if isinstance(half_day_employee_list, str):
+			half_day_employee_list = json.loads(half_day_employee_list)
 
-
-@frappe.whitelist()
-def update_half_day_attendance(
-	employee_list: list | str,
-	date: str | datetime.date,
-	late_entry: int | None = None,
-	early_exit: int | None = None,
-	shift: str | None = None,
-	half_day_status: str | None = None,
-) -> None:
-	if isinstance(employee_list, str):
-		employee_list = json.loads(employee_list)
-
-	for employee in employee_list:
-		frappe.db.set_value(
-			"Attendance", {"employee": employee, "attendance_date": date}, "half_day_status", half_day_status
-		)
-		frappe.db.set_value(
-			"Attendance", {"employee": employee, "attendance_date": date}, "late_entry", late_entry
-		)
-		frappe.db.set_value(
-			"Attendance", {"employee": employee, "attendance_date": date}, "early_exit", early_exit
-		)
-		frappe.db.set_value("Attendance", {"employee": employee, "attendance_date": date}, "shift", shift)
+		for employee in half_day_employee_list:
+			frappe.db.set_value(
+				"Attendance",
+				{"employee": employee, "attendance_date": date},
+				"half_day_status",
+				half_day_status,
+			)
+			frappe.db.set_value(
+				"Attendance", {"employee": employee, "attendance_date": date}, "late_entry", late_entry
+			)
+			frappe.db.set_value(
+				"Attendance", {"employee": employee, "attendance_date": date}, "early_exit", early_exit
+			)
+			frappe.db.set_value("Attendance", {"employee": employee, "attendance_date": date}, "shift", shift)

--- a/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils import getdate
+from frappe.utils import add_days, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
@@ -12,7 +12,9 @@ from hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool import (
 	get_employees,
 	mark_employee_attendance,
 )
+from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
+from hrms.payroll.doctype.salary_slip.test_salary_slip import make_leave_application
 
 
 class TestEmployeeAttendanceTool(IntegrationTestCase):
@@ -66,3 +68,103 @@ class TestEmployeeAttendanceTool(IntegrationTestCase):
 		self.assertEqual(attendance.status, "Present")
 		self.assertEqual(attendance.shift, shift.name)
 		self.assertEqual(attendance.late_entry, 1)
+
+	def test_get_employees_for_half_day_attendance(self):
+		# only half day attendance created from leave type should be fetched to update in the tool
+		employee = frappe.get_doc("Employee", self.employee1)
+		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
+		frappe.get_doc(
+			{
+				"doctype": "Leave Allocation",
+				"employee": employee.name,
+				"employee_name": employee.employee_name,
+				"leave_type": leave_type.name,
+				"from_date": add_days(getdate(), -2),
+				"new_leaves_allocated": 15,
+				"carry_forward": 0,
+				"to_date": add_days(getdate(), 30),
+			}
+		).submit()
+		make_leave_application(
+			employee=employee,
+			from_date=getdate(),
+			to_date=getdate(),
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=getdate(),
+		)
+		mark_attendance(
+			self.employee2, attendance_date=getdate(), status="Half Day", half_day_status="Absent"
+		)
+		total_employees = get_employees(getdate(), company="_Test Company")
+		half_marked_employees = total_employees.get("half_day_marked")
+		self.assertEqual(len(half_marked_employees), 1)
+		self.assertEqual(half_marked_employees[0].get("employee_name"), employee.employee_name)
+
+	def test_update_half_day_attendance(self):
+		shift = setup_shift_type(
+			shift_type="Test Attendance Tool", start_time="08:00:00", end_time="12:00:00"
+		)
+		employee4 = frappe.get_doc("Employee", self.employee4)
+		employee2 = frappe.get_doc("Employee", self.employee2)
+		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
+		date = add_days(getdate(), -1)
+		create_leave_allocation(employee2, leave_type)
+		create_leave_allocation(employee4, leave_type)
+		make_leave_application(
+			employee=employee2,
+			from_date=date,
+			to_date=date,
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=date,
+		)
+		make_leave_application(
+			employee=employee4,
+			from_date=date,
+			to_date=date,
+			leave_type=leave_type.name,
+			half_day=1,
+			half_day_date=date,
+		)
+
+		mark_employee_attendance(
+			employee_list=[self.employee1, self.employee3],
+			status="Present",
+			date=date,
+			shift=shift.name,
+			late_entry=1,
+			early_exit=0,
+			mark_half_day=True,
+			half_day_status="Present",
+			half_day_employee_list=[employee2.name, employee4.name],
+		)
+		attendances = frappe.get_all(
+			"Attendance",
+			filters={"attendance_date": date},
+			fields=["employee", "status", "half_day_status", "shift", "late_entry", "early_exit"],
+		)
+		self.assertEqual(len(attendances), 4)
+		for attendance in attendances:
+			if attendance.get("employee") in (self.employee1, self.employee3):
+				self.assertEqual(attendance.status, "Present")
+				self.assertIsNone(attendance.half_day_status)
+			if attendance.get("employee") in (self.employee2, self.employee4):
+				self.assertEqual(attendance.status, "Half Day")
+				self.assertEqual(attendance.half_day_status, "Present")
+			self.assertEqual(attendance.shift, shift.name)
+
+
+def create_leave_allocation(employee, leave_type):
+	frappe.get_doc(
+		{
+			"doctype": "Leave Allocation",
+			"employee": employee.name,
+			"employee_name": employee.employee_name,
+			"leave_type": leave_type.name,
+			"from_date": add_days(getdate(), -2),
+			"new_leaves_allocated": 15,
+			"carry_forward": 0,
+			"to_date": add_days(getdate(), 30),
+		}
+	).submit()


### PR DESCRIPTION
### Problem
Same as this #2965 but solved in the employee attendance tool


- Attendance tool now shows half day attendances created from leave applications separately and allows to set the status for the other half from the tool
- Added more filters to fetch employee by designation, employment type and employee grade
- Refactored employee selection from a grid of checkboxes to data-table for readability and consistency across all the other bulk tools

-----
#### Before 

https://github.com/user-attachments/assets/f6c07af0-6379-44d7-82cc-c94efc3f4a31

#### After

https://github.com/user-attachments/assets/14ba3f82-764d-49a1-9d9e-4dac685c058e

`no-docs`
