### PR TITLE
fix: form.shift_type is of type string, not reactive

### DIFF
--- a/roster/src/components/ShiftAssignmentDialog.vue
+++ b/roster/src/components/ShiftAssignmentDialog.vue
@@ -492,7 +492,7 @@ const createShiftAssignmentSchedule = createResource({
 	makeParams() {
 		return {
 			employee: (form.employee as { value: string }).value,
-			shift_type: (form.shift_type as { value: string }).value,
+			shift_type: form.shift_type,
 			company: form.company,
 			status: form.status,
 			start_date: form.start_date,


### PR DESCRIPTION
The Link.vue component is returning a string and not a reactive variable, so it should access by `form.shift_type` and not `form.shift_type.value`