### PR TITLE
fix: provident fund report error

### DIFF
--- a/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
+++ b/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
@@ -8,7 +8,23 @@ from frappe.utils import getdate
 
 
 def execute(filters=None):
-	data = get_data(filters)
+	data = []
+	mandatory_components = [
+		"Provident Fund",
+		"Additional Provident Fund",
+		"Provident Fund Loan",
+	]
+	if not frappe.db.exists("Salary Component", {"component_type": ["in", mandatory_components]}):
+		frappe.msgprint(
+			_(
+				"Salary components of type Provident Fund, Additional Provident Fund or Provident Fund Loan are not set up."
+			),
+			title=_("Missing Salary Components"),
+			indicator="red",
+		)
+	else:
+		data = get_data(filters)
+
 	columns = get_columns(filters) if len(data) else []
 
 	return columns, data

--- a/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
+++ b/hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py
@@ -9,12 +9,8 @@ from frappe.utils import getdate
 
 def execute(filters=None):
 	data = []
-	mandatory_components = [
-		"Provident Fund",
-		"Additional Provident Fund",
-		"Provident Fund Loan",
-	]
-	if not frappe.db.exists("Salary Component", {"component_type": ["in", mandatory_components]}):
+	provident_fund_components = ["Provident Fund", "Additional Provident Fund", "Provident Fund Loan"]
+	if not frappe.db.exists("Salary Component", {"component_type": ["in", provident_fund_components]}):
 		frappe.msgprint(
 			_(
 				"Salary components of type Provident Fund, Additional Provident Fund or Provident Fund Loan are not set up."


### PR DESCRIPTION
An error is thrown when accessing Privident Fund Deductions report

**BEFORE**
<img width="1293" alt="Screenshot 2025-06-18 at 8 28 16 PM" src="https://github.com/user-attachments/assets/da07f7d1-3304-471e-9879-740e8121f2b3" />

**AFTER** - Display a message instead 
<img width="1439" alt="Screenshot 2025-06-18 at 8 27 40 PM" src="https://github.com/user-attachments/assets/3a990547-a928-4dd3-b1b9-827c46f23498" />


fix #2583 fix #2503 

