### PR TITLE
fix: include filters for link field

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -72,6 +72,7 @@ const reloadOptions = (searchTextVal) => {
 		params: {
 			txt: searchTextVal,
 			doctype: props.doctype,
+			filters: props.filters
 		},
 	})
 	options.reload()

--- a/frontend/src/views/employee_advance/Form.vue
+++ b/frontend/src/views/employee_advance/Form.vue
@@ -120,6 +120,7 @@ function applyFilters(fields) {
 				company: employeeAdvance.value.company,
 				is_group: 0,
 				root_type: "Asset",
+				account_type: "Receivable",
 				account_currency: ("in", currencies),
 			}
 		}

--- a/frontend/src/views/employee_advance/Form.vue
+++ b/frontend/src/views/employee_advance/Form.vue
@@ -121,7 +121,7 @@ function applyFilters(fields) {
 				is_group: 0,
 				root_type: "Asset",
 				account_type: "Receivable",
-				account_currency: ("in", currencies),
+				account_currency: ["in", currencies],
 			}
 		}
 


### PR DESCRIPTION
Issue: Link field shows all data irrespective of the filter

Fix: Added the account type filter option

Ref: [48011](https://support.frappe.io/helpdesk/tickets/48011)

Before:

<img width="427" height="842" alt="image" src="https://github.com/user-attachments/assets/c41f79eb-97bc-4bbb-ae7b-4589b29e3e0f" />

After:

<img width="427" height="842" alt="image" src="https://github.com/user-attachments/assets/563f2985-db45-4696-a021-8c9bb87ea853" />

Backport: Version-15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Option lists now consistently respect active filters when reloaded, matching initial load results.

* Improvements
  * Employee Advance form now limits “Advance Account” choices to receivable accounts.
  * Currency filtering for account choices is more accurate, considering selected and company currencies to narrow results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->