### PR TITLE
chore: ignore PRs labeled skip-release-notes in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - skip-release-notes


### PR DESCRIPTION
This pull request introduces a configuration update to the release workflow, specifically targeting how changelogs are generated. The change ensures that pull requests labeled with `skip-release-notes` will be excluded from the automatically generated changelog.

The same config is already in place for frappe and erpnext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to support selective filtering of release note entries using label-based exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->