### PR TITLE
feat: Improve validation for missing salary structure assignment

### DIFF
--- a/hrms/payroll/doctype/arrear/arrear.py
+++ b/hrms/payroll/doctype/arrear/arrear.py
@@ -69,7 +69,7 @@ class Arrear(Document):
 		if not assignment:
 			frappe.throw(
 				_(
-					"No active Salary Structure Assignment found for employee {0} with salary structure {1} on or after arrear start date {2}"  # TODO: make error message better
+					"Salary Structure Assignment not found for Employee: {0}. An active assignment for Salary Structure '{1}' must exist on or after {2}.
 				).format(
 					frappe.bold(self.employee),
 					frappe.bold(self.salary_structure),

--- a/hrms/payroll/doctype/arrear/test_arrear.py
+++ b/hrms/payroll/doctype/arrear/test_arrear.py
@@ -193,3 +193,37 @@ class TestArrear(IntegrationTestCase):
 			self.assertIn("Accrued Earnings", accrual_components)
 
 		frappe.db.rollback()
+
+	def test_validate_missing_salary_structure_assignment(self):
+		# Test that arrear creation fails if no salary structure assignment exists
+		emp = make_employee(
+			"test_missing_ssa@salary.com",
+			company="_Test Company",
+			date_of_joining="2021-01-01",
+		)
+		payroll_period = make_payroll_period()
+
+		# Create a salary structure but do not assign it to the employee
+		salary_structure = make_salary_structure(
+			"Test Structure For Missing SSA",
+			"Monthly",
+			company="_Test Company",
+		)
+
+		arrear_doc = frappe.get_doc(
+			{
+				"doctype": "Arrear",
+				"employee": emp,
+				"payroll_period": payroll_period.name,
+				"salary_structure": salary_structure.name,
+				"arrear_start_date": payroll_period.start_date,
+				"company": "_Test Company",
+			}
+		)
+
+		with self.assertRaises(frappe.ValidationError) as e:
+			arrear_doc.save()
+
+		self.assertIn("Salary Structure Assignment not found for Employee", str(e.exception))
+
+		frappe.db.rollback()

--- a/hrms/payroll/doctype/arrear/test_arrear.py
+++ b/hrms/payroll/doctype/arrear/test_arrear.py
@@ -201,7 +201,12 @@ class TestArrear(IntegrationTestCase):
 			company="_Test Company",
 			date_of_joining="2021-01-01",
 		)
-		payroll_period = make_payroll_period()
+		// Create the payroll period (make_payroll_period doesn’t return the doc)
+		make_payroll_period()
+		payroll_period = frappe.get_last_doc(
+			"Payroll Period",
+			filters={"company": "_Test Company"}
+		)
 
 		# Create a salary structure but do not assign it to the employee
 		salary_structure = make_salary_structure(

--- a/hrms/payroll/doctype/arrear/test_arrear.py
+++ b/hrms/payroll/doctype/arrear/test_arrear.py
@@ -201,7 +201,7 @@ class TestArrear(IntegrationTestCase):
 			company="_Test Company",
 			date_of_joining="2021-01-01",
 		)
-		// Create the payroll period (make_payroll_period doesn’t return the doc)
+		# Create the payroll period (make_payroll_period doesn't return the doc)
 		make_payroll_period()
 		payroll_period = frappe.get_last_doc(
 			"Payroll Period",


### PR DESCRIPTION
Improved the error message for missing salary structure assignment in arrears to be more descriptive.

Added a test case to validate that the system throws a 'ValidationError' when an Arrear is created for an employee without a corresponding Salary Structure Assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified validation message when creating an Arrear without a Salary Structure Assignment — now explicitly references employee, salary structure, and arrear start date to improve troubleshooting.

* **Tests**
  * Added an automated test to confirm Arrear creation fails with the expected validation error when no Salary Structure Assignment exists, improving coverage for this scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->