### PR TITLE
fix: add lending version-1 compatability

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -50,7 +50,7 @@ from hrms.payroll.doctype.payroll_period.payroll_period import (
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import (
 	cancel_loan_repayment_entry,
 	make_loan_repayment_entry,
-	process_loan_interest_accruals,
+	process_loan_interest_accrual_and_demand,
 	set_loan_repayment,
 )
 from hrms.payroll.utils import sanitize_expression
@@ -347,7 +347,7 @@ class SalarySlip(TransactionBase):
 				self.set_time_sheet()
 				self.pull_sal_struct()
 
-			process_loan_interest_accruals(self)
+			process_loan_interest_accrual_and_demand(self)
 
 	def set_time_sheet(self):
 		if self.salary_slip_based_on_timesheet:

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -33,7 +33,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		loan_details = _get_loan_details(doc)
 
 		for loan in loan_details:
-			amounts = calculate_amounts(loan.name, doc.end_date, "Regular Payment")
+			amounts = calculate_amounts(loan.name, doc.end_date, "Normal Repayment")
 
 			if amounts["interest_amount"] or amounts["payable_principal_amount"]:
 				doc.append(
@@ -51,7 +51,7 @@ def set_loan_repayment(doc: "SalarySlip"):
 		doc.set("loans", [])
 
 	for payment in doc.get("loans", []):
-		amounts = calculate_amounts(payment.loan, doc.end_date, "Regular Payment")
+		amounts = calculate_amounts(payment.loan, doc.end_date, "Normal Repayment")
 		total_amount = amounts["interest_amount"] + amounts["payable_principal_amount"]
 		if payment.total_payment > total_amount:
 			frappe.throw(
@@ -86,20 +86,44 @@ def _get_loan_details(doc: "SalarySlip") -> dict[str, Any]:
 
 
 @if_lending_app_installed
-def process_loan_interest_accruals(doc: "SalarySlip"):
-	from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-		process_loan_interest_accrual_for_term_loans,
-	)
-
+def process_loan_interest_accrual_and_demand(doc: "SalarySlip"):
 	loans = _get_loan_details(doc)
 	if not loans:
 		return
 
+	is_version_15 = is_lending_version_15()
+	if is_version_15:
+		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+			process_loan_interest_accrual_for_term_loans,
+		)
+	else:
+		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+			process_loan_interest_accrual_for_loans,
+		)
+
 	for loan in loans:
 		if loan.get("is_term_loan"):
-			process_loan_interest_accrual_for_term_loans(
-				posting_date=doc.end_date, loan_product=loan.loan_product, loan=loan.name
-			)
+			if is_version_15:
+				process_loan_interest_accrual_for_term_loans(
+					posting_date=doc.end_date, loan_product=loan.loan_product, loan=loan.name
+				)
+			else:
+				process_loan_interest_accrual_for_loans(doc.end_date, loan.loan_product, loan.name)
+				process_loan_demand(doc.end_date, loan.loan_product, loan.name)
+
+
+def process_loan_demand(posting_date, loan_product, loan):
+	loan_disbursement = frappe.db.get_value(
+		"Loan Disbursement",
+		{"against_loan": loan, "docstatus": 1},
+		"name",
+	)
+	process_loan_demand = frappe.new_doc("Process Loan Demand")
+	process_loan_demand.posting_date = posting_date
+	process_loan_demand.loan_product = loan_product
+	process_loan_demand.loan = loan
+	process_loan_demand.loan_disbursement = loan_disbursement
+	process_loan_demand.submit()
 
 
 @if_lending_app_installed
@@ -124,7 +148,7 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 			doc.company,
 			doc.posting_date,
 			loan.loan_product,
-			"Regular Payment",
+			"Normal Repayment",
 			loan.interest_amount,
 			loan.principal_amount,
 			loan.total_payment,
@@ -158,3 +182,12 @@ def get_payroll_payable_account(company, payroll_entry):
 		payroll_payable_account = frappe.db.get_value("Company", company, "default_payroll_payable_account")
 
 	return payroll_payable_account
+
+
+def is_lending_version_15():
+	lending_version = frappe.db.get_value(
+		"Installed Application",
+		{"parent": "Installed Applications", "app_name": "lending"},
+		"git_branch",
+	)
+	return lending_version == "version-15"


### PR DESCRIPTION
Handle loan repayment via salary slip in accordance with the version of lending installed

- Import the correct methods for processing interest accrual
- If user is on version-1 or develop, handle demand processing

closes #2838 #3006 