### PR TITLE
fix: validate employee advance account to be receivable

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.functions import Abs, Sum
-from frappe.utils import flt, nowdate
+from frappe.utils import flt, get_link_to_form, nowdate
 
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
@@ -28,6 +28,7 @@ class EmployeeAdvance(Document):
 	def validate(self):
 		validate_active_employee(self.employee)
 		self.validate_exchange_rate()
+		self.validate_advance_account_type()
 		self.set_status()
 		self.set_pending_amount()
 
@@ -64,6 +65,15 @@ class EmployeeAdvance(Document):
 	def validate_exchange_rate(self):
 		if not self.exchange_rate:
 			frappe.throw(_("Exchange Rate cannot be zero."))
+
+	def validate_advance_account_type(self):
+		account_type = frappe.db.get_value("Account", self.advance_account, "account_type")
+		if account_type != "Receivable":
+			frappe.throw(
+				_("Employee advance account {0} should of of type {1}.").format(
+					get_link_to_form("Account", self.advance_account), frappe.bold("Receivable")
+				)
+			)
 
 	def set_status(self, update=False):
 		precision = self.precision("paid_amount")

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -268,7 +268,7 @@ def make_bank_entry(dt, dn):
 			"exchange_rate": flt(paying_exchange_rate),
 		},
 	)
-	je.flags.ignore_party_account_validation = True
+
 	return je.as_dict()
 
 

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -70,7 +70,7 @@ class EmployeeAdvance(Document):
 		account_type = frappe.db.get_value("Account", self.advance_account, "account_type")
 		if account_type != "Receivable":
 			frappe.throw(
-				_("Employee advance account {0} should of of type {1}.").format(
+				_("Employee advance account {0} should be of type {1}.").format(
 					get_link_to_form("Account", self.advance_account), frappe.bold("Receivable")
 				)
 			)

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -27,6 +27,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.delete("Employee Advance")
 		self.update_company_in_fiscal_year()
+		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 
 	def test_paid_amount_and_status(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -28,6 +28,7 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		frappe.db.delete("Employee Advance")
 		self.update_company_in_fiscal_year()
 		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
+		frappe.db.set_value("Account", "_Test Employee Advance - _TC", "account_type", "Receivable")
 
 	def test_paid_amount_and_status(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -39,6 +39,7 @@ class TestExpenseClaim(HRMSTestSuite):
 			).insert()
 
 			frappe.db.set_value("Company", company_name, "default_cost_center", cost_center)
+		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -31,4 +31,4 @@ hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendan
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.fix_timesheet_status
-hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents
+hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-08

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -63,7 +63,7 @@ class TestPayrollEntry(FrappeTestCase):
 
 		frappe.db.set_value("Company", "_Test Company", "default_holiday_list", "_Test Holiday List")
 		frappe.db.set_single_value("Payroll Settings", "email_salary_slip_to_employee", 0)
-
+		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 		# set default payable account
 		default_account = frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account")
 		if not default_account or default_account != "_Test Payroll Payable - _TC":


### PR DESCRIPTION
Because without it advance payment ledger entries aren't created
<img width="2256" height="992" alt="image" src="https://github.com/user-attachments/assets/425d0f82-c8ae-4a07-b4a7-fd19d1f48b70" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure that the advance account type is "Receivable" when submitting an employee advance. If not, a clear error message with a clickable link to the account form is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->