### PR TITLE
fix(shift-assignment-tool): fetch employees with with user permission

### DIFF
--- a/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
+++ b/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
@@ -6,9 +6,11 @@ from datetime import timedelta
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.query_builder import Case, Interval
+from frappe.query_builder import Case, Criterion, Interval
 from frappe.query_builder.terms import SubQuery
 from frappe.utils import get_link_to_form
+
+from erpnext.accounts.utils import build_qb_match_conditions
 
 from hrms.hr.utils import validate_bulk_tool_fields
 
@@ -66,6 +68,8 @@ class ShiftAssignmentTool(Document):
 		elif self.status == "Active":
 			query = query.where(Employee.employee.notin(SubQuery(self.get_query_for_employees_with_shifts())))
 
+		query = query.where(Criterion.all(build_qb_match_conditions("Employee")))
+
 		return query.run(as_dict=True)
 
 	def get_shift_requests(self, filters):
@@ -96,6 +100,8 @@ class ShiftAssignmentTool(Document):
 			query = query.where((ShiftRequest.to_date >= self.from_date) | (ShiftRequest.to_date.isnull()))
 		if self.to_date:
 			query = query.where(ShiftRequest.from_date <= self.to_date)
+
+		query = query.where(Criterion.all(build_qb_match_conditions("Employee")))
 
 		data = query.run(as_dict=True)
 		for d in data:


### PR DESCRIPTION
**Issue:** Shift Assignment Tool is fetching all employees irrespective of the user permission.
**ref:** [47828](https://support.frappe.io/helpdesk/tickets/47828)

**Before:**

https://github.com/user-attachments/assets/e8f9a859-81e5-494e-8a9d-28022f7399fb


**After:**

https://github.com/user-attachments/assets/3445932b-7712-4d67-ad48-5384766a208a



**Backport needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Employee lists in the Shift Assignment Tool now respect user permissions, showing only employees the user is allowed to access.
  * Shift Requests are now filtered by the user’s access rights, preventing visibility of unauthorized employee records.
  * Improves data privacy and consistency across shift-related views without changes to the UI or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->