### PR TITLE
fix: return correct no. of payroll subperiods when employee relieving date and salary slip start date are same

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -933,6 +933,6 @@ def get_exact_month_diff(string_ed_date: DateTimeLikeObject, string_st_date: Dat
 	# count the last month only if end date's day > start date's day
 	# to handle cases like 16th Jul 2024 - 15th Jul 2025
 	# where framework's month_diff will calculate diff as 13 months
-	if ed_date.day > st_date.day:
+	if ed_date.day >= st_date.day:
 		diff += 1
 	return diff


### PR DESCRIPTION
<img width="980" alt="Screenshot 2025-05-13 at 10 42 39 PM" src="https://github.com/user-attachments/assets/562eff03-8e16-4ab3-83d1-bdac821b88b8" />

- Fixes the above errror that occurs while processing payroll for employee whose **relieving date and salary slip start date are the same**.
- Previously, `get_exact_month_diff` returned remaining_sub_periods = 0, causing error in amount calculations.
- However, it should **return 1 to account for the single day of salary.**

