### PR TITLE
fix: show employee name for all rows in attendance report

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -403,7 +403,8 @@ def get_rows(employee_details: dict, filters: Filters, holiday_map: dict, attend
 				employee, filters, employee_attendance, holidays
 			)
 			# set employee details in the first row
-			attendance_for_employee[0].update({"employee": employee, "employee_name": details.employee_name})
+			for record in attendance_for_employee:
+				record.update({"employee": employee, "employee_name": details.employee_name})
 
 			records.extend(attendance_for_employee)
 


### PR DESCRIPTION
### Problem
Attendance report shows records grouped by employees but only sets employee details for the first row, while this looks cleaner, if you use inline filters to search, it only shows that one record that has employee name


<img width="728" alt="Screenshot 2025-06-23 at 17 03 54" src="https://github.com/user-attachments/assets/fa057457-8f7f-49d5-835c-8ced702a1e56" />
<img width="672" alt="Screenshot 2025-06-23 at 17 07 48" src="https://github.com/user-attachments/assets/ee9e9e60-8c41-45e3-9c78-49188a4546eb" />

### Fix
Added employee details for all the rows so all of them could be searchable


<img width="735" alt="Screenshot 2025-06-23 at 17 03 15" src="https://github.com/user-attachments/assets/293bba95-3b94-4597-bf7a-5bec40adad79" />
<img width="672" alt="Screenshot 2025-06-23 at 17 03 32" src="https://github.com/user-attachments/assets/772c8aac-5295-481d-9c0f-d9befe9c0321" />


