### PR TITLE
fix(payroll-entry): submit payroll entry while creating salary slips in background job

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -94,14 +94,13 @@ frappe.ui.form.on("Payroll Entry", {
 						});
 					});
 				} else {
-					frm.add_custom_button(__("Create Salary Slips"), function () {
-						frm.call("create_salary_slips");
-					}).addClass("btn-primary");
+					frm.page.set_primary_action(__("Create Salary Slips"), () => {
+						frm.save("Submit").then(() => {
+							frm.page.clear_primary_action();
+							frm.refresh();
+						});
+					});
 				}
-			} else if (frm.doc.docstatus == 1 && frm.doc.status == "Failed") {
-				frm.add_custom_button(__("Create Salary Slips"), function () {
-					frm.call("create_salary_slips");
-				}).addClass("btn-primary");
 			}
 		}
 
@@ -152,8 +151,7 @@ frappe.ui.form.on("Payroll Entry", {
 	},
 
 	create_salary_slip: function (frm) {
-		frm.call({
-			doc: frm.doc,
+		frappe.call({
 			method: "run_doc_method",
 			args: {
 				method: "create_salary_slips",
@@ -175,7 +173,7 @@ frappe.ui.form.on("Payroll Entry", {
 			}).addClass("btn-primary");
 		} else if (!frm.doc.salary_slips_created && frm.doc.status === "Failed") {
 			frm.add_custom_button(__("Create Salary Slips"), function () {
-				frm.trigger("create_salary_slips");
+				frm.trigger("create_salary_slip");
 			}).addClass("btn-primary");
 		}
 	},


### PR DESCRIPTION
**Issue:** Payroll Entry is not submitted while creating salary slips in the background job
**ref:** [47090](https://support.frappe.io/helpdesk/tickets/47090)

**Before:**

https://github.com/user-attachments/assets/b1f3f193-de27-4e23-b58c-b3707b3769bc

**After:**

https://github.com/user-attachments/assets/c7961ac5-8404-4082-bcac-c2ae8dc13bdd


**Backport needed for v15**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Salary Slip creation: replaced the old button flow with a single primary action that saves and submits, then refreshes.
  * Removed the extra “Create Salary Slips” button shown in failure states to reduce confusion.
  * Unified the trigger for creating slips for more consistent behavior and clearer status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->