### PR TITLE
fix: Show remaining amount of claimed amount in rejected section of Employee Claim Summary(PWA) if not fully sanctioned

### DIFF
--- a/frontend/src/components/ExpenseClaimSummary.vue
+++ b/frontend/src/components/ExpenseClaimSummary.vue
@@ -57,7 +57,8 @@
 					<span class="text-gray-800 text-base font-semibold leading-6">
 						{{
 							formatCurrency(
-								summary.data?.total_rejected_amount,
+								summary.data?.total_rejected_amount + 
+								(summary.data?.total_claimed_in_approved - summary.data?.total_approved_amount),
 								company_currency
 							)
 						}}
@@ -79,7 +80,7 @@ import { formatCurrency } from "@/utils/formatters"
 const total_claimed_amount = computed(() => {
 	return (
 		summary.data?.total_pending_amount +
-		summary.data?.total_approved_amount +
+		summary.data?.total_claimed_in_approved +
 		summary.data?.total_rejected_amount
 	)
 })

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -543,6 +543,11 @@ def get_expense_claim_summary(employee: str) -> dict:
 	)
 	sum_approved_claims = Sum(approved_claims_case).as_("total_approved_amount")
 
+	approved_total_claimed_case = (
+		frappe.qb.terms.Case().when(Claim.approval_status == "Approved", Claim.total_claimed_amount).else_(0)
+	)
+	sum_approved_total_claimed = Sum(approved_total_claimed_case).as_("total_claimed_in_approved")
+
 	rejected_claims_case = (
 		frappe.qb.terms.Case().when(Claim.approval_status == "Rejected", Claim.total_claimed_amount).else_(0)
 	)
@@ -554,6 +559,7 @@ def get_expense_claim_summary(employee: str) -> dict:
 			sum_pending_claims,
 			sum_approved_claims,
 			sum_rejected_claims,
+			sum_approved_total_claimed,
 			Claim.company,
 		)
 		.where((Claim.docstatus != 2) & (Claim.employee == employee))


### PR DESCRIPTION
## Reason 
- Continue of PR: #3407

## Changes done
- In case if the approved claim doesn't sanction full amount then show the remaining amount in rejected claim section
- Show sum of all claimed amount in title irrespective of status