### PR TITLE
fix(Roster): do not get value for link fields

### DIFF
--- a/roster/src/components/ShiftAssignmentDialog.vue
+++ b/roster/src/components/ShiftAssignmentDialog.vue
@@ -492,12 +492,12 @@ const createShiftAssignmentSchedule = createResource({
 	makeParams() {
 		return {
 			employee: (form.employee as { value: string }).value,
-			shift_type: (form.shift_type as { value: string }).value,
+			shift_type: form.shift_type,
 			company: form.company,
 			status: form.status,
 			start_date: form.start_date,
 			end_date: form.end_date,
-			shift_location: (form.shift_location as { value: string }).value,
+			shift_location: form.shift_location,
 			repeat_on_days: Object.keys(repeatOnDays).filter(
 				(day) => repeatOnDays[day as keyof typeof repeatOnDays],
 			),


### PR DESCRIPTION
**Issue:** Unable to create shift assignment from Roster
**ref:** [46501](https://support.frappe.io/helpdesk/tickets/46501)

Missed in https://github.com/frappe/hrms/pull/3239
**Before:**

https://github.com/user-attachments/assets/cfd7424c-29dd-47b6-8c91-ff437335de50


**After:**

https://github.com/user-attachments/assets/7ef436aa-923e-45d9-8553-c0ea42337b65


**Backport Needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed an issue where Shift Type and Shift Location selections in the Shift Assignment dialog were not reliably captured, ensuring these choices are correctly saved when creating or editing schedules.
  - Reduced form submission errors related to those fields for more consistent behavior.

- Chores
  - Minor internal adjustments to form value handling to improve reliability without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->