### PR TITLE
fix(income tax computation): include deductions_before_tax_calculatio…

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -433,21 +433,27 @@ class IncomeTaxComputationReport:
 
 		for employee, emp_details in self.employees.items():
 			total_taxable_amount = 0.0
-			annual_taxable_amount = tax_exemption_declaration = standard_tax_exemption_amount = 0.0
+			annual_taxable_amount = tax_exemption_declaration = standard_tax_exemption_amount = (
+				deductions_before_tax_calculation
+			) = 0.0
 
 			last_ss = self.get_last_salary_slip(employee)
 
 			if last_ss and last_ss.end_date == self.payroll_period_end_date:
-				annual_taxable_amount, tax_exemption_declaration, standard_tax_exemption_amount = (
-					frappe.db.get_value(
-						"Salary Slip",
-						last_ss.name,
-						[
-							"annual_taxable_amount",
-							"tax_exemption_declaration",
-							"standard_tax_exemption_amount",
-						],
-					)
+				(
+					annual_taxable_amount,
+					tax_exemption_declaration,
+					deductions_before_tax_calculation,
+					standard_tax_exemption_amount,
+				) = frappe.db.get_value(
+					"Salary Slip",
+					last_ss.name,
+					[
+						"annual_taxable_amount",
+						"tax_exemption_declaration",
+						"deductions_before_tax_calculation",
+						"standard_tax_exemption_amount",
+					],
 				)
 			else:
 				future_salary_slips = self.future_salary_slips.get(employee, [])
@@ -456,6 +462,7 @@ class IncomeTaxComputationReport:
 					annual_taxable_amount = last_ss.get("annual_taxable_amount", 0.0)
 					tax_exemption_declaration = last_ss.get("tax_exemption_declaration", 0.0)
 					standard_tax_exemption_amount = last_ss.get("standard_tax_exemption_amount", 0.0)
+					deductions_before_tax_calculation = last_ss.get("deductions_before_tax_calculation", 0.0)
 
 			if annual_taxable_amount:
 				# Remove exemptions already factored into salary slip so that report can apply its own logic (declaration vs proof)
@@ -463,6 +470,7 @@ class IncomeTaxComputationReport:
 					flt(annual_taxable_amount)
 					+ flt(tax_exemption_declaration)
 					+ flt(standard_tax_exemption_amount)
+					+ flt(deductions_before_tax_calculation)
 					- emp_details["total_exemption"]
 				)
 

--- a/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/test_income_tax_computation.py
@@ -85,10 +85,10 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 			"professional_tax": 2400.0,
 			"standard_tax_exemption": 50000,
 			"total_exemption": 52400.0,
-			"total_taxable_amount": 881200.0,
-			"applicable_tax": 92290.0,
+			"total_taxable_amount": 883600.0,
+			"applicable_tax": 92789.0,
 			"total_tax_deducted": 17997.0,
-			"payable_tax": 74293.0,
+			"payable_tax": 74792.0,
 		}
 
 		for key, val in expected_data.items():
@@ -103,9 +103,9 @@ class TestIncomeTaxComputation(IntegrationTestCase):
 			{
 				"_test_category": 100000.0,
 				"total_exemption": 152400.0,
-				"total_taxable_amount": 781200.0,
-				"applicable_tax": 71490.0,
-				"payable_tax": 53493.0,
+				"total_taxable_amount": 783600.0,
+				"applicable_tax": 71989.0,
+				"payable_tax": 53992.0,
 			}
 		)
 


### PR DESCRIPTION
**Issue:** In the Income Tax Calculation report, `Deductions before tax calculation` value didn't considered in the `Total Taxable Amount` calculation.

**ref:** [48943](https://support.frappe.io/helpdesk/tickets/48943)


**Salary Slip:**
<img width="1851" height="860" alt="image" src="https://github.com/user-attachments/assets/eb938bdc-3cb4-4b34-9095-65a47c41d608" />


**Before:**
<img width="1865" height="608" alt="image" src="https://github.com/user-attachments/assets/a36a331c-175a-4d84-b8ee-81e0833d3037" />



**After:**
<img width="1865" height="613" alt="image" src="https://github.com/user-attachments/assets/47d08111-c052-4476-8e5b-42fd760cef6b" />


**Backport Needed for v15 & v14**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Income tax computation now includes pre-tax deductions in the total taxable amount for more accurate tax results.
  * Pre-tax deduction values are taken from the latest salary slip in the payroll period or the most recent future slip when applicable, ensuring current data is used.

* **Tests**
  * Updated tax calculation tests to reflect revised totals and expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->