### PR TITLE
fix: set default value for filter_based_on for monthly attendance sheet report

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -38,7 +38,8 @@ def execute(filters: Filters | None = None) -> tuple:
 	filters = frappe._dict(filters or {})
 
 	if not filters.filter_based_on:
-		frappe.throw(_("Please select Filter Based On"))
+		# set default filter
+		filters.filter_based_on = "Month"
 
 	if filters.filter_based_on == "Month" and not (filters.month and filters.year):
 		frappe.throw(_("Please select month and year."))


### PR DESCRIPTION
Fixes : #3672

---
When the **Attendance Count** chart runs from the **Shift & Attendance** workspace, it passes the following arguments:

```python
{'summarized_view': 0, 'month': 10, 'year': 2025, 'company': 'T'}
```

However, it does **not include** the `filter_based_on` argument, which causes the report to throw an error.

After checking the `monthly_attendance_sheet.js` file, I found that the default value for `filter_based_on` is `"Month"`.
So instead of throwing an error, I updated the validation to automatically set `filter_based_on = "Month"` when it’s missing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The monthly attendance sheet report now handles requests without explicit filter selections more robustly. When a filter is not provided, the system defaults to month-based view and continues generating the report instead of encountering an error. Existing validation logic for month and year data is fully preserved and remains functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->