### PR TITLE
fix: Rejected expense claim amount to be shown in Rejected section of Expense Claim Summary (PWA)

### DIFF
--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -6,7 +6,7 @@
 		>
 			<div class="flex flex-col gap-1.5">
 				<span class="text-gray-600 text-base font-medium leading-5">
-					{{ __("Total Expense Amount") }}
+					{{ __("Total Claimed Amount") }}
 				</span>
 				<span class="text-gray-800 text-lg font-bold leading-6">
 					{{ formatCurrency(total_claimed_amount, company_currency) }}

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -544,9 +544,7 @@ def get_expense_claim_summary(employee: str) -> dict:
 	sum_approved_claims = Sum(approved_claims_case).as_("total_approved_amount")
 
 	rejected_claims_case = (
-		frappe.qb.terms.Case()
-		.when(Claim.approval_status == "Rejected", Claim.total_sanctioned_amount)
-		.else_(0)
+		frappe.qb.terms.Case().when(Claim.approval_status == "Rejected", Claim.total_claimed_amount).else_(0)
 	)
 	sum_rejected_claims = Sum(rejected_claims_case).as_("total_rejected_amount")
 


### PR DESCRIPTION
### Reason
- The rejected claim amount is not showing in the rejected section of expense claim summary in PWA

### Changes done
- Updated the rejected claim case with total claimed amount which employee had applied for claim
- Change the totle from _Total Expense Amount_ to _Total Claimed Amount_


### Screenshot
 Previously
<img width="250" height="450" alt="image" src="https://github.com/user-attachments/assets/e66bc1fe-187a-4a20-9357-c6ba097d2b58" />


 Now
<img width="250" height="450" alt="image" src="https://github.com/user-attachments/assets/9110eed7-c9fa-4c53-bba5-434f2550522e" />

`no-docs`
