### PR TITLE
fix: refetch cached team leaves after approval

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -131,6 +131,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 	def publish_update(self):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
 		hrms.refetch_resource("hrms:my_leaves", employee_user)
+		hrms.refetch_resource("hrms:team_leaves", employee_user)
 
 	def validate_applicable_after(self):
 		if self.leave_type:


### PR DESCRIPTION
Approved team leaves still showed in the team leaves tabs because publish updates were only refetching employees own cached leaves.
Now the team leaves cache is refetched too after approval.