### PR TITLE
fix: marking attendance if status is set but employees are not selected

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -42,6 +42,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 		frm.set_value("shift", "");
 		frm.set_value("late_entry", 0);
 		frm.set_value("early_exit", 0);
+		frm.set_value("half_day_status", "");
 	},
 
 	load_employees(frm) {

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -24,7 +24,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	company(frm) {
 		frm.trigger("load_employees");
 	},
-	employement_type(frm) {
+	employment_type(frm) {
 		frm.trigger("load_employees");
 	},
 	designation(frm) {
@@ -54,12 +54,12 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					department: frm.doc.department,
 					branch: frm.doc.branch,
 					company: frm.doc.company,
-					employment_type: frm.employement_type,
+					employment_type: frm.doc.employment_type,
 					designation: frm.doc.designation,
 					employee_grade: frm.doc.employee_grade,
 				},
 				freeze: true,
-				freeze_message: __("...Feching Employees"),
+				freeze_message: __("...Fetching Employees"),
 			})
 			.then((r) => {
 				frm.no_employees_to_mark =
@@ -132,6 +132,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 		});
 		if (!frm.get_field(datatable_name)) {
 			const datatable_options = {
+				name: datatable_name,
 				columns: columns,
 				data: data,
 				checkboxColumn: true,
@@ -143,6 +144,20 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				cellHeight: 35,
 				noDataMessage: __(no_data_message),
 				disableReorderColumn: true,
+				events: {
+					onCheckRow: function (row) {
+						let datatable = this.options.name;
+						let check_map = this.rowmanager.checkMap.find(
+							(is_checked) => is_checked === 1,
+						);
+						if (datatable === "unmarked_employees_table") {
+							frm.set_df_property("status", "reqd", check_map);
+						}
+						if (datatable === "half_marked_employees_table") {
+							frm.set_df_property("half_day_status", "reqd", check_map);
+						}
+					},
+				},
 			};
 			frm.fields_dict[datatable_name] = new frappe.DataTable(
 				employee_wrapper.get(0),
@@ -339,7 +354,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 			}
 			if (
 				selected_employees_to_mark_full_day.length > 0 ||
-				selected_employees_to_mark_half_day > 0
+				selected_employees_to_mark_half_day.length > 0
 			) {
 				frm.events.mark_full_day_attendance(
 					frm,

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -77,8 +77,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "\nPresent\nAbsent\nHalf Day\nWork From Home",
-   "reqd": 1
+   "options": "\nPresent\nAbsent\nHalf Day\nWork From Home"
   },
   {
    "collapsible": 1,
@@ -156,15 +155,14 @@
    "fieldname": "half_day_status",
    "fieldtype": "Select",
    "label": "Status for Other Half",
-   "options": "Present\nAbsent",
-   "reqd": 1
+   "options": "Present\nAbsent"
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-05 10:44:35.922422",
+ "modified": "2025-05-13 14:19:39.329723",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Attendance Tool",


### PR DESCRIPTION
### Problem
- Half day attendance wouldn't be marked if status was set but employees weren't. 
- Status and Status for Other Half are required fields depending on if the relevant employees are selected, but they are made mandatory indefinitely.

---- 
#### After

https://github.com/user-attachments/assets/15dfb5bc-c5f3-43cb-bb71-80f9bb675ade
