### PR TITLE
fix(monthly-attendance-sheet): compare using day

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -502,7 +502,7 @@ def get_attendance_status_for_summarized_view(
 
 	for d in total_days:
 		d = getdate(d)
-		if d in attendance_days or (joined_in_current_period and d < joined_date):
+		if d.day in attendance_days or (joined_in_current_period and d < joined_date):
 			continue
 
 		status = get_holiday_status(d, holidays)


### PR DESCRIPTION
**Issue:** Unmarked Days showing incorrectly in the Monthly Attendance Sheet Report

**Ref:** [53889](https://support.frappe.io/helpdesk/tickets/53889)

**Before:**

[Screencast from 2025-12-01 17-15-57.webm](https://github.com/user-attachments/assets/9af80245-812b-4291-a00b-4dd3e1c818f7)


**After:**

[Screencast from 2025-12-01 17-14-02.webm](https://github.com/user-attachments/assets/81134f2b-a5d2-42f7-8c46-934c8ac024a5)



Backport needed for v-15, v-16-beta


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the monthly attendance sheet report where attended dates were not being correctly identified, resulting in inaccurate attendance calculations. The system now properly matches attendance records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->