### PR TITLE
fix: do not reset data for evaluating salary component formulas since that excludes statistical component amounts

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1547,12 +1547,11 @@ class SalarySlip(TransactionBase):
 		)
 
 		# Structured tax amount
-		eval_locals, default_data = self.get_data_for_eval()
 		self.total_structured_tax_amount, __ = calculate_tax_by_tax_slab(
 			self.total_taxable_earnings_without_full_tax_addl_components,
 			self.tax_slab,
 			self.whitelisted_globals,
-			eval_locals,
+			self.data,
 		)
 
 		self.current_structured_tax_amount = (
@@ -1563,7 +1562,7 @@ class SalarySlip(TransactionBase):
 		self.full_tax_on_additional_earnings = 0.0
 		if self.current_additional_earnings_with_full_tax:
 			self.total_tax_amount, __ = calculate_tax_by_tax_slab(
-				self.total_taxable_earnings, self.tax_slab, self.whitelisted_globals, eval_locals
+				self.total_taxable_earnings, self.tax_slab, self.whitelisted_globals, self.data
 			)
 			self.full_tax_on_additional_earnings = self.total_tax_amount - self.total_structured_tax_amount
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -821,6 +821,8 @@ class SalarySlip(TransactionBase):
 				flt(self.gross_pay) * flt(self.exchange_rate), self.precision("base_gross_pay")
 			)
 
+		self.data, self.default_data = self.get_data_for_eval()
+
 		if self.salary_structure:
 			self.calculate_component_amounts("earnings")
 
@@ -1157,8 +1159,6 @@ class SalarySlip(TransactionBase):
 				row.formula = sanitize_expression(row.formula)
 
 	def add_structure_components(self, component_type):
-		self.data, self.default_data = self.get_data_for_eval()
-
 		for struct_row in self._salary_structure_doc.get(component_type):
 			self.add_structure_component(struct_row, component_type)
 


### PR DESCRIPTION
When a statistical component of type 'Earning'  was set as the formula for a Deduction salary component, the amount was being incorrectly set to zero; this was due to data for formula evaluation being reset before evaluating deduction components. While resetting, the amount of statistical components falls back to 0 since  that component or its evaluated amount is not added to salary slip.
