### PR TITLE
fix: loan demand processing and lending tests

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -248,9 +248,6 @@ class TestPayrollEntry(FrappeTestCase):
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1})
 	def test_loan_with_settings_enabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 
@@ -258,8 +255,6 @@ class TestPayrollEntry(FrappeTestCase):
 		loan = create_loan_for_employee(applicant)
 
 		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
-
 		dates = get_start_end_dates("Monthly", nowdate())
 		make_payroll_entry(
 			company="_Test Company",
@@ -292,9 +287,6 @@ class TestPayrollEntry(FrappeTestCase):
 	@change_settings("Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 0})
 	def test_loan_with_settings_disabled(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 
@@ -302,9 +294,8 @@ class TestPayrollEntry(FrappeTestCase):
 		loan = create_loan_for_employee(applicant)
 
 		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
-
 		dates = get_start_end_dates("Monthly", nowdate())
+
 		make_payroll_entry(
 			company="_Test Company",
 			start_date=dates.start_date,
@@ -766,9 +757,6 @@ class TestPayrollEntry(FrappeTestCase):
 
 	def run_test_for_loan_repayment_from_salary(self):
 		from lending.loan_management.doctype.loan.test_loan import make_loan_disbursement_entry
-		from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
-			process_loan_interest_accrual_for_term_loans,
-		)
 
 		frappe.db.delete("Loan")
 		applicant, branch, currency, payroll_payable_account = setup_lending()
@@ -779,7 +767,6 @@ class TestPayrollEntry(FrappeTestCase):
 		loan_doc.save()
 
 		make_loan_disbursement_entry(loan.name, loan.loan_amount, disbursement_date=add_months(nowdate(), -1))
-		process_loan_interest_accrual_for_term_loans(posting_date=nowdate())
 
 		dates = get_start_end_dates("Monthly", nowdate())
 		payroll_entry = make_payroll_entry(

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -205,8 +205,7 @@ class SalarySlip(TransactionBase):
 					frappe.db.get_single_value("Payroll Settings", "email_salary_slip_to_employee")
 				)
 				if email_salary_slip:
-					return
-					# self.email_salary_slip()
+					self.email_salary_slip()
 
 		self.update_payment_status_for_gratuity_and_leave_encashment()
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -136,6 +136,7 @@ class SalarySlip(TransactionBase):
 		return self.__actual_end_date
 
 	def validate(self):
+		# frappe.get_single("Installed Applications").update_versions()
 		self.check_salary_withholding()
 		self.status = self.get_status()
 		validate_active_employee(self.employee)
@@ -204,7 +205,8 @@ class SalarySlip(TransactionBase):
 					frappe.db.get_single_value("Payroll Settings", "email_salary_slip_to_employee")
 				)
 				if email_salary_slip:
-					self.email_salary_slip()
+					return
+					# self.email_salary_slip()
 
 		self.update_payment_status_for_gratuity_and_leave_encashment()
 
@@ -1826,6 +1828,8 @@ class SalarySlip(TransactionBase):
 			"Salary Component", row.salary_component, "round_to_the_nearest_integer", cache=True
 		):
 			amount, additional_amount = rounded(amount or 0), rounded(additional_amount or 0)
+
+		# print(f'\n\n comp: {row.salary_component}, amount: {amount}, additional_amount: {additional_amount}\n\n')
 
 		return amount, additional_amount
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -136,7 +136,6 @@ class SalarySlip(TransactionBase):
 		return self.__actual_end_date
 
 	def validate(self):
-		# frappe.get_single("Installed Applications").update_versions()
 		self.check_salary_withholding()
 		self.status = self.get_status()
 		validate_active_employee(self.employee)
@@ -1827,8 +1826,6 @@ class SalarySlip(TransactionBase):
 			"Salary Component", row.salary_component, "round_to_the_nearest_integer", cache=True
 		):
 			amount, additional_amount = rounded(amount or 0), rounded(additional_amount or 0)
-
-		# print(f'\n\n comp: {row.salary_component}, amount: {amount}, additional_amount: {additional_amount}\n\n')
 
 		return amount, additional_amount
 


### PR DESCRIPTION
call process_daily_loan_demands from lending, and remove processing interest accruals from tests as they are handled during salary slip creation.

fix #2855 