### PR TITLE
fix(Additional Salary): change `validate_update_after_submit` hook to `before_update_after_submit`

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -221,7 +221,7 @@ class AdditionalSalary(Document):
 		no_of_days = date_diff(getdate(end_date), getdate(start_date)) + 1
 		return amount_per_day * no_of_days
 
-	def validate_update_after_submit(self):
+	def on_update_after_submit(self):
 		if not self.disabled:
 			self.validate_recurring_additional_salary_overlap()
 

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -221,7 +221,7 @@ class AdditionalSalary(Document):
 		no_of_days = date_diff(getdate(end_date), getdate(start_date)) + 1
 		return amount_per_day * no_of_days
 
-	def on_update_after_submit(self):
+	def before_update_after_submit(self):
 		if not self.disabled:
 			self.validate_recurring_additional_salary_overlap()
 


### PR DESCRIPTION
### Problem

In the `Additional Salary` DocType, the class `AdditionalSalary` defines a method named `validate_update_after_submit`.
However, this method overrides the core method with the same name in the base class `Document`.

The original `Document.validate_update_after_submit` is responsible for enforcing an important validation rule:

Any field that does **NOT** have **Allow on Submit** must not be changed after submission.

If such a field is changed, **Frappe** should raise a **validation error**.

Because the `AdditionalSalary` class redefines a method with the same name, the core validation is silently bypassed, meaning
Fields that should **NOT** be allowed to change **after submission** were being updated without restriction.

### Fix
To restore the expected behavior of the framework
The method in `AdditionalSalary` was renamed from
`validate_update_after_submit` → `before_update_after_submit`

`before_update_after_submit` is the correct hook provided by Frappe for running custom logic before update-on-submit without overriding the core validation function.

backport version-15-hotfix
backport version-16-beta


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed an internal post-submission validation hook for additional salary handling. Behavior unchanged: overlap validation still runs unless disabled, so there are no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->