### PR TITLE
fix: the double headline in employee checkin on first save

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on("Employee Checkin", {
 	refresh: async (frm) => {
 		if (frm.doc.offshift) {
+			frm.dashboard.clear_headline();
 			frm.dashboard.set_headline(
 				__(
 					"This check-in is outside assigned shift hours and will not be considered for attendance. If a shift is assigned, adjust its time window and Fetch Shift again.",


### PR DESCRIPTION
<img width="1732" height="732" alt="image" src="https://github.com/user-attachments/assets/8d88f739-22c9-4efc-a7bd-09049e72c68e" />
