### PR TITLE
chore: avoid setting salary slip naming series via class method

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "autoname": "format:Sal Slip/{employee}/{#####}",
  "creation": "2013-01-10 16:34:15",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -746,10 +747,11 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-01 21:25:36.651583",
+ "modified": "2025-07-13 17:58:15.095251",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -783,6 +785,7 @@
    "role": "Employee"
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee_name",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -66,7 +66,6 @@ TAX_COMPONENTS_BY_COMPANY = "tax_components_by_company"
 class SalarySlip(TransactionBase):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.series = f"Sal Slip/{self.employee}/.#####"
 		self.whitelisted_globals = {
 			"int": int,
 			"float": float,
@@ -80,9 +79,6 @@ class SalarySlip(TransactionBase):
 			"ceil": ceil,
 			"floor": floor,
 		}
-
-	def autoname(self):
-		self.name = make_autoname(self.series)
 
 	@property
 	def joining_date(self):
@@ -248,11 +244,6 @@ class SalarySlip(TransactionBase):
 			user=employee_user,
 			after_commit=True,
 		)
-
-	def on_trash(self):
-		from frappe.model.naming import revert_series_if_last
-
-		revert_series_if_last(self.series, self.name)
 
 	def get_status(self):
 		if self.docstatus == 2:


### PR DESCRIPTION
This is to avoid overriding custom naming series set via Customize Form.
Earlier naming series was set via code