### PR TITLE
feat(attendance): show mark attendance based on permission

### DIFF
--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -13,129 +13,130 @@ frappe.listview_settings["Attendance"] = {
 
 	onload: function (list_view) {
 		let me = this;
+		if (frappe.perm.has_perm("Attendance", 0, "create")) {
+			list_view.page.add_inner_button(__("Mark Attendance"), function () {
+				let first_day_of_month = moment().startOf("month");
 
-		list_view.page.add_inner_button(__("Mark Attendance"), function () {
-			let first_day_of_month = moment().startOf("month");
+				if (moment().toDate().getDate() === 1) {
+					first_day_of_month = first_day_of_month.subtract(1, "month");
+				}
 
-			if (moment().toDate().getDate() === 1) {
-				first_day_of_month = first_day_of_month.subtract(1, "month");
-			}
-
-			let dialog = new frappe.ui.Dialog({
-				title: __("Mark Attendance"),
-				fields: [
-					{
-						fieldname: "employee",
-						label: __("For Employee"),
-						fieldtype: "Link",
-						options: "Employee",
-						get_query: () => {
-							return {
-								query: "erpnext.controllers.queries.employee_query",
-							};
-						},
-						reqd: 1,
-						onchange: () => me.reset_dialog(dialog),
-					},
-					{
-						fieldtype: "Section Break",
-						fieldname: "time_period_section",
-						hidden: 1,
-					},
-					{
-						label: __("Start"),
-						fieldtype: "Date",
-						fieldname: "from_date",
-						reqd: 1,
-						default: first_day_of_month.toDate(),
-						onchange: () => me.get_unmarked_days(dialog),
-					},
-					{
-						label: __("Status"),
-						fieldtype: "Select",
-						fieldname: "status",
-						options: ["Present", "Absent", "Half Day", "Work From Home"],
-						reqd: 1,
-					},
-					{
-						fieldtype: "Column Break",
-						fieldname: "time_period_column",
-					},
-					{
-						label: __("End"),
-						fieldtype: "Date",
-						fieldname: "to_date",
-						reqd: 1,
-						default: moment().toDate(),
-						onchange: () => me.get_unmarked_days(dialog),
-					},
-					{
-						label: __("Shift"),
-						fieldtype: "Link",
-						fieldname: "shift",
-						options: "Shift Type",
-					},
-
-					{
-						fieldtype: "Section Break",
-						fieldname: "days_section",
-						hidden: 1,
-					},
-					{
-						label: __("Exclude Holidays"),
-						fieldtype: "Check",
-						fieldname: "exclude_holidays",
-						onchange: () => me.get_unmarked_days(dialog),
-					},
-					{
-						label: __("Unmarked Attendance for days"),
-						fieldname: "unmarked_days",
-						fieldtype: "MultiCheck",
-						options: [],
-						columns: 2,
-						select_all: true,
-					},
-				],
-				primary_action(data) {
-					if (cur_dialog.no_unmarked_days_left) {
-						frappe.msgprint(
-							__(
-								"Attendance from {0} to {1} has already been marked for the Employee {2}",
-								[data.from_date, data.to_date, data.employee],
-							),
-						);
-					} else {
-						frappe.confirm(
-							__("Mark attendance as {0} for {1} on selected dates?", [
-								data.status,
-								data.employee,
-							]),
-							() => {
-								frappe.call({
-									method: "hrms.hr.doctype.attendance.attendance.mark_bulk_attendance",
-									args: {
-										data: data,
-									},
-									callback: function (r) {
-										if (r.message === 1) {
-											frappe.show_alert({
-												message: __("Attendance Marked"),
-												indicator: "blue",
-											});
-											cur_dialog.hide();
-										}
-									},
-								});
+				let dialog = new frappe.ui.Dialog({
+					title: __("Mark Attendance"),
+					fields: [
+						{
+							fieldname: "employee",
+							label: __("For Employee"),
+							fieldtype: "Link",
+							options: "Employee",
+							get_query: () => {
+								return {
+									query: "erpnext.controllers.queries.employee_query",
+								};
 							},
-						);
-					}
-					dialog.hide();
-					list_view.refresh();
-				},
-				primary_action_label: __("Mark Attendance"),
+							reqd: 1,
+							onchange: () => me.reset_dialog(dialog),
+						},
+						{
+							fieldtype: "Section Break",
+							fieldname: "time_period_section",
+							hidden: 1,
+						},
+						{
+							label: __("Start"),
+							fieldtype: "Date",
+							fieldname: "from_date",
+							reqd: 1,
+							default: first_day_of_month.toDate(),
+							onchange: () => me.get_unmarked_days(dialog),
+						},
+						{
+							label: __("Status"),
+							fieldtype: "Select",
+							fieldname: "status",
+							options: ["Present", "Absent", "Half Day", "Work From Home"],
+							reqd: 1,
+						},
+						{
+							fieldtype: "Column Break",
+							fieldname: "time_period_column",
+						},
+						{
+							label: __("End"),
+							fieldtype: "Date",
+							fieldname: "to_date",
+							reqd: 1,
+							default: moment().toDate(),
+							onchange: () => me.get_unmarked_days(dialog),
+						},
+						{
+							label: __("Shift"),
+							fieldtype: "Link",
+							fieldname: "shift",
+							options: "Shift Type",
+						},
+
+						{
+							fieldtype: "Section Break",
+							fieldname: "days_section",
+							hidden: 1,
+						},
+						{
+							label: __("Exclude Holidays"),
+							fieldtype: "Check",
+							fieldname: "exclude_holidays",
+							onchange: () => me.get_unmarked_days(dialog),
+						},
+						{
+							label: __("Unmarked Attendance for days"),
+							fieldname: "unmarked_days",
+							fieldtype: "MultiCheck",
+							options: [],
+							columns: 2,
+							select_all: true,
+						},
+					],
+					primary_action(data) {
+						if (cur_dialog.no_unmarked_days_left) {
+							frappe.msgprint(
+								__(
+									"Attendance from {0} to {1} has already been marked for the Employee {2}",
+									[data.from_date, data.to_date, data.employee],
+								),
+							);
+						} else {
+							frappe.confirm(
+								__("Mark attendance as {0} for {1} on selected dates?", [
+									data.status,
+									data.employee,
+								]),
+								() => {
+									frappe.call({
+										method: "hrms.hr.doctype.attendance.attendance.mark_bulk_attendance",
+										args: {
+											data: data,
+										},
+										callback: function (r) {
+											if (r.message === 1) {
+												frappe.show_alert({
+													message: __("Attendance Marked"),
+													indicator: "blue",
+												});
+												cur_dialog.hide();
+											}
+										},
+									});
+								},
+							);
+						}
+						dialog.hide();
+						list_view.refresh();
+					},
+					primary_action_label: __("Mark Attendance"),
+				});
+				dialog.show();
 			});
-			dialog.show();
-		});
+		}
 	},
 
 	reset_dialog: function (dialog) {


### PR DESCRIPTION
**Issue**:
In the attendance list, the Mark Attendance button is enabled for the user with no create permission

**Before**
<img width="1638" height="275" alt="image" src="https://github.com/user-attachments/assets/7a3659de-163d-4c44-9b49-699cee5e6f2f" />

**After**
<img width="1638" height="259" alt="image" src="https://github.com/user-attachments/assets/1a87cb31-c567-47b5-851e-dd449268bfba" />
no-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced attendance marking dialog with multi-field inputs (employee, time period, start/end dates, status, shift) and dynamic date adjustments.
  * New multi-select unmarked-days UI with holiday exclusion and live refresh of selections.
  * Permission-guarded "Mark Attendance" action with confirmation, bulk marking, result alert, and automatic list refresh.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->