### PR TITLE
fix: update status on discard

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -120,6 +120,9 @@ class EmployeeAdvance(Document):
 		else:
 			self.status = status
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def set_total_advance_paid(self):
 		aple = frappe.qb.DocType("Advance Payment Ledger Entry")
 

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -367,6 +367,16 @@ class TestEmployeeAdvance(IntegrationTestCase):
 		self.assertEqual(advance.base_paid_amount, expected_base_paid)
 		self.assertEqual(payment_entry.paid_amount, expected_base_paid)
 
+	def test_status_on_discard(self):
+		employee_name = make_employee("Test_status@employee.advance", "_Test Company")
+		advance = make_employee_advance(employee_name, do_not_submit=True)
+		advance.insert()
+		advance.reload()
+		self.assertEqual(advance.status, "Draft")
+		advance.discard()
+		advance.reload()
+		self.assertEqual(advance.status, "Cancelled")
+
 
 def make_journal_entry_for_advance(advance):
 	frappe.db.set_single_value("Accounts Settings", "make_payment_via_journal_entry", True)

--- a/hrms/hr/doctype/employee_grievance/employee_grievance.json
+++ b/hrms/hr/doctype/employee_grievance/employee_grievance.json
@@ -59,7 +59,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Open\nInvestigated\nResolved\nInvalid",
+   "options": "Open\nInvestigated\nResolved\nInvalid\nCancelled",
    "reqd": 1
   },
   {
@@ -203,7 +203,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-21 15:46:21.711485",
+ "modified": "2025-11-21 17:25:40.972515",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Grievance",
@@ -266,6 +266,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "subject,raised_by,grievance_against_party",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/hrms/hr/doctype/employee_grievance/employee_grievance.py
+++ b/hrms/hr/doctype/employee_grievance/employee_grievance.py
@@ -14,3 +14,6 @@ class EmployeeGrievance(Document):
 					bold(_("Invalid")), bold(_("Resolved"))
 				)
 			)
+
+	def on_discard(self):
+		self.db_set("status", "Cancelled")

--- a/hrms/hr/doctype/employee_referral/employee_referral.json
+++ b/hrms/hr/doctype/employee_referral/employee_referral.json
@@ -83,7 +83,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Pending\nIn Process\nAccepted\nRejected",
+   "options": "Pending\nIn Process\nAccepted\nRejected\nCancelled",
    "permlevel": 1,
    "read_only": 1,
    "reqd": 1
@@ -205,7 +205,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:40.914012",
+ "modified": "2025-11-21 17:26:11.373025",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Referral",
@@ -299,6 +299,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/employee_referral/employee_referral.json
+++ b/hrms/hr/doctype/employee_referral/employee_referral.json
@@ -150,8 +150,7 @@
    "in_standard_filter": 1,
    "label": "Email",
    "options": "Email",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "default": "1",
@@ -205,7 +204,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-21 17:26:11.373025",
+ "modified": "2025-12-06 14:32:15.005720",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Referral",

--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -14,10 +14,14 @@ class EmployeeReferral(Document):
 	def validate(self):
 		validate_active_employee(self.referrer)
 		self.set_full_name()
+		self.set_status()
 		self.set_referral_bonus_payment_status()
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))
+
+	def set_status(self):
+		self.status = "Pending"
 
 	def set_referral_bonus_payment_status(self):
 		if not self.is_applicable_for_referral_bonus:
@@ -25,6 +29,9 @@ class EmployeeReferral(Document):
 		else:
 			if not self.referral_payment_status:
 				self.referral_payment_status = "Unpaid"
+
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -13,9 +13,16 @@ from hrms.hr.utils import validate_active_employee
 class EmployeeReferral(Document):
 	def validate(self):
 		validate_active_employee(self.referrer)
+		self.validate_unique_referral()
 		self.set_full_name()
 		self.set_status()
 		self.set_referral_bonus_payment_status()
+
+	def validate_unique_referral(self):
+		if frappe.db.exists(
+			"Employee Referral", {"name": ("!=", self.name), "email": self.email, "docstatus": ("!=", 2)}
+		):
+			frappe.throw("Referral for this email already exists.")
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))

--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -19,10 +19,15 @@ class EmployeeReferral(Document):
 		self.set_referral_bonus_payment_status()
 
 	def validate_unique_referral(self):
