### PR TITLE
fix: incorrect expense calculation in vehicle log

### DIFF
--- a/hrms/hr/doctype/vehicle_log/vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/vehicle_log.py
@@ -37,8 +37,8 @@ def make_expense_claim(docname):
 
 	vehicle_log = frappe.get_doc("Vehicle Log", docname)
 	service_expense = sum([flt(d.expense_amount) for d in vehicle_log.service_detail])
-
-	claim_amount = service_expense + (flt(vehicle_log.price) * flt(vehicle_log.fuel_qty) or 1)
+	refuelling_expense = flt(vehicle_log.price) * flt(vehicle_log.fuel_qty)
+	claim_amount = service_expense + refuelling_expense
 	if not claim_amount:
 		frappe.throw(_("No additional expenses has been added"))
 


### PR DESCRIPTION
Fixes #3578 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected claim amount calculation for vehicle expense claims to avoid unintended minimum values when fuel cost is zero.
  * Ensures claim amount properly sums service and refueling costs for accurate totals.
  * Displays a validation error when a claim would total zero, preventing invalid submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->