### PR TITLE
chore: avoid setting salary slip naming series via class method only if custom naming series exists

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.json
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "autoname": "format:Sal Slip/{employee}/{#####}",
  "creation": "2013-01-10 16:34:15",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -747,11 +746,10 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-13 17:58:15.095251",
+ "modified": "2024-07-01 21:25:36.651583",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",
- "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -785,7 +783,6 @@
    "role": "Employee"
   }
  ],
- "row_format": "Dynamic",
  "search_fields": "employee_name",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -66,6 +66,7 @@ TAX_COMPONENTS_BY_COMPANY = "tax_components_by_company"
 class SalarySlip(TransactionBase):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
+		self.series = f"Sal Slip/{self.employee}/.#####"
 		self.whitelisted_globals = {
 			"int": int,
 			"float": float,
@@ -79,6 +80,9 @@ class SalarySlip(TransactionBase):
 			"ceil": ceil,
 			"floor": floor,
 		}
+
+	def autoname(self):
+		self.name = make_autoname(self.series)
 
 	@property
 	def joining_date(self):
@@ -244,6 +248,11 @@ class SalarySlip(TransactionBase):
 			user=employee_user,
 			after_commit=True,
 		)
+
+	def on_trash(self):
+		from frappe.model.naming import revert_series_if_last
+
+		revert_series_if_last(self.series, self.name)
 
 	def get_status(self):
 		if self.docstatus == 2:


### PR DESCRIPTION
Reverts frappe/hrms#3338 

Change made: autoname is run only if custom naming series doesnt exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Salary Slips now get automatic, employee-based IDs when no custom naming is configured.
  - System preserves custom naming if you’ve set one.

- Bug Fixes
  - Deleting the most recent Salary Slip correctly reclaims the last sequence number, preventing gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->