### PR TITLE
feat: use fixed 30-day month for salary slip payment days

### DIFF
--- a/hrms/payroll/doctype/payroll_settings/payroll_settings.json
+++ b/hrms/payroll/doctype/payroll_settings/payroll_settings.json
@@ -16,6 +16,7 @@
   "daily_wages_fraction_for_half_day",
   "column_break_rnoq",
   "disable_rounded_total",
+  "use_fixed_30_days",
   "column_break_gzpl",
   "show_leave_balances_in_salary_slip",
   "email_section",
@@ -188,13 +189,19 @@
    "fieldtype": "Link",
    "label": "Sender Copy",
    "options": "Email Account"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_fixed_30_days",
+   "fieldtype": "Check",
+   "label": "Use Fixed 30 Days"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-06-24 11:46:55.338986",
+ "modified": "2025-09-12 16:04:54.805362",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Settings",

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -628,7 +628,18 @@ class SalarySlip(TransactionBase):
 					)
 				)
 
-		payment_days = date_diff(self.actual_end_date, self.actual_start_date) + 1
+		worked_days_in_period = date_diff(self.actual_end_date, self.actual_start_date) + 1
+		calender_days_in_period = date_diff(self.end_date, self.start_date) + 1
+
+		use_fixed_30_days = frappe.db.get_single_value("Payroll Settings", "use_fixed_30_days")
+		if use_fixed_30_days and self.payroll_frequency == "Monthly":
+			month_days = 30
+			payment_days = worked_days_in_period
+			# If employee worked the whole month so normalize to 30
+			if worked_days_in_period == calender_days_in_period:
+				payment_days = month_days
+		else:
+			payment_days = worked_days_in_period
 
 		if not cint(include_holidays_in_total_working_days):
 			holidays = self.get_holidays_for_employee(self.actual_start_date, self.actual_end_date)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -629,15 +629,11 @@ class SalarySlip(TransactionBase):
 				)
 
 		worked_days_in_period = date_diff(self.actual_end_date, self.actual_start_date) + 1
-		calender_days_in_period = date_diff(self.end_date, self.start_date) + 1
+		calendar_days_in_period = date_diff(self.end_date, self.start_date) + 1
 
 		use_fixed_30_days = frappe.db.get_single_value("Payroll Settings", "use_fixed_30_days")
 		if use_fixed_30_days and self.payroll_frequency == "Monthly":
-			month_days = 30
-			payment_days = worked_days_in_period
-			# If employee worked the whole month so normalize to 30
-			if worked_days_in_period == calender_days_in_period:
-				payment_days = month_days
+			payment_days = self.calculate_fixed_30_day_month(worked_days_in_period, calendar_days_in_period)
 		else:
 			payment_days = worked_days_in_period
 
@@ -646,6 +642,41 @@ class SalarySlip(TransactionBase):
 			payment_days -= len(holidays)
 
 		return payment_days
+
+	def calculate_fixed_30_day_month(self, worked_days_in_period, calendar_days_in_period):
+		month_days = 30
+
+		# Case 1: Full month normalize to 30
+		if worked_days_in_period == calendar_days_in_period:
+			payment_days = month_days
+			return payment_days
+
+		# Case 2: Joined and relieved in the same month
+		if (
+			self.joining_date
+			and self.relieving_date
+			and getdate(self.start_date) <= self.joining_date <= getdate(self.end_date)
+			and getdate(self.start_date) <= self.relieving_date <= getdate(self.end_date)
+		):
+			return self.relieving_date.day - self.joining_date.day + 1
+
+		# Case 3: Joined mid-month
+		if (
+			self.joining_date
+			and getdate(self.start_date) < self.joining_date <= getdate(self.end_date)
+			and (not self.relieving_date or self.relieving_date > getdate(self.end_date))
+		):
+			return month_days - (self.joining_date.day - 1)
+
+		# Case 4: Relieved mid-month (joined before start)
+		if (
+			self.relieving_date
+			and getdate(self.start_date) <= self.relieving_date < getdate(self.end_date)
+			and (not self.joining_date or self.joining_date <= getdate(self.start_date))
+		):
+			return self.relieving_date.day
+
+		return worked_days_in_period
 
 	def get_holidays_for_employee(self, start_date, end_date):
 		holiday_list = get_holiday_list_for_employee(self.employee)


### PR DESCRIPTION
Closes: #3539
Backport: version-15

https://github.com/user-attachments/assets/8e5085d0-ddc9-4591-b5c9-738ac1512e32

---
#### Key Changes

*  Add new checkbox `Use Fixed 30 Day` on Payroll Settings to activate the feature. 
* Applies only to **Monthly payroll frequency**.
* Payment days = actual worked days in the payroll period.
* If employee worked the **entire month** => normalize to **30**.

---
#### Covered Cases

- [x]  **Full month** => always `30` (Feb 28, Feb 29, Sep 30, Oct 31).
- [x]  **Mid-month join** => counts actual worked days (e.g., join 15-Feb  => 16 days in Feb 28 and 29)
- [x]  **Mid-month leave** => counts actual worked days (e.g., leave 15-Sep =>  15).
- [x]  **Join + leave mid-month** => counts overlap only.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Use Fixed 30 Days” checkbox in Payroll Settings.
  * When enabled for Monthly payrolls, full worked periods are treated as 30 payment days; partial periods remain prorated.

* **Bug Fixes**
  * Corrected payment-day calculations and ensured holiday exclusion preferences still apply to final payment days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->