### PR TITLE
fix(Earned Leave): fix earned allocation for quaterly, half yearly and yearly leave types

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.utils import (
 	add_days,
 	add_months,
+	add_to_date,
 	get_first_day,
 	get_last_day,
 	get_year_ending,
@@ -618,7 +619,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)[0]
 
 		# quarter passed 2 so leaves allocated should be 6
-		frappe.flags.current_date = add_months(get_year_start(getdate()), 7)
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 3)
 
 		allocate_earned_leaves()
 
@@ -692,7 +693,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		assignment = make_policy_assignment(
 			employee,
-			allocate_on_day="Last Day",
+			allocate_on_day="First Day",
 			earned_leave_frequency="Half-Yearly",
 			annual_allocation=12,
 			assignment_based_on="Leave Period",
@@ -713,7 +714,6 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 
-		# created policy assignment at the begining of the year so allocated leaces should be 0
 		assignment = make_policy_assignment(
 			employee,
 			allocate_on_day="First Day",
@@ -732,7 +732,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(total_leaves_allocated, 6)
 
 		# after 6 months, all 12 leaves should be allocated
-		frappe.flags.current_date = add_months(get_year_start(getdate()), 6)
+		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=6, days=1)
 
 		allocate_earned_leaves()
 

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -640,6 +640,109 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertEqual(total_leaves_allocated, 9)
 
+	def test_half_yearly_earned_leaves_allocated_on_last_day_at_the_start_of_leave_period(self):
+		frappe.flags.current_date = get_year_start(getdate())
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Half-Yearly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+
+		self.assertEqual(total_leaves_allocated, 0.0)
+
+	def test_half_yearly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 7)
+
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Half-Yearly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+
+		self.assertEqual(total_leaves_allocated, 6.0)
+
+	def test_half_yearly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+
+		frappe.flags.current_date = get_year_start(getdate())
+
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Half-Yearly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+
+		self.assertEqual(total_leaves_allocated, 6.0)
+
+	def test_half_yearly_earned_leaves_allocated_by_the_scheduler(self):
+		frappe.flags.current_date = get_year_start(getdate())
+
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+
+		# created policy assignment at the begining of the year so allocated leaces should be 0
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Half-Yearly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+		self.assertEqual(total_leaves_allocated, 6)
+
+		# after 6 months, all 12 leaves should be allocated
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 6)
+
+		allocate_earned_leaves()
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+		self.assertEqual(total_leaves_allocated, 12)
+
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
 		frappe.db.set_value("Leave Type", self.leave_type, "max_leaves_allowed", 0)

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -2,7 +2,6 @@ import frappe
 from frappe.utils import (
 	add_days,
 	add_months,
-	add_to_date,
 	get_first_day,
 	get_last_day,
 	get_year_ending,
@@ -631,7 +630,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(total_leaves_allocated, 6)
 
 		# quarter three passed so leaves allocated should be 9
-		frappe.flags.current_date = add_months(get_year_start(getdate()), 10)
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 9)
 		allocate_earned_leaves()
 
 		total_leaves_allocated = frappe.get_value(
@@ -732,7 +731,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(total_leaves_allocated, 6)
 
 		# after 6 months, all 12 leaves should be allocated
-		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=6, days=1)
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 6)
 
 		allocate_earned_leaves()
 

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -577,7 +577,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		self.assertEqual(total_leaves_allocated, 0.0)
 
-	def test_quatertly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
+	def test_quartertly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
@@ -600,7 +600,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		self.assertEqual(total_leaves_allocated, 3.0)
 
-	def test_quaterly_earned_leaves_allocated_by_the_scheduler(self):
+	def test_quarterly_earned_leaves_allocated_by_the_scheduler(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
@@ -918,7 +918,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertEqual(total_leaves_allocated, 24)
 
-	def test_yearly_leaves_allocated_prorated(self):
+	def test_yearly_leaves_allocated_pro_rated(self):
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=7, days=15)
 		employee.save()

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -530,6 +530,8 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertRaises(frappe.ValidationError, leave_allocation.allocate_leaves_manually, 1)
 
 	def test_quarterly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 5)
