### PR TITLE
fix: show attendance summary after joining date

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -7,6 +7,7 @@ from itertools import groupby
 
 import frappe
 from frappe import _
+from frappe.query_builder import Case
 from frappe.query_builder.functions import Count, Extract, Sum
 from frappe.utils import cint, cstr, getdate
 from frappe.utils.nestedset import get_descendants_of
@@ -320,8 +321,14 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 			Employee.company,
 			Employee.holiday_list,
 			Extract("day", Employee.date_of_joining).as_("joined_date"),
-			Extract("month", Employee.date_of_joining).as_("joined_month"),
-			Extract("year", Employee.date_of_joining).as_("joined_year"),
+			Case()
+			.when(
+				(Extract("month", Employee.date_of_joining) == filters.month)
+				& (Extract("year", Employee.date_of_joining) == filters.year),
+				1,
+			)
+			.else_(0)
+			.as_("joined_in_current_period"),
 		)
 		.where(Employee.company.isin(filters.companies))
 	)
@@ -405,7 +412,9 @@ def get_rows(employee_details: dict, filters: Filters, holiday_map: dict, attend
 		holidays = holiday_map.get(emp_holiday_list)
 
 		if filters.summarized_view:
-			attendance = get_attendance_status_for_summarized_view(employee, filters, holidays, details)
+			attendance = get_attendance_status_for_summarized_view(
+				employee, filters, holidays, details.joined_in_current_period, details.joined_date
+			)
 			if not attendance:
 				continue
 
@@ -443,7 +452,7 @@ def set_defaults_for_summarized_view(filters, row):
 
 
 def get_attendance_status_for_summarized_view(
-	employee: str, filters: Filters, holidays: list, details: dict
+	employee: str, filters: Filters, holidays: list, joined_in_current_period: int, joined_date: int
 ) -> dict:
 	"""Returns dict of attendance status for employee like
 	{'total_present': 1.5, 'total_leaves': 0.5, 'total_absent': 13.5, 'total_holidays': 8, 'unmarked_days': 5}
@@ -454,12 +463,9 @@ def get_attendance_status_for_summarized_view(
 
 	total_days = get_total_days_in_month(filters)
 	total_holidays = total_unmarked_days = 0
-	joined_in_current_period = cint(filters.month) == cint(details.joined_month) and cint(
-		filters.year
-	) == cint(details.joined_year)
 
 	for day in range(1, total_days + 1):
-		if day in attendance_days or (joined_in_current_period and cint(day) < cint(details.joined_date)):
+		if day in attendance_days or (cint(joined_in_current_period) and cint(day) < cint(joined_date)):
 			continue
 
 		status = get_holiday_status(day, holidays)

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -465,7 +465,7 @@ def get_attendance_status_for_summarized_view(
 	total_holidays = total_unmarked_days = 0
 
 	for day in range(1, total_days + 1):
-		if day in attendance_days or (cint(joined_in_current_period) and cint(day) < cint(joined_date)):
+		if day in attendance_days or (joined_in_current_period and day < joined_date):
 			continue
 
 		status = get_holiday_status(day, holidays)

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -459,7 +459,7 @@ def get_attendance_status_for_summarized_view(
 	) == cint(details.joined_year)
 
 	for day in range(1, total_days + 1):
-		if day in attendance_days or (joined_in_current_period and day < details.joined_date):
+		if day in attendance_days or (joined_in_current_period and cint(day) < cint(details.joined_date)):
 			continue
 
 		status = get_holiday_status(day, holidays)


### PR DESCRIPTION
**Issue:** The Monthly Attendance Sheet shows unmarked days and holidays before the employee's joining date
**ref:** [45903](https://support.frappe.io/helpdesk/tickets/45903)

**Employee:**
<img width="1862" height="898" alt="image" src="https://github.com/user-attachments/assets/66d37bf6-d140-4535-a357-42a313d08fe1" />

**Attendance:**
<img width="1858" height="773" alt="image" src="https://github.com/user-attachments/assets/b43d9e8c-03b3-441d-94e7-84df37b4b787" />


**Before:**
<img width="1855" height="732" alt="image" src="https://github.com/user-attachments/assets/156714a6-f832-483d-a380-9273d26b1178" />

**After:**
<img width="1855" height="732" alt="image" src="https://github.com/user-attachments/assets/a51946f7-5c15-4d44-9852-68fee31644c9" />


Backport needed for v14 & v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly Attendance report now respects employee join dates when viewing the selected month, excluding pre-join days from relevant counts and summaries.

* **Bug Fixes**
  * Days before an employee’s join date are excluded from holiday and unmarked-day totals for the selected month.
  * Summarized attendance for employees who joined during the period is more accurate while present/leave/absence tallies remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->