### PR TITLE
fix(Timesheet): billed status

### DIFF
--- a/hrms/overrides/employee_timesheet.py
+++ b/hrms/overrides/employee_timesheet.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from frappe.utils.data import flt
+
 from erpnext.projects.doctype.timesheet.timesheet import Timesheet
 
 
@@ -8,7 +10,7 @@ class EmployeeTimesheet(Timesheet):
 	def set_status(self):
 		self.status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[str(self.docstatus or 0)]
 
-		if self.per_billed == 100:
+		if flt(self.per_billed, self.precision("per_billed")) >= 100.0:
 			self.status = "Billed"
 
 		if self.salary_slip:


### PR DESCRIPTION
At execution time, the _Percentage Billed_ can be != 100 due to miniscule floating point inaccuracies. E.g. `per_billed` could be `100.00000000000001`. We still want to set the _Status_ to "Billed" in those cases.

Copy of https://github.com/frappe/erpnext/pull/40010
Resolves https://github.com/frappe/erpnext/issues/40006