-		if frappe.db.exists(
+		if referral := frappe.db.exists(
 			"Employee Referral", {"name": ("!=", self.name), "email": self.email, "docstatus": ("!=", 2)}
 		):
-			frappe.throw("Referral for this email already exists.")
+			frappe.throw(
+				_("Employee Referral {0} already exists for email: {1}").format(
+					get_link_to_form("Employee Referral", referral), frappe.bold(self.email)
+				),
+				frappe.DuplicateEntryError,
+			)
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -58,7 +58,7 @@ class TestEmployeeReferral(IntegrationTestCase):
 
 	def test_unique_referral(self):
 		referral_1 = create_employee_referral(email="test_ref@example.com")
-		self.assertRaises(frappe.ValidationError, create_employee_referral, email="test_ref@example.com")
+		self.assertRaises(frappe.DuplicateEntryError, create_employee_referral, email="test_ref@example.com")
 		referral_1.cancel()
 		referral_2 = create_employee_referral(email="test_ref@example.com")
 		self.assertTrue(referral_2)

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -56,12 +56,19 @@ class TestEmployeeReferral(IntegrationTestCase):
 		refarral.reload()
 		self.assertEqual(refarral.status, "Cancelled")
 
+	def test_unique_referral(self):
+		referral_1 = create_employee_referral(email="test_ref@example.com")
+		self.assertRaises(frappe.ValidationError, create_employee_referral, email="test_ref@example.com")
+		referral_1.cancel()
+		referral_2 = create_employee_referral(email="test_ref@example.com")
+		self.assertTrue(referral_2)
 
-def create_employee_referral(do_not_submit=False):
+
+def create_employee_referral(email=None, do_not_submit=False):
 	emp_ref = frappe.new_doc("Employee Referral")
 	emp_ref.first_name = "Mahesh"
 	emp_ref.last_name = "Singh"
-	emp_ref.email = "a@b.c"
+	emp_ref.email = email or "a@b.c"
 	emp_ref.date = today()
 	emp_ref.for_designation = create_designation().name
 	emp_ref.referrer = make_employee("testassetmovemp@example.com", company="_Test Company")

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -16,8 +16,8 @@ from hrms.hr.doctype.employee_referral.employee_referral import (
 
 class TestEmployeeReferral(IntegrationTestCase):
 	def setUp(self):
-		frappe.db.sql("DELETE FROM `tabJob Applicant`")
-		frappe.db.sql("DELETE FROM `tabEmployee Referral`")
+		for d in ["Job Applicant", "Employee Referral"]:
+			frappe.db.delete(d)
 
 	def test_workflow_and_status_sync(self):
 		emp_ref = create_employee_referral()
@@ -50,12 +50,14 @@ class TestEmployeeReferral(IntegrationTestCase):
 		add_sal = create_additional_salary(emp_ref)
 		self.assertTrue(add_sal.ref_docname, emp_ref.name)
 
-	def tearDown(self):
-		frappe.db.sql("DELETE FROM `tabJob Applicant`")
-		frappe.db.sql("DELETE FROM `tabEmployee Referral`")
+	def test_status_on_discard(self):
+		refarral = create_employee_referral(do_not_submit=True)
+		refarral.discard()
+		refarral.reload()
+		self.assertEqual(refarral.status, "Cancelled")
 
 
-def create_employee_referral():
+def create_employee_referral(do_not_submit=False):
 	emp_ref = frappe.new_doc("Employee Referral")
 	emp_ref.first_name = "Mahesh"
 	emp_ref.last_name = "Singh"
@@ -65,6 +67,8 @@ def create_employee_referral():
 	emp_ref.referrer = make_employee("testassetmovemp@example.com", company="_Test Company")
 	emp_ref.is_applicable_for_employee_referral_compensation = 1
 	emp_ref.save()
+	if do_not_submit:
+		return emp_ref
 	emp_ref.submit()
 
 	return emp_ref

--- a/hrms/hr/doctype/exit_interview/exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/exit_interview.py
@@ -50,6 +50,9 @@ class ExitInterview(Document):
 		self.update_interview_date_in_employee()
 		self.db_set("status", "Cancelled")
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def update_interview_date_in_employee(self):
 		if self.docstatus == 1:
 			frappe.db.set_value("Employee", self.employee, "held_on", self.date)

--- a/hrms/hr/doctype/exit_interview/test_exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/test_exit_interview.py
@@ -80,6 +80,14 @@ class TestExitInterview(IntegrationTestCase):
 		email_queue = frappe.db.get_all("Email Queue", ["name", "message"], limit=1)
 		self.assertTrue("Subject: Exit Questionnaire Notification" in email_queue[0].message)
 
+	def test_status_on_discard(self):
+		employee = make_employee("test_status@example.com")
+		frappe.db.set_value("Employee", employee, "relieving_date", getdate())
+		interview = create_exit_interview(employee)
+		interview.discard()
+		interview.reload()
+		self.assertEqual(interview.status, "Cancelled")
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.json
+++ b/hrms/hr/doctype/expense_claim/expense_claim.json
@@ -125,7 +125,7 @@
    "fieldtype": "Select",
    "label": "Approval Status",
    "no_copy": 1,
-   "options": "Draft\nApproved\nRejected",
+   "options": "Draft\nApproved\nRejected\nCancelled",
    "permlevel": 1,
    "search_index": 1
   },
@@ -507,7 +507,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-14 18:51:43.818521",
+ "modified": "2025-11-24 11:45:16.354788",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim",

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -128,6 +128,10 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 	def after_delete(self):
 		self.publish_update()
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+		self.db_set("approval_status", "Cancelled")
+
 	def before_submit(self):
 		if not self.payable_account and not self.is_paid:
 			frappe.throw(_("Payable Account is mandatory to submit an Expense Claim"))

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -925,6 +925,18 @@ class TestExpenseClaim(HRMSTestSuite):
 		expense_claim.reload()
 		self.assertEqual(expense_claim.status, "Unpaid")
 
+	def test_status_on_discard(self):
+		payable_account = get_payable_account(company_name)
+		expense_claim = make_expense_claim(
+			payable_account, 300, 200, company_name, "Travel Expenses - _TC3", do_not_submit=True
+		)
+		expense_claim.insert()
+		expense_claim.reload()
+		self.assertEqual(expense_claim.status, "Draft")
+		expense_claim.discard()
+		expense_claim.reload()
+		self.assertEqual(expense_claim.status, "Cancelled")
+
 
 def get_payable_account(company):
 	return frappe.get_cached_value("Company", company, "default_payable_account")

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
@@ -64,7 +64,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Paid\nUnpaid",
+   "options": "Paid\nUnpaid\nCancelled",
    "read_only": 1
   },
   {
@@ -196,7 +196,7 @@
    "table_fieldname": "accounts"
   }
  ],
