### PR TITLE
fix: calculation of future recurring periods for recurring additional salary which affects annual income/ctc amount

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1770,6 +1770,9 @@ class SalarySlip(TransactionBase):
 
 		future_recurring_period = ((to_date.year - from_date.year) * 12) + (to_date.month - from_date.month)
 
+		if future_recurring_period > 0 and to_date.month == from_date.month:
+			future_recurring_period -= 1
+
 		return future_recurring_period
 
 	def get_future_recurring_additional_amount(self, additional_salary, monthly_additional_amount):


### PR DESCRIPTION
- This fix corrects calculation of no. of future  payroll cycles in which a recurring additional salary is applicable, **in cases where payroll period starts and end in same Month (e.g., July 16, 2023 – July 15, 2024)** 
- This was resulting in incorrect ctc/annual income amounts.
- When an Additional Salary is marked as recurring across the entire payroll period (e.g., July 16, 2023 – July 15, 2024), the future applicable periods are calculated to estimate total CTC/annual income in the salary slip (i.e., current + future months amount).
- The original logic calculated the number of future periods as: ((2024 - 2023) * 12 + (7 - 7)) = 12 This results in an incorrect 12-month count, even though the current month is already accounted for and only 11 future months remain.
- This fix adjusts the logic to handle such edge cases where the start and end months are the same and preserves correct behavior for payroll years like April–March where the start and end months differ.

fix #2932 
