### PR TITLE
fix: set Payroll payable account to Payable & cancel linked payment ledgers entry of payroll & journal entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -592,6 +592,7 @@ class PayrollEntry(Document):
 				accounting_dimensions,
 				precision,
 				payable_amount,
+				employee_wise_accounting_enabled,
 			)
 
 			payable_amount = self.set_accounting_entries_for_advance_deductions(
@@ -657,9 +658,7 @@ class PayrollEntry(Document):
 
 		try:
 			if submit_journal_entry:
-				frappe.flags.party_not_required_for_receivable_payable = True
 				journal_entry.submit()
-				frappe.flags.party_not_required_for_receivable_payable = False
 
 			if submitted_salary_slips:
 				self.set_journal_entry_in_salary_slips(submitted_salary_slips, jv_name=journal_entry.name)
@@ -683,7 +682,10 @@ class PayrollEntry(Document):
 		accounting_dimensions,
 		precision,
 		payable_amount,
+		employee_wise_accounting_enabled,
 	):
+		party_not_required = True if not employee_wise_accounting_enabled else False
+
 		# Earnings
 		for acc_cc, amount in earnings.items():
 			payable_amount = self.get_accounting_entries_and_payable_amount(
@@ -697,6 +699,7 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="debit",
 				accounts=accounts,
+				party_not_required=party_not_required,
 			)
 
 		# Deductions
@@ -712,6 +715,7 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="credit",
 				accounts=accounts,
+				party_not_required=party_not_required,
 			)
 
 		return payable_amount
@@ -771,6 +775,7 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="payable",
 				accounts=accounts,
+				party_not_required=True,
 			)
 
 	def get_accounting_entries_and_payable_amount(
@@ -789,6 +794,7 @@ class PayrollEntry(Document):
 		reference_type=None,
 		reference_name=None,
 		is_advance=None,
+		party_not_required=None,
 	):
 		exchange_rate, amt = self.get_amount_and_exchange_rate_for_journal_entry(
 			account, amount, company_currency, currencies
@@ -799,6 +805,7 @@ class PayrollEntry(Document):
 			"exchange_rate": flt(exchange_rate),
 			"cost_center": cost_center,
 			"project": self.project,
+			"party_not_required": party_not_required,
 		}
 
 		if entry_type == "debit":
@@ -1075,6 +1082,7 @@ class PayrollEntry(Document):
 						"reference_type": self.doctype,
 						"reference_name": self.name,
 						"cost_center": self.cost_center,
+						"party_not_required": True,
 					},
 					accounting_dimensions,
 				)

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -626,6 +626,7 @@ class PayrollEntry(Document):
 				),
 				submit_journal_entry=True,
 				submitted_salary_slips=submitted_salary_slips,
+				employee_wise_accounting_enabled=employee_wise_accounting_enabled,
 			)
 
 	def make_journal_entry(
@@ -637,6 +638,7 @@ class PayrollEntry(Document):
 		user_remark="",
 		submitted_salary_slips: list | None = None,
 		submit_journal_entry=False,
+		employee_wise_accounting_enabled=False,
 	) -> str:
 		multi_currency = 0
 		if len(currencies) > 1:
@@ -647,6 +649,7 @@ class PayrollEntry(Document):
 		journal_entry.user_remark = user_remark
 		journal_entry.company = self.company
 		journal_entry.posting_date = self.posting_date
+		journal_entry.party_not_required = True if not employee_wise_accounting_enabled else False
 
 		journal_entry.set("accounts", accounts)
 		journal_entry.multi_currency = multi_currency
@@ -684,8 +687,6 @@ class PayrollEntry(Document):
 		payable_amount,
 		employee_wise_accounting_enabled,
 	):
-		party_not_required = True if not employee_wise_accounting_enabled else False
-
 		# Earnings
 		for acc_cc, amount in earnings.items():
 			payable_amount = self.get_accounting_entries_and_payable_amount(
@@ -699,7 +700,6 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="debit",
 				accounts=accounts,
-				party_not_required=party_not_required,
 			)
 
 		# Deductions
@@ -715,7 +715,6 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="credit",
 				accounts=accounts,
-				party_not_required=party_not_required,
 			)
 
 		return payable_amount
@@ -775,7 +774,6 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="payable",
 				accounts=accounts,
-				party_not_required=True,
 			)
 
 	def get_accounting_entries_and_payable_amount(
@@ -794,7 +792,6 @@ class PayrollEntry(Document):
 		reference_type=None,
 		reference_name=None,
 		is_advance=None,
-		party_not_required=None,
 	):
 		exchange_rate, amt = self.get_amount_and_exchange_rate_for_journal_entry(
 			account, amount, company_currency, currencies
@@ -805,7 +802,6 @@ class PayrollEntry(Document):
 			"exchange_rate": flt(exchange_rate),
 			"cost_center": cost_center,
 			"project": self.project,
-			"party_not_required": party_not_required,
 		}
 
 		if entry_type == "debit":
