### PR TITLE
fix(Earned Leaves): no schedule is created for non earned leave type

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -358,7 +358,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 			self.employee.date_of_joining,
 		)
 
-	def test_absense_of_earned_leave_schedule_for_non_earned_leave_types(self):
+	def test_absence_of_earned_leave_schedule_for_non_earned_leave_types(self):
 		leave_policy = frappe.get_doc(
 			{
 				"doctype": "Leave Policy",
@@ -375,6 +375,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 		}
 
 		leave_policy_assignment = frappe.new_doc("Leave Policy Assignment", **frappe._dict(data))
+		leave_policy_assignment.insert()
 		leave_policy_assignment.submit()
 
 		leave_allocation = frappe.get_doc(

--- a/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leave_schedule.py
@@ -358,6 +358,31 @@ class TestLeaveAllocation(HRMSTestSuite):
 			self.employee.date_of_joining,
 		)
 
+	def test_absense_of_earned_leave_schedule_for_non_earned_leave_types(self):
+		leave_policy = frappe.get_doc(
+			{
+				"doctype": "Leave Policy",
+				"title": "Test Earned Leave Policy",
+				"leave_policy_details": [{"leave_type": self.leave_types[0].name, "annual_allocation": 12}],
+			}
+		).insert()
+
+		data = {
+			"employee": self.employee.name,
+			"leave_policy": leave_policy.name,
+			"effective_from": get_year_start(getdate()),
+			"effective_to": get_year_ending(getdate()),
+		}
+
+		leave_policy_assignment = frappe.new_doc("Leave Policy Assignment", **frappe._dict(data))
+		leave_policy_assignment.submit()
+
+		leave_allocation = frappe.get_doc(
+			"Leave Allocation", {"leave_policy_assignment": leave_policy_assignment.name}
+		)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 12)
+		self.assertFalse(leave_allocation.earned_leave_schedule)
+
 
 def test_allocation_dates(
 	self,

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -119,8 +119,12 @@ class LeavePolicyAssignment(Document):
 
 		new_leaves_allocated = self.get_new_leaves(annual_allocation, leave_details, date_of_joining)
 
-		earned_leave_schedule = self.get_earned_leave_schedule(
-			annual_allocation, leave_details, date_of_joining, new_leaves_allocated
+		earned_leave_schedule = (
+			self.get_earned_leave_schedule(
+				annual_allocation, leave_details, date_of_joining, new_leaves_allocated
+			)
+			if leave_details.is_earned_leave
+			else []
 		)
 
 		allocation = frappe.get_doc(


### PR DESCRIPTION
Check leave type before creating any schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Earned-leave schedule generation is now limited to earned leave types; non-earned leave allocations no longer receive generated schedules, improving allocation accuracy.

* **Tests**
  * Added test coverage verifying that earned-leave schedules are not created for non-earned leave types, ensuring correct behavior across leave configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->