### PR TITLE
feat: Allow employees to reopen grievance

### DIFF
--- a/hrms/hr/doctype/employee_grievance/employee_grievance.js
+++ b/hrms/hr/doctype/employee_grievance/employee_grievance.js
@@ -2,6 +2,48 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Employee Grievance", {
+	refresh: (frm) => {
+		if (
+			frm.doc.owner === frappe.session.user &&
+			frm.doc.docstatus === 1 &&
+			!frm.doc.against_employee_grievance
+		) {
+			frm.add_custom_button(__("Re-open"), () => {
+				let d = new frappe.ui.Dialog({
+					title: "Reason for re-open",
+					fields: [
+						{
+							label: "Reason",
+							fieldname: "reason",
+							fieldtype: "Small Text",
+							reqd: 1,
+						},
+					],
+					size: "large",
+					primary_action_label: "Re-open",
+					primary_action(values) {
+						frappe.model.with_doctype("Employee Grievance", () => {
+							let employeeGrievance = frappe.model.get_new_doc("Employee Grievance");
+							let fields = Object.keys(frm.doc);
+							let fieldsToExclude = ["name", "docstatus"];
+
+							fields.forEach((field) => {
+								if (fieldsToExclude.includes(field)) return;
+								employeeGrievance[field] = frm.doc[field];
+							});
+							employeeGrievance.against_employee_grievance = frm.doc.name;
+							employeeGrievance.reopen_reason = values.reason;
+							employeeGrievance.status = "Open";
+							employeeGrievance.date = frappe.datetime.get_today();
+
+							frappe.set_route("Form", "Employee Grievance", employeeGrievance.name);
+						});
+					},
+				});
+				d.show();
+			});
+		}
+	},
 	setup: function (frm) {
 		frm.set_query("grievance_against_party", function () {
 			return {

--- a/hrms/hr/doctype/employee_grievance/employee_grievance.json
+++ b/hrms/hr/doctype/employee_grievance/employee_grievance.json
@@ -14,6 +14,10 @@
   "date",
   "status",
   "reports_to",
+  "references_section",
+  "against_employee_grievance",
+  "column_break_jyjr",
+  "reopen_reason",
   "grievance_details_section",
   "grievance_against_party",
   "grievance_against",
@@ -198,12 +202,40 @@
    "fieldtype": "Data",
    "label": "Subject",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval: doc.against_employee_grievance",
+   "fieldname": "references_section",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fieldname": "against_employee_grievance",
+   "fieldtype": "Link",
+   "label": "Against Employee Grievance ",
+   "options": "Employee Grievance",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_jyjr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reopen_reason",
+   "fieldtype": "Small Text",
+   "label": "Reason for Re-open"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2024-08-21 15:46:21.711485",
+ "links": [
+  {
+   "link_doctype": "Employee Grievance",
+   "link_fieldname": "against_employee_grievance"
+  }
+ ],
+ "modified": "2025-07-06 13:59:56.142193",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Grievance",


### PR DESCRIPTION
Allow employees to reopen grievances that were marked as resolved by the HR team but are not actually resolved.
This PR adds the option to reopen a grievance even after it is marked as resolved, enabling both employees and the HR team to maintain a clear track of the grievance process.

`no-docs'