+
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 		# allocated after one quarter
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
@@ -553,7 +555,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		self.assertEqual(total_leaves_allocated, 3.0)
 
-	def test_quarterly_earned_leaves_allocated_on_last_day_at_the_start_of_leave_period(self):
+	def test_quarterly_earned_leaves_allocated_on_last_day_at_the_start_of_the_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
@@ -576,8 +578,28 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		self.assertEqual(total_leaves_allocated, 0.0)
 
-	def test_quarterly_earned_leaves_allocated_on_first_day_at_the_start(self):
+	def test_quatertly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
+
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+
+		self.assertEqual(total_leaves_allocated, 3.0)
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -529,80 +529,55 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		self.assertRaises(frappe.ValidationError, leave_allocation.allocate_leaves_manually, 1)
 
-	def test_quarterly_earned_leaves_allocated_in_the_middle_of_leave_period(self):
-		frappe.flags.current_date = add_months(get_year_start(getdate()), 5)
-
+	def test_quarterly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 		# allocated after one quarter
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
-		leave_type = create_earned_leave_type(
-			"Quarterly", earned_leave_frequency="Quarterly", allocate_on_day="Last Day", rounding=0.5
-		)
-		leave_policy = frappe.get_doc(
-			{
-				"doctype": "Leave Policy",
-				"title": leave_type.name,
-				"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 12}],
-			}
-		).insert()
-		leave_period = create_leave_period("Year", start_date=get_year_start(getdate()))
-		lpa = frappe.get_doc(
-			{
-				"doctype": "Leave Policy Assignment",
-				"leave_policy": leave_policy.name,
-				"assignment_based_on": "Leave Period",
-				"leave_period": leave_period.name,
-				"employee": employee.name,
-			}
-		).insert()
-		lpa.submit()
 
-		allocate_earned_leaves()
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
+
 		# quarter passed 1 so leaves allocated should be 3
 		total_leaves_allocated = frappe.get_value(
 			"Leave Allocation",
-			{"employee": employee.name, "leave_type": leave_type.name},
+			{"employee": employee.name, "leave_policy_assignment": assignment},
 			"total_leaves_allocated",
 		)
 
 		self.assertEqual(total_leaves_allocated, 3.0)
 
-	def test_quarterly_earned_leaves_allocated_at_the_start(self):
+	def test_quarterly_earned_leaves_allocated_on_last_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 
-		leave_type = create_earned_leave_type(
-			"Quarterly", earned_leave_frequency="Quarterly", allocate_on_day="Last Day", rounding=0.5
-		)
-		leave_policy = frappe.get_doc(
-			{
-				"doctype": "Leave Policy",
-				"title": leave_type.name,
-				"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 12}],
-			}
-		).insert()
-		leave_period = create_leave_period("Year", start_date=get_year_start(getdate()))
-		lpa = frappe.get_doc(
-			{
-				"doctype": "Leave Policy Assignment",
-				"leave_policy": leave_policy.name,
-				"assignment_based_on": "Leave Period",
-				"leave_period": leave_period.name,
-				"employee": employee.name,
-			}
-		).insert()
-		lpa.submit()
-
-		allocate_earned_leaves()
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)[0]
 
 		total_leaves_allocated = frappe.get_value(
 			"Leave Allocation",
-			{"employee": employee.name, "leave_type": leave_type.name},
+			{"employee": employee.name, "leave_policy_assignment": assignment},
 			"total_leaves_allocated",
 		)
 
 		self.assertEqual(total_leaves_allocated, 0.0)
+
+	def test_quarterly_earned_leaves_allocated_on_first_day_at_the_start(self):
+		frappe.flags.current_date = get_year_start(getdate())
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
@@ -656,7 +631,9 @@ def make_policy_assignment(
 	carry_forward=0,
 	assignment_based_on="Leave Period",
 ):