@@ -943,7 +939,9 @@ class PayrollEntry(Document):
 		bank_entry = None
 		if salary_slip_total > 0:
 			remark = "withheld salaries" if for_withheld_salaries else "salaries"
-			bank_entry = self.set_accounting_entries_for_bank_entry(salary_slip_total, remark)
+			bank_entry = self.set_accounting_entries_for_bank_entry(
+				salary_slip_total, remark, employee_wise_accounting_enabled
+			)
 
 			if for_withheld_salaries:
 				link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
@@ -1008,7 +1006,9 @@ class PayrollEntry(Document):
 
 		return total_loan_repayment
 
-	def set_accounting_entries_for_bank_entry(self, je_payment_amount, user_remark):
+	def set_accounting_entries_for_bank_entry(
+		self, je_payment_amount, user_remark, employee_wise_accounting_enabled
+	):
 		payroll_payable_account = self.payroll_payable_account
 		precision = frappe.get_precision("Journal Entry Account", "debit_in_account_currency")
 
@@ -1082,7 +1082,6 @@ class PayrollEntry(Document):
 						"reference_type": self.doctype,
 						"reference_name": self.name,
 						"cost_center": self.cost_center,
-						"party_not_required": True,
 					},
 					accounting_dimensions,
 				)
@@ -1095,6 +1094,7 @@ class PayrollEntry(Document):
 			user_remark=_("Payment of {0} from {1} to {2}").format(
 				_(user_remark), self.start_date, self.end_date
 			),
+			employee_wise_accounting_enabled=employee_wise_accounting_enabled,
 		)
 
 	def set_journal_entry_in_salary_slips(self, submitted_salary_slips, jv_name=None):

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -107,11 +107,17 @@ class PayrollEntry(Document):
 			)
 
 	def validate_payroll_payable_account(self):
-		if frappe.db.get_value("Account", self.payroll_payable_account, "account_type"):
+		payroll_payable_account_type = frappe.db.get_value(
+			"Account", self.payroll_payable_account, "account_type"
+		)
+		if payroll_payable_account_type != "Payable":
 			frappe.throw(
 				_(
-					"Account type cannot be set for payroll payable account {0}, please remove and try again"
-				).format(frappe.bold(get_link_to_form("Account", self.payroll_payable_account)))
+					"Account type should be set {0} for payroll payable account {1}, please set and try again"
+				).format(
+					frappe.bold("Payable"),
+					frappe.bold(get_link_to_form("Account", self.payroll_payable_account)),
+				)
 			)
 
 	def on_cancel(self):

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -176,7 +176,7 @@ class PayrollEntry(Document):
 			# cancel linked payment ledger entry
 			for pl in journal_entry_payment_ledgers:
 				frappe.get_doc("Payment Ledger Entry", pl).cancel()
-			
+
 			frappe.get_doc("Journal Entry", je).cancel()
 
 	def cancel_linked_payment_ledger_entries(self):
@@ -215,7 +215,6 @@ class PayrollEntry(Document):
 	@frappe.whitelist()
 	def fill_employee_details(self):
 		filters = self.make_filters()
-		print(filters, 'filterss')
 		employees = get_employee_list(filters=filters, as_dict=True, ignore_match_conditions=True)
 		self.set("employees", [])
 

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -125,6 +125,7 @@ class PayrollEntry(Document):
 
 		self.delete_linked_salary_slips()
 		self.cancel_linked_journal_entries()
+		self.cancel_linked_payment_ledger_entries()
 
 		# reset flags & update status
 		self.db_set("salary_slips_created", 0)
@@ -167,7 +168,27 @@ class PayrollEntry(Document):
 
 		# cancel Journal Entries
 		for je in journal_entries:
+			journal_entry_payment_ledgers = frappe.get_all(
+				"Payment Ledger Entry",
+				{"voucher_type": "Journal Entry", "voucher_no": je, "docstatus": 1},
+				distinct=True,
+			)
+			# cancel linked payment ledger entry
+			for pl in journal_entry_payment_ledgers:
+				frappe.get_doc("Payment Ledger Entry", pl).cancel()
+			
 			frappe.get_doc("Journal Entry", je).cancel()
+
+	def cancel_linked_payment_ledger_entries(self):
+		payment_ledgers = frappe.get_all(
+			"Payment Ledger Entry",
+			{"against_voucher_type": self.doctype, "against_voucher_no": self.name, "docstatus": 1},
+			distinct=True,
+		)
+
+		# cancel payment ledger entry
+		for pl in payment_ledgers:
+			frappe.get_doc("Payment Ledger Entry", pl).cancel()
 
 	def get_linked_salary_slips(self):
 		return frappe.get_all("Salary Slip", {"payroll_entry": self.name}, ["name", "docstatus"])
@@ -194,6 +215,7 @@ class PayrollEntry(Document):
 	@frappe.whitelist()
 	def fill_employee_details(self):
 		filters = self.make_filters()
