### PR TITLE
fix(expense-claim): update status after payment unreconcillation

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -184,6 +184,9 @@ doc_events = {
 		"on_cancel": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 		"on_update_after_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
 	},
+	"Unreconcile Payment": {
+		"on_submit": "hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim",
+	},
 	"Journal Entry": {
 		"validate": "hrms.hr.doctype.expense_claim.expense_claim.validate_expense_claim_in_jv",
 		"on_submit": [

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -842,8 +842,13 @@ def update_payment_for_expense_claim(doc, method=None):
 	if doc.doctype == "Payment Entry" and not (doc.payment_type == "Pay" and doc.party):
 		return
 
-	payment_table = "accounts" if doc.doctype == "Journal Entry" else "references"
-	doctype_field = "reference_type" if doc.doctype == "Journal Entry" else "reference_doctype"
+	doctype_field_map = {
+		"Journal Entry": ["accounts", "reference_type"],
+		"Payment Entry": ["references", "reference_doctype"],
+		"Unreconcile Payment": ["allocations", "reference_doctype"],
+	}
+
+	payment_table, doctype_field = doctype_field_map[doc.doctype]
 
 	for d in doc.get(payment_table):
 		if d.get(doctype_field) == "Expense Claim" and d.reference_name:

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -895,32 +895,34 @@ class TestExpenseClaim(HRMSTestSuite):
 		if not employee:
 			employee = make_employee("test_employee1@expenseclaim.com", company=company_name)
 
-		expense_claim = make_expense_claim(payable_account, 300, 200, company_name, "Call")
-		self.assertEqual(expense_claim.status, "Submitted")
+		expense_claim = make_expense_claim(payable_account, 300, 200, company_name, "Travel Expenses - _TC3")
+		self.assertEqual(expense_claim.docstatus, 1)
+		self.assertEqual(expense_claim.status, "Unpaid")
 
 		pe = make_payment_entry(expense_claim, 200)
-		self.assertEqual(pe.docstatus, 1)
-
-		allocate_using_payment_reconciliation(expense_claim, employee, pe, payable_account)
-		expense_claim.load_from_db()
+		expense_claim.reload()
 		self.assertEqual(expense_claim.status, "Paid")
 
 		unreconcile_doc = frappe.new_doc("Unreconcile Payment")
 		unreconcile_doc.company = company_name
+		unreconcile_doc.voucher_type = "Payment Entry"
+		unreconcile_doc.voucher_no = pe.name
 		unreconcile_doc.append(
 			"allocations",
 			{
+				"account": "Travel Expenses - _TC3",
+				"party_type": "Employee",
+				"party": employee,
 				"reference_doctype": "Expense Claim",
 				"reference_name": expense_claim.name,
-				"payment_doctype": "Payment Entry",
-				"payment_name": pe.name,
-				"amount": 200,
+				"allocated_amount": 200,
+				"unlinked": 1,
 			},
 		)
 		unreconcile_doc.insert()
 		unreconcile_doc.submit()
 
-		expense_claim.load_from_db()
+		expense_claim.reload()
 		self.assertEqual(expense_claim.status, "Unpaid")
 
 

--- a/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
+++ b/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
@@ -47,6 +47,6 @@ def get_unclaimed_expese_claims(filters):
 	)
 
 	if filters.get("employee"):
-		query.where(ec.employee == filters.get("employee"))
+		query = query.where(ec.employee == filters.get("employee"))
 
 	return query.run()

--- a/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
+++ b/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Sum
 
 
 def execute(filters=None):
@@ -25,24 +26,27 @@ def get_columns():
 
 
 def get_unclaimed_expese_claims(filters):
-	cond = "1=1"
-	if filters.get("employee"):
-		cond = "ec.employee = %(employee)s"
+	ec = frappe.qb.DocType("Expense Claim")
+	ple = frappe.qb.DocType("Payment Ledger Entry")
 
-	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-	return frappe.db.sql(
-		f"""
-		select
-			ec.employee, ec.employee_name, ec.name, ec.total_sanctioned_amount, ec.total_amount_reimbursed,
-			sum(gle.credit_in_account_currency - gle.debit_in_account_currency) as outstanding_amt
-		from
-			`tabExpense Claim` ec, `tabGL Entry` gle
-		where
-			gle.against_voucher_type = "Expense Claim" and gle.against_voucher = ec.name
-			and gle.party is not null and ec.docstatus = 1 and ec.is_paid = 0 and {cond} group by ec.name
-		having
-			outstanding_amt > 0
-	""",
-		filters,
-		as_list=1,
+	query = (
+		frappe.qb.from_(ec)
+		.join(ple)
+		.on((ec.name == ple.against_voucher_no) & (ple.against_voucher_type == "Expense Claim"))
+		.select(
+			ec.employee,
+			ec.employee_name,
+			ec.name,
+			ec.total_sanctioned_amount,
+			ec.total_amount_reimbursed,
+			Sum(ple.amount).as_("outstanding_amt"),
+		)
+		.where((ec.docstatus == 1) & (ec.is_paid == 0) & (ple.delinked == 0))
+		.groupby(ec.name)
+		.having(Sum(ple.amount) != 0)
 	)
+
+	if filters.get("employee"):
+		query.where(ec.employee == filters.get("employee"))
+
+	return query.run()


### PR DESCRIPTION
**Issue:**
The Expense Claim status is not updated after the payment entry is unreconciled

**Ref:** [52761](https://support.frappe.io/helpdesk/tickets/52761)

**Before:**

[Screencast from 2025-11-11 19-39-49.webm](https://github.com/user-attachments/assets/12578547-a81c-40d2-b350-e4563e46b8b0)


**After:**

[Screencast from 2025-11-11 19-35-45.webm](https://github.com/user-attachments/assets/e16e990e-5ad2-4444-8e4b-7420b9a280b7)


Backport needed for v15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unreconcile payment actions now trigger updates to related Expense Claims.

* **Bug Fixes**
  * Expense Claim status correctly reverts from Paid to Unpaid when a payment reconciliation is reversed.

* **Tests**
  * Added test coverage for unreconciliation workflows validating status rollback.

* **Refactor**
  * Centralized payment lookup logic and migrated unpaid-expense report to the query builder for more reliable data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->