### PR TITLE
fix: auto update last sync for extra long shifts

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -402,7 +402,7 @@ def get_actual_shift_end(shift, current_datetime):
 	actual_shift_start = shift_details["actual_start"]
 	actual_shift_end = shift_details["actual_end"]
 
-	if actual_shift_start.date() < actual_shift_end.date():
+	if (actual_shift_start.date() < actual_shift_end.date()) or (current_datetime < actual_shift_start):
 		# shift start and end are on different days
 		actual_shift_end = add_days(actual_shift_end, -1)
 	return actual_shift_end

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -110,6 +110,20 @@ class TestShiftType(IntegrationTestCase):
 		shift_type.reload()
 		self.assertEqual(shift_type.last_sync_of_checkin, datetime.combine(getdate(), get_time("07:01:00")))
 
+	def test_auto_update_last_sync_of_checkin_when_when_job_runs_on_the_next_day(self):
+		shift_type = setup_shift_type(shift_type="Test Long Shift", start_time="9:00:00", end_time="18:00:00")
+		shift_type.allow_check_out_after_shift_end_time = 330
+		shift_type.last_sync_of_checkin = None
+		shift_type.auto_update_last_sync = 1
+		shift_type.save()
+
+		frappe.flags.current_datetime = datetime.combine(add_days(getdate(), 1), get_time("00:01:00"))
+		update_last_sync_of_checkin()
+
+		shift_type.reload()
+
+		self.assertEqual(shift_type.last_sync_of_checkin, datetime.combine(getdate(), get_time("23:31:00")))
+
 	def test_mark_attendance(self):
 		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
 


### PR DESCRIPTION
Updated condition to update last sync of checkin anytime between last shift end and next shift start along with the test case.