### PR TITLE
chore: workflow to auto close stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # https://github.com/actions/stale
 
-name: "Close Stale Issues and PRs"
+name: "Close Stale PRs"
 on:
   schedule:
     - cron: 0 0 * * *

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,10 @@ jobs:
           days-before-pr-stale: 15
           days-before-pr-close: 3
           stale-pr-label: 'Inactive' 
-          stale-pr-message: 'This pull request is being marked as inactive because it has not had any recent activity.
-                             It will be closed within 3 days if no further activity occurs.
-                             It only takes a comment to keep the contribution alive. And even if it is closed, you can always reopen the PR when you are ready.
-                             Thank you for contributing!'
+          days-before-stale: -1
+          days-before-close: -1
+          stale-pr-message: |
+            This pull request is being marked as inactive because it has not had any recent activity. It will be closed within 3 days if no further activity occurs.
+            It only takes a comment to keep the contribution alive. And even if it is closed, you can always reopen the PR when you are ready.
+            Thank you for contributing!'
           

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,11 +14,10 @@ jobs:
         with:
           days-before-pr-stale: 15
           days-before-pr-close: 3
-          stale-pr-label: 'Inactive' 
+          stale-pr-label: 'Inactive'
           days-before-stale: -1
           days-before-close: -1
           stale-pr-message: |
-            This pull request is being marked as inactive because it has not had any recent activity. It will be closed within 3 days if no further activity occurs.
-            It only takes a comment to keep the contribution alive. And even if it is closed, you can always reopen the PR when you are ready.
-            Thank you for contributing!'
-          
+            This pull request is marked as inactive due to no recent activity. It will be closed in 3 days if no further activity occurs.
+            Comment to keep the contribution alive. You can reopen the PR when ready.
+            Thank you for contributing!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+# https://github.com/actions/stale
+
+name: "Close Stale Issues and PRs"
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 15
+          days-before-pr-close: 3
+          stale-pr-label: 'Inactive' 
+          stale-pr-message: 'This pull request is being marked as inactive because it has not had any recent activity.
+                             It will be closed within 3 days if no further activity occurs.
+                             It only takes a comment to keep the contribution alive. And even if it is closed, you can always reopen the PR when you are ready.
+                             Thank you for contributing!'
+          


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated workflow to manage inactive pull requests: marks PRs as "Inactive" after 15 days, posts a friendly reminder, and closes them after 3 more days without activity. Runs daily and can be triggered manually. Commenting keeps the contribution active; closed PRs can be reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->