### PR TITLE
fix: overtime bugs, remove filter from additional salary & null value if it depends on other fields

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.json
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.json
@@ -142,13 +142,12 @@
    "fieldname": "overtime_type",
    "fieldtype": "Link",
    "label": "Overtime Type",
-   "options": "Overtime Type",
-   "read_only": 1
+   "options": "Overtime Type"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-28 03:09:19.448814",
+ "modified": "2025-12-01 12:23:07.921773",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Assignment",

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.json
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.json
@@ -142,12 +142,13 @@
    "fieldname": "overtime_type",
    "fieldtype": "Link",
    "label": "Overtime Type",
-   "options": "Overtime Type"
+   "options": "Overtime Type",
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-24 14:28:55.135261",
+ "modified": "2025-11-28 03:09:19.448814",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Shift Assignment",

--- a/hrms/hr/doctype/shift_type/shift_type.js
+++ b/hrms/hr/doctype/shift_type/shift_type.js
@@ -42,4 +42,10 @@ frappe.ui.form.on("Shift Type", {
 			frm.set_value("last_sync_of_checkin", "");
 		}
 	},
+
+	allow_overtime: function (frm) {
+		if (!frm.doc.allow_overtime) {
+			frm.set_value("overtime_type", "");
+		}
+	},
 });

--- a/hrms/payroll/doctype/additional_salary/additional_salary.js
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.js
@@ -59,14 +59,11 @@ frappe.ui.form.on("Additional Salary", {
 	set_component_query: function (frm) {
 		if (!frm.doc.company) return;
 
-		let filters = {
-			company: frm.doc.company,
-			disabled: 0,
-		};
-
 		frm.set_query("salary_component", function () {
 			return {
-				filters: filters,
+				filters: {
+					disabled: 0,
+				},
 			};
 		});
 	},

--- a/hrms/payroll/doctype/salary_component/salary_component.js
+++ b/hrms/payroll/doctype/salary_component/salary_component.js
@@ -37,6 +37,12 @@ frappe.ui.form.on("Salary Component", {
 		}
 	},
 
+	do_not_include_in_total: function (frm) {
+		if (!frm.doc.do_not_include_in_total) {
+			frm.set_value("do_not_include_in_accounts", 0);
+		}
+	},
+
 	arrear_component: function (frm) {
 		if (frm.doc.arrear_component) {
 			frm.set_value("depends_on_payment_days", 1);


### PR DESCRIPTION
- [x] Overtime Bugs
- [x] Remove company filter from salary component field in additional Salary
- [x] disable checkbox to ignore accounting entries if include in total is disable in Salary Component

`no-docs`

Closes #3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overtime Type automatically clears when "Allow Overtime" is disabled in Shift Type.
  * Salary component auto-reset when "Include in Total" is turned off.

* **Improvements**
  * Salary component lookup no longer restricted by company, improving accessibility across company contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->