### PR TITLE
fix: Add proper Redis URL scheme to Docker setup

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -16,9 +16,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile


### PR DESCRIPTION
This PR fixes the Redis connection issue in the Docker setup by properly specifying the Redis URL schemes.

## Problem
When running the HRMS project with Docker, the setup fails with the error:
`ValueError: Redis URL must specify one of the following schemes (redis://, rediss://, unix://)`

## Solution
Added the proper URL scheme (`redis://`) to all Redis host configurations in the init.sh script:
- bench set-redis-cache-host redis://redis:6379
- bench set-redis-queue-host redis://redis:6379
- bench set-redis-socketio-host redis://redis:6379

## Testing Done
Verified that with these changes, the Docker setup completes successfully and the application can be accessed at http://localhost:8000.

closes #3031