### PR TITLE
fix: Prevent calling are_opening_entries_required when salary_structure is not set

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -156,7 +156,7 @@ frappe.ui.form.on("Salary Structure Assignment", {
 	},
 
 	toggle_opening_balances_section: function (frm) {
-		if (!frm.doc.from_date || !frm.doc.employee !frm.doc.salary_structure) return;
+		if (!frm.doc.from_date || !frm.doc.employee || !frm.doc.salary_structure) return;
 
 		frm.call("are_opening_entries_required").then((data) => {
 			if (data.message) {

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -156,7 +156,7 @@ frappe.ui.form.on("Salary Structure Assignment", {
 	},
 
 	toggle_opening_balances_section: function (frm) {
-		if (!frm.doc.from_date || !frm.doc.employee) return;
+		if (!frm.doc.from_date || !frm.doc.employee !frm.doc.salary_structure) return;
 
 		frm.call("are_opening_entries_required").then((data) => {
 			if (data.message) {


### PR DESCRIPTION
The system calls the function `are_opening_entries_required` when both the `employee` and `from_date` fields are not empty. However, this function requires a valid `salary_structure` value.

If the `salary_structure` field is `empty`, the function call fails and raises an error, as shown below:

<img width="1011" height="301" alt="image error" src="https://github.com/user-attachments/assets/89b9a933-44fd-4881-9657-194921e791d8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for salary structure assignments to prevent processing when required information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->