### PR TITLE
fix: Add flag to skip receivable/payable account validation in payroll entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -602,6 +602,7 @@ class PayrollEntry(Document):
 				employee_wise_accounting_enabled,
 			)
 
+			frappe.flags.skip_receivable_payable_account_validation = True
 			self.make_journal_entry(
 				accounts,
 				currencies,

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -615,6 +615,7 @@ class PayrollEntry(Document):
 				submit_journal_entry=True,
 				submitted_salary_slips=submitted_salary_slips,
 			)
+			frappe.flags.party_not_required_for_receivable_payable = False
 
 	def make_journal_entry(
 		self,

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -602,7 +602,8 @@ class PayrollEntry(Document):
 				employee_wise_accounting_enabled,
 			)
 
-			frappe.flags.skip_receivable_payable_account_validation = True
+			# when party is not required, skip the validation in journal & gl entry
+			frappe.flags.party_not_required_for_receivable_payable = True
 			self.make_journal_entry(
 				accounts,
 				currencies,


### PR DESCRIPTION
## Reason
- If an advance or loan is given to an employee, then the data of employee shouldn't be reveal even if the Payroll Accounting Entry is based on Employee


`no-docs`

journal & gl changes: https://github.com/frappe/erpnext/pull/49585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payroll accrual journal entries created from Payroll Entry no longer fail due to unnecessary party/account validation.  
  * Accrual postings now proceed reliably without interruptions, reducing manual intervention and failed postings for payroll accruals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->