### PR TITLE
fix: set half day status when leave is not found

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -192,7 +192,7 @@ class Attendance(Document):
 		if self.status in ("On Leave", "Half Day"):
 			if not leave_record:
 				self.modify_half_day_status = 0
-				self.haf_day_status = "Absent"
+				self.half_day_status = "Absent"
 				frappe.msgprint(
 					_("No leave record found for employee {0} on {1}").format(
 						self.employee, format_date(self.attendance_date)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attendance handling when an entry is marked “On Leave” or “Half Day” without a corresponding leave record. Such entries are now reliably treated as “Absent,” ensuring consistent status updates across the UI and reports.
  * Prevents misclassification and data inconsistencies in attendance summaries, exports, and downstream calculations.
  * No changes to user-facing messages; behavior is now aligned with expected attendance rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->