### PR TITLE
fix(user): ensure approver roles even with role profile set

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -161,7 +161,10 @@ override_doctype_class = {
 
 doc_events = {
 	"User": {
-		"validate": "erpnext.setup.doctype.employee.employee.validate_employee_role",
+		"validate": [
+			"erpnext.setup.doctype.employee.employee.validate_employee_role",
+			"hrms.overrides.employee_master.update_approver_user_roles",
+		],
 	},
 	"Company": {
 		"validate": "hrms.overrides.company.validate_default_accounts",

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -98,6 +98,18 @@ def update_approver_role(doc, method=None):
 		user.add_roles("Expense Approver")
 
 
+def update_approver_user_roles(doc, method=None):
+	approver_roles = set()
+	if frappe.db.exists("Employee", {"leave_approver": doc.name}):
+		approver_roles.add("Leave Approver")
+
+	if frappe.db.exists("Employee", {"expense_approver": doc.name}):
+		approver_roles.add("Expense Approver")
+
+	if approver_roles:
+		doc.append_roles(*approver_roles)
+
+
 def update_employee_transfer(doc, method=None):
 	"""Unsets Employee ID in Employee Transfer if doc is deleted"""
 	if frappe.db.exists("Employee Transfer", {"new_employee_id": doc.name, "docstatus": 1}):


### PR DESCRIPTION
**Issue:**
While using role profile in the user, Leave Approver and Expense Approver roles didn't get added to the user.

**Solution :**
- added the approver roles after the role profile roles are added

**ref:** [48422](https://support.frappe.io/helpdesk/tickets/48422)
**closes:** #3553

**Before :** 

[Before.webm](https://github.com/user-attachments/assets/420803b3-ef6f-48fc-86a1-680bbf07890c)




**After :** 

[After.webm](https://github.com/user-attachments/assets/067f5b1d-f580-42af-8b32-d1d648c2ec4c)


Backport needed for v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User validation now detects when a user is referenced as a Leave or Expense Approver on employee records and automatically assigns the corresponding approver roles.

- **Enhancements**
  - Validation now executes multiple checks and appends approver roles without duplicates, keeping user roles synchronized with employee references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->