### PR TITLE
ci: don't run test cases for changed translation files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - "**.md"
       - "**.html"
       - "**.csv"
+      - "**.po"
+      - "**.pot"
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"


### PR DESCRIPTION
I think HRMS doesn't have translation-specific test cases. So it should be safe to ignore server tests when only translation files are changed, and save some energy.

Similarly, changes to CSV files (old translation format) are already being ignored.