### PR TITLE
feat: Calculate & Show Income tax breakup section in Salary Slip if it is overwritten from Additional salary

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1415,11 +1415,11 @@ class SalarySlip(TransactionBase):
 		additional_salary = frappe.db.get_value(
 			"Additional Salary",
 			component.additional_salary,
-			["amount", "salary_component", "overwrite_salary_structure_amount"],
+			["amount", "overwrite_salary_structure_amount"],
 			as_dict=1,
 		)
 		self.additional_salary_amount = additional_salary.amount
-		self.additional_salary_component = additional_salary.salary_component
+		self.additional_salary_component = component.salary_component
 
 		if additional_salary.overwrite_salary_structure_amount:
 			return True

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1565,8 +1565,6 @@ class SalarySlip(TransactionBase):
 			self.full_tax_on_additional_earnings = self.total_tax_amount - self.total_structured_tax_amount
 
 		current_tax_amount = self.current_structured_tax_amount + self.full_tax_on_additional_earnings
-		# if flt(current_tax_amount) < 0:
-		# 	current_tax_amount = 0
 
 		current_tax_amount = max(0, flt(current_tax_amount))
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1326,17 +1326,6 @@ class SalarySlip(TransactionBase):
 			else:
 				self.other_deduction_components.append(d.salary_component)
 
-		self._component_based_variable_tax = {}
-
-		if tax_components and self.payroll_period and self.salary_structure:
-			self.tax_slab = self.get_income_tax_slabs()
-			self.compute_taxable_earnings_for_year()
-
-		if self.handle_additional_salary_tax_component():
-			self._component_based_variable_tax.setdefault(self.additional_salary_component, {})
-			self.calculate_variable_tax(self.additional_salary_component, True)
-			return
-
 		# consider manually added tax component
 		if not tax_components:
 			tax_components = [
@@ -1352,6 +1341,16 @@ class SalarySlip(TransactionBase):
 				indicator="blue",
 				alert=True,
 			)
+
+		self._component_based_variable_tax = {}
+		if tax_components and self.payroll_period and self.salary_structure:
+			self.tax_slab = self.get_income_tax_slabs()
+			self.compute_taxable_earnings_for_year()
+
+		if self.handle_additional_salary_tax_component():
+			self._component_based_variable_tax.setdefault(self.additional_salary_component, {})
+			self.calculate_variable_tax(self.additional_salary_component, True)
+			return
 
 		for tax_component in tax_components:
 			self._component_based_variable_tax.setdefault(tax_component, {})

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1467,6 +1467,61 @@ class TestSalarySlip(IntegrationTestCase):
 		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 2), 125439.65)
 		self.assertEqual(flt(salary_slip.total_income_tax, 2), 136843.25)
 
