### PR TITLE
fix: Employee advance allocated total as per sanctioned amount in Expense Claim

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -200,7 +200,7 @@ frappe.ui.form.on("Expense Claim", {
 	},
 
 	update_employee_advance_claimed_amount: function (frm) {
-		let amount_to_be_allocated = frm.doc.grand_total;
+		let amount_to_be_allocated = frm.doc.total_sanctioned_amount;
 		$.each(frm.doc.advances || [], function (i, advance) {
 			if (amount_to_be_allocated >= advance.unclaimed_amount - advance.return_amount) {
 				advance.allocated_amount =


### PR DESCRIPTION
### Reason
In Expense claim, the allocated amount of advances is not updated to sum of expense amount added in expense table

### Changes done
- updated the logic to use total sanctioned amount instead of grand total as sanction amount keeps the sum of total expenses added

Bug:

https://github.com/user-attachments/assets/e0a2e168-49e6-42c7-9bb1-2029f657b7b9

Fix:

https://github.com/user-attachments/assets/35111ce3-20e5-4238-a67d-9284ec36d6d6

`no-docs`