### PR TITLE
feat(Earned Leave): Earned Leave Schedule

### DIFF
--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
@@ -8,11 +8,17 @@
   "column_break_dmml",
   "allocation_date",
   "number_of_leaves",
-  "is_allocated"
+  "attempted",
+  "failed",
+  "column_break_pzdq",
+  "is_allocated",
+  "allocated_via",
+  "section_break_amtg",
+  "failure_reason"
  ],
  "fields": [
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "allocation_date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -20,7 +26,7 @@
    "read_only": 1
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "number_of_leaves",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -33,19 +39,60 @@
    "fieldname": "is_allocated",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Is allocated",
+   "label": "Is Allocated",
    "read_only": 1
   },
   {
    "fieldname": "column_break_dmml",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_pzdq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "failure_reason",
+   "fieldtype": "Code",
+   "label": "Failure Reason",
+   "options": "HTML",
+   "read_only": 1
+  },
+  {
+   "columns": 3,
+   "fieldname": "allocated_via",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Allocated Via",
+   "options": "\nScheduler\nLeave Policy Assignment",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_amtg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "attempted",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Attempted",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "failed",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Failed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-26 14:36:34.453084",
+ "modified": "2025-08-28 10:29:05.825102",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Earned Leave Schedule",

--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
@@ -64,7 +64,7 @@
    "in_list_view": 1,
    "in_preview": 1,
    "label": "Allocated Via",
-   "options": "\nScheduler\nLeave Policy Assignment",
+   "options": "\nScheduler\nLeave Policy Assignment\nManually",
    "read_only": 1
   },
   {
@@ -92,7 +92,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-28 10:29:05.825102",
+ "modified": "2025-09-08 13:02:10.998159",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Earned Leave Schedule",

--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
@@ -52,9 +52,8 @@
   },
   {
    "fieldname": "failure_reason",
-   "fieldtype": "Code",
+   "fieldtype": "Small Text",
    "label": "Failure Reason",
-   "options": "HTML",
    "read_only": 1
   },
   {
@@ -92,7 +91,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-09-08 13:02:10.998159",
+ "modified": "2025-11-14 14:12:01.503330",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Earned Leave Schedule",

--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-08-25 18:22:43.626487",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "allocation_date",
+  "number_of_leaves",
+  "is_allocated",
+  "allocate_manually"
+ ],
+ "fields": [
+  {
+   "fieldname": "allocation_date",
+   "fieldtype": "Date",
+   "label": "Allocation Date"
+  },
+  {
+   "fieldname": "number_of_leaves",
+   "fieldtype": "Float",
+   "label": "Number of Leaves"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_allocated",
+   "fieldtype": "Check",
+   "label": "Is allocated"
+  },
+  {
+   "fieldname": "allocate_manually",
+   "fieldtype": "Button",
+   "label": "Allocate Manually"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-08-25 18:25:35.616726",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Earned Leave Schedule",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
@@ -5,39 +5,47 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "column_break_dmml",
   "allocation_date",
   "number_of_leaves",
-  "is_allocated",
-  "allocate_manually"
+  "is_allocated"
  ],
  "fields": [
   {
+   "columns": 3,
    "fieldname": "allocation_date",
    "fieldtype": "Date",
-   "label": "Allocation Date"
+   "in_list_view": 1,
+   "label": "Allocation Date",
+   "read_only": 1
   },
   {
+   "columns": 3,
    "fieldname": "number_of_leaves",
    "fieldtype": "Float",
-   "label": "Number of Leaves"
+   "in_list_view": 1,
+   "label": "Number of Leaves",
+   "read_only": 1
   },
   {
+   "columns": 3,
    "default": "0",
    "fieldname": "is_allocated",
    "fieldtype": "Check",
-   "label": "Is allocated"
+   "in_list_view": 1,
+   "label": "Is allocated",
+   "read_only": 1
   },
   {
-   "fieldname": "allocate_manually",
-   "fieldtype": "Button",
-   "label": "Allocate Manually"
+   "fieldname": "column_break_dmml",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-25 18:25:35.616726",
+ "modified": "2025-08-26 14:36:34.453084",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Earned Leave Schedule",

--- a/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.py
+++ b/hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EarnedLeaveSchedule(Document):
+	pass

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -20,6 +20,7 @@ frappe.ui.form.on("Leave Allocation", {
 				return value;
 			}
 		};
+
 		frm.refresh_field("earned_leave_schedule");
 	},
 	onload: function (frm) {
@@ -116,6 +117,8 @@ frappe.ui.form.on("Leave Allocation", {
 				);
 			}
 		}
+
+		frm.trigger("toggle_retry_button");
 	},
 
 	expire_allocation: function (frm) {
@@ -178,6 +181,33 @@ frappe.ui.form.on("Leave Allocation", {
 				"Leave Policy",
 			);
 		}
+	},
+
+	toggle_retry_button: function (frm) {
+		toggle_button = frm.doc.earned_leave_schedule.some((row) => row.attempted && row.failed);
+		frm.toggle_display("retry_failed_allocations", toggle_button);
+	},
+
+	retry_failed_allocations: function (frm) {
+		let failed_allocations = frm.doc.earned_leave_schedule.filter(
+			(row) => row.attempted && row.failed,
+		);
+
+		frappe.call({
+			method: "retry_failed_allocations",
+			doc: frm.doc,
+			args: failed_allocations,
+			freeze: true,
+			freeze_message: __("Retrying allocations"),
+			callback: function (r) {
+				frappe.show_alert({
+					message: __("Retry Successful"),
+					indicator: "green",
+				});
+				frm.reload_doc();
+				frm.refresh_field("retry_failed_allocations");
+			},
+		});
 	},
 
 	calculate_total_leaves_allocated: function (frm) {

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -169,19 +169,21 @@ frappe.ui.form.on("Leave Allocation", {
 	},
 
 	toggle_retry_button: function (frm) {
-		toggle_button = frm.doc.earned_leave_schedule.some((row) => row.attempted && row.failed);
+		const earned_leave_schedule = frm.doc.earned_leave_schedule || [];
+		let toggle_button =
+			earned_leave_schedule.some((row) => row.attempted && row.failed) && frm.perm[0]?.write;
 		frm.toggle_display("retry_failed_allocations", toggle_button);
 	},
 
 	retry_failed_allocations: function (frm) {
-		let failed_allocations = frm.doc.earned_leave_schedule.filter(
+		let failed_allocations = (frm.doc.earned_leave_schedule || []).filter(
 			(row) => row.attempted && row.failed,
 		);
 
 		frappe.call({
 			method: "retry_failed_allocations",
 			doc: frm.doc,
-			args: failed_allocations,
+			args: { failed_allocations },
 			freeze: true,
 			freeze_message: __("Retrying allocations"),
 			callback: function (r) {

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -6,22 +6,7 @@ cur_frm.add_fetch("employee", "employee_name", "employee_name");
 
 frappe.ui.form.on("Leave Allocation", {
 	setup: function (frm) {
-		const df = frappe.meta.get_docfield(
-			"Earned Leave Schedule",
-			"allocation_date",
-			frm.doc.name,
-		);
-		df.formatter = function (value, df, options, row) {
-			if (row.attempted && row.failed) {
-				return `<span class="indicator red">${value}</span>`;
-			} else if (row.attempted && row.is_allocated) {
-				return `<span class="indicator green">${value}</span>`;
-			} else {
-				return value;
-			}
-		};
-
-		frm.refresh_field("earned_leave_schedule");
+		frm.trigger("set_indicator");
 	},
 	onload: function (frm) {
 		// Ignore cancellation of doctype on cancel all.
@@ -117,7 +102,7 @@ frappe.ui.form.on("Leave Allocation", {
 				);
 			}
 		}
-
+		frm.trigger("set_indicator");
 		frm.trigger("toggle_retry_button");
 	},
 
@@ -208,6 +193,23 @@ frappe.ui.form.on("Leave Allocation", {
 				frm.refresh_field("retry_failed_allocations");
 			},
 		});
+	},
+	set_indicator: function (frm) {
+		const df = frappe.meta.get_docfield(
+			"Earned Leave Schedule",
+			"allocation_date",
+			frm.doc.name,
+		);
+		df.formatter = function (value, df, options, row) {
+			if (row.attempted && row.failed) {
+				return `<span class="indicator red">${value}</span>`;
+			} else if (row.attempted && row.is_allocated) {
+				return `<span class="indicator green">${value}</span>`;
+			} else {
+				return value;
+			}
+		};
+		frm.refresh_field("earned_leave_schedule");
 	},
 
 	calculate_total_leaves_allocated: function (frm) {

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -5,6 +5,23 @@
 cur_frm.add_fetch("employee", "employee_name", "employee_name");
 
 frappe.ui.form.on("Leave Allocation", {
+	setup: function (frm) {
+		const df = frappe.meta.get_docfield(
+			"Earned Leave Schedule",
+			"allocation_date",
+			frm.doc.name,
+		);
+		df.formatter = function (value, df, options, row) {
+			if (row.attempted && row.failed) {
+				return `<span class="indicator red">${value}</span>`;
+			} else if (row.attempted && row.is_allocated) {
+				return `<span class="indicator green">${value}</span>`;
+			} else {
+				return value;
+			}
+		};
+		frm.refresh_field("earned_leave_schedule");
+	},
 	onload: function (frm) {
 		// Ignore cancellation of doctype on cancel all.
 		frm.ignore_doctypes_on_cancel_all = ["Leave Ledger Entry"];

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -30,6 +30,8 @@
   "carry_forwarded_leaves_count",
   "expired",
   "amended_from",
+  "earned_leave_schedule_section",
+  "earned_leave_schedule",
   "notes",
   "description"
  ],
@@ -230,6 +232,17 @@
    "options": "Company",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "depends_on": "doc.earned_leave_schedule",
+   "fieldname": "earned_leave_schedule_section",
+   "fieldtype": "Section Break",
+   "label": "Earned Leave Schedule"
+  },
+  {
+   "fieldname": "earned_leave_schedule",
+   "fieldtype": "Table",
+   "options": "Earned Leave Schedule"
   }
  ],
  "icon": "fa fa-ok",
@@ -237,7 +250,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:00.219099",
+ "modified": "2025-08-25 18:39:42.058661",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",
@@ -275,6 +288,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee,employee_name,leave_type,total_leaves_allocated",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -241,6 +241,7 @@
    "label": "Earned Leave Schedule"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "earned_leave_schedule",
    "fieldtype": "Table",
    "options": "Earned Leave Schedule"
@@ -251,7 +252,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-26 14:32:54.162055",
+ "modified": "2025-08-28 10:41:04.715740",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -234,7 +234,8 @@
    "reqd": 1
   },
   {
-   "depends_on": "doc.earned_leave_schedule",
+   "collapsible": 1,
+   "collapsible_depends_on": "true;",
    "fieldname": "earned_leave_schedule_section",
    "fieldtype": "Section Break",
    "label": "Earned Leave Schedule"
@@ -250,7 +251,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-25 18:39:42.058661",
+ "modified": "2025-08-26 14:32:54.162055",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -235,7 +235,7 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:doc.earned_leave_schedule.length;",
+   "depends_on": "eval:doc.earned_leave_schedule && doc.earned_leave_schedule.length;",
    "fieldname": "earned_leave_schedule_section",
    "fieldtype": "Section Break",
    "label": "Earned Leave Schedule"
@@ -258,7 +258,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-08 16:08:44.666709",
+ "modified": "2025-11-12 12:54:03.589896",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -236,6 +236,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "true;",
+   "depends_on": "eval:doc.earned_leave_schedule.length;",
    "fieldname": "earned_leave_schedule_section",
    "fieldtype": "Section Break",
    "label": "Earned Leave Schedule"
@@ -252,7 +253,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-28 10:41:04.715740",
+ "modified": "2025-09-07 17:52:39.864217",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.json
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.json
@@ -32,6 +32,7 @@
   "amended_from",
   "earned_leave_schedule_section",
   "earned_leave_schedule",
+  "retry_failed_allocations",
   "notes",
   "description"
  ],
@@ -234,18 +235,22 @@
    "reqd": 1
   },
   {
-   "collapsible": 1,
-   "collapsible_depends_on": "true;",
    "depends_on": "eval:doc.earned_leave_schedule.length;",
    "fieldname": "earned_leave_schedule_section",
    "fieldtype": "Section Break",
    "label": "Earned Leave Schedule"
   },
   {
-   "allow_on_submit": 1,
    "fieldname": "earned_leave_schedule",
    "fieldtype": "Table",
-   "options": "Earned Leave Schedule"
+   "options": "Earned Leave Schedule",
+   "read_only": 1
+  },
+  {
+   "fieldname": "retry_failed_allocations",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Retry Failed Allocations"
   }
  ],
  "icon": "fa fa-ok",
@@ -253,7 +258,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-07 17:52:39.864217",
+ "modified": "2025-09-08 16:08:44.666709",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -411,6 +411,54 @@ class LeaveAllocation(Document):
 		leave_adjustment.submit()
 		frappe.msgprint(_("Adjustment Created Successfully"), indicator="green", alert=True)
 
+	@frappe.whitelist()
+	def retry_failed_allocations(self, failed_allocations):
+		max_leaves_allowed, frequency = frappe.db.get_values(
+			"Leave Type", self.leave_type, ["max_leaves_allowed", "earned_leave_frequency"]
+		)[0]
+
+		annual_allocation = frappe.get_value(
+			"Leave Policy Detail",
+			{"parent": self.leave_policy, "leave_type": self.leave_type},
+			"annual_allocation",
+		)
+
+		for allocation in failed_allocations:
+			new_allocation = flt(self.total_leaves_allocated) + flt(allocation["number_of_leaves"])
+
+			new_allocation_without_cf = flt(self.get_existing_leave_count()) + flt(
+				allocation["number_of_leaves"]
+			)
+
+			if new_allocation > max_leaves_allowed and max_leaves_allowed > 0:
+				frappe.throw(
+					msg=_(
+						"Cannot allocate more leaves due to maximum leaves allowed limit of {0} in {1} leave type."
+					).format(frappe.bold(max_leaves_allowed), frappe.bold(self.leave_type)),
+					title=_("Retry Failed"),
+				)
+
+			elif new_allocation_without_cf > annual_allocation and frequency != "Yearly":
+				frappe.throw(
+					msg=_(
+						"Cannot allocate more leaves due to maximum leave allocation limit of {0} in leave policy assignment"
+					).format(frappe.bold(annual_allocation)),
+					title=_("Retry Failed"),
+				)
+
+			else:
+				self.db_set("total_leaves_allocated", new_allocation, update_modified=False)
+				create_additional_leave_ledger_entry(
+					self, allocation["number_of_leaves"], allocation["allocation_date"]
+				)
+				earned_leave_schedule = frappe.qb.DocType("Earned Leave Schedule")
+				frappe.qb.update(earned_leave_schedule).where(
+					(earned_leave_schedule.parent == self.name)
+					& (earned_leave_schedule.allocation_date == allocation["allocation_date"])
+				).set(earned_leave_schedule.is_allocated, 1).set(earned_leave_schedule.attempted, 1).set(
+					earned_leave_schedule.allocated_via, "Manually"
+				).set(earned_leave_schedule.failed, 0).set(earned_leave_schedule.failure_reason, "").run()
+
 
 def get_previous_allocation(from_date, leave_type, employee):
 	"""Returns document properties of previous allocation"""

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -254,7 +254,24 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 
 	def test_schedule_when_doj_is_in_the_middle_of_leave_period(self):
-		pass
+		self.employee.date_of_joining = add_months(get_year_start(getdate()), 4)
+		self.employee.save()
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
+		earned_leave_schedule = create_earned_leave_schedule(
+			self.employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=24,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)
+
+		self.assertEqual(len(earned_leave_schedule), 3)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 4)
+		self.assertEqual(earned_leave_schedule[0].allocation_date, add_months(get_year_start(getdate()), 4))
+		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
+		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
 	def test_schedule_when_assignment_is_based_on_doj(self):
 		pass

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -286,7 +286,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 			start_date=add_months(get_year_start(getdate()), 4),
 			end_date=get_year_ending(getdate()),
 		)
-		frappe.db.commit()
+
 		self.assertEqual(len(earned_leave_schedule), 3)
 		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 4)
 		self.assertEqual(earned_leave_schedule[0].allocation_date, add_months(get_year_start(getdate()), 4))

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -171,6 +171,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 			start_date=get_year_start(getdate()),
 			end_date=get_year_ending(getdate()),
 		)
+
 		allocation_dates = [allocation.allocation_date for allocation in earned_leave_schedule]
 		self.assertEqual(len(earned_leave_schedule), 2)
 		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 12)
