### PR TITLE
fix: leave balance when allocations are manually expired

### DIFF
--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1419,7 +1419,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		)
 		leave_allocation.submit()
 
-		expire_allocation(leave_allocation, expiry_date=add_days(getdate(), -1))
+		expire_allocation(leave_allocation, expiry_date=getdate())
 
 		leave_balance = get_leave_balance_on(
 			employee=employee.name, leave_type=leave_type.name, date=getdate()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leave balances and available-for-consumption now account for manually expired allocations immediately; balances update (including dropping to zero) as of the manual expiry date.

* **Refactor**
  * Leave-balance report queries rewritten to use aggregated database summaries for allocations, expiries, and carry-forwards for more efficient and accurate calculations.

* **Tests**
  * Added tests covering manual expiry behavior and its effect on reported balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->