### PR TITLE
fix: consider overtime for default shift

### DIFF
--- a/hrms/hr/doctype/overtime_type/test_overtime_type.py
+++ b/hrms/hr/doctype/overtime_type/test_overtime_type.py
@@ -21,7 +21,7 @@ def create_overtime_type(**args):
 	args = frappe._dict(args)
 
 	overtime_type = frappe.new_doc("Overtime Type")
-	overtime_type.name = "_Test Overtime"
+	overtime_type.name = args.get("name") or "_Test Overtime"
 	overtime_type.overtime_calculation_method = args.overtime_calculation_method or "Salary Component Based"
 	overtime_type.standard_multiplier = 1
 	overtime_type.applicable_for_weekend = args.applicable_for_weekend or 0

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -601,6 +601,8 @@ def get_shift_details(shift_type_name: str, for_timestamp: datetime | None = Non
 
 	actual_start = start_datetime - timedelta(minutes=shift_type.begin_check_in_before_shift_start_time)
 	actual_end = end_datetime + timedelta(minutes=shift_type.allow_check_out_after_shift_end_time)
+	allow_overtime = shift_type.allow_overtime
+	overtime_type = shift_type.overtime_type
 
 	return frappe._dict(
 		{
@@ -609,6 +611,8 @@ def get_shift_details(shift_type_name: str, for_timestamp: datetime | None = Non
 			"end_datetime": end_datetime,
 			"actual_start": actual_start,
 			"actual_end": actual_end,
+			"allow_overtime": allow_overtime,
+			"overtime_type": overtime_type,
 		}
 	)
 
@@ -623,6 +627,8 @@ def get_shift_type(shift_type_name: str) -> dict:
 			"end_time",
 			"begin_check_in_before_shift_start_time",
 			"allow_check_out_after_shift_end_time",
+			"allow_overtime",
+			"overtime_type",
 		],
 		as_dict=1,
 	)

--- a/hrms/hr/doctype/shift_assignment_tool/test_shift_assignment_tool.py
+++ b/hrms/hr/doctype/shift_assignment_tool/test_shift_assignment_tool.py
@@ -112,6 +112,7 @@ class TestShiftAssignmentTool(IntegrationTestCase):
 
 	def test_get_shift_requests(self):
 		today = getdate()
+		setup_shift_type(shift_type="Day Shift")
 
 		for emp in [self.emp1, self.emp2, self.emp3, self.emp4, self.emp5]:
 			employee = frappe.get_doc("Employee", emp)
@@ -251,6 +252,7 @@ class TestShiftAssignmentTool(IntegrationTestCase):
 			employee.shift_request_approver = "employee1@test.com"
 			employee.save()
 
+		setup_shift_type(shift_type="Day Shift")
 		request1 = make_shift_request(
 			employee=self.emp1,
 			employee_name="employee1@test.com",


### PR DESCRIPTION
**Issue:** Overtime is not considered for the Shift Type, which is set in the default shift in the employee master

**Ref:** [53576](https://support.frappe.io/helpdesk/tickets/53576?view=VIEW-HD+Ticket-781)


**Before:**

[Screencast from 2025-11-24 13-20-15.webm](https://github.com/user-attachments/assets/901727a6-3913-4aab-a919-15e62a306a47)


**After:**

[Screencast from 2025-11-24 13-18-29.webm](https://github.com/user-attachments/assets/6d59e24d-64b1-40ee-a623-f88e916101ac)


Backport needed for v16-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift records now include overtime settings (allow overtime and overtime type). Per-assignment overtime preferences are applied when resolving shifts, affecting overtime calculation and reporting.

* **Tests**
  * Added an automated test verifying overtime is calculated and recorded on attendance when a default shift is exceeded (checks overtime type, working hours, and overtime duration).
  * Test setup helpers updated to allow custom overtime-type names and ensure a Day Shift exists before relevant tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->