### PR TITLE
Feat/fix init path 3623

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   frappe:
     image: frappe/bench:latest
-    command: bash /workspace/init.sh
+    command: bash /workspace/docker/init.sh
     environment:
       - SHELL=/bin/bash
     working_dir: /home/frappe

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - SHELL=/bin/bash
     working_dir: /home/frappe
     volumes:
-      - .:/workspace
+      - ..:/workspace
     ports:
       - 8000:8000
       - 9000:9000

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Delegate to the actual init script kept under docker/
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/docker/init.sh" "$@"


### PR DESCRIPTION

### **Summary**

* Added a **root-level `init.sh`** that forwards to `docker/init.sh` so environments looking for `/workspace/init.sh` continue to work.
* Mounted the **project root (`../:/workspace`)** into the container so `docker/init.sh` is available at the expected path.
* Fixed the Coolify deployment error:

  ```
  bash: /workspace/init.sh: No such file or directory
  ```
* **Closes #3623.**

---

### **Testing**

```bash
# Verify that docker/init.sh exists in container
docker compose run --rm frappe bash -lc 'ls /workspace/docker'

# Rebuild and start the app
docker compose up --build frappe
```

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initialization script to use the proper shell and fixed missing newline.
  * Ensures existing environments auto-start the bench instead of stopping at a message.
  * Updated Docker command and volume paths for reliable startup and correct workspace resolution.

* **Refactor**
  * Introduced a top-level initialization wrapper that delegates to the Docker script with safer defaults and consistent argument handling.

* **Chores**
  * Aligned Docker configuration to use the new initialization path, improving startup consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->