### PR TITLE
fix: add Employee Status filter to income tax report

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.js
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.js
@@ -10,7 +10,7 @@ frappe.query_reports["Income Tax Computation"] = {
 			fieldtype: "Link",
 			options: "Company",
 			default: frappe.defaults.get_user_default("Company"),
-			width: "100px",
+			width: "90px",
 			reqd: 1,
 		},
 		{
@@ -18,7 +18,7 @@ frappe.query_reports["Income Tax Computation"] = {
 			label: __("Payroll Period"),
 			fieldtype: "Link",
 			options: "Payroll Period",
-			width: "100px",
+			width: "90px",
 			reqd: 1,
 		},
 		{
@@ -26,14 +26,23 @@ frappe.query_reports["Income Tax Computation"] = {
 			label: __("Employee"),
 			fieldtype: "Link",
 			options: "Employee",
-			width: "100px",
+			width: "90px",
 		},
 		{
 			fieldname: "department",
 			label: __("Department"),
 			fieldtype: "Link",
 			options: "Department",
-			width: "100px",
+			width: "90px",
+		},
+
+		{
+			fieldname: "employee_status",
+			label: __("Employee Status"),
+			fieldtype: "Select",
+			options: "Active\nInactive\nSuspended\nLeft",
+			default: "Active",
+			width: "90px",
 		},
 		{
 			fieldname: "consider_tax_exemption_declaration",

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -49,7 +49,7 @@ class IncomeTaxComputationReport:
 		self.data = list(self.employees.values())
 
 	def get_employee_details(self):
-		filters, or_filters = self.get_employee_filters()
+		filters = self.get_employee_filters()
 		fields = [
 			"name as employee",
 			"employee_name",
@@ -59,7 +59,7 @@ class IncomeTaxComputationReport:
 			"relieving_date",
 		]
 
-		employees = frappe.get_all("Employee", filters=filters, or_filters=or_filters, fields=fields)
+		employees = frappe.get_all("Employee", filters=filters, fields=fields)
 		ss_assignments = self.get_ss_assignments([d.employee for d in employees])
 
 		for d in employees:
@@ -72,9 +72,6 @@ class IncomeTaxComputationReport:
 
 	def get_employee_filters(self):
 		filters = {"company": self.filters.company}
-		or_filters = {
-			"relieving_date": ["between", [self.payroll_period_start_date, self.payroll_period_end_date]],
-		}
 		if self.filters.employee:
 			filters = {"name": self.filters.employee}
 		elif self.filters.department:
@@ -82,7 +79,7 @@ class IncomeTaxComputationReport:
 		elif self.filters.employee_status:
 			filters["status"] = self.filters.employee_status
 
-		return filters, or_filters
+		return filters
 
 	def get_ss_assignments(self, employees):
 		ss_assignments = frappe.get_all(

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -73,13 +73,14 @@ class IncomeTaxComputationReport:
 	def get_employee_filters(self):
 		filters = {"company": self.filters.company}
 		or_filters = {
-			"status": "Active",
 			"relieving_date": ["between", [self.payroll_period_start_date, self.payroll_period_end_date]],
 		}
 		if self.filters.employee:
 			filters = {"name": self.filters.employee}
 		elif self.filters.department:
 			filters.update({"department": self.filters.department})
+		elif self.filters.employee_status:
+			filters["status"] = self.filters.employee_status
 
 		return filters, or_filters
 


### PR DESCRIPTION
Only "Active" employees and employees with Relieving Date set to a date within the selected payroll period were listed in Income Tax Computation Report, now users can filter the report based on Employee Status; the default status is set to "Active"


https://github.com/user-attachments/assets/47ae5f23-658a-439f-b901-d8015188a4e0

