### PR TITLE
fix(leave encashment): add payable filter to payable account field

### DIFF
--- a/hrms/hr/doctype/leave_encashment/leave_encashment.js
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.js
@@ -39,6 +39,7 @@ frappe.ui.form.on("Leave Encashment", {
 				filters: {
 					company: frm.doc.company,
 					account_currency: ["in", currencies],
+					account_type: "Payable",
 				},
 			};
 		});

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -72,7 +72,7 @@ class LeaveEncashment(AccountsController):
 			self.create_gl_entries(cancel=True)
 
 		self.create_leave_ledger_entry(submit=False)
-		self.ignore_linked_doctypes = ["GL Entry", "Advance Payment Ledger Entry"]
+		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry", "Advance Payment Ledger Entry"]
 		self.set_status(update=True)
 
 	@frappe.whitelist()


### PR DESCRIPTION
**Issue:**

1. The Payable account field in Leave encashment didn't filter with the account type payable
2. The account type with Payable is used for the Leave Encashment; it'll create a Payment Ledger Entry, as it is not part of the ignore_linked_doctypes. Unable to cancel the Submitted Leave Encashment

**Before:**

https://github.com/user-attachments/assets/dbea1f7d-714f-4f44-892f-2c6645cff71f


**After:**

https://github.com/user-attachments/assets/cb71ef86-0037-4b65-a4d9-549f90e923cd



Backport needed for v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Leave Encashment: Payable account picker now limits choices to payable accounts matching the selected company and currency.
  * Leave Encashment: Cancellation now also ignores additional linked payment ledger entries to reduce cancellation errors.

* **Documentation**
  * Clarified account selection and cancellation behavior for Leave Encashment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->