### PR TITLE
fix: the naming series issue during salary slip import using data import tool

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -66,7 +66,6 @@ TAX_COMPONENTS_BY_COMPANY = "tax_components_by_company"
 class SalarySlip(TransactionBase):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.series = f"Sal Slip/{self.employee}/.#####"
 		self.whitelisted_globals = {
 			"int": int,
 			"float": float,
@@ -82,6 +81,7 @@ class SalarySlip(TransactionBase):
 		}
 
 	def autoname(self):
+		self.series = f"Sal Slip/{self.employee}/.#####"
 		self.name = make_autoname(self.series)
 
 	@property


### PR DESCRIPTION
As `series` is set in the class `__init__` method in the `SalarySlip` class with the data import tool, the name is not generating properly because the employee value is None. I have moved the `series` set to the `autoname` function that fixes the issue.