### PR TITLE
fix: validate existing shift assignments for schedule

### DIFF
--- a/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
+++ b/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
@@ -309,6 +309,7 @@ class ShiftAssignmentTool(Document):
 		assignment.shift_location = self.shift_location
 		assignment.enabled = 0 if self.end_date else 1
 		assignment.create_shifts_after = self.start_date
+		assignment.flags.ingore_validate = True
 		assignment.save()
 		return assignment
 

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
@@ -107,7 +107,7 @@
    "link_fieldname": "shift_schedule_assignment"
   }
  ],
- "modified": "2024-12-10 15:44:00.063685",
+ "modified": "2025-07-10 18:34:44.009398",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Schedule Assignment",
@@ -147,8 +147,10 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
- "title_field": "employee_name"
+ "title_field": "employee_name",
+ "track_changes": 1
 }

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
@@ -42,7 +42,7 @@
    "fieldname": "create_shifts_after",
    "fieldtype": "Date",
    "label": "Create Shifts After",
-   "mandatory_depends_on": "eval:doc.status === 'Active'"
+   "mandatory_depends_on": "eval:doc.enabled"
   },
   {
    "fieldname": "shift_details_section",
@@ -107,7 +107,7 @@
    "link_fieldname": "shift_schedule_assignment"
   }
  ],
- "modified": "2025-07-10 18:34:44.009398",
+ "modified": "2025-07-10 18:48:42.170391",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Schedule Assignment",

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
@@ -126,5 +126,10 @@ def process_auto_shift_creation():
 		pluck="name",
 	)
 	for d in shift_schedule_assignments:
-		doc = frappe.get_doc("Shift Schedule Assignment", d)
-		doc.create_shifts(add_days(doc.create_shifts_after, 1))
+		try:
+			doc = frappe.get_doc("Shift Schedule Assignment", d)
+			doc.create_shifts(add_days(doc.create_shifts_after, 1))
+		except Exception as e:
+			frappe.log_error(e)
+
+			continue

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
@@ -115,9 +115,7 @@ class ShiftScheduleAssignment(Document):
 			self.shift_location,
 			self.name,
 		)
-		self.create_shifts_after = end_date
-		self.flags.ignore_validate = True
-		self.save()
+		self.db_set("create_shifts_after", end_date)
 
 
 def process_auto_shift_creation():

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
@@ -116,6 +116,7 @@ class ShiftScheduleAssignment(Document):
 			self.name,
 		)
 		self.create_shifts_after = end_date
+		self.flags.ignore_validate = True
 		self.save()
 
 

--- a/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
+++ b/hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py
@@ -2,13 +2,65 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_days, get_weekday, getdate, nowdate
+from frappe.utils import add_days, get_link_to_form, get_weekday, getdate, nowdate
 
 from hrms.hr.doctype.shift_assignment_tool.shift_assignment_tool import create_shift_assignment
 
 
 class ShiftScheduleAssignment(Document):
