### PR TITLE
refactor: half day payment calculation handling in payroll processing

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -503,7 +503,6 @@ class SalarySlip(TransactionBase):
 					self.absent_days += unmarked_days  # will be treated as absent
 					self.payment_days -= unmarked_days
 				half_absent_days = self.get_half_absent_days(
-					payroll_settings.include_holidays_in_total_working_days,
 					consider_marked_attendance_on_holidays,
 					holidays,
 				)
@@ -527,9 +526,7 @@ class SalarySlip(TransactionBase):
 
 		return unmarked_days
 
-	def get_half_absent_days(
-		self, include_holidays_in_total_working_days, consider_marked_attendance_on_holidays, holidays
-	):
+	def get_half_absent_days(self, consider_marked_attendance_on_holidays, holidays):
 		"""Calculates the number of half absent days for an employee within a date range"""
 		Attendance = frappe.qb.DocType("Attendance")
 		query = (

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -495,22 +495,19 @@ class SalarySlip(TransactionBase):
 
 			consider_unmarked_attendance_as = payroll_settings.consider_unmarked_attendance_as or "Present"
 
-			if (
-				payroll_settings.payroll_based_on == "Attendance"
-				and consider_unmarked_attendance_as == "Absent"
-			):
-				unmarked_days = self.get_unmarked_days(
-					payroll_settings.include_holidays_in_total_working_days, holidays
-				)
+			if payroll_settings.payroll_based_on == "Attendance":
+				if consider_unmarked_attendance_as == "Absent":
+					unmarked_days = self.get_unmarked_days(
+						payroll_settings.include_holidays_in_total_working_days, holidays
+					)
+					self.absent_days += unmarked_days  # will be treated as absent
+					self.payment_days -= unmarked_days
 				half_absent_days = self.get_half_absent_days(
-					payroll_settings.include_holidays_in_total_working_days,
-					consider_marked_attendance_on_holidays,
-					holidays,
-				)
-				self.absent_days += (
-					unmarked_days + half_absent_days * daily_wages_fraction_for_half_day
-				)  # will be treated as absent
-				self.payment_days -= unmarked_days + half_absent_days * daily_wages_fraction_for_half_day
+						payroll_settings.include_holidays_in_total_working_days,
+						consider_marked_attendance_on_holidays,
+						holidays,
+					)
+				self.payment_days -= (half_absent_days * daily_wages_fraction_for_half_day)
 		else:
 			self.payment_days = 0
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -743,7 +743,7 @@ class SalarySlip(TransactionBase):
 				]
 
 			if d.status == "Half Day" and d.leave_type and d.leave_type in leave_type_map.keys():
-				equivalent_lwp = 1 - daily_wages_fraction_for_half_day if d.half_day_status == "Absent" else 1
+				equivalent_lwp = 1 - daily_wages_fraction_for_half_day
 
 				if leave_type_map[d.leave_type]["is_ppl"]:
 					equivalent_lwp *= (

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -503,10 +503,10 @@ class SalarySlip(TransactionBase):
 					self.absent_days += unmarked_days  # will be treated as absent
 					self.payment_days -= unmarked_days
 				half_absent_days = self.get_half_absent_days(
-						payroll_settings.include_holidays_in_total_working_days,
-						consider_marked_attendance_on_holidays,
-						holidays,
-					)
+					payroll_settings.include_holidays_in_total_working_days,
+					consider_marked_attendance_on_holidays,
+					holidays,
+				)
 				self.payment_days -= (half_absent_days * daily_wages_fraction_for_half_day)
 		else:
 			self.payment_days = 0

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -296,9 +296,10 @@ class TestSalarySlip(IntegrationTestCase):
 		# from half lwp
 		self.assertEqual(ss.leave_without_pay, 0.5)
 
-		self.assertEqual(ss.absent_days, 1)
+		self.assertEqual(ss.absent_days, 2.5)
 
-		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 1.5)
+		# total payment days = total working days - lwp - absent days
+		self.assertEqual(ss.payment_days, days_in_month - no_of_holidays - 0.5 - 2.5)
 
 		# Gross pay calculation based on attendances
 		gross_pay = 78000 - (
@@ -778,7 +779,6 @@ class TestSalarySlip(IntegrationTestCase):
 			emp_id,
 			first_sunday,
 			"Half Day",
-			leave_type="Leave Without Pay",
 			half_day_status="Absent",
 			ignore_validate=True,
 		)


### PR DESCRIPTION
### Reason
The half day payment was not considered in payment days when the option `Consider Unmarked Attendance As` was set to **Present** 

### Changes done
- Move the logic to calculate half day payment outside this condition as when half day record is found, it will calculate the payment days accordingly
- Update leave without pay with other half status of half day

<img width="1850" height="868" alt="image" src="https://github.com/user-attachments/assets/2b399218-a323-4ff8-a116-173e2f2dcd94" />

<img width="1854" height="548" alt="image" src="https://github.com/user-attachments/assets/8e7c1b9a-f38d-476b-aab5-4808861c3944" />


<img width="2162" height="466" alt="image" src="https://github.com/user-attachments/assets/aa42b94e-a8e5-4957-99b9-ee14e4dc53f6" />




`no-docs`