### PR TITLE
feat: handle salary structure arrears

### DIFF
--- a/hrms/payroll/doctype/arrear/arrear.js
+++ b/hrms/payroll/doctype/arrear/arrear.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Arrear", {
+	setup(frm) {
+		company_fliter = {
+			filters: {
+				company: frm.doc.company || "",
+			},
+		};
+		frm.set_query("employee", () => {
+			return company_fliter;
+		});
+		frm.set_query("payroll_period", () => {
+			return company_fliter;
+		});
+		frm.set_query("salary_structure", () => {
+			return company_fliter;
+		});
+	},
+	refresh(frm) {},
+
+	employee: (frm) => {
+		if (frm.doc.employee) {
+			frappe.run_serially([
+				() => frm.trigger("get_employee_currency"),
+				() => frm.trigger("set_company"),
+			]);
+		} else {
+			frm.set_value("company", null);
+		}
+	},
+
+	salary_structure: (frm) => {},
+
+	get_employee_currency: (frm) => {
+		frappe.call({
+			method: "hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment.get_employee_currency",
+			args: {
+				employee: frm.doc.employee,
+			},
+			callback: function (r) {
+				if (r.message) {
+					console.log(r.message);
+					frm.set_value("currency", r.message);
+					// frm.refresh_field("currency");
+				}
+			},
+		});
+	},
+
+	set_company: (frm) => {
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Employee",
+				fieldname: "company",
+				filters: {
+					name: frm.doc.employee,
+				},
+			},
+			callback: (data) => {
+				if (data.message) {
+					frm.set_value("company", data.message.company);
+				}
+			},
+		});
+	},
+});

--- a/hrms/payroll/doctype/arrear/arrear.json
+++ b/hrms/payroll/doctype/arrear/arrear.json
@@ -1,0 +1,131 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-09-15 16:08:13.216474",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name",
+  "payroll_period",
+  "salary_structure",
+  "arrear_start_date",
+  "column_break_itzd",
+  "company",
+  "currency",
+  "payroll_date",
+  "section_break_ubws",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_ubws",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Arrear",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_itzd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "employee.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.employee;",
+   "fieldname": "payroll_period",
+   "fieldtype": "Link",
+   "label": "Payroll Period",
+   "options": "Payroll Period",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.salary_structure",
+   "fieldname": "payroll_date",
+   "fieldtype": "Date",
+   "label": "Payroll Date",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.salary_structure;",
+   "description": " Salary slips starting on or after this date will be considered for arrear calculations",
+   "fieldname": "arrear_start_date",
+   "fieldtype": "Date",
+   "label": "Arrear Start Date",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.payroll_period;",
+   "fieldname": "salary_structure",
+   "fieldtype": "Link",
+   "label": "Salary Structure",
+   "options": "Salary Structure",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.employee;",
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency",
+   "read_only": 1,
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-09-15 20:26:17.412941",
+ "modified_by": "Administrator",
+ "module": "Payroll",
+ "name": "Arrear",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/payroll/doctype/arrear/arrear.json
+++ b/hrms/payroll/doctype/arrear/arrear.json
@@ -42,6 +42,7 @@
    "fieldname": "employee",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -61,6 +62,7 @@
    "fetch_from": "employee.company",
    "fieldname": "company",
    "fieldtype": "Link",
+   "in_standard_filter": 1,
    "label": "Company",
    "options": "Company",
    "reqd": 1
@@ -69,6 +71,7 @@
    "depends_on": "eval:doc.employee;",
    "fieldname": "payroll_period",
    "fieldtype": "Link",
+   "in_standard_filter": 1,
    "label": "Payroll Period",
    "options": "Payroll Period",
    "reqd": 1
@@ -145,7 +148,7 @@
    "link_fieldname": "ref_docname"
   }
  ],
- "modified": "2025-09-23 11:14:48.087132",
+ "modified": "2025-09-23 12:19:23.661340",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Arrear",

