### PR TITLE
fix(leave-policy-assignment): skip leave allocation when New Leaves …

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -127,9 +127,9 @@ class LeavePolicyAssignment(Document):
 		)
 
 		if new_leaves_allocated == 0 and not leave_details.is_earned_leave:
-			text = _("Leave allocation is skipped for {0}, as the new leave is 0").format(
-				frappe.bold(leave_details.name)
-			)
+			text = _(
+				"Leave allocation is skipped for {0}, because number of leaves to be allocated is 0."
+			).format(frappe.bold(leave_details.name))
 
 			frappe.get_doc(
 				{

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -126,7 +126,7 @@ class LeavePolicyAssignment(Document):
 			else []
 		)
 
-		if new_leaves_allocated == 0:
+		if new_leaves_allocated == 0 and not leave_details.is_earned_leave:
 			text = "{prefix} {leave_type}<br>{error_message}".format(
 				leave_type=frappe.bold(leave_details.name),
 				prefix=frappe.bold(_("Leave allocation is skipped for:")),

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -127,11 +127,10 @@ class LeavePolicyAssignment(Document):
 		)
 
 		if new_leaves_allocated == 0 and not leave_details.is_earned_leave:
-			text = "{prefix} {leave_type}<br>{error_message}".format(
-				leave_type=frappe.bold(leave_details.name),
-				prefix=frappe.bold(_("Leave allocation is skipped for:")),
-				error_message="New leave allocated for the leave type is 0",
+			text = _("Leave allocation is skipped for {0}, as the new leave is 0").format(
+				frappe.bold(leave_details.name)
 			)
+
 			frappe.get_doc(
 				{
 					"doctype": "Comment",

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -118,8 +118,6 @@ class LeavePolicyAssignment(Document):
 			carry_forward = 0
 
 		new_leaves_allocated = self.get_new_leaves(annual_allocation, leave_details, date_of_joining)
-		print(new_leaves_allocated)
-
 		earned_leave_schedule = (
 			self.get_earned_leave_schedule(
 				annual_allocation, leave_details, date_of_joining, new_leaves_allocated

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -118,6 +118,7 @@ class LeavePolicyAssignment(Document):
 			carry_forward = 0
 
 		new_leaves_allocated = self.get_new_leaves(annual_allocation, leave_details, date_of_joining)
+		print(new_leaves_allocated)
 
 		earned_leave_schedule = (
 			self.get_earned_leave_schedule(
@@ -126,6 +127,23 @@ class LeavePolicyAssignment(Document):
 			if leave_details.is_earned_leave
 			else []
 		)
+
+		if new_leaves_allocated == 0:
+			text = "{prefix} {leave_type}<br>{error_message}".format(
+				leave_type=frappe.bold(leave_details.name),
+				prefix=frappe.bold(_("Leave allocation is skipped for:")),
+				error_message="New leave allocated for the leave type is 0",
+			)
+			frappe.get_doc(
+				{
+					"doctype": "Comment",
+					"comment_type": "Comment",
+					"reference_doctype": "Leave Policy Assignment",
+					"reference_name": self.name,
+					"content": text,
+				}
+			).insert(ignore_permissions=True)
+			return None, 0
 
 		allocation = frappe.get_doc(
 			doctype="Leave Allocation",

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -314,6 +314,19 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		)
 		assignment.submit()
 
+		comments = frappe.get_all(
+			"Comment",
+			filters={
+				"reference_doctype": "Leave Policy Assignment",
+				"reference_name": assignment.name,
+			},
+			fields=["content"],
+		)
+
+		self.assertEqual(len(comments), 2)
+		self.assertIn(casual.name, comments[0]["content"])
+		self.assertIn(sick.name, comments[1]["content"])
+
 		allocations = frappe.get_all(
 			"Leave Allocation",
 			filters={"leave_policy_assignment": assignment.name},

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -269,3 +269,58 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		# months passed (18) are calculated correctly but total allocation of 36 exceeds 24 hence 24
 		# this upper cap is intentional, without that 36 leaves would be allocated correctly
 		self.assertEqual(earned_leave_allocation, 24)
+
+	def test_skip_zero_allocation_leaves(self):
+		today = getdate()
+		leave_period = create_leave_period(get_year_start(today), get_year_ending(today))
+
+		sick = create_leave_type(
+			leave_type_name="_Test Sick Leave", non_encashable_leaves=0, max_leaves_allowed=2
+		)
+		casual = create_leave_type(
+			leave_type_name="_Test Casual Leave", non_encashable_leaves=0, max_leaves_allowed=12
+		)
+		annual = create_leave_type(
+			leave_type_name="_Test Annual Leave", non_encashable_leaves=0, max_leaves_allowed=27
+		)
+		compoff = create_leave_type(
+			leave_type_name="_Test Comp Off", non_encashable_leaves=0, max_leaves_allowed=26
+		)
+		leave_policy = frappe.get_doc(
+			{
+				"doctype": "Leave Policy",
+				"title": "Test Zero allocation Policy",
+				"leave_policy_details": [
+					{"leave_type": sick.name, "annual_allocation": 2},
+					{"leave_type": casual.name, "annual_allocation": 2},
+					{"leave_type": annual.name, "annual_allocation": 27},
+					{"leave_type": compoff.name, "annual_allocation": 26},
+				],
+			}
+		).submit()
+
+		self.employee.date_of_joining = add_days(leave_period.to_date, -45)
+		self.employee.save()
+
+		assignment = create_assignment(
+			self.employee.name,
+			frappe._dict(
+				{
+					"assignment_based_on": "Leave Period",
+					"leave_policy": leave_policy.name,
+					"leave_period": leave_period.name,
+				}
+			),
+		)
+		assignment.submit()
+
+		allocations = frappe.get_all(
+			"Leave Allocation",
+			filters={"leave_policy_assignment": assignment.name},
+			fields=["leave_type", "new_leaves_allocated"],
+		)
+
+		self.assertEqual(allocations[0]["leave_type"], compoff.name)
+		self.assertEqual(allocations[0]["new_leaves_allocated"], 3)
+		self.assertEqual(allocations[1]["leave_type"], annual.name)
+		self.assertEqual(allocations[1]["new_leaves_allocated"], 3)


### PR DESCRIPTION
**Issue:** Leave Policy Assignment defines leaves to allocate for varying leave types with different allocation count. For leave types whose annual allocation is sparse, the rounded off number comes out to be 0 if the leave policy is assigned late within the leave period. Leave allocation throws exceptions in this case but that also prevents allocation for other leave types and submitting the leave policy assignment.

**Fix:** [54425](https://support.frappe.io/helpdesk/tickets/54425?view=VIEW-HD+Ticket-781)
A comment is added in leave policy assignment for skipped allocations while letting the document be submitted.

**Before:**

[Screencast from 2025-11-30 14-43-26.webm](https://github.com/user-attachments/assets/43e63a71-4b70-4d67-976c-a15d2aaaa69b)


**After:**

[Screencast from 2025-11-30 14-41-53.webm](https://github.com/user-attachments/assets/5b3c7ea0-de28-4edb-87d8-68874cacc9d0)


Backport needed for v-14, v-15, v-16-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip creating leave allocations for non-earned leave types when the computed allocation is zero; an automatic comment is logged on the assignment and no allocation is created.

* **Tests**
  * Added test coverage to verify zero-allocation handling across leave types and to confirm correct allocations are still created where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->