### PR TITLE
fix: round with field precision

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -352,6 +352,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 	def validate_advances(self):
 		self.total_advance_amount = 0
+		precision = self.precision("total_advance_amount")
 
 		for d in self.get("advances"):
 			self.round_floats_in(d)
@@ -367,8 +368,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			d.advance_paid = ref_doc.paid_amount
 			d.unclaimed_amount = flt(ref_doc.paid_amount) - flt(ref_doc.claimed_amount)
 
-			if d.allocated_amount and flt(d.allocated_amount) > (
-				flt(d.unclaimed_amount) - flt(d.return_amount)
+			if d.allocated_amount and flt(d.allocated_amount) > flt(
+				flt(d.unclaimed_amount) - flt(d.return_amount), precision
 			):
 				frappe.throw(
 					_("Row {0}# Allocated amount {1} cannot be greater than unclaimed amount {2}").format(
@@ -380,7 +381,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 		if self.total_advance_amount:
 			self.round_floats_in(self, ["total_advance_amount"])
-			precision = self.precision("total_advance_amount")
 			amount_with_taxes = flt(
 				(flt(self.total_sanctioned_amount, precision) + flt(self.total_taxes_and_charges, precision)),
 				precision,


### PR DESCRIPTION
**Issue:** Unable to create an Expense Claim for the amount 0.01 when the advance is partially claimed and returned.
**ref:** [46724](https://support.frappe.io/helpdesk/tickets/46724)

**Steps to Reproduce:**
- Create Employee Advance for 9,000
- Create an Expense Claim for 3,596.77
- Create an Advance Return for 5,403.22
```
9,000 - 3,596.77 - 5,403.22 = 0.01
```
- Create an Expense Claim for the remaining amount 0.01 to make the Employee Advance `Partly Claimed and Returned`


**Before:**

https://github.com/user-attachments/assets/e0ee99d1-8862-4d89-8eae-b75582e08108


**After:**

https://github.com/user-attachments/assets/f3f7961d-2e4b-4fa5-b9d6-ec8ff5ebe750


**Backport needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal precision handling in expense advance validation to prevent rounding-related errors.
  * Ensured comparisons use consistent rounding so allocated, unclaimed, and returned amounts are evaluated uniformly.
  * Standardized precision for totals and taxes to produce more accurate expense claim calculations.
  * Removed inconsistent local precision behavior to maintain predictable validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->