### PR TITLE
fix: fetch component details from salary component

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -761,16 +761,15 @@ class SalarySlip(TransactionBase):
 				break
 
 		if not row_exists:
-			wages_row = {
-				"salary_component": salary_component,
-				"abbr": frappe.db.get_value(
-					"Salary Component", salary_component, "salary_component_abbr", cache=True
-				),
-				"amount": self.hour_rate * self.total_working_hours,
-				"default_amount": 0.0,
-				"additional_amount": 0.0,
-			}
-			doc.append("earnings", wages_row)
+			wages_row = get_salary_component_data(salary_component)
+			wages_amount = self.hour_rate * self.total_working_hours
+
+			self.update_component_row(
+				wages_row,
+				wages_amount,
+				"earnings",
+				default_amount=wages_amount,
+			)
 
 	def set_salary_structure_assignment(self):
 		self._salary_structure_assignment = frappe.db.get_value(


### PR DESCRIPTION
**Issue:** Timesheet component not being added with `Is Tax Applicable`
**ref:** [46756](https://support.frappe.io/helpdesk/tickets/46756)

**Salary Structure:**
<img width="1807" height="668" alt="image" src="https://github.com/user-attachments/assets/a1cf6c36-0eb5-4d4c-86b5-f29cacbfe098" />


**Before:**
<img width="1803" height="764" alt="image" src="https://github.com/user-attachments/assets/9a9736e3-1579-41ee-8da4-348c1ff0ffe1" />


**After:**
<img width="1809" height="864" alt="image" src="https://github.com/user-attachments/assets/1c9a6e91-9368-4370-962b-7a02984b1e17" />



**Backport needed for v15 and v14**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures hourly wage earnings are calculated from rate × hours and reflected as the default amount, improving accuracy on salary slips.
  * Reduces inconsistencies in how hourly wage components appear in earnings.

* **Refactor**
  * Streamlined how hourly wage earnings are added/updated on salary slips using a standardized component update flow for greater consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->