### PR TITLE
Show Username/Password Login only if not disabled

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -10,7 +10,7 @@
 				</div>
 
 				<div class="mx-auto mt-10 w-full px-8 sm:w-96">
-					<form class="flex flex-col space-y-4" @submit.prevent="submit">
+					<form v-if="!user_pass_login_disabled.data" class="flex flex-col space-y-4" @submit.prevent="submit">
 						<Input
 							:label="__('Email')"
 							:placeholder="__('johndoe@mail.com')"
@@ -36,7 +36,7 @@
 					</form>
 
 					<template v-if="authProviders.data?.length">
-						<div class="text-center text-sm text-gray-600 my-4">or</div>
+						<div v-if="!user_pass_login_disabled.data" class="text-center text-sm text-gray-600 my-4">or</div>
 						<div class="space-y-4">
 							<a
 								v-for="provider in authProviders.data"
@@ -49,6 +49,8 @@
 							</a>
 						</div>
 					</template>
+
+					<div v-else-if="user_pass_login_disabled.data" class="text-center text-gray-600 py-8">{{ __("No login methods are available. Please contact your administrator.") }}</div>
 				</div>
 			</div>
 
@@ -161,6 +163,13 @@ async function submit(e) {
 		errorMessage.value = error.messages.join("\n")
 	}
 }
+
+const user_pass_login_disabled = createResource({
+	url: "hrms.api.system_settings.get_user_pass_login_disabled",
+	method: 'GET',
+	initialData: [1],
+	auto: true,
+})
 
 const authProviders = createResource({
 	url: "hrms.api.oauth.oauth_providers",

--- a/hrms/api/system_settings.py
+++ b/hrms/api/system_settings.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+@frappe.whitelist(allow_guest=True)
+def get_user_pass_login_disabled():
+	return frappe.get_system_settings("disable_user_pass_login")


### PR DESCRIPTION
Fixes #3422

This PR improves the Login-UX by conditionally displaying the Username/Password Login  only if it is not disabled in the System Settings.

Currently the login form is always shown, even when username/password login is disabled. The user only sees an error after attempting to log in.

- A new API endpoint was added to fetch the `disable_user_pass_login` setting.

- `Login.vue` uses this setting to determine whether to render the username/password login form.


#### Before
<img width="861" height="1089" alt="image" src="https://github.com/user-attachments/assets/6b399201-0d36-47f7-af2e-5a1cff65a78e" />

#### After

<img width="770" height="805" alt="image" src="https://github.com/user-attachments/assets/1464f0d7-3609-4c79-ad41-18a90ca617c7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login page now hides the username/password form and related UI when that method is disabled.
  * Shows a clear message if no login methods are available and prompts users to contact the administrator.

* **Bug Fixes**
  * Better handling and messaging for cases where all login options are disabled, preventing confusing or empty login states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->