### PR TITLE
fix: update amount on advance payment ledger entry

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -31,6 +31,6 @@ hrms.patches.v15_0.set_half_day_status_to_present_in_exisiting_half_day_attendan
 hrms.patches.v14_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.create_marginal_relief_field_for_india_localisation
 hrms.patches.v15_0.fix_timesheet_status
-hrms.patches.v15_0.update_advance_payment_ledger_amount
-hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-07-14
+hrms.patches.v15_0.update_advance_payment_ledger_amount #2025-09-23
+hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim

--- a/hrms/patches/v15_0/update_advance_payment_ledger_amount.py
+++ b/hrms/patches/v15_0/update_advance_payment_ledger_amount.py
@@ -55,11 +55,11 @@ def update_journal_entry(advance_doctypes):
 			advance_ledger.amount,
 			Case()
 			.when(
-				(jea.debit_in_account_currency > 0) & (advance_ledger.amount < 0),
+				(jea.debit_in_account_currency > 0) & (advance_ledger.amount <= 0),
 				jea.debit_in_account_currency,
 			)
 			.when(
-				(jea.credit_in_account_currency > 0) & (advance_ledger.amount > 0),
+				(jea.credit_in_account_currency > 0) & (advance_ledger.amount >= 0),
 				jea.credit_in_account_currency * -1,
 			)
 			.else_(advance_ledger.amount),
@@ -68,8 +68,8 @@ def update_journal_entry(advance_doctypes):
 			jea.reference_type.isin(advance_doctypes)
 			& jea.docstatus.eq(1)
 			& (
-				((jea.debit_in_account_currency > 0) & (advance_ledger.amount < 0))
-				| ((jea.credit_in_account_currency > 0) & (advance_ledger.amount > 0))
+				((jea.debit_in_account_currency > 0) & (advance_ledger.amount <= 0))
+				| ((jea.credit_in_account_currency > 0) & (advance_ledger.amount >= 0))
 			)
 		)
 	).run()


### PR DESCRIPTION
**Issue:** Unable to cancel the Journal Entries linked with Employee Advance

**Root Cause:**
When Employee Advance is paid with a Journal Entry, the amount will be in the debit. In the [patch](https://github.com/frappe/erpnext/blob/29ca1a1f40224a183b7ce6fbc52855ac692ea8f8/erpnext/patches/v15_0/create_advance_payment_ledger_records.py#L88) credit amount is used for the Advance ledger creation if the Account type is receivable. So the Advance Ledgers were created with an amount of 0, and the paid amount is set as 0 in the employee advance



**ref:** [48926](https://support.frappe.io/helpdesk/tickets/48926)

```
  File "apps/erpnext/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py", line 36, in on_update
    update_voucher_outstanding(self.against_voucher_type, self.against_voucher_no, None, None, None)
  File "apps/erpnext/erpnext/accounts/utils.py", line 1917, in update_voucher_outstanding
    ref_doc.set_total_advance_paid()
  File "apps/hrms/hrms/hr/doctype/employee_advance/employee_advance.py", line 177, in set_total_advance_paid
    frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
  File "apps/frappe/frappe/__init__.py", line 609, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 574, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 525, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Return amount cannot be greater than unclaimed amount
```


**Backport needed for version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of zero-amount journal entries when reconciling advances, ensuring zero is treated as valid in adjustments. This improves accuracy of advance ledger updates and prevents missed or incorrect updates in edge cases, leading to more reliable advance paid totals.

* **Chores**
  * Updated patch records to reflect current dates, improving traceability of applied updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->