+	def validate(self):
+		self.validate_existing_shift_assignments()
+
+	def validate_existing_shift_assignments(self):
+		if self.has_value_changed("create_shifts_after") and not self.is_new():
+			existing_shift_assignments, last_shift_end_date = self.get_existing_shift_assignments()
+			if existing_shift_assignments:
+				frappe.throw(
+					msg=_(
+						"Shift assignments for {0} after {1} are already created. Please change {2} date to a date later than {3} {4}"
+					).format(
+						frappe.bold(self.shift_schedule),
+						frappe.bold(self.create_shifts_after),
+						frappe.bold("Create Shifts After"),
+						frappe.bold(last_shift_end_date),
+						(
+							"<br><br><ul><li>"
+							+ "</li><li>".join(
+								get_link_to_form("Shift Assignment", shift)
+								for shift in existing_shift_assignments
+							)
+							+ "</li></ul>"
+						),
+					),
+					title=_("Existing Shift Assignments"),
+				)
+
+	def get_existing_shift_assignments(self):
+		shift_schedule_assignment = frappe.qb.DocType("Shift Schedule Assignment")
+		shift_assignment = frappe.qb.DocType("Shift Assignment")
+
+		query = (
+			frappe.qb.from_(shift_assignment)
+			.inner_join(shift_schedule_assignment)
+			.on(shift_assignment.shift_schedule_assignment == shift_schedule_assignment.name)
+			.select(shift_assignment.name, shift_assignment.end_date)
+			.where(
+				(shift_assignment.end_date >= self.create_shifts_after)
+				& (shift_assignment.status == "Active")
+				& (shift_assignment.employee == self.employee)
+			)
+			.orderby(shift_assignment.end_date)
+		)
+
+		existing_shifts = query.run(as_dict=True)
+
+		existing_shift_assignments = [shift.name for shift in existing_shifts]
+		last_shift_end_date = existing_shifts[-1].end_date if existing_shifts else None
+
+		return existing_shift_assignments, last_shift_end_date
+
 	def create_shifts(self, start_date: str, end_date: str | None = None) -> None:
 		shift_schedule = frappe.get_doc("Shift Schedule", self.shift_schedule)
 		gap = {

--- a/hrms/hr/doctype/shift_schedule_assignment/test_shift_schedule_assignment.py
+++ b/hrms/hr/doctype/shift_schedule_assignment/test_shift_schedule_assignment.py
@@ -1,20 +1,56 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, getdate
+
+from erpnext.setup.doctype.employee.test_employee import make_employee
+
+from hrms.hr.doctype.shift_schedule.shift_schedule import get_or_insert_shift_schedule
+from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record depdendencies are recursively loaded
 # Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class TestShiftScheduleAssignment(IntegrationTestCase):
-	"""
-	Integration tests for ShiftScheduleAssignment.
-	Use this class for testing interactions between multiple components.
-	"""
+	def setUp(self):
+		frappe.db.delete("Shift Type", "Shift Schedule" "Shift Schedule Assignment")
 
-	pass
+		self.employee = make_employee("test@scheduleassignment.com", company="_Test Company")
+		self.shift_type = setup_shift_type(
+			shift_type="Test Schedule Assignment", start_time="08:00:00", end_time="12:00:00"
+		)
+		self.shift_schedule = get_or_insert_shift_schedule(self.shift_type.name, "Every Week", ["Monday"])
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_existing_shift_assignment_validation(self):
+		shift_schedule_assignment = frappe.get_doc(
+			{
+				"doctype": "Shift Schedule Assignment",
+				"employee": self.employee,
+				"company": "_Test Company",
+				"shift_schedule": self.shift_schedule,
+				"shift_status": "Active",
+				"create_shifts_after": add_days(getdate(), -10),
+			}
+		).insert()
+		create_shifts_after = shift_schedule_assignment.create_shifts_after
+
+		shift_schedule_assignment.create_shifts(
+			add_days(create_shifts_after, 1), add_days(create_shifts_after, 15)
+		)
+
+		shift_schedule_assignment.reload()
+		shift_schedule_assignment.create_shifts_after = getdate()
+
+		self.assertRaises(frappe.ValidationError, shift_schedule_assignment.save)
+		shift_schedule_assignment.reload()
+		shift_schedule_assignment.create_shifts_after = add_days(getdate(), 6)
+
+		shift_schedule_assignment.save()
+		self.assertEqual(shift_schedule_assignment.create_shifts_after, add_days(getdate(), 6))


### PR DESCRIPTION
### Problem

1. Process shift assignment job uses create shift after date in Shift schedule assignment to track which shift schedules to pick to create shift assignments for the next three months. It also updates create shifts after to the next shift instance date after every assignment. Since `Create Shifts After` field remains editable, if the date is accidentally changed to a past date the background job fails with duplicate shift assignment error, preventing all shifts from being assigned. 
2. Activity shift assignments isn't tracked so referencing past modifications is impossible

### Fixes

To-do

- [x] Prevent user from editing date if shift assignments exist for future dates
- [x] Turn tracking changes on
- [x] Keep user activity separate from background job activity log
- [x] Catch exceptions and let next shifts be assigned
- [x] use db_set to change `create_shifts_after` to avoid unnecessary version clutter
- [x] Test for the validation

------

### After

<img width="2278" height="996" alt="image" src="https://github.com/user-attachments/assets/a0c50c93-9eda-46a6-b6f2-edfce563daf1" />

<img width="2112" height="1144" alt="image" src="https://github.com/user-attachments/assets/2d49def8-f011-4a8e-8bed-9a5e9ce5ccaa" />

<img width="2164" height="1162" alt="image" src="https://github.com/user-attachments/assets/ba0a0b00-0326-490a-b524-b0111b4cb2fd" />

<img width="1940" height="572" alt="image" src="https://github.com/user-attachments/assets/b2c2d9a5-1821-4a18-b4c4-29e158e7e970" />
