### PR TITLE
fix(link-field): pass modelValue on load

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -91,7 +91,7 @@ watch(
 	() => props.doctype,
 	() => {
 		if (!props.doctype || props.doctype === options.doctype) return
-		reloadOptions("")
+		reloadOptions(props.modelValue)
 	},
 	{ immediate: true }
 )


### PR DESCRIPTION
**Issue:** The value is not being set in the Link field, even though the value exists and the necessary permissions are granted.

**Steps to Reproduce:**

1. Create more than 10 Employee records.

2. Create a Leave Application for the first employee you created.

3. Go to HRMS > Team Requests.

4. Notice that in the Team Request, the Employee Link field from the Leave Application is not mapped.

Ref: [46959](https://support.frappe.io/helpdesk/tickets/46959)

**Before:**

https://github.com/user-attachments/assets/277cf965-15a4-4cba-9cb5-491abd8ebd15

**After:**

https://github.com/user-attachments/assets/314ebf9f-b5fd-4247-a9b8-2cc3789e8902

**Backport needed: v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switching document types no longer clears the current search input; your existing search text is preserved and options update accordingly when the document type changes, preventing unnecessary retyping and providing a smoother, more consistent filtering experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->