### PR TITLE
fix(Timesheet): add patch to update wrong status

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -30,3 +30,4 @@ hrms.patches.v15_0.create_accounting_dimensions_in_leave_encashment
 hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendance
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
+hrms.patches.v15_0.fix_timesheet_status

--- a/hrms/patches/v15_0/fix_timesheet_status.py
+++ b/hrms/patches/v15_0/fix_timesheet_status.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def execute():
+	"""There was a bug where per_billed was not exactly 100, but slightly more
+	or less. This caused the status to not be correctly updated to "Billed".
+
+	This patch re-runs the fixed `set_status()` on all Timesheets that are
+	fully billed but still have the status "Submitted". If the status changed
+	(likely to "Billed"), it silently updates the value in the database.
+	"""
+	for ts_name in frappe.get_all(
+		"Timesheet", filters={"per_billed": 100, "status": "Submitted"}, pluck="name"
+	):
+		ts = frappe.get_doc("Timesheet", ts_name)
+		old_status = ts.status
+		ts.set_status()
+		if ts.status != old_status:
+			ts.db_set("status", ts.status, update_modified=False)


### PR DESCRIPTION
Addendum to https://github.com/frappe/hrms/pull/3339

There was a bug where per_billed was not exactly 100, but slightly more or less. This caused the status to not be correctly updated to "Billed".

This patch re-runs the fixed `set_status()` on all Timesheets that are fully billed but still have the status "Submitted". If the status changed (likely to "Billed"), it silently updates the value in the database.