### PR TITLE
fix: fix employee advance bugs

### DIFF
--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -271,7 +271,7 @@ def get_total_amount_and_exchange_rate(ref_doc, party_account_currency, company_
 		exchange_rate = ref_doc.get("exchange_rate")
 		if party_account_currency != ref_doc.currency:
 			total_amount = flt(total_amount) * flt(exchange_rate)
-		if party_account_currency == company_currency:
+		if party_account_currency == company_currency and party_account_currency == ref_doc.currency:
 			exchange_rate = 1
 	elif ref_doc.doctype == "Leave Encashment":
 		total_amount = ref_doc.encashment_amount


### PR DESCRIPTION
#### Problem 1
Before #3441 and frappe/erpnext#48341,
GL entries were being referred to get paid and returned amount in employee advance and set status accordingly. GL entries recorded payments in company currency and hence dividing by exchange rate always resulted in correct comparisons.
Advanced Payment Ledger Entries however record in account currency which may or not be same as company currency, hence, the conversion with exchange rate is only required in certain conditions.

#### Fix
- [x] Added condition for exchange rate conversion
- [x] Test for employee advance when company currency is different
- [x] Test for employee advance when account currency is different 

#### Problem 2
`get_total_amount_and_exchange_rate` function would override employee advance exchange rate if account and company currencies were same resulting in incorrect outstanding amount calculation
- [x] Modified condition to calculate correct outstanding amount
- [x] Test for employee advance when employee advance currency is different 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced multi-currency handling for Employee Advances and related Payment Entries, with currency-aware calculations across company, account, and advance currencies.

- Bug Fixes
  - Corrected paid and returned amount calculations for accuracy across currencies.
  - Applied exchange rates consistently, avoiding unintended rate overrides.
  - Added validation to prevent using invalid advance accounts, with clearer error messages.

- Tests
  - Added comprehensive cross-currency test coverage for Employee Advances.
  - Improved test utilities and cleanup to maintain reliable defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->