### PR TITLE
fix: filter query default employee advance account by account type

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -27,7 +27,7 @@ frappe.ui.form.on("Employee Advance", {
 					is_group: 0,
 					company: frm.doc.company,
 					account_currency: ["in", currencies],
-					account_type: ["in", ["Payable", "Receivable"]],
+					account_type: "Receivable",
 				},
 			};
 		});

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -27,6 +27,7 @@ frappe.ui.form.on("Employee Advance", {
 					is_group: 0,
 					company: frm.doc.company,
 					account_currency: ["in", currencies],
+					account_type: ["in", ["Payable", "Receivable"]],
 				},
 			};
 		});

--- a/hrms/public/js/erpnext/company.js
+++ b/hrms/public/js/erpnext/company.js
@@ -18,6 +18,7 @@ frappe.ui.form.on("Company", {
 					company: frm.doc.name,
 					is_group: 0,
 					root_type: "Asset",
+					account_type: ["in", ["Payable", "Receivable"]],
 				},
 			};
 		});

--- a/hrms/public/js/erpnext/company.js
+++ b/hrms/public/js/erpnext/company.js
@@ -18,7 +18,7 @@ frappe.ui.form.on("Company", {
 					company: frm.doc.name,
 					is_group: 0,
 					root_type: "Asset",
-					account_type: ["in", ["Payable", "Receivable"]],
+					account_type: "Receivable",
 				},
 			};
 		});


### PR DESCRIPTION
Employee advance is a receivable account and now this filter should help users set the correct account. 
<img width="1061" alt="Screenshot 2025-05-21 at 13 53 27" src="https://github.com/user-attachments/assets/34016559-5969-4e0e-a5b4-1f7822e9b50e" />

Filtering by account type will help them set the correct account type in the first place.


https://github.com/user-attachments/assets/7ef4d06b-4247-44d8-8033-c670ee97cf41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated account selection filters in Employee Advance and Company forms to only show accounts with an account type of "Receivable". This ensures more accurate and relevant account choices for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->