### PR TITLE
Revert "fix: check multi currency when salary slip currency differs from company currency"

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -625,7 +625,7 @@ class PayrollEntry(Document):
 		submit_journal_entry=False,
 	) -> str:
 		multi_currency = 0
-		if len(currencies) > 1 or currencies[0] != erpnext.get_company_currency(self.company):
+		if len(currencies) > 1:
 			multi_currency = 1
 
 		journal_entry = frappe.new_doc("Journal Entry")


### PR DESCRIPTION
Reverts frappe/hrms#3181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected multi-currency handling in Payroll journal entries: entries are now marked as multi-currency only when multiple currencies are involved, ensuring single-currency entries are treated appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->