### PR TITLE
feat: filter unmarked attendance by shift in employee attendance tool #3362

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -47,6 +47,8 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					employment_type: frm.doc.employment_type,
 					designation: frm.doc.designation,
 					employee_grade: frm.doc.employee_grade,
+					shift: frm.doc.shift,
+					filter_by_shift: frm.doc.filter_by_shift,
 				},
 				freeze: true,
 				freeze_message: __("...Fetching Employees"),

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -14,6 +14,7 @@
   "company",
   "branch",
   "department",
+  "filter_by_shift",
   "column_break_bhny",
   "employment_type",
   "designation",
@@ -102,6 +103,7 @@
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
+   "mandatory_depends_on": "filter_by_shift",
    "options": "Shift Type"
   },
   {
@@ -172,13 +174,19 @@
    "fieldtype": "HTML",
    "label": "Horizontal Break",
    "options": "<hr>"
+  },
+  {
+   "default": "0",
+   "fieldname": "filter_by_shift",
+   "fieldtype": "Check",
+   "label": "Filter by Shift"
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-26 09:42:36.888216",
+ "modified": "2025-08-07 09:26:38.614559",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Attendance Tool",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -89,35 +89,37 @@ def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[di
 
 	return unmarked_attendance
 
+
 def _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date):
 	# Fetch employees based on Shift Assignment
 	shift_assigned_employees = frappe.get_list(
-		'Shift Assignment',
-		filters = {
-			'shift_type': shift,
-			'start_date': ['<=', frappe.utils.getdate(date)],
+		"Shift Assignment",
+		filters={
+			"shift_type": shift,
+			"start_date": ["<=", frappe.utils.getdate(date)],
 		},
-		fields=['employee']
+		fields=["employee"],
 	)
 	# Fetch employees based on default shifts
 	default_shift_employees = frappe.get_list(
-		'Employee',
-		filters = {
-			'default_shift': shift,
+		"Employee",
+		filters={
+			"default_shift": shift,
 		},
-		fields=['employee']
+		fields=["employee"],
 	)
 
 	all_employees_with_shift = shift_assigned_employees + default_shift_employees
-	distinct_employees_with_shift = {emp['employee'] for emp in all_employees_with_shift}
+	distinct_employees_with_shift = {emp["employee"] for emp in all_employees_with_shift}
 
 	# Filter unmarked attendance based on assigned employees
 	shiftwise_unmarked_attendance = []
 	for emp in unmarked_attendance:
-		if emp['employee'] in distinct_employees_with_shift:
+		if emp["employee"] in distinct_employees_with_shift:
 			shiftwise_unmarked_attendance.append(emp)
 
 	return shiftwise_unmarked_attendance
+
 
 @frappe.whitelist()
 def mark_employee_attendance(

--- a/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
@@ -11,6 +11,7 @@ from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool import (
 	get_employees,
 	mark_employee_attendance,
+	_get_unmarked_attendance_with_shift,
 )
 from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
@@ -154,6 +155,69 @@ class TestEmployeeAttendanceTool(IntegrationTestCase):
 				self.assertEqual(attendance.half_day_status, "Present")
 			self.assertEqual(attendance.shift, shift.name)
 
+	def test_get_unmarked_attendance_with_shift(self):
+			self.shift = frappe.get_doc({
+				"doctype": "Shift Type",
+				"name": "Shift 1",
+				"start_time":"09:00:00",
+				"end_time":"end_time",
+			}).insert()
+			self.employee1 = frappe.get_doc({
+				"doctype": "Employee",
+				"first_name": "Morning Shift Assigned",
+				"employee": "EMP001",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": "",
+				"gender" : "Male",
+			}).insert()
+
+			self.employee2 = frappe.get_doc({
+				"doctype": "Employee",
+				"first_name": "Test Default Shift",
+				"employee": "EMP002",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": self.shift,
+				"gender" : "Male",
+
+			}).insert()
+
+			self.employee3 = frappe.get_doc({
+				"doctype": "Employee",
+				"first_name": "Test Not Assigned",
+				"employee": "EMP003",
+				"date_of_birth": "1992-01-01",
+				"date_of_joining": "2023-01-01",
+				"default_shift": "",
+				"gender" : "Male",
+			}).insert()
+
+			# Assign a shift to employee1 via Shift Assignment
+			self.shift_assignment = frappe.get_doc({
+				"doctype": "Shift Assignment",
+				"employee": self.employee1.name,
+				"shift_type": self.shift,
+				"start_date": frappe.utils.getdate("2023-02-28"),
+				"end_date": frappe.utils.getdate("2023-03-10")
+			}).insert()
+			# Prepare the unmarked_attendance sample input
+			unmarked_attendance = [
+				{"employee": self.employee1.name},
+				{"employee": self.employee2.name},
+				{"employee": self.employee3.name}
+			]
+
+			shift = "Morning Shift"
+			date = "2023-03-01"
+
+			result = _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date)
+
+			# Only employee1 and employee2 have the shift (assigned/default)
+			filtered = set([emp['employee'] for emp in result])
+			self.assertIn(self.employee1.name, filtered)
+			self.assertIn(self.employee2.name, filtered)
+			self.assertNotIn(self.employee3.name, filtered)
 
 def create_leave_allocation(employee, leave_type):
 	frappe.get_doc(

--- a/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
@@ -156,14 +156,7 @@ class TestEmployeeAttendanceTool(IntegrationTestCase):
 			self.assertEqual(attendance.shift, shift.name)
 
 	def test_get_unmarked_attendance_with_shift(self):
-		self.shift = frappe.get_doc(
-			{
-				"doctype": "Shift Type",
-				"name": "Shift 1",
-				"start_time": "09:00:00",
-				"end_time": "17:00:00",
-			}
-		).insert()
+		self.shift = setup_shift_type(shift_type="Shift 1", start_time="08:00:00", end_time="10:00:00")
 		self.employee1 = frappe.get_doc(
 			{
 				"doctype": "Employee",


### PR DESCRIPTION
Closes #3362

> Please provide enough information so that others can review your pull request:
- Shift field is already present in Employee Attendance DocType.
- Shift field is not used in filters while fetching employees
- But while marking the attendance the field is used
- So I added another `_get_unmarked_attendance_with_shift()` to fetch the employees based on shift assignment 

> Explain the **details** for making this change. What existing problem does the pull request solve?
If ERPNext setup has over 4,000 employees, and their HR team uses the Employee Attendance Tool exclusively to mark attendance.
-     Each shift contains around 1,000+ employees.
-     Currently, the tool fetches employees from all shifts, regardless of which shift is being assigned .
-     As a result, HR staff have to manually remove employees who are not part of the target shift before proceeding.
-     This process is time-consuming given the volume of employees.
-     A shift-based filter would significantly improve efficiency and accuracy when marking attendance.
<img width="1721" height="917" alt="image" src="https://github.com/user-attachments/assets/49dc486e-e735-44a8-b72e-5ec556ed8c56" />
> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
Added `Filter By Shift` check box in filters section and made `Shift` reqd 
<img width="1920" height="634" alt="image" src="https://github.com/user-attachments/assets/38c013fd-d51d-48ef-a262-6a574d9e1186" />


https://github.com/user-attachments/assets/82e98b99-ab0d-44de-99bf-372e31d8a8b2








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Filter by Shift" option to the Employee Attendance Tool; when enabled, Shift becomes required and can be used to narrow results.

* **Bug Fixes**
  * Employee lists now correctly show unmarked attendance only for employees on the selected shift (via assignment or default).

* **Tests**
  * Added tests to validate shift-based filtering of unmarked attendance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
`no-docs`