### PR TITLE
fix: Gross pay calculation to update total in it if component added manually

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -164,7 +164,6 @@ class SalarySlip(TransactionBase):
 
 		self.set_salary_structure_assignment()
 		self.calculate_net_pay()
-		self.set_totals()
 		self.compute_year_to_date()
 		self.compute_month_to_date()
 		self.compute_component_wise_year_to_date()
@@ -2048,7 +2047,9 @@ class SalarySlip(TransactionBase):
 		amount, additional_amount = row.amount, row.additional_amount
 		timesheet_component = self._salary_structure_doc.salary_component
 
-		if (
+		if not row.additional_salary and not row.default_amount:
+			amount, additional_amount = amount, additional_amount
+		elif (
 			self.salary_structure
 			and cint(row.depends_on_payment_days)
 			and cint(self.total_working_days)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -164,6 +164,7 @@ class SalarySlip(TransactionBase):
 
 		self.set_salary_structure_assignment()
 		self.calculate_net_pay()
+		self.set_totals()
 		self.compute_year_to_date()
 		self.compute_month_to_date()
 		self.compute_component_wise_year_to_date()


### PR DESCRIPTION
## Reason
- If a salary component amount is 0(default_amount) in salary structure, then if component added manually with amount doesn't get updated after the document is saved.

## changes done
- update amount of manually added component in gross_pay in case default_amount is not found from salary structure
##Screenshot
Before
<img width="2556" height="1332" alt="image" src="https://github.com/user-attachments/assets/90e61d9c-bebf-45ba-b86c-e035ad96aed3" />

After
<img width="2574" height="1340" alt="image" src="https://github.com/user-attachments/assets/86dcb44d-3f93-4ad5-a693-d82990508291" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation order in salary slips to ensure gross pay, total deductions, and net pay are finalized before generating month-to-date and year-to-date summaries.
  * Ensures base and rounded totals are consistent across slip totals and summary sections, reducing discrepancies users may observed in aggregated figures.
  * Prevents simple pay components with explicit values from being altered by payment-day adjustments while retaining scaling for overwritten or timing-sensitive components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->