### PR TITLE
fix: only fetch data if field grouped by fields are permitted

### DIFF
--- a/hrms/hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py
+++ b/hrms/hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py
@@ -32,8 +32,19 @@ def get_data(
 	if not to_date:
 		to_date = getdate()
 
-	hiring = get_records(from_date, to_date, "date_of_joining", filters.get("company"))
-	attrition = get_records(from_date, to_date, "relieving_date", filters.get("company"))
+	permitted_fields = frappe.model.get_permitted_fields("Employee", user=frappe.session.user)
+
+	hiring = (
+		get_records(from_date, to_date, "date_of_joining", filters.get("company"))
+		if "date_of_joinig" in permitted_fields
+		else []
+	)
+
+	attrition = (
+		get_records(from_date, to_date, "relieving_date", filters.get("company"))
+		if "relieving_date" in permitted_fields
+		else []
+	)
 
 	hiring_data = get_result(hiring, filters.get("time_interval"), from_date, to_date, "Count")
 	attrition_data = get_result(attrition, filters.get("time_interval"), from_date, to_date, "Count")


### PR DESCRIPTION
If the groupby fields have higher level permissions, the fetching hiring vs attribution chart throws error for users that don't have the said permissions. ( should this be handled in get_list instead?)

<img width="2724" height="1320" alt="image" src="https://github.com/user-attachments/assets/ca0266a4-b9e8-443f-9dd9-9ec539d0ff30" />