### PR TITLE
fix: update expense claim outstanding amount and status on payment unreconcile

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -208,6 +208,9 @@ doc_events = {
 	},
 	"Project": {"validate": "hrms.controllers.employee_boarding_controller.update_employee_boarding_status"},
 	"Task": {"on_update": "hrms.controllers.employee_boarding_controller.update_task"},
+	"Unreconcile Payment": {
+		"on_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_expense_claim_on_unreconcile_payment"
+	}
 }
 
 # Scheduled Tasks

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -644,3 +644,18 @@ def get_allocation_amount(paid_amount=None, claimed_amount=None, return_amount=N
 		return flt(paid_amount) - (flt(claimed_amount) + flt(return_amount))
 	else:
 		frappe.throw(_("Invalid parameters provided. Please pass the required arguments."))
+
+
+def update_expense_claim_on_unreconcile_payment(doc, method=None):
+	"""
+		Updates Expense Claim when unreconcile payment is submitted
+		We need to Check if allocations have reference to Expense Claim
+		and then update the total amount reimbursed in Expense Claim.
+	"""
+
+	# Loop through allocations in the unreconcile payment
+	for alloc in doc.allocations:
+		# Check if the allocation reference is an Expense Claim
+		if alloc.reference_doctype == "Expense Claim" and alloc.reference_name:
+			expense_claim = frappe.get_doc("Expense Claim", alloc.reference_name)
+			update_reimbursed_amount(expense_claim)


### PR DESCRIPTION

### Description

This PR fixes an issue in **HRMS (Frappe/ERPNext)** where **Expense Claims** were not updating their **outstanding amount and status** when a **Payment Entry** linked to the claim was **unreconciled**.

**Issue:**  
- When an Expense Claim is submitted, users can create a Payment Entry to reimburse the employee.  
- On Payment Entry submission, the **Expense Claim** gets its **outstanding amount and status** updated correctly.  
- However, if the Payment Entry is **unreconciled**, the **Expense Claim** was **not updating**, leaving incorrect outstanding amounts and status.

**Solution Implemented:**  
- Added a new handler: `update_expense_claim_on_unreconcile_payment`  
- On unreconcile payment submission:  
  1. Loop through allocations in the Unreconcile Payment  
  2. Check if the allocation has reference to an **Expense Claim**.  
  3. Fetch the related **Expense Claim** document.  
  4. Call `update_reimbursed_amount()` to recalculate outstanding amount and update status.  

This ensures that **Expense Claims** now remain accurate.  

### Testing

1. Create an Expense Claim and submit it.
2. Create a Payment Entry against the Expense Claim and submit.
3. Confirm that the outstanding amount and status update correctly.
4. Unreconcile the Payment Entry.
5. Verify that the Expense Claim outstanding amount and status update correctly.
