### PR TITLE
fix: recurring additional salary creation error and payroll date overlaps

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -132,6 +132,7 @@ class AdditionalSalary(Document):
 					& (AdditionalSalary.employee == self.employee)
 					& (AdditionalSalary.overwrite_salary_structure_amount == 1)
 					& (AdditionalSalary.docstatus == 1)
+					& (AdditionalSalary.disabled == 0)
 					& (
 						(AdditionalSalary.payroll_date == self.payroll_date)
 						| (
@@ -139,7 +140,6 @@ class AdditionalSalary(Document):
 							& (AdditionalSalary.to_date >= self.payroll_date)
 						)
 					)
-					& (AdditionalSalary.disabled == 0)
 				)
 			)
 			.limit(1)

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -139,6 +139,7 @@ class AdditionalSalary(Document):
 							& (AdditionalSalary.to_date >= self.payroll_date)
 						)
 					)
+					& (AdditionalSalary.disabled == 0)
 				)
 			)
 			.limit(1)

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -121,16 +121,28 @@ class AdditionalSalary(Document):
 		if not self.overwrite_salary_structure_amount:
 			return
 
-		existing_additional_salary = frappe.db.exists(
-			"Additional Salary",
-			{
-				"name": ["!=", self.name],
-				"salary_component": self.salary_component,
-				"payroll_date": self.payroll_date,
-				"overwrite_salary_structure_amount": 1,
-				"employee": self.employee,
-				"docstatus": 1,
-			},
+		AdditionalSalary = frappe.qb.DocType("Additional Salary")
+		existing_additional_salary = (
+			(
+				frappe.qb.from_(AdditionalSalary)
+				.select(AdditionalSalary.name)
+				.where(
+					(AdditionalSalary.name != self.name)
+					& (AdditionalSalary.salary_component == self.salary_component)
+					& (AdditionalSalary.employee == self.employee)
+					& (AdditionalSalary.overwrite_salary_structure_amount == 1)
+					& (AdditionalSalary.docstatus == 1)
+					& (
+						(AdditionalSalary.payroll_date == self.payroll_date)
+						| (
+							(AdditionalSalary.from_date <= self.payroll_date)
+							& (AdditionalSalary.to_date >= self.payroll_date)
+						)
+					)
+				)
+			)
+			.limit(1)
+			.run(pluck=True)
 		)
 
 		if existing_additional_salary:

--- a/hrms/payroll/doctype/additional_salary/test_additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/test_additional_salary.py
@@ -147,6 +147,24 @@ class TestAdditionalSalary(IntegrationTestCase):
 		self.assertIsNone(tds_component.additional_salary)
 		self.assertNotEqual(tds_component.amount, 5000)
 
+	def test_validate_duplicate_or_overlapping_additional_salary(self):
+		emp_id = make_employee("test_additional@salary.com")
+		make_salary_structure("Test Salary Structure Additional Salary", "Monthly", employee=emp_id)
+		date = nowdate()
+		get_additional_salary(emp_id, overwrite_salary_structure=1)
+		additional_salary_doc = frappe.get_doc(
+			{
+				"doctype": "Additional Salary",
+				"employee": emp_id,
+				"salary_component": "Recurring Salary Component",
+				"payroll_date": date,
+				"amount": 5000,
+				"overwrite_salary_structure_amount": 1,
+			}
+		)
+		with self.assertRaises(frappe.ValidationError):
+			additional_salary_doc.save()
+
 
 def get_additional_salary(
 	emp_id, recurring=True, payroll_date=None, salary_component=None, overwrite_salary_structure=0


### PR DESCRIPTION
## **This PR addresses 2 issues:**

  ### 1. Recurring Additional Salaries with same employee, salary component and overwrite enabled but non-overlapping date ranges should be allowed
**Before:**
![before-recurring-fix](https://github.com/user-attachments/assets/e03a4210-ba07-4bff-a092-684738d1a9fb)

**After**
![after-recurring-fix](https://github.com/user-attachments/assets/e58ec86c-b78d-4889-85a2-0c905d970ccd)

       
 ### 2. Non-recurring Additional Salary and payroll date within the date range of an existing recurring Additional Salary should throw an error during creation if both has overwrite enabled. Error was being raised only while processing salary
**Before**
![before-overlap-fix](https://github.com/user-attachments/assets/968111ad-9f3e-49fc-9eb2-20b3df4934ff)

**After**
![after-overlap-fix](https://github.com/user-attachments/assets/abb57d88-33e7-457c-8b3b-991fd5840d62)

closes #2578 