- "modified": "2024-04-19 15:45:04.206575",
+ "modified": "2025-12-10 18:00:46.722706",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Full and Final Statement",
@@ -242,6 +242,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py
@@ -14,6 +14,7 @@ from hrms.hr.doctype.full_and_final_statement.full_and_final_statement_loan_util
 
 class FullandFinalStatement(Document):
 	def before_insert(self):
+		self.status = "Unpaid"
 		self.get_outstanding_statements()
 
 	def validate(self):
@@ -33,6 +34,9 @@ class FullandFinalStatement(Document):
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry",)
 		cancel_loan_repayment(self)
+
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
 
 	def validate_relieving_date(self):
 		if not self.relieving_date:

--- a/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
@@ -71,6 +71,11 @@ class TestFullandFinalStatement(IntegrationTestCase):
 		self.assertEqual(debit_entry.reference_type, "Full and Final Statement")
 		self.assertEqual(debit_entry.reference_name, self.fnf.name)
 
+	def test_status_on_discard(self):
+		self.fnf.discard()
+		self.fnf.reload()
+		self.assertEqual(self.fnf.status, "Cancelled")
+
 
 def create_full_and_final_statement(employee):
 	fnf = frappe.new_doc("Full and Final Statement")

--- a/hrms/hr/doctype/interview/interview.json
+++ b/hrms/hr/doctype/interview/interview.json
@@ -64,7 +64,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nUnder Review\nCleared\nRejected",
+   "options": "Pending\nUnder Review\nCleared\nRejected\nCancelled",
    "reqd": 1
   },
   {
@@ -199,7 +199,7 @@
    "link_fieldname": "interview"
   }
  ],
- "modified": "2024-03-27 13:09:51.655366",
+ "modified": "2025-11-21 17:24:02.676395",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Interview",
@@ -263,6 +263,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -121,6 +121,9 @@ class Interview(Document):
 
 		frappe.msgprint(_("Interview Rescheduled successfully"), indicator="green")
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 @frappe.whitelist()
 def get_interviewers(interview_round: str) -> list[str]:

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -196,6 +196,15 @@ class TestInterview(IntegrationTestCase):
 
 		self.assertEqual(job_applicant.status, "Accepted")
 