-	leave_type = create_earned_leave_type("Test Earned Leave", allocate_on_day, rounding)
+	leave_type = create_earned_leave_type(
+		"Test Earned Leave", allocate_on_day, rounding, earned_leave_frequency=earned_leave_frequency
+	)
 	leave_period = create_leave_period("Test Earned Leave Period", start_date=start_date, end_date=end_date)
 	leave_policy = frappe.get_doc(
 		{

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.utils import (
 	add_days,
 	add_months,
+	add_to_date,
 	get_first_day,
 	get_last_day,
 	get_year_ending,
@@ -530,8 +531,6 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertRaises(frappe.ValidationError, leave_allocation.allocate_leaves_manually, 1)
 
 	def test_quarterly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
-		frappe.flags.current_date = add_months(get_year_start(getdate()), 5)
-
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
 		# allocated after one quarter
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
@@ -640,6 +639,44 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertEqual(total_leaves_allocated, 9)
 
+	def test_quarterly_leaves_allocated_pro_rated(self):
+		# joined 1 month 10 days after the leave period date
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=1, days=10)
+		employee.save()
+
+		# make policy assignment on the same day
+		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=1, days=10)
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+			rounding=0.25,
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+		# no allocation at the beginning
+		self.assertEqual(total_leaves_allocated, 0)
+
+		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=3, days=-1)
+		allocate_earned_leaves()
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+		# 1 full for full month + 1/(28 days of feb)*20 days = 0.7142 rounded to 0.25 = 1.75
+		self.assertEqual(total_leaves_allocated, 1.75)
+
 	def test_half_yearly_earned_leaves_allocated_on_last_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 		employee = frappe.get_doc("Employee", "_T-Employee-00002")
@@ -742,8 +779,46 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertEqual(total_leaves_allocated, 12)
 
+	def test_half_yearly_leaves_allocated_pro_rated(self):
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=3, days=25)
+		employee.save()
+
+		# make policy assignment on the same day
+		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=3, days=25)
+		assignment = make_policy_assignment(
+			employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Half-Yearly",
+			annual_allocation=12,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+			rounding=0.25,
+		)[0]
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+
+		self.assertEqual(total_leaves_allocated, 0)
+
+		frappe.flags.current_date = add_to_date(get_year_start(getdate()), months=6, days=-1)
+		allocate_earned_leaves()
+
+		total_leaves_allocated = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment},
+			"total_leaves_allocated",
+		)
+		# 2 full + 1/30*5 = 2.166 rounded to 0.25
+		self.assertEqual(total_leaves_allocated, 2.25)
+
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
+		frappe.db.set_value("Employee", "_T-Employee-00002", "date_of_joining", self.original_doj)
 		frappe.db.set_value("Leave Type", self.leave_type, "max_leaves_allowed", 0)
 		frappe.flags.current_date = None
 

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -171,7 +171,6 @@ class LeavePolicyAssignment(Document):
 		periods_passed = self.get_periods_passed(
 			leave_details.earned_leave_frequency, current_date, from_date, consider_current_period
 		)
