### PR TITLE
fix(additional_salary): remove component type from component filter

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.js
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.js
@@ -20,9 +20,7 @@ frappe.ui.form.on("Additional Salary", {
 	},
 
 	onload: function (frm) {
-		if (frm.doc.type) {
-			frm.trigger("set_component_query");
-		}
+		frm.trigger("set_component_query");
 	},
 
 	employee: function (frm) {
@@ -55,16 +53,17 @@ frappe.ui.form.on("Additional Salary", {
 	},
 
 	company: function (frm) {
-		frm.set_value("type", "");
 		frm.trigger("set_component_query");
 	},
 
 	set_component_query: function (frm) {
 		if (!frm.doc.company) return;
-		let filters = { company: frm.doc.company };
-		if (frm.doc.type) {
-			filters.type = frm.doc.type;
-		}
+
+		let filters = {
+			company: frm.doc.company,
+			disabled: 0,
+		};
+
 		frm.set_query("salary_component", function () {
 			return {
 				filters: filters,


### PR DESCRIPTION
**Issue:** 
After cancelling and amending an Additional Salary record, the salary component filter is set to the value of the component type.

**Ref:** [#51455](https://support.frappe.io/helpdesk/tickets/51455)

**Fix:**
As the component type is read-only and fetched from the salary component, removed the component type from the salary component filter.

**Before:**

[Screencast from 2025-10-22 13-37-04.webm](https://github.com/user-attachments/assets/c22ba8d1-0422-42a0-b5c7-c4f44c6d31bd)

**After:**

[Screencast from 2025-10-22 13-38-30.webm](https://github.com/user-attachments/assets/8ec4d041-a159-4c77-95c5-a84041985f56)


backport needed for v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent behavior in additional salary component selection by ensuring components are properly loaded on form initialization and company changes.
  * Removed unintended field clearing that occurred when changing the company, preventing data loss during form updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->