@@ -219,7 +220,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		allocation_dates = [allocation.allocation_date for allocation in earned_leave_schedule]
 		self.assertEqual(len(earned_leave_schedule), 2)
-		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 12)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 24)
 		test_allocation_dates(
 			self,
 			allocation_dates,
@@ -242,7 +243,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		allocation_dates = [allocation.allocation_date for allocation in earned_leave_schedule]
 		self.assertEqual(len(earned_leave_schedule), 2)
-		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 12)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 24)
 		test_allocation_dates(
 			self,
 			allocation_dates,
@@ -360,7 +361,7 @@ def get_last_days_of_quarters(start_date, end_date):
 
 def get_first_days_of_half_years(start_date, end_date):
 	year_range = range(start_date.year, end_date.year + 1)
-	return [date(year, month, calendar.monthrange(year, month)[1]) for year in year_range for month in (1, 7)]
+	return [date(year, month, 1) for year in year_range for month in (1, 7)]
 
 
 def get_last_days_of_half_years(start_date, end_date):
@@ -372,7 +373,7 @@ def get_last_days_of_half_years(start_date, end_date):
 
 def get_first_days_of_years(start_date, end_date):
 	year_range = range(start_date.year, end_date.year + 1)
-	return [date(year, 1, calendar.monthrange(year, 1)[1]) for year in year_range]
+	return [date(year, 1, 1) for year in year_range]
 
 
 def get_last_days_of_years(start_date, end_date):

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -294,7 +294,22 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
 	def test_schedule_when_leave_policy_is_assigned_in_middle_of_the_period(self):
-		pass
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
+		earned_leave_schedule = create_earned_leave_schedule(
+			self.employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=24,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)
+
+		self.assertEqual(len(earned_leave_schedule), 3)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 12)
+		self.assertEqual(earned_leave_schedule[0].allocation_date, add_months(get_year_start(getdate()), 4))
+		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
+		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
 
 def test_allocation_dates(

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -292,7 +292,7 @@ def test_allocation_dates(
 		},
 	}
 
