### PR TITLE
fix: calculation of other taxes and charges in income tax

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2174,7 +2174,7 @@ def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=Non
 	from hrms.hr.utils import calculate_tax_with_marginal_relief
 
 	tax_amount = 0
-	other_taxes_and_charges = 0
+	total_other_taxes_and_charges = 0
 
 	if annual_taxable_earning > tax_slab.tax_relief_limit:
 		eval_locals.update({"annual_taxable_earning": annual_taxable_earning})
@@ -2204,11 +2204,11 @@ def calculate_tax_by_tax_slab(annual_taxable_earning, tax_slab, eval_globals=Non
 
 			if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
 				continue
-
-			other_taxes_and_charges += tax_amount * flt(d.percent) / 100
+			other_taxes_and_charges = tax_amount * flt(d.percent) / 100
 			tax_amount += other_taxes_and_charges
+			total_other_taxes_and_charges += other_taxes_and_charges
 
-	return tax_amount, other_taxes_and_charges
+	return tax_amount, total_other_taxes_and_charges
 
 
 def eval_tax_slab_condition(condition, eval_globals=None, eval_locals=None):


### PR DESCRIPTION
- The `other_taxes_and_charges` variable was cumulatively updated within the loop, leading to an inflated tax amount when multiple slabs of Other Taxes and Charges were applicable. 
- This change ensures that other_taxes_and_charges is recalculated for each applicable slab and introduces total_other_taxes_and_charges to return the total amount.