### PR TITLE
fix: hrms_rate_translation

### DIFF
--- a/hrms/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+++ b/hrms/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
@@ -62,7 +62,7 @@
    "fieldname": "rate",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Rate",
+   "label": "Tax Rate",
    "oldfieldname": "rate",
    "oldfieldtype": "Currency"
   },
@@ -110,7 +110,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-10-10 14:57:01.414550",
+ "modified": "2025-07-03 06:47:07.323871",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Taxes and Charges",


### PR DESCRIPTION
Rate is impossible to translate correctly across the applications.
Here it actually is Tax Rate
Backport v-15-hotfix