### PR TITLE
Addressing Issue 3777 in HRMS -> Employee Advance and Expense Claim

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -143,8 +143,10 @@ frappe.ui.form.on("Employee Advance", {
 					paid_amount: frm.doc.paid_amount,
 					base_paid_amount: frm.doc.base_paid_amount,
 					claimed_amount: frm.doc.claimed_amount,
+					unclaimed_amount: frm.doc.unclaimed_amount,
 					return_amount: frm.doc.return_amount,
 					payment_via_journal_entry: frm.doc.__onload.make_payment_via_journal_entry,
+					advance_account: frm.doc.advance_account,
 				},
 			},
 			callback: function (r) {

--- a/hrms/hr/doctype/employee_advance/employee_advance.json
+++ b/hrms/hr/doctype/employee_advance/employee_advance.json
@@ -25,6 +25,7 @@
   "base_paid_amount",
   "pending_amount",
   "claimed_amount",
+  "unclaimed_amount",
   "return_amount",
   "section_break_7",
   "column_break_18",
@@ -122,7 +123,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nPaid\nUnpaid\nClaimed\nReturned\nPartly Claimed and Returned\nCancelled",
+   "options": "Draft\nPaid\nUnpaid\nClaimed\nReturned\nPartly Claimed\nPartly Claimed and Returned\nCancelled",
    "read_only": 1
   },
   {
@@ -239,12 +240,20 @@
    "no_copy": 1,
    "options": "currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "unclaimed_amount",
+   "fieldtype": "Currency",
+   "label": "Unclaimed Amount",
+   "no_copy": 1,
+   "options": "currency",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-10 23:18:24.203679",
+ "modified": "2025-11-23 19:16:05.775526",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Advance",
@@ -306,6 +315,10 @@
   {
    "color": "Yellow",
    "title": "Partly Claimed and Returned"
+  },
+  {
+   "color": "Yellow",
+   "title": "Partly Claimed"
   },
   {
    "color": "Red",

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -103,6 +103,12 @@ class EmployeeAdvance(Document):
 				and total_amount == flt(self.paid_amount, precision)
 			):
 				status = "Partly Claimed and Returned"
+			elif (
+				flt(self.claimed_amount) > 0
+				and flt(self.return_amount) == 0
+				and flt(self.claimed_amount, precision) < flt(self.paid_amount, precision)
+			):
+				status = "Partly Claimed"
 			elif flt(self.paid_amount) > 0 and (
 				flt(self.advance_amount, precision) == flt(self.paid_amount, precision)
 				or (self.paid_amount and self.repay_unclaimed_amount_from_salary)
@@ -187,6 +193,7 @@ class EmployeeAdvance(Document):
 
 		base_paid_amount = aple_paid_amount.get("base_paid_amount") or 0
 		self.db_set("base_paid_amount", base_paid_amount)
+		self.db_set("unclaimed_amount", paid_amount - return_amount)
 
 	def update_claimed_amount(self):
 		ec = frappe.qb.DocType("Expense Claim")
@@ -204,7 +211,16 @@ class EmployeeAdvance(Document):
 				& (ec.docstatus == 1)
 			)
 		).run()[0][0] or 0
+		paid_amount, return_amount = frappe.db.get_value(
+			"Employee Advance", self.name, ["paid_amount", "return_amount"]
+		)
 		frappe.db.set_value("Employee Advance", self.name, "claimed_amount", flt(claimed_amount))
+		frappe.db.set_value(
+			"Employee Advance",
+			self.name,
+			"unclaimed_amount",
+			flt(paid_amount) - flt(claimed_amount) - flt(return_amount),
+		)
 		self.reload()
 		self.set_status(update=True)
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
+frappe.provide("erpnext.accounts");
 frappe.provide("hrms.hr");
 frappe.provide("erpnext.accounts.dimensions");
 
