### PR TITLE
fix: Gross pay calculation to consider component amount which didn't get compute via salary structure & are added Manually

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1706,7 +1706,7 @@ class SalarySlip(TransactionBase):
 			)
 			amount = (
 				flt(
-					(flt(row.default_amount) * flt(self.payment_days) / cint(self.total_working_days)),
+					((flt(row.default_amount) or flt(row.amount)) * flt(self.payment_days) / cint(self.total_working_days)),
 					row.precision("amount"),
 				)
 				+ additional_amount

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1706,7 +1706,11 @@ class SalarySlip(TransactionBase):
 			)
 			amount = (
 				flt(
-					((flt(row.default_amount) or flt(row.amount)) * flt(self.payment_days) / cint(self.total_working_days)),
+					(
+						(flt(row.default_amount) or flt(row.amount))
+						* flt(self.payment_days)
+						/ cint(self.total_working_days)
+					),
 					row.precision("amount"),
 				)
 				+ additional_amount


### PR DESCRIPTION
## Reason
- Salary Component added manually didn't get sum up in gross pay

## Changes Done
- Consider adding the Amount if default amount is not found while calculating net pay to update gross_pay

## Screenshot
Before:
<img width="2556" height="1332" alt="image" src="https://github.com/user-attachments/assets/90e61d9c-bebf-45ba-b86c-e035ad96aed3" />

After:
<img width="2574" height="1340" alt="image" src="https://github.com/user-attachments/assets/86dcb44d-3f93-4ad5-a693-d82990508291" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed salary component proration so a component's explicit amount is used when its default amount is blank or zero, preventing incorrect zero/undercalculated per-day values and ensuring accurate prorated totals without changing rounding or extra-amount handling.

- **Chores**
  - Internal payroll calculation logic refined for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->