+	def test_income_tax_breakup_when_tax_added_via_additional_salary(self):
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+
+		frappe.db.delete("Income Tax Slab", {"currency": "INR"})
+		emp = make_employee(
+			"test_employee_ss_income_tax_breakup_added_via_addnl_salary@salary.com",
+			company="_Test Company",
+			date_of_joining="2021-01-01",
+		)
+
+		payroll_period = frappe.get_last_doc("Payroll Period", filters={"company": "_Test Company"})
+		create_tax_slab(payroll_period, effective_date=payroll_period.start_date, allow_tax_exemption=True)
+
+		salary_structure_name = "Test Salary Structure to test Income Tax Breakup"
+		if not frappe.db.exists("Salary Structure", salary_structure_name):
+			salary_structure_doc = make_salary_structure(
+				salary_structure_name,
+				"Monthly",
+				company="_Test Company",
+				employee=emp,
+				from_date=payroll_period.start_date,
+				payroll_period=payroll_period,
+				test_tax=True,
+				base=65000,
+			)
+
+		create_exemption_declaration(emp, payroll_period.name)
+
+		create_additional_salary_for_non_taxable_component(emp, payroll_period, company="_Test Company")
+
+		# create TDS of 12000 via addnl salary doctype
+		create_additional_salary_for_income_tax(emp, payroll_period, company="_Test Company")
+
+		create_employee_other_income(emp, payroll_period.name, company="_Test Company")
+
+		# Create Salary Slip
+		salary_slip = make_salary_slip(
+			salary_structure_doc.name, employee=emp, posting_date=payroll_period.start_date
+		)
+
+		monthly_tax_amount = 12000  # as 12000 is passed in addnl salary creation
+
+		self.assertEqual(salary_slip.ctc, 1216000.0)
+		self.assertEqual(salary_slip.income_from_other_sources, 10000.0)
+		self.assertEqual(salary_slip.non_taxable_earnings, 10000.0)
+		self.assertEqual(salary_slip.total_earnings, 1226000.0)
+		self.assertEqual(salary_slip.standard_tax_exemption_amount, 50000.0)
+		self.assertEqual(salary_slip.tax_exemption_declaration, 100000.0)
+		self.assertEqual(salary_slip.deductions_before_tax_calculation, 2400.0)
+		self.assertEqual(salary_slip.annual_taxable_amount, 1063600.0)
+		self.assertEqual(flt(salary_slip.income_tax_deducted_till_date, 2), monthly_tax_amount)
+		self.assertEqual(flt(salary_slip.current_month_income_tax, 2), monthly_tax_amount)
+		self.assertEqual(flt(salary_slip.future_income_tax_deductions, 2), 124843.25)  # as 136843.25 - 12000
+		self.assertEqual(flt(salary_slip.total_income_tax, 2), 136843.25)
+
 	def test_consistent_future_earnings_irrespective_of_payment_days(self):
 		"""
 		For CTC calculation, verifies that future non taxable earnings remain
@@ -2170,7 +2225,7 @@ def create_tax_slab(
 		{"from_amount": 1000001, "percent_deduction": 30},
 	]
 
-	income_tax_slab_name = frappe.db.get_value("Income Tax Slab", {"currency": currency})
+	income_tax_slab_name = frappe.db.get_value("Income Tax Slab", {"currency": currency, "docstatus": 1})
 
 	if not income_tax_slab_name:
 		income_tax_slab = frappe.new_doc("Income Tax Slab")
@@ -2571,6 +2626,32 @@ def create_additional_salary_for_non_taxable_component(employee, payroll_period,
 		}
 	).insert()
 
+	add_sal.submit()
+
+
+def create_additional_salary_for_income_tax(employee, payroll_period, company):
+	data = [
+		{
+			"salary_component": "TDS",
+			"abbr": "T",
+			"type": "Deduction",
+			"is_income_tax_component": 1,
+		},
+	]
+	make_salary_component(data, True, company_list=[company])
+
+	add_sal = frappe.get_doc(
+		{
+			"doctype": "Additional Salary",
+			"employee": employee,
+			"company": company,
+			"salary_component": "Income Tax",
+			"overwrite_salary_structure_amount": 1,
+			"amount": 12000,
+			"currency": "INR",
+			"payroll_date": payroll_period.start_date,
+		}
+	).insert()
 	add_sal.submit()
 
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1480,7 +1480,7 @@ class TestSalarySlip(IntegrationTestCase):
 		payroll_period = frappe.get_last_doc("Payroll Period", filters={"company": "_Test Company"})
 		create_tax_slab(payroll_period, effective_date=payroll_period.start_date, allow_tax_exemption=True)
 
-		salary_structure_name = "Test Salary Structure to test Income Tax Breakup"
+		salary_structure_name = "Test Salary Structure to test Income Tax Breakup added via addnl salary"
 		if not frappe.db.exists("Salary Structure", salary_structure_name):
 			salary_structure_doc = make_salary_structure(
 				salary_structure_name,
@@ -2645,7 +2645,7 @@ def create_additional_salary_for_income_tax(employee, payroll_period, company):
 			"doctype": "Additional Salary",
 			"employee": employee,
 			"company": company,
-			"salary_component": "Income Tax",
+			"salary_component": "TDS",
 			"overwrite_salary_structure_amount": 1,
 			"amount": 12000,
 			"currency": "INR",

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -243,7 +243,7 @@ def create_salary_structure_assignment(
 	if not payroll_period:
 		payroll_period = create_payroll_period(company="_Test Company")
 
-	income_tax_slab = frappe.db.get_value("Income Tax Slab", {"currency": currency})
+	income_tax_slab = frappe.db.get_value("Income Tax Slab", {"currency": currency, "docstatus": 1})
 
 	if not income_tax_slab:
 		income_tax_slab = create_tax_slab(payroll_period, allow_tax_exemption=True, currency=currency)


### PR DESCRIPTION
## Reason
- If the income tax is added in additional salary with the checkbox **Overwrite Salary Structure Amount** enabled, then the additional salary amount gets added in salary slip skipping the normal flow of income tax. In this process the **Income tax breakup** section in salary slip is not shown which raises concern in users to get the detailed calculation based on additional salary.

## Changes done
- get the additional salary amount & add in current month tax directly
- updated the func `calculate_variable_tax` to update the current month tax amount
- call func which calculates the yearly tax applicable & other totals before checking the additional salary record as it will be shown either way

## Screenshot

https://github.com/user-attachments/assets/17c0ea6f-3fe7-4072-afea-e6dc10125d59


`no-docs`

closes #3459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned salary-slip tax flow to separately handle Additional Salary, support overwrite-aware processing, and record per-component current-month tax amounts.
  * Added company-scoped tax component resolution with caching for company-specific defaults.

* **Bug Fixes**
  * Tax-slab selection restricted to submitted slabs to avoid incorrect lookups.
  * Ensured non-negative current-month tax calculation and correct handling when Additional Salary overwrites structured amounts.

* **Tests**
  * Added tests and helpers covering income-tax breakup when tax is applied via an Additional Salary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->