### PR TITLE
fix: validate updated paid amount

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -174,7 +174,7 @@ class EmployeeAdvance(Document):
 		precision = self.precision("return_amount")
 		return_amount = flt(return_amount, precision)
 
-		if return_amount > 0 and return_amount > flt(self.paid_amount - self.claimed_amount, precision):
+		if return_amount > 0 and return_amount > flt(paid_amount - self.claimed_amount, precision):
 			frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
 
 		self.db_set("paid_amount", paid_amount)


### PR DESCRIPTION
**Issue:** Able to cancel the Employee Advance Payment. after posting the return entry
**ref:** [49763](https://support.frappe.io/helpdesk/tickets/49763)

**Before:**

https://github.com/user-attachments/assets/be70a4b9-51cb-4a8f-8e38-6740c77dce99



**After:**

https://github.com/user-attachments/assets/0bec46d0-b404-49a3-9e4e-57d2cb31c931




**Backport Needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation in Employee Advance: return amounts are now checked against the correctly computed paid amount, preventing spurious errors and ensuring returns only flag when they truly exceed available unclaimed balance (including currency-adjusted scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->