### PR TITLE
fix: set correct condition for paid and returned amount

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -258,7 +258,7 @@ def make_bank_entry(dt, dn):
 			"exchange_rate": flt(paying_exchange_rate),
 		},
 	)
-
+	je.flags.ignore_party_account_validation = True
 	return je.as_dict()
 
 

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -31,3 +31,4 @@ hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendan
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.fix_timesheet_status
+hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents

--- a/hrms/patches/v15_0/call_set_total_advance_paid_on_advance_documents.py
+++ b/hrms/patches/v15_0/call_set_total_advance_paid_on_advance_documents.py
@@ -29,5 +29,9 @@ def call_set_total_advance_paid(doctype) -> list:
 	).run(as_dict=True)
 
 	for entry in entries:
-		advance_payment_ledger = frappe.get_doc(entry.against_voucher_type, entry.against_voucher_no)
-		advance_payment_ledger.set_total_advance_paid()
+		try:
+			advance_payment_ledger = frappe.get_doc(entry.against_voucher_type, entry.against_voucher_no)
+			advance_payment_ledger.set_total_advance_paid()
+		except Exception as e:
+			frappe.log_error(e)
+			continue

--- a/hrms/patches/v15_0/call_set_total_advance_paid_on_advance_documents.py
+++ b/hrms/patches/v15_0/call_set_total_advance_paid_on_advance_documents.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	"""
+	Description:
+	Call set_total_advance_paid for advance ledger entries
+	"""
+	advance_doctpyes = ["Employee Advance", "Leave Encashment", "Gratuity"]
+
+	for doctype in advance_doctpyes:
+		if frappe.db.has_table(doctype):
+			call_set_total_advance_paid(doctype)
+
+
+def call_set_total_advance_paid(doctype) -> list:
+	aple = DocType("Advance Payment Ledger Entry")
+	advance_doctype = DocType(doctype)
+
+	date = frappe.utils.getdate("31-07-2025")
+
+	entries = (
+		frappe.qb.from_(aple)
+		.left_join(advance_doctype)
+		.on(aple.against_voucher_no == advance_doctype.name)
+		.select(aple.against_voucher_no, aple.against_voucher_type)
+		.where((aple.delinked == 0) & (advance_doctype.creation >= date))
+	).run(as_dict=True)
+
+	for entry in entries:
+		advance_payment_ledger = frappe.get_doc(entry.against_voucher_type, entry.against_voucher_no)
+		advance_payment_ledger.set_total_advance_paid()


### PR DESCRIPTION
- Employee advance is a receivable account, but it wasn't enforced so, there's a small chance of having employee advance entries made with a payable type account.
 - Added condition to calculate paid and returned amount based on how the the account is set. 
 - added to patch to update status on existing entries
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation of paid and returned amounts for advances, ensuring accurate totals based on the type of account involved.

* **Chores**
  * Added a new patch to update advance documents with corrected paid and returned amount calculations for relevant entries created after July 31, 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->