### PR TITLE
fix(salary-register): include loan repayment in total deduction

### DIFF
--- a/hrms/payroll/report/salary_register/salary_register.py
+++ b/hrms/payroll/report/salary_register/salary_register.py
@@ -66,8 +66,8 @@ def execute(filters=None):
 			row.update(
 				{
 					"gross_pay": flt(ss.gross_pay) * flt(ss.exchange_rate),
-					"total_deduction": flt(ss.total_deduction) * flt(ss.exchange_rate)
-					+ flt(ss.total_loan_repayment),
+					"total_deduction": (flt(ss.total_deduction) + flt(ss.total_loan_repayment))
+					* flt(ss.exchange_rate),
 					"net_pay": flt(ss.net_pay) * flt(ss.exchange_rate),
 				}
 			)

--- a/hrms/payroll/report/salary_register/salary_register.py
+++ b/hrms/payroll/report/salary_register/salary_register.py
@@ -74,7 +74,11 @@ def execute(filters=None):
 
 		else:
 			row.update(
-				{"gross_pay": ss.gross_pay, "total_deduction": ss.total_deduction, "net_pay": ss.net_pay}
+				{
+					"gross_pay": ss.gross_pay,
+					"total_deduction": flt(ss.total_deduction) + flt(ss.total_loan_repayment),
+					"net_pay": ss.net_pay,
+				}
 			)
 
 		data.append(row)

--- a/hrms/payroll/report/salary_register/salary_register.py
+++ b/hrms/payroll/report/salary_register/salary_register.py
@@ -66,7 +66,8 @@ def execute(filters=None):
 			row.update(
 				{
 					"gross_pay": flt(ss.gross_pay) * flt(ss.exchange_rate),
-					"total_deduction": flt(ss.total_deduction) * flt(ss.exchange_rate),
+					"total_deduction": flt(ss.total_deduction) * flt(ss.exchange_rate)
+					+ flt(ss.total_loan_repayment),
 					"net_pay": flt(ss.net_pay) * flt(ss.exchange_rate),
 				}
 			)
@@ -225,15 +226,15 @@ def get_columns(earning_types, ded_types):
 	columns.extend(
 		[
 			{
-				"label": _("Total Deduction"),
-				"fieldname": "total_deduction",
+				"label": _("Loan Repayment"),
+				"fieldname": "total_loan_repayment",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,
 			},
 			{
-				"label": _("Loan Repayment"),
-				"fieldname": "total_loan_repayment",
+				"label": _("Total Deduction"),
+				"fieldname": "total_deduction",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,


### PR DESCRIPTION
**Description:**
Include loan repayment amount in the Total Deduction Amount of the salary register report

**ref:** [50084](https://support.frappe.io/helpdesk/tickets/50084)

**Before:**
<img width="1919" height="1080" alt="Before including" src="https://github.com/user-attachments/assets/0e399730-416f-4601-9d14-d2ab818d1af5" />

**After:**
<img width="1919" height="1080" alt="after including" src="https://github.com/user-attachments/assets/2196d676-18a8-4c52-b9c9-41c1d3bd135b" />


Backport needed for v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Salary Register now includes loan repayments when calculating Total Deduction for both matching and non-matching report/company currency scenarios, ensuring deduction totals are accurate.
  - Column headers for Loan Repayment and Total Deduction corrected so each value appears under the proper label, improving report clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->