### PR TITLE
feat(PWA): enable PDF download option via showDownloadPDFButton prop

### DIFF
--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -43,7 +43,7 @@
 							{ label: __('Reload'), onClick: () => reloadDoc() },
 							{
 								label: __('Download PDF'),
-								condition: () => props.allowDownload,
+								condition: () => props.showDownloadPDFButton,
 								onClick: () => (handleDownload()),
 							},
 						]"
@@ -380,7 +380,7 @@ const props = defineProps({
 		required: false,
 		default: true,
 	},
-	allowDownload: {
+	showDownloadPDFButton: {
 		type: Boolean,
 		required: false,
 		default: false,

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -41,6 +41,11 @@
 								onClick: () => (showDeleteDialog = true),
 							},
 							{ label: __('Reload'), onClick: () => reloadDoc() },
+							{
+								label: __('Download PDF'),
+								condition: () => props.allowDownload,
+								onClick: () => (handleDownload()),
+							},
 						]"
 						:button="{
 							label: __('Menu'),
@@ -332,6 +337,7 @@ import { FileAttachment, guessStatusColor } from "@/composables"
 import useWorkflow from "@/composables/workflow"
 import { getCompanyCurrency } from "@/data/currencies"
 import { formatCurrency } from "@/utils/formatters"
+import { useDownloadPDF } from "@/utils/commonUtils"
 
 const props = defineProps({
 	doctype: {
@@ -374,9 +380,15 @@ const props = defineProps({
 		required: false,
 		default: true,
 	},
+	allowDownload: {
+		type: Boolean,
+		required: false,
+		default: false,
+	},
 })
 const emit = defineEmits(["validateForm", "update:modelValue"])
 const router = useRouter()
+const { downloadPDF } = useDownloadPDF()
 
 const __ = inject("$translate")
 
@@ -662,7 +674,7 @@ async function handleDocUpdate(action) {
 		} else if (action == "cancel") {
 			params.docstatus = 2
 		}
-
+		
 		await documentResource.setValue.submit(params)
 		await documentResource.get.promise
 		resetForm()
@@ -708,6 +720,14 @@ function resetForm() {
 	nextTick(() => {
 		isFormDirty.value = false
 		isFormUpdated.value = true
+	})
+}
+function handleDownload() {
+	if (!props.id) return
+	downloadPDF({
+		doctype: props.doctype,
+		docname: props.id,
+		filename: props.id,
 	})
 }
 

--- a/frontend/src/utils/commonUtils.js
+++ b/frontend/src/utils/commonUtils.js
@@ -1,0 +1,57 @@
+import { toast } from "frappe-ui"
+
+export function useDownloadPDF() {
+	async function downloadPDF({ doctype, docname, filename = null }) {
+		
+		const headers = {
+			"X-Frappe-Site-Name": window.location.hostname,
+		}
+		if (window.csrf_token) {
+			headers["X-Frappe-CSRF-Token"] = window.csrf_token
+		}
+
+		fetch("/api/method/hrms.api._download_pdf", {
+			method: "POST",
+			headers,
+			body: new URLSearchParams({ doctype: doctype, docname: docname }),
+			responseType: "blob",
+		}).then((response) => {
+				if (response.ok) {
+					return response.blob()
+				} else {
+					toast({
+						title: "Download Failed",
+						text: `Error downloading PDF`,
+						type: "error",
+						icon: "alert-circle",
+						position: "bottom-center",
+						iconClasses: "text-red-500",
+					})
+				}
+			})
+			.then((blob) => {
+				if (!blob) return
+				const blobUrl = window.URL.createObjectURL(blob)
+				const link = document.createElement("a")
+				link.href = blobUrl
+				link.download = `${filename || docname}.pdf`
+				link.click()
+				setTimeout(() => {
+					window.URL.revokeObjectURL(blobUrl)
+				}, 3000)
+			})
+			.catch((error) => {
+				toast({
+					title: __("Error"),
+					text: __("Error downloading PDF", [__(error)]),
+					icon: "alert-circle",
+					position: "bottom-center",
+					iconClasses: "text-red-500",
+				})
+			})
+	}
+
+	return {
+		downloadPDF,
+	}
+}

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -12,7 +12,7 @@
 				:tabs="tabs"
 				:showAttachmentView="true"
 				@validateForm="validateForm"
-				:allowDownload="true"
+				:showDownloadPDFButton="true"
 			>
 				<!-- Child Tables -->
 				<template #expenses="{ isFormReadOnly }">

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -12,7 +12,7 @@
 				:tabs="tabs"
 				:showAttachmentView="true"
 				@validateForm="validateForm"
-				:showFormButton="false"
+				:showFormButton="expenseClaim?.docstatus !== 1"
 			>
 				<!-- Child Tables -->
 				<template #expenses="{ isFormReadOnly }">
@@ -48,9 +48,11 @@
 				<template #formButton>
 					<ErrorMessage :message="downloadError" class="mt-2" />
 					<Button
+						v-if="expenseClaim?.name && expenseClaim?.docstatus === 1"
 						class="w-full rounded py-5 text-base disabled:bg-gray-700 disabled:text-white"
 						@click="downloadPDF"
 						variant="solid"
+						:loading="loading"
 					>
 						{{ __("Download PDF") }}
 					</Button>

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -52,7 +52,7 @@
 
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
-import { createResource, ErrorMessage, Button } from "frappe-ui"
+import { createResource } from "frappe-ui"
 import { computed, ref, watch, inject } from "vue"
 
 import FormView from "@/components/FormView.vue"

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -133,10 +133,10 @@ function downloadPDF() {
 		headers["X-Frappe-CSRF-Token"] = window.csrf_token
 	}
 
-	fetch("/api/method/hrms.api.download_salary_slip", {
+	fetch("/api/method/hrms.api._download_pdf", {
 		method: "POST",
 		headers,
-		body: new URLSearchParams({ name: salarySlipName }),
+		body: new URLSearchParams({doctype: "Salary Slip" ,docname: salarySlipName }),
 		responseType: "blob",
 	})
 		.then((response) => {

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -774,6 +774,25 @@ def download_salary_slip(name: str):
 	return f"data:{content_type};base64," + base64content.decode("utf-8")
 
 
+@frappe.whitelist()
+def download_expense_claim(name: str):
+	import base64
+
+	from frappe.utils.print_format import download_pdf
+
+	default_print_format = frappe.get_meta("Expense Claim").default_print_format or "Standard"
+
+	try:
+		download_pdf("Expense Claim", name, format=default_print_format)
+	except Exception:
+		frappe.throw(_("Failed to download Expense Claim PDF"))
+
+	base64content = base64.b64encode(frappe.local.response.filecontent)
+	content_type = frappe.local.response.type
+
+	return f"data:{content_type};base64," + base64content.decode("utf-8")
+
+
 # Workflow
 @frappe.whitelist()
 def get_workflow(doctype: str) -> dict:

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -756,36 +756,17 @@ def delete_attachment(filename: str):
 
 
 @frappe.whitelist()
-def download_salary_slip(name: str):
+def _download_pdf(doctype: str, docname: str) -> str:
 	import base64
 
 	from frappe.utils.print_format import download_pdf
 
-	default_print_format = frappe.get_meta("Salary Slip").default_print_format or "Standard"
+	default_print_format = frappe.get_meta(doctype).default_print_format or "Standard"
 
 	try:
-		download_pdf("Salary Slip", name, format=default_print_format)
-	except Exception:
-		frappe.throw(_("Failed to download Salary Slip PDF"))
-
-	base64content = base64.b64encode(frappe.local.response.filecontent)
-	content_type = frappe.local.response.type
-
-	return f"data:{content_type};base64," + base64content.decode("utf-8")
-
-
-@frappe.whitelist()
-def download_expense_claim(name: str):
-	import base64
-
-	from frappe.utils.print_format import download_pdf
-
-	default_print_format = frappe.get_meta("Expense Claim").default_print_format or "Standard"
-
-	try:
-		download_pdf("Expense Claim", name, format=default_print_format)
-	except Exception:
-		frappe.throw(_("Failed to download Expense Claim PDF"))
+		download_pdf(doctype, docname, format=default_print_format)
+	except Exception as e:
+		frappe.throw(_("Failed to download PDF: {0}").format(str(e)))
 
 	base64content = base64.b64encode(frappe.local.response.filecontent)
 	content_type = frappe.local.response.type


### PR DESCRIPTION
Closes: #3280

Added `showDownloadPDFButton` prop to `FormView` component to allow any form to be downloaded as a PDF. When `showDownloadPDFButton` is set to `true`, a "Download PDF" button is added to the Menu. Refactored code to support this functionality using a new `downloadPDF` utility.

![Screenshot from 2025-07-09 23-55-05](https://github.com/user-attachments/assets/25d9455a-ccfe-4904-b8f1-97892b4e640f)

[download_pdf_feature.webm](https://github.com/user-attachments/assets/bec80eb2-1c77-443b-be4b-140eb6d7a46f)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Download PDF" option in form headers so users can download the current document as a PDF.

* **Bug Fixes**
  * Improved error reporting and user-facing notifications for PDF download failures.

* **Refactor**
  * Unified and simplified the PDF download flow to support multiple document types and consistent behavior across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
`no-docs`