### PR TITLE
fix(salary-slip): do not default amount as amount

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2080,8 +2080,8 @@ class SalarySlip(TransactionBase):
 			and cint(row.depends_on_payment_days)
 		):
 			amount, additional_amount = 0, 0
-		elif not row.amount:
-			amount = flt(row.default_amount) + flt(row.additional_amount)
+		elif not row.amount and row.additional_amount:
+			amount = flt(row.additional_amount)
 
 		# apply rounding
 		if frappe.db.get_value(


### PR DESCRIPTION
**Issue:**
Salary Slip shows the component value, even if the Payment Days is zero

**ref:** [52843](https://support.frappe.io/helpdesk/tickets/52843), [53035](https://support.frappe.io/helpdesk/tickets/53035)

**Salary Structure:**
<img width="1856" height="906" alt="image" src="https://github.com/user-attachments/assets/0115e22f-cfa2-4460-b008-8b030d536bda" />

**Payment Days:**
<img width="1858" height="900" alt="image" src="https://github.com/user-attachments/assets/d784f691-9bd2-4d16-bc68-0d2f0cfaa238" />

**Before:**
<img width="1822" height="903" alt="image" src="https://github.com/user-attachments/assets/5c243090-d106-4c59-b983-3546bb3d21ff" />


**After:**
<img width="1857" height="899" alt="image" src="https://github.com/user-attachments/assets/1ff71e9f-34c3-4de8-b84e-78322a69afb7" />


**Backport needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected per-row salary computation when a base amount is missing but an additional amount exists. The system now uses only the additional amount in that case, producing accurate per-row values, rounding, and overall salary slip totals to prevent previous overcounts or misrounded results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->