### PR TITLE
fix: prompt user to set Default Employee Advance Account when submitting Employee Advance doc

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.json
+++ b/hrms/hr/doctype/employee_advance/employee_advance.json
@@ -162,8 +162,7 @@
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
    "label": "Advance Account",
-   "options": "Account",
-   "reqd": 1
+   "options": "Account"
   },
   {
    "fieldname": "mode_of_payment",
@@ -239,9 +238,10 @@
    "fieldtype": "Column Break"
   }
  ],
+ "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-29 12:05:13.623633",
+ "modified": "2025-06-16 12:09:38.685483",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Advance",

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -25,6 +25,21 @@ class EmployeeAdvance(Document):
 			"Accounts Settings", "make_payment_via_journal_entry"
 		)
 
+	def before_save(self):
+		if not self.get("advance_account"):
+			default_advance_account = frappe.db.get_value(
+				"Company", self.company, "default_employee_advance_account"
+			)
+			if default_advance_account:
+				self.advance_account = default_advance_account
+			else:
+				frappe.throw(
+					_(
+						'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0}.'
+					).format(self.company),
+					title=_("Missing Advance Account"),
+				)
+
 	def validate(self):
 		validate_active_employee(self.employee)
 		self.validate_exchange_rate()


### PR DESCRIPTION
Advance Account field Employee Advance doctype is fetched from Company doc, if its not set, prompt user to set it:

**BEFORE**
![Screen Recording 2025-06-16 at 12 46 51 PM](https://github.com/user-attachments/assets/337cef85-c507-4607-b8b7-210466def815)

**AFTER**
![Screen Recording 2025-06-16 at 12 42 29 PM](https://github.com/user-attachments/assets/21ed39fe-6978-4c08-888f-7e6cbe1c8e78)

fix #3221 