### PR TITLE
fix: exclude cancelled leave ledger entries

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -1142,7 +1142,8 @@ def get_manually_expired_leaves(
 		frappe.qb.from_(ledger)
 		.select(ledger.leaves)
 		.where(
-			(ledger.employee == employee)
+			(ledger.docstatus == 1)
+			& (ledger.employee == employee)
 			& (ledger.leave_type == leave_type)
 			& (ledger.from_date >= from_date)
 			& (ledger.to_date <= end_date)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consider only approved ledger entries when marking manually expired leaves, preventing incorrect expiries.

* **Impact**
  * Improves accuracy of leave balances and expiry status in employee and admin views.
  * Reduces discrepancies in leave reports and downstream calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->