### PR TITLE
fix(leave_allocation): allow over allocation

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -56,6 +56,7 @@ class LeaveAllocation(Document):
 		company = frappe.db.get_value("Employee", self.employee, "company")
 		leave_period = get_leave_period(self.from_date, self.to_date, company)
 		max_leaves_allowed = frappe.db.get_value("Leave Type", self.leave_type, "max_leaves_allowed")
+		allow_over_allocation = frappe.db.get_value("Leave Type", self.leave_type, "allow_over_allocation")
 
 		if max_leaves_allowed > 0:
 			leave_allocated = 0
@@ -68,7 +69,7 @@ class LeaveAllocation(Document):
 					exclude_allocation=self.name,
 				)
 			leave_allocated += flt(self.new_leaves_allocated)
-			if leave_allocated > max_leaves_allowed:
+			if leave_allocated > max_leaves_allowed and not allow_over_allocation:
 				frappe.throw(
 					_(
 						"Total allocated leaves are more than maximum allocation allowed for {0} leave type for employee {1} in the period"

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -55,9 +55,9 @@ class LeaveAllocation(Document):
 	def validate_leave_allocation_days(self):
 		company = frappe.db.get_value("Employee", self.employee, "company")
 		leave_period = get_leave_period(self.from_date, self.to_date, company)
-		max_leaves_allowed = frappe.db.get_value("Leave Type", self.leave_type, "max_leaves_allowed")
-		allow_over_allocation = frappe.db.get_value("Leave Type", self.leave_type, "allow_over_allocation")
-
+		max_leaves_allowed, allow_over_allocation = frappe.db.get_value(
+			"Leave Type", self.leave_type, ["max_leaves_allowed", "allow_over_allocation"]
+		)
 		if max_leaves_allowed > 0:
 			leave_allocated = 0
 			if leave_period:


### PR DESCRIPTION
**Issue:**
The system is not allowing leave overallocation, even though the allow_over_allocation is checked in the leave type

**ref:** [#51918](https://support.frappe.io/helpdesk/tickets/51918)

**Before:**

[Screencast from 2025-10-30 18-27-10.webm](https://github.com/user-attachments/assets/ab3f02a0-8190-471d-9418-81fbe29f451a)


**After:**

[Screencast from 2025-10-30 18-25-46.webm](https://github.com/user-attachments/assets/33d5b547-986c-49cf-aa48-9e585dc8e044)

Backport needed for v15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Leave Types can now control whether allocations are permitted to exceed maximum limits. When over-allocation is enabled on a Leave Type, users can allocate leaves beyond the configured maximum, providing greater flexibility in leave policy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->