### PR TITLE
fix: ignore translations from frappe and erpnext

### DIFF
--- a/.github/helper/update_pot_file.sh
+++ b/.github/helper/update_pot_file.sh
@@ -8,6 +8,10 @@ pip install frappe-bench
 bench -v init frappe-bench --skip-assets --skip-redis-config-generation --python "$(which python)" --frappe-branch "${BASE_BRANCH}"
 cd ./frappe-bench || exit
 
+# We want to exclude strings from ERPNext from HRMS's translations.
+echo "Get ERPNext..."
+bench get-app --skip-assets --branch "${BASE_BRANCH}" erpnext
+
 echo "Get HRMS..."
 bench get-app --skip-assets hrms "${GITHUB_WORKSPACE}"
 

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -367,3 +367,6 @@ company_data_to_be_ignored = [
 	"Employee Onboarding Template",
 	"Employee Separation Template",
 ]
+
+# List of apps whose translatable strings should be excluded from this app's translations.
+ignore_translatable_strings_from = ["frappe", "erpnext"]


### PR DESCRIPTION
Don't write translatable strings into HRMS's `.pot`-file for messages that are already specified in the Frappe Framework or ERPNext. If a translatable string exists there, we don't want to override it with our own.

This should reduce our translation file by ~4,500 lines (28%).

Depends on https://github.com/frappe/frappe/pull/34544
POC in ERPNext: https://github.com/frappe/erpnext/pull/50438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the translation build workflow to retrieve the upstream application before fetching this app, adjusting the fetch sequence used during translation builds.
  * Added a configuration to exclude translatable strings originating from the Frappe and ERPNext apps, narrowing which external strings are incorporated into this app’s translation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->