### PR TITLE
fix: add frontend/yarn.lock into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ hrms/docs/current
 node_modules/
 dist/
 __pycache__/
+yarn.lock
 
 # build/
 .vscode
@@ -20,3 +21,4 @@ hrms/public/frontend
 hrms/www/hrms.html
 hrms/public/roster
 hrms/www/roster.html
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ hrms/public/frontend
 hrms/www/hrms.html
 hrms/public/roster
 hrms/www/roster.html
-


### PR DESCRIPTION
On `bench update` the yarn.lock is always created by yarn building asset (js/css,etc..).
It's confusing to check if hrms app code was really changed by configuration (workspace title etc...)  or if it's only from yarn build asset process

A similar PR was validated in crm application https://github.com/frappe/crm/pull/205