### PR TITLE
feat: create attendance request from attendance

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.js
+++ b/hrms/hr/doctype/attendance/attendance.js
@@ -12,5 +12,15 @@ frappe.ui.form.on("Attendance", {
 				query: "erpnext.controllers.queries.employee_query",
 			};
 		});
+
+		if(frm.doc.docstatus === 1 && frm.doc.status == "Absent") {
+			frm.add_custom_button(__("Attendance Request"), () => {
+				frappe.new_doc('Attendance Request', {
+					'employee': frm.doc.employee,
+					'from_date': frm.doc.attendance_date,
+					'to_date': frm.doc.attendance_date,
+				});
+			}, __("Create"));
+		}
 	},
 });

--- a/hrms/hr/doctype/attendance/attendance.js
+++ b/hrms/hr/doctype/attendance/attendance.js
@@ -13,14 +13,18 @@ frappe.ui.form.on("Attendance", {
 			};
 		});
 
-		if(frm.doc.docstatus === 1 && frm.doc.status == "Absent") {
-			frm.add_custom_button(__("Attendance Request"), () => {
-				frappe.new_doc('Attendance Request', {
-					'employee': frm.doc.employee,
-					'from_date': frm.doc.attendance_date,
-					'to_date': frm.doc.attendance_date,
-				});
-			}, __("Create"));
+		if (frm.doc.docstatus === 1 && frm.doc.status === "Absent") {
+			frm.add_custom_button(
+				__("Attendance Request"),
+				() => {
+					frappe.new_doc("Attendance Request", {
+						employee: frm.doc.employee,
+						from_date: frm.doc.attendance_date,
+						to_date: frm.doc.attendance_date,
+					});
+				},
+				__("Create"),
+			);
 		}
 	},
 });


### PR DESCRIPTION
<img width="1731" height="879" alt="image" src="https://github.com/user-attachments/assets/e24ff476-d96c-4f93-a28f-d2e54fb46c1c" />
Added a new feature to create an Attendance Request directly from the Attendance form, allowing users to quickly raise correction requests for missed or incorrect attendance entries without re-entering details. The feature adds a “Attendance Request” button that auto-fills relevant fields such as employee, date, and attendance details, making the process faster, more accurate, and user-friendly.


`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Attendance Request” button on submitted Attendance records marked as Absent. Tapping it creates a new Attendance Request with the employee and both from/to dates prefilled to the attendance date, streamlining request creation. The button appears only for submitted Absent records and does not affect other statuses or draft/cancelled records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->