### PR TITLE
feat: Calculate & Show Income tax breakup section in Salary Slip if it is overwritten from Additional salary (backport #3449)

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -989,9 +989,7 @@ class SalarySlip(TransactionBase):
 				- self.income_tax_deducted_till_date
 			)
 
-			self.current_month_income_tax = self.current_structured_tax_amount + self.get(
-				"full_tax_on_additional_earnings", 0
-			)
+			self.current_month_income_tax = self.get("current_tax_amount", 0)
 
 			# non included current_month_income_tax separately as its already considered
 			# while calculating income_tax_deducted_till_date
@@ -1349,9 +1347,6 @@ class SalarySlip(TransactionBase):
 			else:
 				self.other_deduction_components.append(d.salary_component)
 
-		if self.handle_additional_salary_tax_component():
-			return
-
 		# consider manually added tax component
 		if not tax_components:
 			tax_components = [
@@ -1368,16 +1363,23 @@ class SalarySlip(TransactionBase):
 				alert=True,
 			)
 
+		self._component_based_variable_tax = {}
 		if tax_components and self.payroll_period and self.salary_structure:
 			self.tax_slab = self.get_income_tax_slabs()
 			self.compute_taxable_earnings_for_year()
 
-		self._component_based_variable_tax = {}
-		for d in tax_components:
-			self._component_based_variable_tax.setdefault(d, {})
-			tax_amount = self.calculate_variable_based_on_taxable_salary(d)
-			tax_row = get_salary_component_data(d)
-			self.update_component_row(tax_row, tax_amount, "deductions")
+		if self.handle_additional_salary_tax_component():
+			self._component_based_variable_tax.setdefault(self.additional_salary_component, {})
+			self.calculate_variable_tax(self.additional_salary_component, True)
+			return
+
+		for tax_component in tax_components:
+			self._component_based_variable_tax.setdefault(tax_component, {})
+			self.calculate_variable_based_on_taxable_salary(tax_component)
+			if self._component_based_variable_tax[tax_component]:
+				tax_amount = self._component_based_variable_tax[tax_component]["current_tax_amount"]
+				tax_row = get_salary_component_data(tax_component)
+				self.update_component_row(tax_row, tax_amount, "deductions")
 
 	def get_tax_components(self) -> list:
 		"""
@@ -1433,9 +1435,16 @@ class SalarySlip(TransactionBase):
 		if not component:
 			return False
 
-		if frappe.db.get_value(
-			"Additional Salary", component.additional_salary, "overwrite_salary_structure_amount"
-		):
+		additional_salary = frappe.db.get_value(
+			"Additional Salary",
+			component.additional_salary,
+			["amount", "overwrite_salary_structure_amount"],
+			as_dict=1,
+		)
+		self.additional_salary_amount = additional_salary.amount
+		self.additional_salary_component = component.salary_component
+
+		if additional_salary.overwrite_salary_structure_amount:
 			return True
 		else:
 			# overwriting disabled, remove addtional salary tax component
@@ -1547,7 +1556,7 @@ class SalarySlip(TransactionBase):
 
 		return self.calculate_variable_tax(tax_component)
 
-	def calculate_variable_tax(self, tax_component):
+	def calculate_variable_tax(self, tax_component, has_additional_salary_tax_component=False):
 		self.previous_total_paid_taxes = self.get_tax_paid_in_period(
 			self.payroll_period.start_date, self.start_date, tax_component
 		)
@@ -1561,9 +1570,12 @@ class SalarySlip(TransactionBase):
 			eval_locals,
 		)
 
-		self.current_structured_tax_amount = (
-			self.total_structured_tax_amount - self.previous_total_paid_taxes
-		) / self.remaining_sub_periods
+		if has_additional_salary_tax_component:
+			self.current_structured_tax_amount = self.additional_salary_amount
+		else:
+			self.current_structured_tax_amount = (
+				self.total_structured_tax_amount - self.previous_total_paid_taxes
+			) / self.remaining_sub_periods
 
 		# Total taxable earnings with additional earnings with full tax
 		self.full_tax_on_additional_earnings = 0.0
@@ -1573,9 +1585,14 @@ class SalarySlip(TransactionBase):
 			)
 			self.full_tax_on_additional_earnings = self.total_tax_amount - self.total_structured_tax_amount
 
-		current_tax_amount = self.current_structured_tax_amount + self.full_tax_on_additional_earnings
-		if flt(current_tax_amount) < 0:
-			current_tax_amount = 0
+		self.current_tax_amount = max(
+			0,
+			flt(
+				self.current_structured_tax_amount
+				if has_additional_salary_tax_component
+				else (self.current_structured_tax_amount + self.full_tax_on_additional_earnings)
+			),
+		)
 
 		self._component_based_variable_tax[tax_component].update(
 			{
@@ -1583,11 +1600,9 @@ class SalarySlip(TransactionBase):
 				"total_structured_tax_amount": self.total_structured_tax_amount,
 				"current_structured_tax_amount": self.current_structured_tax_amount,
 				"full_tax_on_additional_earnings": self.full_tax_on_additional_earnings,
-				"current_tax_amount": current_tax_amount,
+				"current_tax_amount": self.current_tax_amount,
 			}
 		)
-
-		return current_tax_amount
 
 	def get_income_tax_slabs(self):
 		income_tax_slab = self._salary_structure_assignment.income_tax_slab

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -243,7 +243,7 @@ def create_salary_structure_assignment(
 	if not payroll_period:
 		payroll_period = create_payroll_period(company="_Test Company")
 
-	income_tax_slab = frappe.db.get_value("Income Tax Slab", {"currency": currency})
+	income_tax_slab = frappe.db.get_value("Income Tax Slab", {"currency": currency, "docstatus": 1})
 
 	if not income_tax_slab:
 		income_tax_slab = create_tax_slab(payroll_period, allow_tax_exemption=True, currency=currency)


### PR DESCRIPTION
Manual Backport of #3449 

## Reason
- If the income tax is added in additional salary with the checkbox **Overwrite Salary Structure Amount** enabled, then the additional salary amount gets added in salary slip skipping the normal flow of income tax. In this process the **Income tax breakup** section in salary slip is not shown which raises concern in users to get the detailed calculation based on additional salary.

## Changes done
- get the additional salary amount & add in current month tax directly
- updated the func `calculate_variable_tax` to update the current month tax amount
- call func which calculates the yearly tax applicable & other totals before checking the additional salary record as it will be shown either way

## Screenshot

https://github.com/user-attachments/assets/17c0ea6f-3fe7-4072-afea-e6dc10125d59


`no-docs`

closes #3459 

Backport #3449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for charging income tax via an Additional Salary (TDS) component, with an option to overwrite the month’s structured tax and reflect precise per-component tax amounts in deductions.
  * Salary Slip now reports accurate current-month tax and updated projected future tax deductions.

* **Bug Fixes**
  * Income Tax Slab selection now considers only submitted slabs for assignments.

* **Tests**
  * Added test coverage validating tax behavior when tax is added via an Additional Salary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->