--- a/hrms/payroll/doctype/arrear/arrear.json
+++ b/hrms/payroll/doctype/arrear/arrear.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:{Arrear}/{employee}/{#####}",
  "creation": "2025-09-15 16:08:13.216474",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -144,10 +145,11 @@
    "link_fieldname": "ref_docname"
   }
  ],
- "modified": "2025-09-22 15:57:39.583277",
+ "modified": "2025-09-23 11:14:48.087132",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Arrear",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -159,6 +161,20 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
    "share": 1,
    "submit": 1,
    "write": 1

--- a/hrms/payroll/doctype/arrear/arrear.json
+++ b/hrms/payroll/doctype/arrear/arrear.json
@@ -7,13 +7,18 @@
  "field_order": [
   "employee",
   "employee_name",
-  "payroll_period",
   "salary_structure",
   "arrear_start_date",
   "column_break_itzd",
   "company",
   "currency",
+  "payroll_period",
   "payroll_date",
+  "arrears_tab",
+  "section_break_zegb",
+  "earning_arrears",
+  "deduction_arrears",
+  "accrual_arrears",
   "section_break_ubws",
   "amended_from"
  ],
@@ -98,13 +103,43 @@
    "options": "Currency",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "section_break_zegb",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "earning_arrears",
+   "fieldname": "earning_arrears",
+   "fieldtype": "Table",
+   "label": "Earning Arrears",
+   "options": "Payroll Correction Child"
+  },
+  {
+   "depends_on": "deduction_arrears",
+   "fieldname": "deduction_arrears",
+   "fieldtype": "Table",
+   "label": "Deduction Arrears",
+   "options": "Payroll Correction Child"
+  },
+  {
+   "depends_on": "accrual_arrears",
+   "fieldname": "accrual_arrears",
+   "fieldtype": "Table",
+   "label": "Accrual Arrears",
+   "options": "Payroll Correction Child"
+  },
+  {
+   "fieldname": "arrears_tab",
+   "fieldtype": "Tab Break",
+   "label": "Arrears"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-15 20:26:17.412941",
+ "modified": "2025-09-22 14:35:03.984366",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Arrear",

--- a/hrms/payroll/doctype/arrear/arrear.json
+++ b/hrms/payroll/doctype/arrear/arrear.json
@@ -138,8 +138,13 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-09-22 14:35:03.984366",
+ "links": [
+  {
+   "link_doctype": "Additional Salary",
+   "link_fieldname": "ref_docname"
+  }
+ ],
+ "modified": "2025-09-22 15:57:39.583277",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Arrear",
@@ -162,5 +167,6 @@
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "employee_name"
 }

--- a/hrms/payroll/doctype/arrear/arrear.py
+++ b/hrms/payroll/doctype/arrear/arrear.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Arrear(Document):
+	pass

--- a/hrms/payroll/doctype/arrear/arrear.py
+++ b/hrms/payroll/doctype/arrear/arrear.py
@@ -6,6 +6,9 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import getdate
 
+from hrms.payroll.doctype.employee_benefit_ledger.employee_benefit_ledger import (
+	delete_employee_benefit_ledger_entry,
+)
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 
 
@@ -26,6 +29,9 @@ class Arrear(Document):
 		self.validate_arrear_details()
 		self.create_additional_salary()
 		self.create_benefit_ledger_entry()
+
+	def on_cancel(self):
+		delete_employee_benefit_ledger_entry("reference_document", self.name)
 
 	def validate_dates(self):
 		if self.arrear_start_date and self.payroll_period:

--- a/hrms/payroll/doctype/arrear/arrear.py
+++ b/hrms/payroll/doctype/arrear/arrear.py
@@ -98,7 +98,7 @@ class Arrear(Document):
 			)
 
 	def calculate_salary_structure_arrears(self):
-		"""Calculate arrear amounts for each component across all salary slips."""
+		# calculate arrear amounts for each component across processed salary slips and populate child tables
 		existing_salary_slips = self.get_existing_salary_slips()
 		salary_slip_names = [slip.get("name") for slip in existing_salary_slips]
 
@@ -137,7 +137,7 @@ class Arrear(Document):
 
 		return salary_slips
 
