### PR TITLE
chore(report): reorder column in salary register

### DIFF
--- a/hrms/payroll/report/salary_register/salary_register.py
+++ b/hrms/payroll/report/salary_register/salary_register.py
@@ -225,15 +225,15 @@ def get_columns(earning_types, ded_types):
 	columns.extend(
 		[
 			{
-				"label": _("Loan Repayment"),
-				"fieldname": "total_loan_repayment",
+				"label": _("Total Deduction"),
+				"fieldname": "total_deduction",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,
 			},
 			{
-				"label": _("Total Deduction"),
-				"fieldname": "total_deduction",
+				"label": _("Loan Repayment"),
+				"fieldname": "total_loan_repayment",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,


### PR DESCRIPTION
**Description:**
In the Salary Register report, Total Deduction only takes into account the deduction component, which is part of the deductions table in the salary slip, and excludes the loan repayment. So reordered the columns to match the salary slip

**ref:** [50084](https://support.frappe.io/helpdesk/tickets/50084)

**Before:** 

<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/0a86cb6d-86f3-4265-90a6-fe3521f5a9eb" />



**After:**

<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/f903fea9-7115-4725-b6f5-0c467c0fef1e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Salary Register so "Total Deduction" and "Loan Repayment" headers now match their corresponding data fields.
  * Adjusted the order of these columns for correct on-screen display and exported reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->