### PR TITLE
fix(leave_application): correct argument type for leave_type in get_approved_leaves_for_period

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -139,7 +139,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			if leave_type.applicable_after > 0:
 				date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
 				leave_days = get_approved_leaves_for_period(
-					self.employee, False, date_of_joining, self.from_date
+					self.employee, self.leave_type, date_of_joining, self.from_date
 				)
 				number_of_days = date_diff(getdate(self.from_date), date_of_joining)
 				if number_of_days >= 0:


### PR DESCRIPTION
Replaced hardcoded `False` with `self.leave_type` when calling  get_approved_leaves_for_period to ensure the function receives a  string instead of a boolean. This resolves FrappeTypeError raised  during validation.

--------------------------------------------------------------
16:33:13 web.1         |   File "apps/hrms/hrms/hr/doctype/leave_application/leave_application.py", line 89, in validate
16:33:13 web.1         |     self.validate_applicable_after()
16:33:13 web.1         |   File "apps/hrms/hrms/hr/doctype/leave_application/leave_application.py", line 147, in validate_applicable_after
16:33:13 web.1         |     leave_days = get_approved_leaves_for_period(
16:33:13 web.1         |   File "apps/hrms/hrms/hr/doctype/leave_application/leave_application.py", line 1451, in get_approved_leaves_for_period
16:33:13 web.1         |     leave_days += get_number_of_leave_days(
16:33:13 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 30, in wrapper
16:33:13 web.1         |     args, kwargs = transform_parameter_types(func, args, kwargs)
16:33:13 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 149, in transform_parameter_types
16:33:13 web.1         |     raise_type_error(current_arg, current_arg_type, current_arg_value, current_exception=e)
16:33:13 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 64, in raise_type_error
16:33:13 web.1         |     raise FrappeTypeError(
16:33:13 web.1         | frappe.exceptions.FrappeTypeError: Argument 'leave_type' should be of type 'str' but got 'bool' instead.

<!--


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leave application validation to accurately calculate eligibility by considering the specific leave type when reviewing approved leave history. The system now correctly filters leave records by type when determining whether new applications meet required working day thresholds for approval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->