### PR TITLE
feat(pwa): Show LWP details consumed/quota on leaves tab

### DIFF
--- a/frontend/src/components/LeaveBalance.vue
+++ b/frontend/src/components/LeaveBalance.vue
@@ -37,15 +37,27 @@
 					{{ __("{0} balance", [__(leave_type, null, "Leave Type")]) }}
 				</div>
 			</div>
+			<div class="flex flex-col bg-white border-none rounded-lg drop-shadow-md gap-2 p-4 items-start first:ml-4">
+			<SemicircleChart
+					:percentage="LeaveWithoutPayDetails.data.balance_percentage"
+					:colorClass="getChartColor(1)"
+			/>
+			<div class="text-gray-800 font-bold text-base">	
+					{{ `${LeaveWithoutPayDetails.data.lwps_consumed}/${LeaveWithoutPayDetails.data.max_lwps_allowed}` }}
+			</div>
+			<div class="text-gray-600 font-normal text-sm w-24 leading-4">
+					{{ __("{0} balance", [__(LeaveWithoutPayDetails.data.leave_type, null, "Leave Type")]) }}
+			</div>
+		 </div>
 		</div>
-
 		<EmptyState :message="__('You have no leaves allocated')" v-else />
 	</div>
 </template>
 
 <script setup>
 import SemicircleChart from "@/components/SemicircleChart.vue"
-import { leaveBalance } from "@/data/leaves"
+
+import { leaveBalance, LeaveWithoutPayDetails } from "@/data/leaves"
 import { inject } from "vue"
 
 const __ = inject("$translate")

--- a/frontend/src/data/leaves.js
+++ b/frontend/src/data/leaves.js
@@ -71,12 +71,12 @@ export const leaveBalance = createResource({
 })
 
 export const LeaveWithoutPayDetails = createResource({
-	url: "hrms.api.get_lwps_details",
+	url: "hrms.api.get_lwp_details",
 	params: {
 		employee: employeeResource.data.name,
 	},
 	auto: true,
-	cache: "hrms:lwps_details",
+	cache: "hrms:lwp_details",
 	transform(data) {
 		return data || 0
 	},

--- a/frontend/src/data/leaves.js
+++ b/frontend/src/data/leaves.js
@@ -69,3 +69,15 @@ export const leaveBalance = createResource({
 		)
 	},
 })
+
+export const LeaveWithoutPayDetails = createResource({
+	url: "hrms.api.get_lwps_details",
+	params: {
+		employee: employeeResource.data.name,
+	},
+	auto: true,
+	cache: "hrms:lwps_details",
+	transform(data) {
+		return data || 0
+	},
+})

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -811,7 +811,7 @@ def get_permitted_fields_for_write(doctype: str) -> list[str]:
 
 
 @frappe.whitelist()
-def get_lwps_details(employee: str) -> int:
+def get_lwp_details(employee: str) -> int:
 	result = frappe._dict(
 		{"leave_type": None, "max_lwps_allowed": 0.0, "lwps_consumed": 0.0, "balance_percentage": 0.0}
 	)

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -808,3 +808,49 @@ def get_allowed_states_for_workflow(workflow: dict, user_id: str) -> list[str]:
 @frappe.whitelist()
 def get_permitted_fields_for_write(doctype: str) -> list[str]:
 	return get_permitted_fields(doctype, permission_type="write")
+
+
+@frappe.whitelist()
+def get_lwps_details(employee: str) -> int:
+	result = frappe._dict(
+		{"leave_type": None, "max_lwps_allowed": 0.0, "lwps_consumed": 0.0, "balance_percentage": 0.0}
+	)
+
+	company = frappe.get_value("Employee", employee, "company", cache=True)
+
+	leave_period = frappe.get_value(
+		"Leave Period",
+		{"company": company, "is_active": True},
+		["name", "from_date", "to_date"],
+		as_dict=True,
+		cache=True,
+	)
+
+	count_lwps = frappe.db.count(
+		"Leave Application",
+		filters={
+			"employee": employee,
+			"leave_type": ("=", "Leave Without Pay"),
+			"from_date": [">=", leave_period.from_date],
+			"to_date": ["<=", leave_period.to_date],
+			"docstatus": 1,
+		},
+	)
+	if count_lwps:
+		result.lwps_consumed = count_lwps
+
+	lwps = frappe.get_list("Leave Type", filters={"is_lwp": 1}, pluck="name")
+
+	if lwps:
+		result.leave_type = lwps[0]
+		result.max_lwps_allowed = frappe.get_value("Leave Type", lwps[0], "max_leaves_allowed")
+
+	# calculate balance
+	if result.max_lwps_allowed > 0:
+		result.balance_percentage = round(
+			max(0, 100 - (result.lwps_consumed / result.max_lwps_allowed * 100)), 2
+		)
+	else:
+		result.balance_percentage = 100.0
+
+	return result

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -811,9 +811,14 @@ def get_permitted_fields_for_write(doctype: str) -> list[str]:
 
 
 @frappe.whitelist()
-def get_lwp_details(employee: str) -> int:
+def get_lwp_details(employee: str) -> dict:
 	result = frappe._dict(
-		{"leave_type": None, "max_lwps_allowed": 0.0, "lwps_consumed": 0.0, "balance_percentage": 0.0}
+		{
+			"leave_type": "Leave Without Pay",
+			"max_lwps_allowed": frappe.get_value("Leave Type", "Leave Without Pay", "max_leaves_allowed"),
+			"lwps_consumed": 0.0,
+			"balance_percentage": 0.0,
+		}
 	)
 
 	company = frappe.get_value("Employee", employee, "company", cache=True)
@@ -826,7 +831,7 @@ def get_lwp_details(employee: str) -> int:
 		cache=True,
 	)
 
-	count_lwps = frappe.db.count(
+	lwps_consumed = frappe.db.count(
 		"Leave Application",
 		filters={
 			"employee": employee,
@@ -836,14 +841,8 @@ def get_lwp_details(employee: str) -> int:
 			"docstatus": 1,
 		},
 	)
-	if count_lwps:
-		result.lwps_consumed = count_lwps
-
-	lwps = frappe.get_list("Leave Type", filters={"is_lwp": 1}, pluck="name")
-
-	if lwps:
-		result.leave_type = lwps[0]
-		result.max_lwps_allowed = frappe.get_value("Leave Type", lwps[0], "max_leaves_allowed")
+	if lwps_consumed:
+		result.lwps_consumed = lwps_consumed
 
 	# calculate balance
 	if result.max_lwps_allowed > 0:


### PR DESCRIPTION
Old PR: #3254 
Closes #3166 

---
![Screenshot from 2025-07-01 16-24-06](https://github.com/user-attachments/assets/c86b1de2-50d2-4451-b4dc-b3d4ba9768da)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Leave Without Pay (LWP) details card to the Leave Balance dashboard. It visualizes remaining balance with a semicircle chart and shows consumed vs allowed days, displayed alongside existing leave-type cards.
  * Data loads automatically for the signed-in employee and reflects the active leave period, offering an at-a-glance view of LWP usage and remaining allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->