### PR TITLE
fix: status not found while fetching attendance requests

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -202,7 +202,6 @@ def get_attendance_requests(
 	limit: int | None = None,
 ) -> list[dict]:
 	filters = get_filters("Attendance Request", employee, None, for_approval)
-	print(filters)
 	fields = [
 		"name",
 		"reason",

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -202,6 +202,7 @@ def get_attendance_requests(
 	limit: int | None = None,
 ) -> list[dict]:
 	filters = get_filters("Attendance Request", employee, None, for_approval)
+	print(filters)
 	fields = [
 		"name",
 		"reason",
@@ -247,7 +248,7 @@ def get_filters(
 		if workflow := get_workflow(doctype):
 			allowed_states = get_allowed_states_for_workflow(workflow, approver_id)
 			filters[workflow.workflow_state_field] = ("in", allowed_states)
-		else:
+		elif doctype != "Attendance Request":
 			approver_field_map = {
 				"Shift Request": "approver",
 				"Leave Application": "leave_approver",


### PR DESCRIPTION
#3133 introduced status not found error because I reused the get_filters function without removing status filter.

There's no status field in attendance request.

This fixes it.