-	for dt, de in zip(allocation_dates, schedule_map[earned_leave_frequency][allocate_on_day], strict=False):
+	for dt, de in zip(allocation_dates, schedule_map[earned_leave_frequency][allocate_on_day], strict=True):
 		self.assertEqual(dt, de)
 
 

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -294,7 +294,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
 		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
-	def test_schedule_when_leave_policy_is_assigned_in_middle_of_the_period(self):
+	def test_schedule_when_leave_policy_is_assigned_in_middle_of_the_period_allocated_on_first_day(self):
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
 		earned_leave_schedule = create_earned_leave_schedule(
 			self.employee,
@@ -311,6 +311,24 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(earned_leave_schedule[0].allocation_date, add_months(get_year_start(getdate()), 4))
 		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
 		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
+
+	def test_schedule_when_leave_policy_is_assigned_in_middle_of_the_period_allocated_on_last_day(self):
+		frappe.flags.current_date = get_last_day(add_months(get_year_start(getdate()), 7))
+		earned_leave_schedule = create_earned_leave_schedule(
+			self.employee,
+			allocate_on_day="Last Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=24,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+		)
+
+		self.assertEqual(len(earned_leave_schedule), 3)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 12)
+		self.assertEqual(earned_leave_schedule[0].allocation_date, frappe.flags.current_date)
+		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
+		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_ending(getdate()), -3))
 
 
 def test_allocation_dates(

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -274,7 +274,24 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
 	def test_schedule_when_assignment_is_based_on_doj(self):
-		pass
+		self.employee.date_of_joining = add_months(get_year_start(getdate()), 4)
+		self.employee.save()
+		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
+		earned_leave_schedule = create_earned_leave_schedule(
+			self.employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Quarterly",
+			annual_allocation=24,
+			assignment_based_on="Joining Date",
+			start_date=add_months(get_year_start(getdate()), 4),
+			end_date=get_year_ending(getdate()),
+		)
+		frappe.db.commit()
+		self.assertEqual(len(earned_leave_schedule), 3)
+		self.assertEqual(earned_leave_schedule[0].number_of_leaves, 4)
+		self.assertEqual(earned_leave_schedule[0].allocation_date, add_months(get_year_start(getdate()), 4))
+		self.assertEqual(earned_leave_schedule[1].number_of_leaves, 6)
+		self.assertEqual(earned_leave_schedule[1].allocation_date, add_months(get_year_start(getdate()), 6))
 
 	def test_schedule_when_leave_policy_is_assigned_in_middle_of_the_period(self):
 		pass

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -38,6 +38,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		from_date = get_year_start(getdate())
 		to_date = get_year_ending(getdate())
 		self.holiday_list = make_holiday_list(from_date=from_date, to_date=to_date)
+		frappe.db.set_value("Email Account", "_Test Email Account 1", "default_outgoing", 1)
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -47,9 +47,12 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 		employee = frappe.get_doc("Employee", "_T-Employee-00001")
 		self.original_doj = employee.date_of_joining
-
 		employee.date_of_joining = add_months(getdate(), -24)
 		employee.save()
+
+		employee2 = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee2.date_of_joining = add_months(getdate(), -24)
+		employee2.save()
 
 		self.employee = employee
 		self.leave_type = "Test Earned Leave"

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -1079,6 +1079,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 			"Earned Leave Schedule", {"parent": leave_allocation.name, "attempted": 1, "failed": 1}, ["*"]
 		)
 		self.assertFalse(failed_allocations)
