### PR TITLE
fix: include today's date while bulk marking attendance

### DIFF
--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -59,7 +59,7 @@ frappe.listview_settings["Attendance"] = {
 						fieldtype: "Date",
 						fieldname: "to_date",
 						reqd: 1,
-						default: moment().subtract(1, "days").toDate(),
+						default: moment().toDate(),
 						onchange: () => me.get_unmarked_days(dialog),
 					},
 					{
@@ -142,7 +142,7 @@ frappe.listview_settings["Attendance"] = {
 		fields.exclude_holidays.value = false;
 
 		fields.to_date.datepicker.update({
-			maxDate: moment().subtract(1, "days").toDate(),
+			maxDate: moment().toDate(),
 		});
 
 		this.get_unmarked_days(dialog);


### PR DESCRIPTION
### Problem

#215 introduced setting time period with specific dates, but restricted marking until `yesterday`. Since Attendance doctype allows creating attendance for today I see no reason why it should be restricted here.

----
#### Before

https://github.com/user-attachments/assets/7c823be0-2c76-4185-ab82-db3ab591be23


#### After

https://github.com/user-attachments/assets/9d7c438a-c3f1-48d2-948a-54f6183a2269

