### PR TITLE
fix: currency fields formatting to NaN

### DIFF
--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -6,7 +6,7 @@
 				<div class="text-base font-normal text-gray-800">
 					{{ title }}
 				</div>
-				<div class="text-xs font-normal text-gray-500">
+				<div v-if="doc?.gross_pay" class="text-xs font-normal text-gray-500">
 					<span>
 						{{
 							__("{0}: {1}", [
@@ -20,7 +20,7 @@
 			</div>
 		</template>
 		<template #right>
-			<span class="text-gray-700 font-normal rounded text-base">
+			<span v-if="doc?.net_pay" class="text-gray-700 font-normal rounded text-base">
 				{{ formatCurrency(doc.net_pay, doc.currency) }}
 			</span>
 			<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />

--- a/frontend/src/views/salary_slip/Dashboard.vue
+++ b/frontend/src/views/salary_slip/Dashboard.vue
@@ -3,7 +3,7 @@
 		<template #body>
 			<div class="flex flex-col items-center my-7 p-4">
 				<div class="flex flex-col w-full bg-white rounded py-5 px-3.5 gap-5">
-					<div v-if="lastSalarySlip" class="flex flex-col w-full gap-1.5">
+					<div v-if="lastSalarySlip && lastSalarySlip.year_to_date" class="flex flex-col w-full gap-1.5">
 						<span class="text-gray-600 text-sm font-medium leading-5">
 							{{ __("Year To Date") }}
 						</span>


### PR DESCRIPTION
### Issue
Some currency fields like Net Pay or Gross Pay  that get formatted in salary slip maybe sensitive to some users and get bumped to a higher perm level. In that case their formatting evaluates to NaN
<img width="674" height="840" alt="image" src="https://github.com/user-attachments/assets/8426286a-2cd1-40dd-9f42-c37332255078" />

### Fix
The fields are only shown if the values exist
<img width="689" height="620" alt="image" src="https://github.com/user-attachments/assets/c13cc88b-35a2-4eac-be3f-b3c73a860e0a" />