+		frappe.set_user("Administrator")
 
 	def test_allocating_earned_leave_when_schedule_doesnt_exist(self):
 		frappe.flags.current_date = get_year_start(getdate())

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -1080,6 +1080,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertFalse(failed_allocations)
 		frappe.set_user("Administrator")
+		frappe.get_doc("User", self.employee.user_id).remove_roles("HR Manager")
 
 	def test_allocating_earned_leave_when_schedule_doesnt_exist(self):
 		frappe.flags.current_date = get_year_start(getdate())
@@ -1139,6 +1140,8 @@ class TestLeaveAllocation(HRMSTestSuite):
 		self.assertEqual(total_leaves_allocated_with_no_schedule[0], 4)
 		self.assertEqual(total_leaves_allocated_with_no_schedule[1], 4)
 		self.assertEqual(total_leaves_allocated_with_schedule, 4)
+
+		frappe.delete_doc_if_exists("Employee", employee2.name, force=1)
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -1052,7 +1052,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 	def test_allocating_earned_leave_when_schedule_doesnt_exist(self):
 		frappe.flags.current_date = get_year_start(getdate())
-		assignment = make_policy_assignment(
+		assignment1 = make_policy_assignment(
 			self.employee,
 			allocate_on_day="First Day",
 			earned_leave_frequency="Monthly",
@@ -1062,22 +1062,33 @@ class TestLeaveAllocation(HRMSTestSuite):
 			end_date=get_year_ending(getdate()),
 			rounding=0.25,
 		)[0]
-		total_leaves_allocated = frappe.get_value(
-			"Leave Allocation",
-			{"employee": self.employee.name, "leave_policy_assignment": assignment},
-			"total_leaves_allocated",
-		)
-		self.assertEqual(total_leaves_allocated, 2)
 		frappe.db.delete("Earned Leave Schedule")
+		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		assignment2 = make_policy_assignment(
+			employee,
+			allocate_on_day="First Day",
+			earned_leave_frequency="Monthly",
+			annual_allocation=24,
+			assignment_based_on="Leave Period",
+			start_date=get_year_start(getdate()),
+			end_date=get_year_ending(getdate()),
+			rounding=0.25,
+		)[0]
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 1)
 		allocate_earned_leaves()