+	def test_status_on_discard(self):
+		job_applicant = create_job_applicant()
+		interview = create_interview_and_dependencies(job_applicant.name, status="Pending")
+
+		interview.discard()
+		interview.reload()
+
+		self.assertEqual(interview.status, "Cancelled")
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/hrms/hr/doctype/job_offer/job_offer.json
+++ b/hrms/hr/doctype/job_offer/job_offer.json
@@ -67,7 +67,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Awaiting Response\nAccepted\nRejected",
+   "options": "Awaiting Response\nAccepted\nRejected\nCancelled",
    "print_hide": 1
   },
   {
@@ -170,10 +170,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-28 16:29:10.149418",
+ "modified": "2025-12-11 11:44:33.901454",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Offer",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -193,6 +194,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/hrms/hr/doctype/job_offer/job_offer.py
+++ b/hrms/hr/doctype/job_offer/job_offer.py
@@ -54,6 +54,9 @@ class JobOffer(Document):
 			fields=["name"],
 		)
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 def update_job_applicant(status, job_applicant):
 	if status in ("Accepted", "Rejected"):

--- a/hrms/hr/doctype/job_offer/test_job_offer.py
+++ b/hrms/hr/doctype/job_offer/test_job_offer.py
@@ -69,6 +69,13 @@ class TestJobOffer(IntegrationTestCase):
 
 		self.assertEqual(get_offer_acceptance_rate().get("value"), 50)
 
+	def test_status_on_save(self):
+		job_offer = create_job_offer()
+		job_offer.save()
+		job_offer.discard()
+		job_offer.reload()
+		self.assertEqual(job_offer.status, "Cancelled")
+
 
 def create_job_offer(**args):
 	args = frappe._dict(args)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -116,6 +116,9 @@ class LeaveApplication(Document, PWANotificationsMixin):
 	def before_cancel(self):
 		self.status = "Cancelled"
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def on_cancel(self):
 		self.create_leave_ledger_entry(submit=False)
 		# notify leave applier about cancellation

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1427,6 +1427,14 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		self.assertEqual(leave_balance, 0)
 
+	def test_status_on_discard(self):
+		make_allocation_record()
+		application = self.get_application(self.leave_applications[0])
+		application.save()
+		application.discard()
+		application.reload()
+		self.assertEqual(application.status, "Cancelled")
+
 
 def create_carry_forwarded_allocation(employee, leave_type, date=None):
 	date = date or nowdate()

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -313,6 +313,9 @@ class LeaveEncashment(AccountsController):
 
 		return gl_entry
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 def create_leave_encashment(leave_allocation):
 	"""Creates leave encashment for the given allocations"""

--- a/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
@@ -419,6 +419,13 @@ class TestLeaveEncashment(IntegrationTestCase):
 		args.update(kwargs)
 		return create_leave_encashment(**args)
 
+	def test_status_on_discard(self):
+		encashment = self.create_test_leave_encashment()
+		encashment.save()
+		encashment.discard()
+		encashment.reload()
+		self.assertEqual(encashment.status, "Cancelled")
+
 
 def create_leave_encashment(**args):
 	if args:

--- a/hrms/hr/doctype/shift_request/shift_request.py
+++ b/hrms/hr/doctype/shift_request/shift_request.py
@@ -72,6 +72,9 @@ class ShiftRequest(Document, PWANotificationsMixin):
 				shift_assignment_doc = frappe.get_doc("Shift Assignment", shift["name"])
 				shift_assignment_doc.cancel()
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def validate_default_shift(self):
 		default_shift = frappe.get_value("Employee", self.employee, "default_shift")
 		if self.shift_type == default_shift:

--- a/hrms/hr/doctype/shift_request/test_shift_request.py
+++ b/hrms/hr/doctype/shift_request/test_shift_request.py
@@ -249,7 +249,7 @@ class TestShiftRequest(HRMSTestSuite):
 		shift_request = make_shift_request(user, do_not_submit=True)
 		shift_request.discard()
 		shift_request.reload()
-		self.assertTrue(shift_request.status, "Cancelled")
+		self.assertEqual(shift_request.status, "Cancelled")
 
 
 def set_shift_approver(department):

--- a/hrms/hr/doctype/shift_request/test_shift_request.py
+++ b/hrms/hr/doctype/shift_request/test_shift_request.py
@@ -235,6 +235,22 @@ class TestShiftRequest(HRMSTestSuite):
 			}
 		).submit()
 
+	def test_status_on_discard(self):
+		setup_shift_type(shift_type="Day Shift")
+		employee = frappe.get_doc("Employee", "_T-Employee-00001")
+		user = "test_approver_emp@example.com"
+		make_employee(user, "_Test Company")
+
+		# set approver for employee
+		employee.reload()
+		employee.shift_request_approver = user
+		employee.save()
+
+		shift_request = make_shift_request(user, do_not_submit=True)
+		shift_request.discard()
+		shift_request.reload()
+		self.assertTrue(shift_request.status, "Cancelled")
+
 
 def set_shift_approver(department):
 	department_doc = frappe.get_doc("Department", department)

