### PR TITLE
fix: variable name spelling error

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.js
@@ -29,7 +29,7 @@ frappe.ui.form.on("Employee Checkin", {
 	},
 
 	add_fetch_shift_button(frm) {
-		if (frm.doc.attendace) return;
+		if (frm.doc.attendance) return;
 		frm.add_custom_button(__("Fetch Shift"), function () {
 			frappe.call({
 				method: "fetch_shift",


### PR DESCRIPTION
Variable name spelling error (`attendace `=> `attendance`)
backport version-15-hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo that prevented the "Fetch Shift" button in Employee Check-in from appearing correctly; the button now displays and behaves properly based on attendance status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->