-		total_leaves_allocated = frappe.get_value(
+		total_leaves_allocated_with_no_schedule = frappe.get_value(
 			"Leave Allocation",
-			{"employee": self.employee.name, "leave_policy_assignment": assignment},
+			{"employee": self.employee.name, "leave_policy_assignment": assignment1},
+			"total_leaves_allocated",
+		)
+		total_leaves_allocated_with_schedule = frappe.get_value(
+			"Leave Allocation",
+			{"employee": employee.name, "leave_policy_assignment": assignment2},
 			"total_leaves_allocated",
 		)
 
-		self.assertEqual(total_leaves_allocated, 4)
+		self.assertEqual(total_leaves_allocated_with_no_schedule, 4)
+		self.assertEqual(total_leaves_allocated_with_schedule, 4)
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -216,7 +216,7 @@ class LeavePolicyAssignment(Document):
 		self, annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
 	):
 		from hrms.hr.utils import get_monthly_earned_leave as get_periodically_earned_leave
-		from hrms.hr.utils import get_period_start_and_end
+		from hrms.hr.utils import get_sub_period_start_and_end
 
 		periodically_earned_leave = get_periodically_earned_leave(
 			date_of_joining,
@@ -231,7 +231,7 @@ class LeavePolicyAssignment(Document):
 			# if the employee joined within the allocation period in some previous month,
 			# calculate pro-rated leave for that month
 			# and normal monthly earned leave for remaining passed months
-			start_date, end_date = get_period_start_and_end(
+			start_date, end_date = get_sub_period_start_and_end(
 				date_of_joining, leave_details.earned_leave_frequency
 			)
 			leaves = get_periodically_earned_leave(
@@ -413,6 +413,7 @@ def create_assignment_for_multiple_employees(employees, data):
 			frappe.db.savepoint(savepoint)
 			assignment.submit()
 		except Exception:
+			print
 			frappe.db.rollback(save_point=savepoint)
 			assignment.log_error("Leave Policy Assignment submission failed")
 			failed.append(assignment.name)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -319,7 +319,6 @@ class LeavePolicyAssignment(Document):
 				pro_rated_period_end,
 			)
 			schedule[0]["number_of_leaves"] = pro_rated_earned_leave
-
 		return schedule
 
 

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -413,7 +413,6 @@ def create_assignment_for_multiple_employees(employees, data):
 			frappe.db.savepoint(savepoint)
 			assignment.submit()
 		except Exception:
-			print
 			frappe.db.rollback(save_point=savepoint)
 			assignment.log_error("Leave Policy Assignment submission failed")
 			failed.append(assignment.name)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -257,7 +257,12 @@ class LeavePolicyAssignment(Document):
 		months_to_add = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(
 			leave_details.earned_leave_frequency
 		)
-
+		date = get_expected_allocation_date_for_period(
+			leave_details.earned_leave_frequency,
+			leave_details.allocate_on_day,
+			max(from_date, getdate(date_of_joining)),
+			date_of_joining,
+		)
 		schedule = []
 		if new_leaves_allocated:
 			schedule.append(
@@ -269,13 +274,13 @@ class LeavePolicyAssignment(Document):
 					"attempted": 1,
 				}
 			)
+			date = get_expected_allocation_date_for_period(
+				leave_details.earned_leave_frequency,
+				leave_details.allocate_on_day,
+				add_to_date(today, months=months_to_add),
+				date_of_joining,
+			)
 
-		date = get_expected_allocation_date_for_period(
-			leave_details.earned_leave_frequency,
-			leave_details.allocate_on_day,
-			max(from_date, getdate(date_of_joining)),
-			date_of_joining,
-		)
 		if from_date < getdate(date_of_joining):
 			pro_rated_earned_leave = get_monthly_earned_leave(
 				date_of_joining,

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -291,7 +291,7 @@ class LeavePolicyAssignment(Document):
 
 		while date <= to_date:
 			date_already_passed = today > date
-			if date > last_allocated_date:
+			if date >= last_allocated_date:
 				row = {
 					"allocation_date": date,
 					"number_of_leaves": periodically_earned_leave,

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -272,7 +272,9 @@ class LeavePolicyAssignment(Document):
 			row = {
 				"allocation_date": date,
 				"number_of_leaves": periodically_earned_leave,
-				"is_allocated": 0 if date >= today else 1,
+				"is_allocated": 1 if date <= today else 0,
+				"allocated_via": "Leave Policy Assignment" if date <= today else None,
+				"attempted": 1 if date <= today else 0,
 			}
 			schedule.append(row)
 			date = add_to_date(date, months=months_to_add)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -124,19 +124,17 @@ class LeavePolicyAssignment(Document):
 		)
 
 		allocation = frappe.get_doc(
-			dict(
-				doctype="Leave Allocation",
-				employee=self.employee,
-				leave_type=leave_details.name,
-				from_date=self.effective_from,
-				to_date=self.effective_to,
-				new_leaves_allocated=new_leaves_allocated,
-				leave_period=self.leave_period if self.assignment_based_on == "Leave Policy" else "",
-				leave_policy_assignment=self.name,
-				leave_policy=self.leave_policy,
-				carry_forward=carry_forward,
-				earned_leave_schedule=earned_leave_schedule,
-			)
+			doctype="Leave Allocation",
+			employee=self.employee,
+			leave_type=leave_details.name,
+			from_date=self.effective_from,
+			to_date=self.effective_to,
+			new_leaves_allocated=new_leaves_allocated,
+			leave_period=self.leave_period if self.assignment_based_on == "Leave Policy" else "",
+			leave_policy_assignment=self.name,
+			leave_policy=self.leave_policy,
+			carry_forward=carry_forward,
+			earned_leave_schedule=earned_leave_schedule,
 		)
 		allocation.save(ignore_permissions=True)
 		allocation.submit()

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import calendar
 import datetime
 
 import frappe
@@ -593,11 +594,15 @@ def create_additional_leave_ledger_entry(allocation, leaves, date):
 
 
 def get_expected_allocation_date_for_period(frequency, allocate_on_day, date, date_of_joining=None):
+	try:
+		doj = date_of_joining.replace(month=date.month, year=date.year)
+	except ValueError:
+		doj = datetime.date(date.year, date.month, calendar.monthrange(date.year, date.month)[1])
 	return {
 		"Monthly": {
 			"First Day": get_first_day(date),
 			"Last Day": get_last_day(date),
-			"Date of Joining": date_of_joining.replace(month=date.month, year=date.year),
+			"Date of Joining": doj,
 		},
 		"Quarterly": {
 			"First Day": get_quarter_start(date),
@@ -619,7 +624,7 @@ def get_salary_assignments(employee, payroll_period):
 
 	if not assignments or getdate(assignments[0].from_date) > getdate(start_date):
 		# if no assignments found for the given period
-		# or the  assignment hast started in the middle of the period
+		# or the assignment has started in the middle of the period
 		# get the last one assigned before the period start date
 		past_assignment = frappe.get_all(
 			"Salary Structure Assignment",

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -522,24 +522,30 @@ def create_additional_leave_ledger_entry(allocation, leaves, date):
 def check_effective_date(from_date, today, frequency, allocate_on_day):
 	from_date = getdate(from_date)
 
-	expected_date = {
-		"Monthly": {
-			"First Day": get_first_day(today),
-			"Last Day": get_last_day(today),
-			"Date of Joining": from_date,
-		},
-		"Quarterly": {
-			"First Day": get_quarter_start(today),
-			"Last Day": get_quarter_ending(today),
-		},
-		"Half-Yearly": {"First Day": get_semester_start(today), "Last Day": get_semester_end(today)},
-		"Yearly": {"First Day": get_year_start(today), "Last Day": get_year_ending(today)},
-	}[frequency][allocate_on_day]
+	expected_date = get_expected_allocation_date_for_period(
+		frequency, allocate_on_day, today, date_of_joining=from_date
+	)
 
 	if allocate_on_day == "Date of Joining":
 		return expected_date.day == today.day
 	else:
 		return expected_date == today
+
+
+def get_expected_allocation_date_for_period(frequency, allocate_on_day, date, date_of_joining=None):
+	return {
+		"Monthly": {
+			"First Day": get_first_day(date),
+			"Last Day": get_last_day(date),
+			"Date of Joining": date_of_joining,
+		},
+		"Quarterly": {
+			"First Day": get_quarter_start(date),
+			"Last Day": get_quarter_ending(date),
+		},
+		"Half-Yearly": {"First Day": get_semester_start(date), "Last Day": get_semester_end(date)},
+		"Yearly": {"First Day": get_year_start(date), "Last Day": get_year_ending(date)},
+	}[frequency][allocate_on_day]
 
 
 def get_salary_assignments(employee, payroll_period):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -480,7 +480,7 @@ def send_email_for_failed_allocations(failed_allocations):
 		subject=_("Failure of Automatic Allocation of Earned Leaves"),
 		message=_(
 			"Automatic Leave Allocation has failed for the following Earned Leaves: {0}. Please check {1} for more details."
-		).format(get_link_to_form("Error Log", label="Error Log List"), allocations),
+		).format(allocations, get_link_to_form("Error Log", label="Error Log List")),
 	)
 
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -388,7 +388,6 @@ def get_upcoming_earned_leave_from_schedule(allocation_name, today):
 		"Earned Leave Schedule",
 		{"parent": allocation_name, "attempted": 0, "allocation_date": today},
 		["allocation_date", "number_of_leaves"],
-		cache=True,
 	)
 
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -448,9 +448,7 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 
 def log_allocation_error(allocation_name, error):
 	error_log = frappe.log_error(error, reference_doctype="Leave Allocation")
-	text = _("{0}. Check error log {1} for more details.").format(
-		error_log.method, get_link_to_form("Error Log", error_log.name)
-	)
+	text = _("{0}. Check error log for more details.").format(error_log.method)
 	earned_leave_schedule = qb.DocType("Earned Leave Schedule")
 	today = getdate(frappe.flags.current_date) or getdate()
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -476,13 +476,7 @@ def get_monthly_earned_leave(
 		if pro_rated:
 			if not (period_start_date or period_end_date):
 				today_date = frappe.flags.current_date or getdate()
-
-				period_start_date, period_end_date = {
-					"Monthly": (get_first_day(today_date), get_last_day(today_date)),
-					"Quarterly": (get_quarter_start(today_date), get_quarter_ending(today_date)),
-					"Half-Yearly": (get_semester_start(today_date), get_semester_end(today_date)),
-					"Yearly": (get_year_start(today_date), get_year_ending(today_date)),
-				}.get(frequency)
+				period_start_date, period_end_date = get_sub_period_start_and_end(today_date, frequency)
 
 			earned_leaves = calculate_pro_rated_leaves(
 				earned_leaves, date_of_joining, period_start_date, period_end_date, is_earned_leave=True
@@ -491,6 +485,15 @@ def get_monthly_earned_leave(
 		earned_leaves = round_earned_leaves(earned_leaves, rounding)
 
 	return earned_leaves
+
+
+def get_sub_period_start_and_end(date, frequency):
+	return {
+		"Monthly": (get_first_day(date), get_last_day(date)),
+		"Quarterly": (get_quarter_start(date), get_quarter_ending(date)),
+		"Half-Yearly": (get_semester_start(date), get_semester_end(date)),
+		"Yearly": (get_year_start(date), get_year_ending(date)),
+	}.get(frequency)
 
 
 def round_earned_leaves(earned_leaves, rounding):

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -566,7 +566,7 @@ def get_leave_allocations(date, leave_type):
 			& (leave_allocation.leave_policy.isnotnull())
 			& (employee.status != "Left")
 		)
-		.groupby(earned_leave_schedule.parent)
+		.groupby(leave_allocation.name)
 	)
 	return query.run(as_dict=1) or []
 


### PR DESCRIPTION
- New child doctype to show earned leave schedule in leave allocation document
- Show failed allocations with indicators
- Button to retry failed allocations shown for users with write permission to the document
- Send email to HR managers with a list of failed leave allocations
- Log failure in error log list
- If leave policy is assigned in the middle of the leave period, a single entry is made for past allocations to reduce clutter
- Tests obviously


For more info, refer #1959
<img width="2500" height="1586" alt="Screenshot From 2025-09-09 10-06-47" src="https://github.com/user-attachments/assets/47e976ae-4e31-4dd8-b219-46e5d4aabc7a" />

https://github.com/user-attachments/assets/4b4a1ad2-a97c-4abd-a3df-6f1eb67cdb2d

Closes #1959 
`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earned Leave Schedule child table added to Leave Allocation with allocation dates, amounts, status, failure reasons, and a "Retry Failed Allocations" action.

* **Improvements**
  * Automatic schedule generation from policy assignments with cadence and prorating, visual red/green indicators, error logging and batch failure email alerts, and a manual retry workflow that reconciles allocations with validations.

* **Tests**
  * Comprehensive test suite covering schedule generation, proration, allocation failures, retry behavior, permissions, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