--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -312,6 +312,9 @@ class Gratuity(AccountsController):
 	def _is_experience_beyond_slab(self, slab: dict, experience: float) -> bool:
 		return bool(slab.from_year < experience and (slab.to_year < experience and slab.to_year != 0))
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 def get_last_salary_slip(employee: str) -> dict | None:
 	salary_slip = frappe.db.get_value(

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -133,6 +133,9 @@ class PayrollEntry(Document):
 		self.set_status(update=True, status="Cancelled")
 		self.db_set("error_message", "")
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 	def cancel(self):
 		if len(self.get_linked_salary_slips()) > 50:
 			msg = _("Payroll Entry cancellation is queued. It may take a few minutes")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -1043,6 +1043,22 @@ class TestPayrollEntry(FrappeTestCase):
 			24000,
 		)
 
+	def test_status_on_discard(self):
+		company = frappe.get_doc("Company", "_Test Company")
+		employee = frappe.db.get_value("Employee", {"company": "_Test Company"})
+		setup_salary_structure(employee, company)
+
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = get_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company.default_payroll_payable_account,
+			currency=company.default_currency,
+			company=company.name,
+		)
+		payroll_entry.discard()
+		self.assertEqual(payroll_entry.status, "Cancelled")
+
 
 def get_payroll_entry(**args):
 	args = frappe._dict(args)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -1057,6 +1057,7 @@ class TestPayrollEntry(FrappeTestCase):
 			company=company.name,
 		)
 		payroll_entry.discard()
+		payroll_entry.reload()
 		self.assertEqual(payroll_entry.status, "Cancelled")
 
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2377,6 +2377,9 @@ class SalarySlip(TransactionBase):
 					},
 				)
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 def get_benefits_details_parent(employee, payroll_period, salary_structure_assignment):
 	"""Returns the parent and doctype of benefit details based on the following logic:

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1821,6 +1821,13 @@ class TestSalarySlip(IntegrationTestCase):
 
 		self.assertEqual(salary_slip.total_income_tax, total_income_tax)
 
+	def test_status_on_discard(self):
+		salary_slip = make_salary_slip_with_non_taxable_component()
+		salary_slip.save()
+		salary_slip.discard()
+		salary_slip.reload()
+		self.assertEqual(salary_slip.status, "Cancelled")
+
 
 class TestSalarySlipSafeEval(IntegrationTestCase):
 	def test_safe_eval_for_salary_slip(self):

--- a/hrms/payroll/doctype/salary_withholding/salary_withholding.py
+++ b/hrms/payroll/doctype/salary_withholding/salary_withholding.py
@@ -97,6 +97,9 @@ class SalaryWithholding(Document):
 		}
 		return frequency_dict.get(self.payroll_frequency)
 
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
+
 
 @frappe.whitelist()
 def get_payroll_frequency(employee: str, posting_date: str | date) -> str | None:

--- a/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py
+++ b/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py
@@ -138,6 +138,12 @@ class TestSalaryWithholding(IntegrationTestCase):
 		payroll_entry.reload()
 		return next(employee for employee in payroll_entry.employees if employee.employee == self.employee1)
 
+	def test_status_on_discard(self):
+		salary_withholding = create_salary_withholding(self.employee1, getdate())
+		salary_withholding.discard()
+		salary_withholding.reload()
+		self.assertEqual(salary_withholding.status, "Cancelled")
+
 
 def create_salary_withholding(employee: str, from_date: str, number_of_withholding_cycles: int = 0):
 	doc = frappe.new_doc("Salary Withholding")


### PR DESCRIPTION
Closes #1702

Transaction doctypes with status
- [x] Employee Advance
- [x] Employee Grievance
- [x] Expense Claim
- [x] Employee Referral
- [x] Exit interview
- [x] Interview
- [x] Salary withholding
- [x] Gratuity
- [x] Full and final statement
- [x] Payroll Entry
- [x] Job Offer
- [x] Shift Request
- [x] Leave Application
- [x] Leave Encashment
- [x] Salary Slip

Skipping Doctypes (status values for these don't fit in the same category as those above)
- Shift Assignment
- Attendance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Cancelled" status option across many HR documents and ensured discarded documents persist as "Cancelled".
  * UI metadata updated to enable dynamic row formatting for several HR screens.

* **Bug Fixes**
  * Prevent duplicate employee referrals by email via validation.

* **Tests**
  * Added coverage verifying discard → "Cancelled" behavior and referral uniqueness checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->