### PR TITLE
chore: move employee advance account validation to before_submit hook

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -25,7 +25,13 @@ class EmployeeAdvance(Document):
 			"Accounts Settings", "make_payment_via_journal_entry"
 		)
 
-	def before_save(self):
+	def validate(self):
+		validate_active_employee(self.employee)
+		self.validate_exchange_rate()
+		self.set_status()
+		self.set_pending_amount()
+
+	def before_submit(self):
 		if not self.get("advance_account"):
 			default_advance_account = frappe.db.get_value(
 				"Company", self.company, "default_employee_advance_account"
@@ -39,12 +45,6 @@ class EmployeeAdvance(Document):
 					).format(self.company),
 					title=_("Missing Advance Account"),
 				)
-
-	def validate(self):
-		validate_active_employee(self.employee)
-		self.validate_exchange_rate()
-		self.set_status()
-		self.set_pending_amount()
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Payment Ledger Entry")

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -41,7 +41,7 @@ class EmployeeAdvance(Document):
 			else:
 				frappe.throw(
 					_(
-						'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0}.'
+						'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0} and submit this document.'
 					).format(self.company),
 					title=_("Missing Advance Account"),
 				)


### PR DESCRIPTION
In Employee Advance, code to prompt the user to set **default advance account** in company record has been moved to before_submit hook from before_save.

ref #3232