-		print(periods_passed, leave_details.earned_leave_frequency)
 		if periods_passed > 0:
 			new_leaves_allocated = self.calculate_leaves_for_passed_period(
 				annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -3,7 +3,6 @@
 
 
 import json
-from datetime import datetime
 
 import frappe
 from frappe import _, bold
@@ -20,8 +19,6 @@ from frappe.utils import (
 	get_link_to_form,
 	get_quarter_ending,
 	get_quarter_start,
-	get_year_ending,
-	get_year_start,
 	getdate,
 	rounded,
 )
@@ -271,6 +268,8 @@ def calculate_periods_passed(
 
 
 def is_earned_leave_applicable_for_current_period(date_of_joining, allocate_on_day, earned_leave_frequency):
+	from hrms.hr.utils import get_semester_end, get_semester_start
+
 	date = getdate(frappe.flags.current_date) or getdate()
 	# If the date of assignment creation is >= the leave type's "Allocate On" date,
 	# then the current month should be considered
@@ -391,17 +390,3 @@ def get_leave_type_details():
 	for d in leave_types:
 		leave_type_details.setdefault(d.name, d)
 	return leave_type_details
-
-
-def get_semester_start(date):
-	if date.month <= 6:
-		return get_year_start(date)
-	else:
-		return add_months(get_year_start(date), 6)
-
-
-def get_semester_end(date):
-	if date.month > 6:
-		return get_year_ending(date)
-	else:
-		return add_months(get_year_ending(date), -6)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -195,12 +195,11 @@ class LeavePolicyAssignment(Document):
 		return current_date, from_date
 
 	def get_periods_passed(self, earned_leave_frequency, current_date, from_date, consider_current_period):
-		frequency_map = {
+		periods_per_year, months_per_period = {
 			"Monthly": (12, 1),
 			"Quarterly": (4, 3),
 			"Half-Yearly": (2, 6),
-		}
-		periods_per_year, months_per_period = frequency_map.get(earned_leave_frequency)
+		}.get(earned_leave_frequency)
 
 		periods_passed = calculate_periods_passed(
 			current_date, from_date, periods_per_year, months_per_period, consider_current_period

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -9,7 +9,6 @@ from frappe import _, bold
 from frappe.model.document import Document
 from frappe.utils import (
 	add_months,
-	add_to_date,
 	cint,
 	comma_and,
 	date_diff,
@@ -21,7 +20,6 @@ from frappe.utils import (
 	get_quarter_ending,
 	get_quarter_start,
 	getdate,
-	month_diff,
 	rounded,
 )
 
@@ -145,17 +143,10 @@ class LeavePolicyAssignment(Document):
 		if leave_details.is_compensatory:
 			new_leaves_allocated = 0
 		# if earned leave is being allcated after the effective period, then let them be calculated pro-rata
-
 		elif leave_details.is_earned_leave and current_date < getdate(self.effective_to):
-			if leave_details.earned_leave_frequency == "Quarterly":
-				new_leaves_allocated = self.get_leaves_for_passed_quarters(
-					annual_allocation, leave_details, date_of_joining
-				)
-			else:
-				new_leaves_allocated = self.get_leaves_for_passed_months(
-					annual_allocation, leave_details, date_of_joining
-				)
-
+			new_leaves_allocated = self.get_leaves_for_passed_period(
+				annual_allocation, leave_details, date_of_joining
+			)
 		else:
 			# calculate pro-rated leaves for other leave types
 			new_leaves_allocated = calculate_pro_rated_leaves(
@@ -172,82 +163,26 @@ class LeavePolicyAssignment(Document):
 
 		return flt(new_leaves_allocated, precision)
 
-	def get_leaves_for_passed_months(self, annual_allocation, leave_details, date_of_joining):
-		from hrms.hr.utils import get_monthly_earned_leave
-
-		def _get_months_passed(current_date, from_date, consider_current_month):
-			months_passed = 0
-			if current_date.year == from_date.year and current_date.month >= from_date.month:
-				months_passed = current_date.month - from_date.month
-				if consider_current_month:
-					months_passed += 1
-
-			elif current_date.year > from_date.year:
-				months_passed = (
-					(12 - from_date.month)
-					+ (current_date.year - from_date.year - 1) * 12
-					+ current_date.month
-				)
-				if consider_current_month:
-					months_passed += 1
-
-			return months_passed
-
-		def _get_pro_rata_period_end_date(consider_current_month):
-			# for earned leave, pro-rata period ends on the last day of the month
-			date = getdate(frappe.flags.current_date) or getdate()
-			if consider_current_month:
-				period_end_date = get_last_day(date)
-			else:
-				period_end_date = get_last_day(add_months(date, -1))
-
-			return period_end_date
-
-		def _calculate_leaves_for_passed_months(consider_current_month):
-			monthly_earned_leave = get_monthly_earned_leave(
-				date_of_joining,
-				annual_allocation,
-				leave_details.earned_leave_frequency,
-				leave_details.rounding,
-				pro_rated=False,
-			)
-
-			period_end_date = _get_pro_rata_period_end_date(consider_current_month)
-
-			if getdate(self.effective_from) <= date_of_joining <= period_end_date:
-				# if the employee joined within the allocation period in some previous month,
-				# calculate pro-rated leave for that month
-				# and normal monthly earned leave for remaining passed months
-				leaves = get_monthly_earned_leave(
-					date_of_joining,
-					annual_allocation,
-					leave_details.earned_leave_frequency,
-					leave_details.rounding,
-					get_first_day(date_of_joining),
-					get_last_day(date_of_joining),
-				)
-
-				leaves += monthly_earned_leave * (months_passed - 1)
-			else:
-				leaves = monthly_earned_leave * months_passed
-
-			return leaves
-
-		consider_current_month = is_earned_leave_applicable_for_current_month(
-			date_of_joining, leave_details.allocate_on_day
+	def get_leaves_for_passed_period(self, annual_allocation, leave_details, date_of_joining):
+		consider_current_period = is_earned_leave_applicable_for_current_period(
+			date_of_joining, leave_details.allocate_on_day, leave_details.earned_leave_frequency
 		)
 		current_date, from_date = self.get_current_and_from_date(date_of_joining)
-		months_passed = _get_months_passed(current_date, from_date, consider_current_month)
-
-		if months_passed > 0:
-			new_leaves_allocated = _calculate_leaves_for_passed_months(consider_current_month)
+		periods_passed = self.get_periods_passed(
+			leave_details.earned_leave_frequency, current_date, from_date, consider_current_period
+		)
+		print(periods_passed, leave_details.earned_leave_frequency)
+		if periods_passed > 0:
+			new_leaves_allocated = self.calculate_leaves_for_passed_period(
+				annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
+			)
 		else:
 			new_leaves_allocated = 0
 
 		return new_leaves_allocated
 
 	def get_current_and_from_date(self, date_of_joining):
-		current_date = frappe.flags.current_date or getdate()
+		current_date = getdate(frappe.flags.current_date) or getdate()
 		if current_date > getdate(self.effective_to):
 			current_date = getdate(self.effective_to)
 
@@ -257,31 +192,23 @@ class LeavePolicyAssignment(Document):
 
 		return current_date, from_date
 
-	def get_leaves_for_passed_quarters(self, annual_allocation, leave_details, date_of_joining):
-		from hrms.hr.utils import get_monthly_earned_leave
+	def get_periods_passed(self, earned_leave_frequency, current_date, from_date, consider_current_period):
+		frequency_map = {
+			"Monthly": get_months_passed,
+			"Quarterly": get_quarters_passed,
+		}
+		calculate_periods_passed = frequency_map.get(earned_leave_frequency)
 
-		def _get_passed_quarters(current_date, from_date, consider_current_quarter):
-			quarters_passed = 0
-			current_date = getdate(frappe.flags.current_date)
-			from_date = getdate(from_date)
+		periods_passed = calculate_periods_passed(current_date, from_date, consider_current_period)
 
-			from_quarter = (from_date.year * 4) + ((from_date.month - 1) // 3)
-			current_quarter = (current_date.year * 4) + ((current_date.month - 1) // 3)
+		return periods_passed
 
-			quarters_passed = current_quarter - from_quarter
+	def calculate_leaves_for_passed_period(
+		self, annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
+	):
+		from hrms.hr.utils import get_monthly_earned_leave as get_periodically_earned_leave
 
-			if consider_current_quarter:
-				quarters_passed += 1
-
-			return quarters_passed
-
-		current_date, from_date = self.get_current_and_from_date(date_of_joining)
-		consider_current_quarter = is_earned_leave_applicable_for_current_quarter(
-			leave_details.allocate_on_day
-		)
-		number_of_passed_quarters = _get_passed_quarters(current_date, from_date, consider_current_quarter)
-
-		quarterly_earned_leave = get_monthly_earned_leave(
+		periodically_earned_leave = get_periodically_earned_leave(
 			date_of_joining,
 			annual_allocation,
 			leave_details.earned_leave_frequency,
@@ -289,10 +216,91 @@ class LeavePolicyAssignment(Document):
 			pro_rated=False,
 		)
 
-		if number_of_passed_quarters > 0:
-			return number_of_passed_quarters * quarterly_earned_leave
+		period_end_date = get_pro_rata_period_end_date(consider_current_period)
+
+		if getdate(self.effective_from) <= date_of_joining <= period_end_date:
+			# if the employee joined within the allocation period in some previous month,
+			# calculate pro-rated leave for that month
+			# and normal monthly earned leave for remaining passed months
+			leaves = get_periodically_earned_leave(
+				date_of_joining,
+				annual_allocation,
+				leave_details.earned_leave_frequency,
+				leave_details.rounding,
+				get_first_day(date_of_joining),
+				get_last_day(date_of_joining),
+			)
+
+			leaves += periodically_earned_leave * (periods_passed - 1)
 		else:
-			return 0
+			leaves = periodically_earned_leave * periods_passed
+
+		return leaves
+
+
+def get_pro_rata_period_end_date(consider_current_month):
+	# for earned leave, pro-rata period ends on the last day of the month
+	# pro rata period end date is different for different periods
+
+	date = getdate(frappe.flags.current_date) or getdate()
+	if consider_current_month:
+		period_end_date = get_last_day(date)
+	else:
+		period_end_date = get_last_day(add_months(date, -1))
+
+	return period_end_date
+
+
+def get_months_passed(current_date, from_date, consider_current_month):
+	months_passed = 0
+	if current_date.year == from_date.year and current_date.month >= from_date.month:
+		months_passed = current_date.month - from_date.month
+		if consider_current_month:
+			months_passed += 1
+
+	elif current_date.year > from_date.year:
+		months_passed = (
+			(12 - from_date.month) + (current_date.year - from_date.year - 1) * 12 + current_date.month
+		)
+		if consider_current_month:
+			months_passed += 1
+
+	return months_passed
+
+
+def get_quarters_passed(current_date, from_date, consider_current_quarter):
+	quarters_passed = 0
+	current_date = getdate(frappe.flags.current_date)
+	from_date = getdate(from_date)
+
+	from_quarter = (from_date.year * 4) + ((from_date.month - 1) // 3)
+	current_quarter = (current_date.year * 4) + ((current_date.month - 1) // 3)
+
+	quarters_passed = current_quarter - from_quarter
+
+	if consider_current_quarter:
+		quarters_passed += 1
+
+	return quarters_passed
+
+
+def is_earned_leave_applicable_for_current_period(date_of_joining, allocate_on_day, earned_leave_frequency):
+	date = getdate(frappe.flags.current_date) or getdate()
+	# If the date of assignment creation is >= the leave type's "Allocate On" date,
+	# then the current month should be considered
+	# because the employee is already entitled for the leave of that month
+
+	condition_map = {
+		"Monthly": (
+			(allocate_on_day == "Date of Joining" and date.day >= date_of_joining.day)
+			or (allocate_on_day == "First Day" and date >= get_first_day(date))
+			or (allocate_on_day == "Last Day" and date == get_last_day(date))
+		),
+		"Quarterly": (allocate_on_day == "First Day" and date >= get_quarter_start(date))
+		or (allocate_on_day == "Last Day" and date == get_quarter_ending(date)),
+	}
+
+	return condition_map.get(earned_leave_frequency)
 
 
 def calculate_pro_rated_leaves(
@@ -310,32 +318,6 @@ def calculate_pro_rated_leaves(
 	if is_earned_leave:
 		return flt(leaves, precision)
 	return rounded(leaves)
-
-
-def is_earned_leave_applicable_for_current_month(date_of_joining, allocate_on_day):
-	date = getdate(frappe.flags.current_date) or getdate()
-
-	# If the date of assignment creation is >= the leave type's "Allocate On" date,
-	# then the current month should be considered
-	# because the employee is already entitled for the leave of that month
-	if (
-		(allocate_on_day == "Date of Joining" and date.day >= date_of_joining.day)
-		or (allocate_on_day == "First Day" and date >= get_first_day(date))
-		or (allocate_on_day == "Last Day" and date == get_last_day(date))
-	):
-		return True
-	return False
-
-
-def is_earned_leave_applicable_for_current_quarter(allocate_on_day):
-	date = getdate(frappe.flags.current_date)
-
-	if (allocate_on_day == "First Day" and date >= get_quarter_start(date)) or (
-		allocate_on_day == "Last Day" and date == get_quarter_ending(date)
-	):
-		return True
-
-	return False
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -145,7 +145,7 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		self.employee.date_of_joining = add_months(first_day, -5)
 		self.employee.save()
 		assignment = create_assignment(self.employee.name, frappe._dict(data))
-		new_leaves_allocated = assignment.get_leaves_for_passed_months(
+		new_leaves_allocated = assignment.get_leaves_for_passed_period(
 			annual_allocation, leave_type, self.employee.date_of_joining
 		)
 		self.assertEqual(new_leaves_allocated, 5)
@@ -153,7 +153,7 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		self.employee.date_of_joining = add_months(first_day, -35)
 		self.employee.save()
 		assignment = create_assignment(self.employee.name, frappe._dict(data))
-		new_leaves_allocated = assignment.get_leaves_for_passed_months(
+		new_leaves_allocated = assignment.get_leaves_for_passed_period(
 			annual_allocation, leave_type, self.employee.date_of_joining
 		)
 		self.assertEqual(new_leaves_allocated, 30)
@@ -165,7 +165,7 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 			"leave_period": leave_period.name,
 		}
 		assignment = create_assignment(self.employee.name, frappe._dict(data))
-		new_leaves_allocated = assignment.get_leaves_for_passed_months(
+		new_leaves_allocated = assignment.get_leaves_for_passed_period(
 			annual_allocation, leave_type, self.employee.date_of_joining
 		)
 		self.assertEqual(new_leaves_allocated, 20)

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -537,10 +537,10 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 		"Yearly": {"First Day": get_year_start(today), "Last Day": get_year_ending(today)},
 	}[frequency][allocate_on_day]
 
-	if expected_date.day == today.day:
-		return True
-
-	return False
+	if allocate_on_day == "Date of Joining":
+		return expected_date.day == today.day
+	else:
+		return expected_date == today
 
 
 def get_salary_assignments(employee, payroll_period):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -10,6 +10,7 @@ from frappe.query_builder import Criterion
 from frappe.query_builder.custom import ConstantColumn
 from frappe.utils import (
 	add_days,
+	add_months,
 	comma_and,
 	cstr,
 	flt,
@@ -20,6 +21,10 @@ from frappe.utils import (
 	get_last_day,
 	get_link_to_form,
 	get_number_format_info,
+	get_quarter_ending,
+	get_quarter_start,
+	get_year_ending,
+	get_year_start,
 	getdate,
 	nowdate,
 )
@@ -433,8 +438,12 @@ def get_monthly_earned_leave(
 		if pro_rated:
 			if not (period_start_date or period_end_date):
 				today_date = frappe.flags.current_date or getdate()
-				period_end_date = get_last_day(today_date)
-				period_start_date = get_first_day(today_date)
+
+				period_start_date, period_end_date = {
+					"Monthly": (get_first_day(today_date), get_last_day(today_date)),
+					"Quarterly": (get_quarter_start(today_date), get_quarter_ending(today_date)),
+					"Half-Yearly": (get_semester_start(today_date), get_semester_end(today_date)),
+				}.get(frequency)
 
 			earned_leaves = calculate_pro_rated_leaves(
 				earned_leaves, date_of_joining, period_start_date, period_end_date, is_earned_leave=True
@@ -508,27 +517,24 @@ def create_additional_leave_ledger_entry(allocation, leaves, date):
 
 
 def check_effective_date(from_date, today, frequency, allocate_on_day):
-	from dateutil import relativedelta
-
 	from_date = get_datetime(from_date)
 	today = frappe.flags.current_date or get_datetime(today)
-	rd = relativedelta.relativedelta(today, from_date)
 
 	expected_date = {
-		"First Day": get_first_day(today),
-		"Last Day": get_last_day(today),
-		"Date of Joining": from_date,
-	}[allocate_on_day]
+		"Monthly": {
+			"First Day": get_first_day(today),
+			"Last Day": get_last_day(today),
+			"Date of Joining": from_date,
+		},
+		"Quarterly": {
+			"First Day": get_quarter_start(today),
+			"Last Day": get_quarter_ending(today),
+		},
+		"Half-Yearly": {"First Day": get_semester_start(today), "Last Day": get_semester_end(today)},
+	}[frequency][allocate_on_day]
 
 	if expected_date.day == today.day:
-		if frequency == "Monthly":
-			return True
-		elif frequency == "Quarterly" and not rd.months % 3:
-			return True
-		elif frequency == "Half-Yearly" and not rd.months % 6:
-			return True
-		elif frequency == "Yearly" and not rd.months % 12:
-			return True
+		return True
 
 	return False
 
@@ -938,3 +944,17 @@ def get_exact_month_diff(string_ed_date: DateTimeLikeObject, string_st_date: Dat
 	if ed_date.day >= st_date.day:
 		diff += 1
 	return diff
+
+
+def get_semester_start(date):
+	if date.month <= 6:
+		return get_year_start(date)
+	else:
+		return add_months(get_year_start(date), 6)
+
+
+def get_semester_end(date):
+	if date.month > 6:
+		return get_year_ending(date)
+	else:
+		return add_months(get_year_ending(date), -6)

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -402,8 +402,10 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 
 	if (
 		new_allocation != allocation.total_leaves_allocated
-		# annual allocation as per policy should not be exceeded
-		and new_allocation_without_cf <= annual_allocation
+		# annual allocation as per policy should not be exceeded except for yearly leaves
+		and (
+			new_allocation_without_cf <= annual_allocation or e_leave_type.earned_leave_frequency == "Yearly"
+		)
 	):
 		today_date = frappe.flags.current_date or getdate()
 
@@ -443,6 +445,7 @@ def get_monthly_earned_leave(
 					"Monthly": (get_first_day(today_date), get_last_day(today_date)),
 					"Quarterly": (get_quarter_start(today_date), get_quarter_ending(today_date)),
 					"Half-Yearly": (get_semester_start(today_date), get_semester_end(today_date)),
+					"Yearly": (get_year_start(today_date), get_year_ending(today_date)),
 				}.get(frequency)
 
 			earned_leaves = calculate_pro_rated_leaves(
@@ -531,6 +534,7 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 			"Last Day": get_quarter_ending(today),
 		},
 		"Half-Yearly": {"First Day": get_semester_start(today), "Last Day": get_semester_end(today)},
+		"Yearly": {"First Day": get_year_start(today), "Last Day": get_year_ending(today)},
 	}[frequency][allocate_on_day]
 
 	if expected_date.day == today.day:

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -523,11 +523,11 @@ def check_effective_date(from_date, today, frequency, allocate_on_day):
 	if expected_date.day == today.day:
 		if frequency == "Monthly":
 			return True
-		elif frequency == "Quarterly" and rd.months % 3:
+		elif frequency == "Quarterly" and not rd.months % 3:
 			return True
-		elif frequency == "Half-Yearly" and rd.months % 6:
+		elif frequency == "Half-Yearly" and not rd.months % 6:
 			return True
-		elif frequency == "Yearly" and rd.months % 12:
+		elif frequency == "Yearly" and not rd.months % 12:
 			return True
 
 	return False


### PR DESCRIPTION
Earned Leave Types show you an option to configure the leaves to earn for varied periods, like monthly, quarterly, half yearly and yearly, but the same logic used to calculate monthly leaves was being used to calculate for other types, which would result in wild over allocation of leaves for other periods. 
Calculations for quarterly leaves were fixed with #3428, half yearly and yearly leaves remain with a bunch of edge cases

To Do
- [x] Test cases for all quarterly earned leaves
- [x] Refactor current logic to accommodate other frequencies
- [x] Calculations for half yearly earned leaves
- [x] Test cases for half-yearly earned leaves
- [x] Calculations for yearly leaves
- [x] Test cases for yearly leaves

Fixes #286, #303 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Full frequency support for earned leave: Monthly, Quarterly, Half‑Yearly (semester), and Yearly.

- Bug Fixes
  - Allocations respect period boundaries and assignment end dates; yearly allocations may bypass annual caps when applicable.
  - Improved pro‑rata handling for mid‑period joiners and accurate scheduler-driven allocations.

- Refactor
  - Unified period‑based allocation logic for consistent behavior across frequencies.

- Tests
  - Expanded coverage for frequencies, allocation timing, and scheduler scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->