### PR TITLE
fix: inaccurate lwp calculation in salary slip when partially paid leave exists for employee

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -653,7 +653,7 @@ class SalarySlip(TransactionBase):
 
 		for d in working_days_list:
 			if self.relieving_date and d > self.relieving_date:
-				continue
+				break
 
 			leave = leaves.get(d)
 
@@ -674,7 +674,7 @@ class SalarySlip(TransactionBase):
 
 			if cint(leave.is_ppl):
 				equivalent_lwp_count *= (
-					fraction_of_daily_salary_per_leave if fraction_of_daily_salary_per_leave else 1
+					(1 - fraction_of_daily_salary_per_leave) if fraction_of_daily_salary_per_leave else 1
 				)
 
 			lwp += equivalent_lwp_count


### PR DESCRIPTION
The value of field **fraction_of_daily_salary_per_leave** in Leave Type for partially paid leaves represents the portion of salary that IS paid, not the unpaid portion.

If **Fraction of Daily Salary per Leave** = 0.6, the employee is paid 60% of their daily salary for that leave day.

For LWP (Leave Without Pay) calculation, we need to know what portion of the day is considered unpaid.
So for a full day of leave with 60% payment, the equivalent LWP should be 0.4 days.

Therefore, when calculating the LWP equivalent:
* Previous code: `equivalent_lwp_count *= fraction_of_daily_salary_per_leave` would incorrectly calculate 0.6 days of LWP for a day that's 60% paid.
* Changed code: `equivalent_lwp_count *= (1 - fraction_of_daily_salary_per_leave)` would correctly calculate 0.4 days of LWP.


**BEFORE**
![fin](https://github.com/user-attachments/assets/70b9ba60-1b4b-464f-ad9f-e863d461363e)

**AFTER**
<img width="1351" alt="Screenshot 2025-06-16 at 6 08 06 PM" src="https://github.com/user-attachments/assets/40d9fe0e-2090-4eba-bab6-01c96edd15f0" />


fix #3052 fix #129