-	def fetch_existing_salary_components(self, salary_slips):
+	def fetch_existing_salary_components(self, salary_slips: list):
 		"""Fetch salary components and amounts from existing salary slips with arrear_component enabled.
 		Returns a dict: {"earnings": {component: total}, "deductions": {component: total}, "accruals": {component: total}}
 		"""
@@ -265,7 +265,7 @@ class Arrear(Document):
 
 		return {"earnings": preview_earnings, "deductions": preview_deductions, "accruals": preview_accruals}
 
-	def compute_component_differences(self, existing_components, new_components):
+	def compute_component_differences(self, existing_components: dict, new_components: dict):
 		"""Calculate component differences between existing and preview salary slips.
 		existing_components and new_components params are dicts with keys 'earnings','deductions','accruals'
 		"""

--- a/hrms/payroll/doctype/arrear/arrear.py
+++ b/hrms/payroll/doctype/arrear/arrear.py
@@ -1,9 +1,293 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import getdate
+
+from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 
 
 class Arrear(Document):
-	pass
+	@property
+	def payroll_period_details(self):
+		if not hasattr(self, "__payroll_period_details"):
+			self.__payroll_period_details = frappe.get_doc("Payroll Period", self.payroll_period)
+		return self.__payroll_period_details
+
+	def validate(self):
+		self.validate_dates()
+		self.validate_salary_structure_assignment()
+		self.calculate_component_arrears()
+
+	def validate_dates(self):
+		if self.arrears_from_date and self.payroll_period:
+			if getdate(self.arrears_from_date) < self.payroll_period_details.start_date:
+				frappe.throw(
+					_("From Date {0} cannot be before Payroll Period start date {1}").format(
+						self.arrears_from_date, self.payroll_period_details.start_date
+					)
+				)
+			elif getdate(self.arrears_from_date) > (self.payroll_period_details.end_date):
+				frappe.throw(
+					_("From Date {0} cannot be after Payroll Period end date {1}").format(
+						self.arrears_from_date, self.payroll_period_details.end_date
+					)
+				)
+
+	def validate_salary_structure_assignment(self):
+		# Validate salary structure assignment exists for the employee and salary structure
+		if not (self.employee and self.salary_structure and self.payroll_period):
+			return
+
+		assignment = frappe.db.get_value(
+			"Salary Structure Assignment",
+			{
+				"employee": self.employee,
+				"salary_structure": self.salary_structure,
+				"docstatus": 1,
+				"from_date": (">=", self.arrears_from_date),
+			},
+			["name", "from_date"],
+			as_dict=True,
+		)
+
+		if not assignment:
+			frappe.throw(
+				_(
+					"No active Salary Structure Assignment found for employee {0} with salary structure {1} on or after arrear start date {2}"  # TODO: make error message better
+				).format(
+					frappe.bold(self.employee),
+					frappe.bold(self.salary_structure),
+					frappe.bold(self.arrears_from_date) or "",
+				)
+			)
+
+	def get_existing_salary_slips(self):
+		salary_slips = []
+
+		if self.employee and self.arrears_from_date:
+			filters = {
+				"employee": self.employee,
+				"docstatus": 1,
+				"start_date": (">=", self.arrears_from_date),
+			}
+
+			salary_slips = frappe.get_all(
+				"Salary Slip",
+				filters=filters,
+				fields=["name", "posting_date", "start_date", "end_date"],
+				order_by="start_date",
+			)
+		if not salary_slips:
+			frappe.throw(
+				_("No salary slips found for the selected employee from {0}").format(self.arrears_from_date)
+			)
+
+		return salary_slips
+
+	def calculate_component_arrears(self):
+		"""Calculate arrear amounts for each component across all salary slips."""
+		existing_salary_slips = self.get_existing_salary_slips()
+		salary_slip_names = [slip.get("name") for slip in existing_salary_slips]
+
+		# Existing components from processed slips
+		existing_components = self.fetch_existing_salary_components(salary_slip_names)
+		# Preview components using the new salary structure
+		new_structure_components = self.generate_preview_components(existing_salary_slips)
+
+		component_differences = self.compute_component_differences(
+			existing_components, new_structure_components
+		)
+
+		if component_differences:
+			self.populate_arrear_tables(component_differences)
+
+	def fetch_existing_salary_components(self, salary_slips):
+		"""Fetch salary components and amounts from existing salary slips with arrear_component enabled.
+		Returns a dict: {"earnings": {component: total}, "deductions": {component: total}, "accruals": {component: total}}
+		"""
+		SalarySlipDetail = frappe.qb.DocType("Salary Detail")
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+
+		slip_details = (
+			frappe.qb.from_(SalarySlipDetail)
+			.join(SalaryComponent)
+			.on(SalarySlipDetail.salary_component == SalaryComponent.name)
+			.select(
+				SalarySlipDetail.parentfield,
+				SalarySlipDetail.salary_component,
+				SalarySlipDetail.amount,
+			)
+			.where(
+				(SalarySlipDetail.parent.isin(salary_slips))
+				& (SalarySlipDetail.additional_salary.isnull())
+				& (SalarySlipDetail.variable_based_on_taxable_salary == 0)
+				& (SalaryComponent.arrear_component == 1)
+			)
+		).run(as_dict=True)
+
+		earnings_totals = {}
+		deductions_totals = {}
+
+		# Sum amounts per component grouped by parentfield
+		for detail in slip_details:
+			comp = detail.salary_component
+			amt = detail.amount
+			parentfield = detail.parentfield
+			if parentfield == "earnings":
+				earnings_totals[comp] = earnings_totals.get(comp, 0.0) + amt
+			elif parentfield == "deductions":
+				deductions_totals[comp] = deductions_totals.get(comp, 0.0) + amt
+
+		accrual_totals = self.fetch_existing_accrual_components(salary_slips)
+
+		if not (earnings_totals or deductions_totals or accrual_totals):
+			frappe.throw(_("No arrear components found in the existing salary slips."))
+
+		return {"earnings": earnings_totals, "deductions": deductions_totals, "accruals": accrual_totals}
+
+	def fetch_existing_accrual_components(self, salary_slips: list):
+		"""Fetch accrual components from existing salary slips with arrear_component enabled."""
+		if not salary_slips:
+			return {}
+
+		AccruedBenefit = frappe.qb.DocType("Employee Benefit Detail")
+		SalaryComponent = frappe.qb.DocType("Salary Component")
+
+		accrual_details = (
+			frappe.qb.from_(AccruedBenefit)
+			.inner_join(SalaryComponent)
+			.on(AccruedBenefit.salary_component == SalaryComponent.name)
+			.select(
+				AccruedBenefit.salary_component,
+				AccruedBenefit.amount,
+			)
+			.where((AccruedBenefit.parent.isin(salary_slips)) & (SalaryComponent.arrear_component == 1))
+		).run(as_dict=True)
+
+		accrual_totals = {}
+		for detail in accrual_details:
+			comp = detail.get("salary_component")
+			amt = detail.get("amount", 0.0)
+			accrual_totals[comp] = accrual_totals.get(comp, 0.0) + amt
+
+		return accrual_totals
+
+	def generate_preview_components(self, salary_slips: list):
+		# Generate preview salary slip with new salary structure and return component and amounts.
+		if not salary_slips:
+			return {}
+
+		preview_earnings = {}
+		preview_deductions = {}
+		preview_accruals = {}
+
+		def is_arrear_component(component):
+			return frappe.get_cached_value("Salary Component", component, "arrear_component")
+
+		for slip in salary_slips:
+			# Build a preview salary slip doc (do not save)
+			salary_slip_doc = frappe.get_doc(
+				{
+					"doctype": "Salary Slip",
+					"employee": self.employee,
+					"salary_structure": self.salary_structure,
+					"posting_date": slip.get("posting_date"),
+					"start_date": slip.get("start_date"),
+					"end_date": slip.get("end_date"),
+				}
+			)
+
+			# make_salary_slip usually expects (salary_structure, salary_slip_doc, employee)
+			preview_slip = make_salary_slip(self.salary_structure, salary_slip_doc, self.employee)
+
+			# earnings
+			for row in preview_slip.get("earnings", []) or []:
+				if (not getattr(row, "additional_salary", None)) and is_arrear_component(
+					row.salary_component
+				):
+					preview_earnings[row.salary_component] = preview_earnings.get(
+						row.salary_component, 0.0
+					) + getattr(row, "amount", 0.0)
+
+			# deductions
+			for row in preview_slip.get("deductions", []) or []:
+				if (
+					not getattr(row, "additional_salary", None)
+					and not getattr(row, "variable_based_on_taxable_salary", False)
+					and is_arrear_component(row.salary_component)
+				):
+					preview_deductions[row.salary_component] = preview_deductions.get(
+						row.salary_component, 0.0
+					) + getattr(row, "amount", 0.0)
+
+			# accruals
+			for row in getattr(preview_slip, "accrued_benefits", []) or []:
+				if is_arrear_component(row.salary_component):
+					preview_accruals[row.salary_component] = preview_accruals.get(
+						row.salary_component, 0.0
+					) + getattr(row, "amount", 0.0)
+
+		return {"earnings": preview_earnings, "deductions": preview_deductions, "accruals": preview_accruals}
+
+	def compute_component_differences(self, existing_components, new_components):
+		"""Calculate component differences between existing and preview salary slips.
+		existing_components and new_components params are dicts with keys 'earnings','deductions','accruals'
+		"""
+		if not existing_components:
+			existing_components = {"earnings": {}, "deductions": {}, "accruals": {}}
+		if not new_components:
+			new_components = {"earnings": {}, "deductions": {}, "accruals": {}}
+
+		earnings_diff = {}
+		deductions_diff = {}
+		accruals_diff = {}
+
+		# earnings
+		for comp, amount in new_components.get("earnings", {}).items():
+			existing_amount = existing_components.get("earnings", {}).get(comp, 0.0)
+			diff = amount - existing_amount
+			if diff > 0:
+				earnings_diff[comp] = diff
+
+		# deductions
+		for comp, amount in new_components.get("deductions", {}).items():
+			existing_amount = existing_components.get("deductions", {}).get(comp, 0.0)
+			diff = amount - existing_amount
+			if diff > 0:
+				deductions_diff[comp] = diff
+
+		# accruals
+		for comp, amount in new_components.get("accruals", {}).items():
+			existing_amount = existing_components.get("accruals", {}).get(comp, 0.0)
+			diff = amount - existing_amount
+			if diff > 0:
+				accruals_diff[comp] = diff
+
+		result = {}
+		if earnings_diff or deductions_diff or accruals_diff:
+			result = {"earnings": earnings_diff, "deductions": deductions_diff, "accruals": accruals_diff}
+
+		if not result:
+			frappe.throw(
+				_("There are no arrear differences between existing and new salary structure components.")
+			)
+
+		return result
+
+	def populate_arrear_tables(self, component_differences: dict):
+		# populate arrear amounts into child tables on this doc
+		self.set("earning_arrears", [])
+		self.set("deduction_arrears", [])
+		self.set("accrual_arrears", [])
+
+		for comp, total_amount in component_differences.get("earnings", {}).items():
+			self.append("earning_arrears", {"salary_component": comp, "amount": total_amount})
+
+		for comp, total_amount in component_differences.get("deductions", {}).items():
+			self.append("deduction_arrears", {"salary_component": comp, "amount": total_amount})
+
+		for comp, total_amount in component_differences.get("accruals", {}).items():
+			self.append("accrual_arrears", {"salary_component": comp, "amount": total_amount})