@@ -411,6 +412,7 @@ frappe.ui.form.on("Expense Claim", {
 
 	employee: function (frm) {
 		frm.events.get_advances(frm);
+		frm.trigger("set_expense_approver");
 	},
 
 	cost_center: function (frm) {
@@ -418,6 +420,13 @@ frappe.ui.form.on("Expense Claim", {
 	},
 
 	mode_of_payment: async function (frm) {
+		erpnext.accounts.pos.get_payment_mode_account(
+			frm,
+			frm.doc.mode_of_payment,
+			function (account) {
+				frm.set_value("bank_or_cash_account", account);
+			},
+		);
 		if (frm.doc.mode_of_payment) {
 			var mode_of_payment_type = (
 				await frappe.db.get_value("Mode of Payment", frm.doc.mode_of_payment, "type")
@@ -510,6 +519,21 @@ frappe.ui.form.on("Expense Claim", {
 			frm.save();
 		});
 		$(".form-message").prop("hidden", true);
+	},
+	set_expense_approver: function (frm) {
+		if (frm.doc.employee) {
+			return frappe.call({
+				method: "hrms.hr.doctype.expense_claim.expense_claim.get_expense_approver",
+				args: {
+					employee: frm.doc.employee,
+				},
+				callback: function (r) {
+					if (r && r.message) {
+						frm.set_value("expense_approver", r.message);
+					}
+				},
+			});
+		}
 	},
 });
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -147,8 +147,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		update_reimbursed_amount(self)
 		self.update_claimed_amount_in_employee_advance()
 		self.create_exchange_gain_loss_je()
-		if not frappe.db.get_single_value("Accounts Settings", "make_payment_via_journal_entry"):
-			self.update_against_claim_in_pe()
 
 	def on_update_after_submit(self):
 		if self.check_if_fields_updated([], {"taxes": ("account_head",), "expenses": ()}):
@@ -257,8 +255,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					"against": ",".join([d.default_account for d in self.expenses]),
 					"party_type": "Employee",
 					"party": self.employee,
-					"against_voucher_type": self.doctype,
-					"against_voucher": self.name,
+					"against_voucher_type": "Payment Entry",
+					"against_voucher": data.payment_entry,
 					"advance_voucher_type": "Employee Advance",
 					"advance_voucher_no": data.employee_advance,
 					"transaction_exchange_rate": self.exchange_rate,
@@ -460,7 +458,14 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			adv_doc = frappe.db.get_value(
 				"Employee Advance",
 				d.employee_advance,
-				["posting_date", "advance_account", "paid_amount"],
+				[
+					"posting_date",
+					"advance_account",
+					"paid_amount",
+					"claimed_amount",
+					"unclaimed_amount",
+					"advance_account",
+				],
 				as_dict=1,
 			)
 			aple_doc = frappe.db.get_value(
@@ -468,10 +473,11 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				{"voucher_no": d.payment_entry, "event": "Submit", "delinked": 0},
 				"amount",
 			)
-			d.posting_date = adv_doc.posting_date
 			d.advance_account = adv_doc.advance_account
+			d.posting_date = adv_doc.posting_date
 			d.advance_paid = aple_doc if aple_doc else adv_doc.paid_amount
-			# d.unclaimed_amount = flt(ref_doc.paid_amount) - flt(ref_doc.claimed_amount)
+			d.advance_paid = abs(d.advance_paid)
+			d.unclaimed_amount = adv_doc.unclaimed_amount
 
 			if d.allocated_amount and flt(d.allocated_amount) > flt(
 				flt(d.unclaimed_amount) - flt(d.return_amount), precision
@@ -510,35 +516,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				expense.default_account = get_expense_claim_account(expense.expense_type, self.company)[
 					"account"
 				]
-
-	def update_against_claim_in_pe(self):
-		reference_against_pe = []
-		for advance in self.advances:
-			if flt(advance.allocated_amount) > 0:
-				args = frappe._dict(
-					{
-						"voucher_type": "Payment Entry",
-						"voucher_no": advance.payment_entry,
-						"against_voucher_type": self.doctype,
-						"against_voucher": self.name,
-						"voucher_detail_no": advance.payment_entry_reference,
-						"account": advance.advance_account,
-						"party_type": "Employee",
-						"party": self.employee,
-						"is_advance": "Yes",
-						"dr_or_cr": "credit_in_account_currency",
-						"unadjusted_amount": flt(advance.advance_paid),
-						"allocated_amount": flt(advance.allocated_amount),
-						"precision": advance.precision("advance_paid"),
-						"exchange_rate": advance.exchange_rate,
-						"difference_posting_date": advance.posting_date,
-					}
-				)
-				reference_against_pe.append(args)
-		if reference_against_pe:
-			for pe_ref in reference_against_pe:
-				payment_entry = frappe.get_doc("Payment Entry", pe_ref.voucher_no)
-				update_reference_in_payment_entry(pe_ref, payment_entry, skip_ref_details_update_for_pe=True)
 
 
 def update_reimbursed_amount(doc):
@@ -684,6 +661,7 @@ def get_advances(expense_claim, advance_id=None):
 		advance.posting_date,
 		advance.paid_amount,
 		advance.claimed_amount,
+		advance.unclaimed_amount,
 		advance.return_amount,
 		advance.advance_account,
 	)
@@ -730,8 +708,8 @@ def get_expense_claim(advance_details):
 		default_payable_account if advance_details.currency == erpnext.get_company_currency(company) else None
 	)
 	expense_claim.cost_center = default_cost_center
-	expense_claim.is_paid = 1 if flt(advance_details.paid_amount) else 0
-
+	expense_claim.is_paid = 0
+	expense_claim.payable_account = advance_details.advance_account
 	get_expense_claim_advances(expense_claim, advance_details)
 	return expense_claim
 
@@ -755,7 +733,7 @@ def get_expense_claim_advances(expense_claim, advance_details):
 		allocated_amount = get_allocation_amount(
 			paid_amount=paid_amount, claimed_amount=claimed_amount, return_amount=return_amount
 		)
-		unclaimed_amount = paid_amount - claimed_amount
+		unclaimed_amount = paid_amount - claimed_amount - return_amount
 		expense_claim.append(
 			"advances",
 			{
@@ -796,12 +774,10 @@ def get_expense_claim_advances(expense_claim, advance_details):
 
 		for pe in payment_entries:
 			advance_paid = flt(pe.advance_paid) + flt(pe.unallocated_amount)
-			unclaimed_amount = flt(pe.advance_paid)
-			if flt(pe.pe_ref_allocated_amount):
-				unclaimed_amount = flt(pe.pe_ref_allocated_amount) + flt(pe.unallocated_amount)
+			unclaimed_amount = flt(advance_details.unclaimed_amount)
 			allocated_amount = get_allocation_amount(
 				paid_amount=flt(pe.advance_paid),
-				claimed_amount=(flt(pe.advance_paid) - unclaimed_amount),
+				claimed_amount=(flt(pe.advance_paid) - unclaimed_amount - return_amount),
 				return_amount=(return_amount),
 			)
 
@@ -890,3 +866,19 @@ def get_allocation_amount(paid_amount=None, claimed_amount=None, return_amount=N
 		return flt(paid_amount) - (flt(claimed_amount) + flt(return_amount))
 	else:
 		frappe.throw(_("Invalid parameters provided. Please pass the required arguments."))
+
+
+@frappe.whitelist()
+def get_expense_approver(employee):
+	expense_approver, department = frappe.db.get_value(
+		"Employee", employee, ["expense_approver", "department"]
+	)
+
+	if not expense_approver and department:
+		expense_approver = frappe.db.get_value(
+			"Department Approver",
+			{"parent": department, "parentfield": "expense_approvers", "idx": 1},
+			"approver",
+		)
+
+	return expense_approver

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -246,9 +246,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				)
 			)
 
-		make_payment_via_je = frappe.db.get_single_value(
-			"Accounts Settings", "make_payment_via_journal_entry"
-		)
 		# gl entry against advance
 		for data in self.advances:
 			if data.allocated_amount:
@@ -266,13 +263,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					"advance_voucher_no": data.employee_advance,
 					"transaction_exchange_rate": self.exchange_rate,
 				}
-				if not make_payment_via_je:
-					gl_dict.update(
-						{
-							"voucher_type": "Payment Entry",
-							"voucher_no": data.payment_entry,
-						}
-					)
 				gl_entry.append(self.get_gl_dict(gl_dict, account_currency=self.currency))
 
 		self.add_tax_gl_entries(gl_entry)


### PR DESCRIPTION
What this PR Provides:

1. Expense Claim Ledger is now balanced - Voucher Type is Expense Claim rather than Payment Entry
2. After submission in Expense Claim, the credit account GL Entry record is now correctly linked to Expense Claim rather than Payment Entry
3. The **Returned Amount** is now correctly assigned, it used to assign the value of the claimed amount
4. Creating an Expense Claim without an Employee Advance no longer gets linked to the **most recent** payment entry
5. The field **Is Paid** in the Expense Claim is now defaulted to 0 when creating the expense claim from an Employee Advance
6. **The Bank/Cash Account** is now automatically fetched after selecting the mode of payment
7. After selecting an employee in the Expense Claim, the corresponding **Expense Approver** is now automatically fetched
8. Added **Unclaimed Amount** field in Employee Advance
9. Added **Partially Claimed** Status to Employee Advance

This is in response to issue no. https://github.com/frappe/hrms/issues/3777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Unclaimed Amount" field to Employee Advance to track remaining funds.
  * Added "Partly Claimed" status option to Employee Advance workflow.
  * Automatic expense approver retrieval when employee is selected.

* **Improvements**
  * Enhanced unclaimed amount calculations when processing advance claims.
  * Improved Payment Entry references in GL entries.
  * Better payment mode account resolution for expense claims.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->