### PR TITLE
fix: sync amount_based_on_formula field while syncing formula field of a component with linked salary structure

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -73,6 +73,8 @@ class SalaryComponent(Document):
 
 	@frappe.whitelist()
 	def update_salary_structures(self, field, value, structures=None):
+		is_formula_related = field == "formula"
+
 		if not structures:
 			structures = self.get_structures_to_be_updated()
 
@@ -87,6 +89,10 @@ class SalaryComponent(Document):
 				(d for d in salary_structure.get(f"{self.type.lower()}s") if d.salary_component == self.name),
 				None,
 			)
+			if is_formula_related:
+				value = value if self.amount_based_on_formula else None
+				salary_detail_row.set("amount_based_on_formula", self.amount_based_on_formula)
+
 			salary_detail_row.set(field, value)
 			salary_structure.db_update_all()
 			salary_structure.flags.updater_reference = {


### PR DESCRIPTION
While syncing compoent formula, **Amount based on formula** field was not being synced to the components in salary structures
**Before**
![before](https://github.com/user-attachments/assets/32f407b5-9767-4bc3-b789-c5a2343fb9bb)

**After**
![after](https://github.com/user-attachments/assets/7a7d1310-e553-4016-8077-5e29d34b4546)




fix #3123 