--- a/hrms/payroll/doctype/arrear/test_arrear.py
+++ b/hrms/payroll/doctype/arrear/test_arrear.py
@@ -1,20 +1,155 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, add_months, getdate
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+from erpnext.setup.doctype.employee.test_employee import make_employee
+
+from hrms.payroll.doctype.salary_structure.salary_structure import (
+	make_salary_slip,
+)
+from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 
-class IntegrationTestArrear(IntegrationTestCase):
-	"""
-	Integration tests for Arrear.
-	Use this class for testing interactions between multiple components.
-	"""
+class TestArrear(IntegrationTestCase):
+	def test_arrear_calculation(self):
+		# Test arrear calculation when new salary structure is applied retroactively later in the payroll period after salary slip creation
+		emp = make_employee(
+			"test_salary_structure_arrear@salary.com",
+			company="_Test Company",
+			date_of_joining="2021-01-01",
+		)
+		current_payroll_period = frappe.get_last_doc("Payroll Period", filters={"company": "_Test Company"})
 
-	pass
+		# Create initial salary structure with lower salary
+		old_salary_structure = make_salary_structure(
+			"Test Old Salary Structure",
+			"Monthly",
+			company="_Test Company",
+			employee=emp,
+			payroll_period=current_payroll_period,
+			test_arrear=True,
+			base=50000,  # Lower base salary
+		)
+
+		# Create new payroll period for next year
+		next_year_start = add_days(current_payroll_period.end_date, 1)
+		next_year_end = add_months(current_payroll_period.end_date, 1)
+
+		new_payroll_period = frappe.get_doc(
+			{
+				"doctype": "Payroll Period",
+				"name": f"Test Payroll Period {getdate(next_year_start).year}",
+				"company": "_Test Company",
+				"start_date": next_year_start,
+				"end_date": next_year_end,
+			}
+		)
+		new_payroll_period.insert()
+
+		# Create and submit salary slip for first month of new payroll period with old structure
+		first_month_slip = make_salary_slip(
+			old_salary_structure.name, employee=emp, posting_date=next_year_start
+		)
+		first_month_slip.save()
+		first_month_slip.submit()
+
+		# Create new salary structure with higher salary for same employee
+		new_salary_structure = make_salary_structure(
+			"Test New Arrear Salary Structure",
+			"Monthly",
+			employee=emp,
+			from_date=next_year_start,
+			company="_Test Company",
+			payroll_period=new_payroll_period,
+			base=75000,  # Higher base salary
+			test_arrear=True,
+			test_accrual_component=True,
+			test_salary_structure_arrear=True,
+		)
+
+		previous_structure_arrear_components = {
+			"earnings": {"Basic Salary": 50000, "Special Allowance": 25000},
+			"deductions": {"Professional Tax": 200},
+		}
+
+		current_structure_arrear_components = {
+			"earnings": {"Basic Salary": 75000, "Special Allowance": 37500},
+			"deductions": {"Professional Tax": 300},
+			"accruals": {"Accrued Earnings": 1000},
+		}
+
+		arrear_doc = frappe.get_doc(
+			{
+				"doctype": "Arrear",
+				"employee": emp,
+				"payroll_period": new_payroll_period.name,
+				"salary_structure": new_salary_structure.name,
+				"arrear_start_date": next_year_start,
+				"payroll_date": add_months(next_year_start, 2),  # next month
+				"company": "_Test Company",
+			}
+		)
+		arrear_doc.save()
+
+		earning_arrears = {row.salary_component: row.amount for row in arrear_doc.earning_arrears}
+		deduction_arrears = {row.salary_component: row.amount for row in arrear_doc.deduction_arrears}
+		accrual_arrears = {row.salary_component: row.amount for row in arrear_doc.accrual_arrears}
+
+		# Earnings differences
+		for comp, new_amt in current_structure_arrear_components["earnings"].items():
+			old_amt = previous_structure_arrear_components["earnings"].get(comp, 0)
+			diff = new_amt - old_amt
+			self.assertIn(comp, earning_arrears)
+			self.assertEqual(
+				earning_arrears[comp],
+				diff,
+			)
+
+		# Deductions differences
+		for comp, new_amt in current_structure_arrear_components["deductions"].items():
+			old_amt = previous_structure_arrear_components["deductions"].get(comp, 0)
+			diff = new_amt - old_amt
+			self.assertIn(comp, deduction_arrears)
+			self.assertEqual(
+				deduction_arrears[comp],
+				diff,
+			)
+		# Accrual differences (new only, no previous)
+		for comp, new_amt in current_structure_arrear_components["accruals"].items():
+			old_amt = previous_structure_arrear_components["earnings"].get(comp, 0)
+			diff = new_amt - old_amt
+			self.assertIn(comp, accrual_arrears)
+			self.assertEqual(
+				accrual_arrears[comp],
+				diff,
+			)
+
+		arrear_doc.submit()
+
+		# Validate additional salary creation
+		additional_salary_entries = frappe.get_all(
+			"Additional Salary",
+			filters={"ref_docname": arrear_doc.name, "employee": emp},
+			fields=["salary_component", "type"],
+		)
+		self.assertTrue(additional_salary_entries, "Additional salary entries should be created")
+		earning_components = [
+			e["salary_component"] for e in additional_salary_entries if e["type"] == "Earning"
+		]
+		self.assertIn("Basic Salary", earning_components)
+		self.assertIn("Special Allowance", earning_components)
+
+		# Validate benefit ledger creation
+		benefit_entries = frappe.get_all(
+			"Employee Benefit Ledger",
+			filters={"reference_document": arrear_doc.name, "employee": emp},
+			fields=["salary_component"],
+		)
+		if benefit_entries:
+			accrual_components = [e["salary_component"] for e in benefit_entries]
+			self.assertIn("Accrued Earnings", accrual_components)
+
+		frappe.db.rollback()

