### PR TITLE
fix: serialize latitude longitude update and geolocation refresh

### DIFF
--- a/hrms/public/js/utils/index.js
+++ b/hrms/public/js/utils/index.js
@@ -194,12 +194,14 @@ $.extend(hrms, {
 
 		navigator.geolocation.getCurrentPosition(
 			async (position) => {
-				frm.set_value("latitude", position.coords.latitude);
-				frm.set_value("longitude", position.coords.longitude);
-
-				await frm.call("set_geolocation");
-				frappe.dom.unfreeze();
+				frappe.run_serially([
+					() => frm.set_value("latitude", position.coords.latitude),
+					() => frm.set_value("longitude", position.coords.longitude),
+					() => frm.call("set_geolocation"),
+					() => frappe.dom.unfreeze(),
+				]);
 			},
+
 			(error) => {
 				frappe.dom.unfreeze();
 


### PR DESCRIPTION
**Issue:** The Shift Location was not being saved after fetching geolocation when the latitude and longitude values are 0

**Ref:** [53816](https://support.frappe.io/helpdesk/tickets/53816?view=VIEW-HD+Ticket-781)

**Before:**

[Screencast from 2025-11-25 01-36-10.webm](https://github.com/user-attachments/assets/ba07f384-55bb-487c-a2c9-b6cca23f28bb)


**After:**

[Screencast from 2025-11-25 01-37-24.webm](https://github.com/user-attachments/assets/9bcfbe63-442e-43c1-904f-a92fda6eef86)


Backport needed for v15, v16-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of geolocation handling to streamline sequential steps. No visible user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->