### PR TITLE
fix: ensure appraisal creation progress bar completes

### DIFF
--- a/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
+++ b/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
@@ -166,6 +166,7 @@ def create_appraisals_for_cycle(appraisal_cycle: AppraisalCycle, publish_progres
 	Creates appraisals for employees in the appraisee list of appraisal cycle,
 	if not already created
 	"""
+	total = len(appraisal_cycle.appraisees)
 	count = 0
 
 	for employee in appraisal_cycle.appraisees:
@@ -185,15 +186,13 @@ def create_appraisals_for_cycle(appraisal_cycle: AppraisalCycle, publish_progres
 			)
 			appraisal.set_kras_and_rating_criteria()
 			appraisal.insert()
-
+		except frappe.DuplicateEntryError:
+			# already exists, skip
+			pass
+		finally:
 			if publish_progress:
 				count += 1
-				frappe.publish_progress(
-					count * 100 / len(appraisal_cycle.appraisees), title=_("Creating Appraisals") + "..."
-				)
-		except frappe.DuplicateEntryError:
-			# already exists
-			pass
+				frappe.publish_progress(count * 100 / total, title=_("Creating Appraisals") + "...")
 
 
 def validate_active_appraisal_cycle(appraisal_cycle: str) -> None:


### PR DESCRIPTION
## Problem
Previously, if an appraisal already existed, the loading bar could freeze mid-way because `DuplicateEntryError` was silently skipped without updating progress.

## Solution
Moved the `publish_progress` call into a `finally` block so that the progress count increments even if the appraisal already exists. This ensures the loading bar always reaches 100%.

## Notes
- No changes to database schema or other functionality.  
- PR follows the [commit message conventions](https://github.com/frappe/erpnext/wiki/Contribution-Guidelines).  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Progress updates during appraisal generation are now reliably reported for every appraisee, even when errors occur.
  - Duplicate appraisees are skipped without interrupting the process, while progress continues to advance.

- Improvements
  - More accurate and consistent progress calculation, ensuring a smooth 0–100% completion experience.
  - Clearer, uninterrupted feedback during appraisal creation for large cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->