### PR TITLE
fix(PWA): set leave approver only if empty

### DIFF
--- a/frontend/src/views/leave/Form.vue
+++ b/frontend/src/views/leave/Form.vue
@@ -259,9 +259,11 @@ function setLeaveApprovers(data) {
 			: approver.name,
 		value: approver.name,
 	}))
-
-	leaveApplication.value.leave_approver = data?.leave_approver
-	leaveApplication.value.leave_approver_name = data?.leave_approver_name
+	if (!leaveApplication.value.leave_approver){
+		leaveApplication.value.leave_approver = data?.leave_approver
+		leaveApplication.value.leave_approver_name = data?.leave_approver_name
+	}
+	
 }
 
 function setLeaveTypes(data) {


### PR DESCRIPTION
Leave is approver in the PWA form when it already has a value, which sometimes results in showing incorrect leave approver in the form view.

#### Before
![image](https://github.com/user-attachments/assets/b6f1c927-2f12-4f1a-a961-92a8dcd05ee2)

![image](https://github.com/user-attachments/assets/e5dd9426-185e-4fd2-a96b-560b20c6e99c)

#### After
![image](https://github.com/user-attachments/assets/7e710aa5-fca8-4226-8c37-a9e801fd53cc)