### PR TITLE
fix: update loan status when cancelled payroll entry

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -173,6 +173,10 @@ def cancel_loan_repayment_entry(doc: "SalarySlip"):
 			repayment_entry = frappe.get_doc("Loan Repayment", loan.loan_repayment_entry)
 			repayment_entry.cancel()
 
+			loan_status = frappe.db.get_value("Loan", loan.loan, "status")
+			if loan_status == "Closed":
+				frappe.db.set_value("Loan", loan.loan, "status", "Disbursed")
+
 
 def get_payroll_payable_account(company, payroll_entry):
 	if payroll_entry:


### PR DESCRIPTION
- update loan status when cancelled payroll entry

Before:

[before_loan_status.webm](https://github.com/user-attachments/assets/fb7e48f5-e116-43ac-a01a-8b8ff18f9a56)


After:

[after_loan_status.webm](https://github.com/user-attachments/assets/b48967b6-44d3-494b-8076-01f9cf749a85)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When a loan repayment entry is canceled, the associated loan’s status now updates correctly: if previously marked “Closed,” it reverts to “Disbursed.”
  * Ensures loan records, payroll processing, and reports reflect the current repayment state accurately.
  * Reduces manual corrections by automatically aligning loan status with repayment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->