+		print(filters, 'filterss')
 		employees = get_employee_list(filters=filters, as_dict=True, ignore_match_conditions=True)
 		self.set("employees", [])
 
@@ -594,7 +616,6 @@ class PayrollEntry(Document):
 			)
 
 			# when party is not required, skip the validation in journal & gl entry
-			frappe.flags.party_not_required_for_receivable_payable = True
 			self.make_journal_entry(
 				accounts,
 				currencies,
@@ -606,7 +627,6 @@ class PayrollEntry(Document):
 				submit_journal_entry=True,
 				submitted_salary_slips=submitted_salary_slips,
 			)
-			frappe.flags.party_not_required_for_receivable_payable = False
 
 	def make_journal_entry(
 		self,
@@ -638,7 +658,9 @@ class PayrollEntry(Document):
 
 		try:
 			if submit_journal_entry:
+				frappe.flags.party_not_required_for_receivable_payable = True
 				journal_entry.submit()
+				frappe.flags.party_not_required_for_receivable_payable = False
 
 			if submitted_salary_slips:
 				self.set_journal_entry_in_salary_slips(submitted_salary_slips, jv_name=journal_entry.name)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -82,6 +82,9 @@ class TestPayrollEntry(FrappeTestCase):
 		if payroll_account and payroll_account.account_type != "Payable":
 			frappe.db.set_value("Account", "_Test Payroll Payable - _TC", "account_type", "Payable")
 
+		if "lending" in frappe.get_installed_apps():
+			frappe.db.set_value("Company", "_Test Company", "loan_accrual_frequency", "Monthly")
+
 	def test_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")
 		employee = frappe.db.get_value("Employee", {"company": "_Test Company"})
@@ -1204,17 +1207,21 @@ def create_loan_for_employee(applicant):
 
 
 def get_repayment_party_type(loan):
-	loan_repayment_entry, payroll_payable_account = frappe.db.get_value(
-		"Loan Repayment", {"against_loan": loan}, ["name", "payroll_payable_account"]
+	loan_repayment = frappe.db.get_value(
+		"Loan Repayment", {"against_loan": loan}, ["name", "payroll_payable_account"], as_dict=True
 	)
+	if not loan_repayment:
+		return "", ""
 
-	party_type, party = frappe.db.get_value(
+	return frappe.db.get_value(
 		"GL Entry",
-		{"voucher_no": loan_repayment_entry, "account": payroll_payable_account, "is_cancelled": 0},
+		{
+			"voucher_no": loan_repayment.name,
+			"account": loan_repayment.payroll_payable_account,
+			"is_cancelled": 0,
+		},
 		["party_type", "party"],
-	)
-
-	return party_type, party
+	) or ("", "")
 
 
 def submit_bank_entry(payroll_entry_id):

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -77,6 +77,8 @@ class TestPayrollEntry(FrappeTestCase):
 			frappe.db.set_value(
 				"Company", "_Test Company", "default_payroll_payable_account", "_Test Payroll Payable - _TC"
 			)
+		else:
+			frappe.db.set_value("Account", "_Test Payroll Payable - _TC", "account_type", "Payable")
 
 	def test_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -77,7 +77,9 @@ class TestPayrollEntry(FrappeTestCase):
 			frappe.db.set_value(
 				"Company", "_Test Company", "default_payroll_payable_account", "_Test Payroll Payable - _TC"
 			)
-		else:
+
+		payroll_account = frappe.get_doc("Account", "_Test Payroll Payable - _TC")
+		if payroll_account and payroll_account.account_type != "Payable":
 			frappe.db.set_value("Account", "_Test Payroll Payable - _TC", "account_type", "Payable")
 
 	def test_payroll_entry(self):


### PR DESCRIPTION
## Reason
- Previously, when generating salary slip from payroll entry, Payroll Payable Account type had to be set empty as Party & Party Type were needed if Payroll accounting entry was based on Employee.
- Flags added in #3564 need to be removed and the checkbox added in journal entry will be to to skip party validation

## Changes done
- Updated validation to ensure Payroll Payable Account has account type set to "Payable" instead of requiring it to be empty
- Cancel all the linked document related to payroll and it journal
- Removed flags to skip party validation and instead use checkbox 'party_not_required' to skip validation

￼￼
![payable_account_validation](https://github.com/user-attachments/assets/1188e630-6444-4504-8b94-a53d2af1b96c)

Closes #3023, #1484

Changes in journal entry: https://github.com/frappe/erpnext/pull/49638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payroll Payable Account now enforces type “Payable” with clearer error messages.
  * Cancelling a Payroll Entry also cancels linked payment ledger entries and related journal entries to avoid orphaned records.

* **New Features**
  * Payroll, accrual, bank and journal flows respect per-employee (employee-wise) accounting when enabled, routing payables and party handling accordingly.

* **Tests**
  * Test setup ensures payroll payable account type and improves loan-repayment lookup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->