--- a/hrms/payroll/doctype/arrear/test_arrear.py
+++ b/hrms/payroll/doctype/arrear/test_arrear.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestArrear(IntegrationTestCase):
+	"""
+	Integration tests for Arrear.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/hrms/payroll/doctype/payroll_correction/payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/payroll_correction.py
@@ -110,7 +110,12 @@ class PayrollCorrection(Document):
 	def populate_breakup_table(self):
 		# Get arrear salary components from salary slip that are not additional salary and add amounts to the breakup table
 		salary_slip = frappe.get_doc("Salary Slip", self.salary_slip_reference)
-		precision = frappe.db.get_single_value("System Settings", "currency_precision") or 2
+
+		precision = (
+			salary_slip.precision("gross_pay")
+			or frappe.db.get_single_value("System Settings", "currency_precision")
+			or 2
+		)
 		if not salary_slip:
 			frappe.throw(_("Salary Slip not found."))
 

--- a/hrms/payroll/doctype/payroll_correction/payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/payroll_correction.py
@@ -99,6 +99,7 @@ class PayrollCorrection(Document):
 					"leave_without_pay": slip.get("leave_without_pay"),
 					"month_name": month_name,
 					"working_days": slip.get("total_working_days"),
+					"payment_days": slip.get("payment_days"),
 					"start_date": slip.get("start_date"),
 				}
 			)

--- a/hrms/payroll/doctype/payroll_correction_child/payroll_correction_child.json
+++ b/hrms/payroll/doctype/payroll_correction_child/payroll_correction_child.json
@@ -15,25 +15,28 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Salary Component",
-   "options": "Salary Component"
+   "options": "Salary Component",
+   "reqd": 1
   },
   {
    "fieldname": "amount",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Amount"
+   "label": "Amount",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-04 19:18:44.111050",
+ "modified": "2025-09-22 14:55:21.744355",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Correction Child",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -85,7 +85,7 @@
    "fieldtype": "Check",
    "label": "Depends on Payment Days",
    "print_hide": 1,
-   "read_only_depends_on": "eval:doc.arrear_component==1"
+   "read_only_depends_on": "eval:doc.arrear_component && !doc.amount_based_on_formula"
   },
   {
    "default": "0",
@@ -291,7 +291,7 @@
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-19 21:36:05.950099",
+ "modified": "2025-09-23 11:28:17.375819",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -20,6 +20,7 @@ class SalaryComponent(Document):
 		self.validate_abbr()
 		self.validate_accounts()
 		self.validate_accrual_component()
+		self.valide_arrear_component()
 
 	def on_update(self):
 		# set old values (allowing multiline strings for better readability in the doctype form)
@@ -87,6 +88,13 @@ class SalaryComponent(Document):
 					),
 					title=_("Invalid Accrual Component"),
 				)
+
+	def valide_arrear_component(self):
+		if self.variable_based_on_taxable_salary and self.arrear_component:
+			frappe.throw(
+				_("Arrear Component cannot be set for Salary Components based on taxable salary."),
+				title=_("Invalid Arrear Component"),
+			)
 
 	@frappe.whitelist()
 	def get_structures_to_be_updated(self):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -2017,6 +2017,7 @@ def make_earning_salary_component(
 			"type": "Earning",
 			"amount_based_on_formula": 1,
 			"depends_on_payment_days": 0,
+			"arrear_component": 1 if test_arrear else 0,
 		},
 		{"salary_component": "Leave Encashment", "abbr": "LE", "type": "Earning"},
 		{
@@ -2053,6 +2054,7 @@ def make_earning_salary_component(
 					"type": "Earning",
 					"accrual_component": 1,
 					"amount": 1000,
+					"arrear_component": 1,
 				}
 			]
 		)
@@ -2080,14 +2082,19 @@ def make_earning_salary_component(
 	return data
 
 
-def make_deduction_salary_component(setup=False, test_tax=False, company_list=None):
+def make_deduction_salary_component(
+	setup=False, test_tax=False, company_list=None, test_salary_structure_arrear=False
+):
 	data = [
 		{
 			"salary_component": "Professional Tax",
 			"abbr": "PT",
 			"type": "Deduction",
-			"amount": 200,
+			"amount": 300
+			if test_salary_structure_arrear
+			else 200,  # setting a different amount to test salary structure arrear calculation
 			"exempted_from_income_tax": 1,
+			"arrear_component": 1,
 		}
 	]
 	if not test_tax:

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -164,13 +164,14 @@ def make_salary_structure(
 	dont_submit=False,
 	other_details=None,
 	test_tax=False,
-	test_arrear=False,
 	company=None,
 	currency=None,
 	payroll_period=None,
 	include_flexi_benefits=False,
 	base=None,
 	test_accrual_component=False,
+	test_arrear=False,
+	test_salary_structure_arrear=False,
 ):
 	if not currency:
 		currency = erpnext.get_default_currency()
@@ -198,7 +199,10 @@ def make_salary_structure(
 			test_arrear=test_arrear,
 		),
 		"deductions": make_deduction_salary_component(
-			setup=True, test_tax=test_tax, company_list=["_Test Company"]
+			setup=True,
+			test_tax=test_tax,
+			company_list=["_Test Company"],
+			test_salary_structure_arrear=test_salary_structure_arrear,
 		),
 		"employee_benefits": employee_benefits,
 		"payroll_frequency": payroll_frequency,


### PR DESCRIPTION
Review and approval of new salary structures often takes time and is assigned to employee much later than the applicable date.

When a new Salary Structure Assignment is approved and applied (e.g., June 2025 onward, but effective from April 2025), and salary for past months (April, May) has already been processed, this feature calculates and compensates the employee for the arrears, ensuring their paid salary matches the new structure.


Step 1: Navigate to Arrears doctype
1.	Go to HR > Payroll > Arrears

Step 2: Select Employee, Salary Structure, and the date from which arrears needs to paid for.

Step 3: Save and Submit

- Upon save system will populate earning, deduction and accrual arrears in respective child tables.
- Based on Payroll Date, additional salary will be created for earnings and deductions after submission. Accruals are tracked in Employee Benefit Ledger

<img width="648" height="290" alt="Screenshot 2025-09-23 at 1 26 14 PM" src="https://github.com/user-attachments/assets/cade5d41-35af-4925-8088-71ac2e77195c" />

<img width="973" height="721" alt="Screenshot 2025-09-23 at 1 21 03 PM" src="https://github.com/user-attachments/assets/8f6a9aa8-49f9-4b2a-808e-d33210391d83" />

Demo:

![arrear-less](https://github.com/user-attachments/assets/c0cead9a-b56b-4790-aeae-bfd8866eae2c)


draft documentation: https://docs.frappe.io/hr/arrears

