### PR TITLE
fix: update amount on advance payment ledger entry

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -31,5 +31,5 @@ hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendan
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.fix_timesheet_status
-# hrms.patches.v15_0.update_advance_payment_ledger_amount
-# hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-14
+hrms.patches.v15_0.update_advance_payment_ledger_amount
+hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-14

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -31,4 +31,5 @@ hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendan
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.fix_timesheet_status
-hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-08
+# hrms.patches.v15_0.update_advance_payment_ledger_amount
+# hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-14

--- a/hrms/patches/v15_0/update_advance_payment_ledger_amount.py
+++ b/hrms/patches/v15_0/update_advance_payment_ledger_amount.py
@@ -1,0 +1,75 @@
+import frappe
+from frappe.query_builder import Case
+
+
+def execute():
+	advance_doctypes = ["Employee Advance", "Leave Encashment", "Gratuity"]
+
+	update_payment_entry(advance_doctypes)
+	update_journal_entry(advance_doctypes)
+
+
+def update_payment_entry(advance_doctypes):
+	pe = frappe.qb.DocType("Payment Entry")
+	per = frappe.qb.DocType("Payment Entry Reference")
+	advance_ledger = frappe.qb.DocType("Advance Payment Ledger Entry")
+
+	(
+		frappe.qb.update(pe)
+		.inner_join(per)
+		.on(per.parent.eq(pe.name))
+		.inner_join(advance_ledger)
+		.on(
+			advance_ledger.voucher_no.eq(pe.name)
+			& advance_ledger.voucher_type.eq("Payment Entry")
+			& advance_ledger.against_voucher_type.eq(per.reference_doctype)
+			& advance_ledger.against_voucher_no.eq(per.reference_name)
+		)
+		.set(advance_ledger.amount, per.allocated_amount)
+		.where(
+			per.reference_doctype.isin(advance_doctypes)
+			& pe.docstatus.eq(1)
+			& pe.payment_type.eq("Pay")
+			& (advance_ledger.amount < 0)
+		)
+	).run()
+
+
+def update_journal_entry(advance_doctypes):
+	je = frappe.qb.DocType("Journal Entry")
+	jea = frappe.qb.DocType("Journal Entry Account")
+	advance_ledger = frappe.qb.DocType("Advance Payment Ledger Entry")
+
+	(
+		frappe.qb.update(jea)
+		.inner_join(je)
+		.on(je.name == jea.parent)
+		.inner_join(advance_ledger)
+		.on(
+			advance_ledger.voucher_type.eq("Journal Entry")
+			& advance_ledger.voucher_no.eq(je.name)
+			& advance_ledger.against_voucher_type.eq(jea.reference_type)
+			& advance_ledger.against_voucher_no.eq(jea.reference_name)
+		)
+		.set(
+			advance_ledger.amount,
+			Case()
+			.when(
+				(jea.debit_in_account_currency > 0) & (advance_ledger.amount < 0),
+				jea.debit_in_account_currency,
+			)
+			.when(
+				(jea.credit_in_account_currency > 0) & (advance_ledger.amount > 0),
+				jea.credit_in_account_currency * -1,
+			)
+			.else_(advance_ledger.amount),
+		)
+		.where(
+			jea.reference_type.isin(advance_doctypes)
+			& jea.docstatus.eq(1)
+			& (
+				((jea.debit_in_account_currency > 0) & (advance_ledger.amount < 0))
+				| ((jea.credit_in_account_currency > 0) & (advance_ledger.amount > 0))
+			)
+		)
+	).run()


### PR DESCRIPTION
**Issue:**
The patch `erpnext.patches.v15_0.create_advance_payment_ledger_records` creates the Advance Payment Ledger Entry in [Negative Amount](https://github.com/frappe/erpnext/blob/29ca1a1f40224a183b7ce6fbc52855ac692ea8f8/erpnext/patches/v15_0/create_advance_payment_ledger_records.py#L127). The PR [49051](https://github.com/frappe/erpnext/pull/49051) has created the Advance Payment Ledger Entries with a negative amount for the Employee Advance Payments

In Employee Advance, the Payment Entry amount will be added as positive, and the return amount will be added as negative. So the `set_total_advance_paid` function uses `amount > 0` to get the paid amount and `amount < 0` to get the returned amount.

Since the Advance Payment Ledger Entries of the older payments were created in negative, and the `amount > 0` to get the paid amount. The `paid_amount` is considered as 0, and while returning the amount, users get the `Paid Amount cannot be greater than the requested advance amount` error.

```
  File "apps/erpnext/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py", line 36, in on_update
    update_voucher_outstanding(self.against_voucher_type, self.against_voucher_no, None, None, None)
  File "apps/erpnext/erpnext/accounts/utils.py", line 1914, in update_voucher_outstanding
    ref_doc.set_total_advance_paid()
  File "apps/hrms/hrms/hr/doctype/employee_advance/employee_advance.py", line 168, in set_total_advance_paid
    frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
  File "apps/frappe/frappe/__init__.py", line 609, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 574, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 525, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Return amount cannot be greater than unclaimed amount
```



**Solution:**
Added a patch to update the Advance Payment Ledger Entry Amount based on the payment and return.

ref: [46426](https://support.frappe.io/helpdesk/tickets/46426), [45850](https://support.frappe.io/helpdesk/tickets/45850), [46442](https://support.frappe.io/helpdesk/tickets/46442), [46558](https://support.frappe.io/helpdesk/tickets/46558), [45730](https://support.frappe.io/helpdesk/tickets/45730)


Backport needed for version-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Corrects Advance Payment Ledger amounts by reconciling with Payment Entries and Journal Entries.
  * Ensures accurate balances for Employee Advance, Leave Encashment, and Gratuity.
  * Resolves sign inconsistencies on ledger entries, improving reports and statements.

* Chores
  * Updated patch sequence to include the new ledger correction and refreshed scheduling of a related patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->