### PR TITLE
perf(Auto Attendance): Use background job to process auto attendance

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.js
+++ b/hrms/hr/doctype/shift_type/shift_type.js
@@ -28,8 +28,11 @@ frappe.ui.form.on("Shift Type", {
 
 			frm.call({
 				doc: frm.doc,
-				method: "process_attendance_manually",
+				method: "process_auto_attendance",
 				freeze: true,
+				args: {
+					is_manually_triggered: true,
+				},
 				callback: (r) => {
 					frappe.msgprint(__(r.message));
 				},

--- a/hrms/hr/doctype/shift_type/shift_type.js
+++ b/hrms/hr/doctype/shift_type/shift_type.js
@@ -28,10 +28,10 @@ frappe.ui.form.on("Shift Type", {
 
 			frm.call({
 				doc: frm.doc,
-				method: "process_auto_attendance",
+				method: "process_attendance_manually",
 				freeze: true,
-				callback: () => {
-					frappe.msgprint(__("Attendance has been marked as per employee check-ins"));
+				callback: (r) => {
+					frappe.msgprint(__(r.message));
 				},
 			});
 		});

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -122,7 +122,8 @@ class ShiftType(Document):
 					self._process(logs)
 					return "Attendance has been marked as per employee check-ins."
 				except Exception as e:
-					frappe.log_error(e)
+					error_log = frappe.log_error(e)
+					return f"An error occured during marking attendance. Refer the full error log {get_link_to_form('Error Log',error_log.name,label='here')}"
 		else:
 			self._process(logs)
 

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -861,6 +861,13 @@ class TestShiftType(IntegrationTestCase):
 		)
 		self.assertRaises(frappe.ValidationError, shift_type.save)
 
+	def test_bg_job_creation_for_large_checkins(self):
+		shift = setup_shift_type(shift_type="Test Shift", start_time="10:00:00", end_time="18:00:00")
+		frappe.flags.test_bg_job = True
+		shift.process_auto_attendance(is_manually_triggered=True)
+		job = frappe.get_all("RQ Job", {"job_id": f"process_auto_attendance_{shift.name}"})
+		self.assertTrue(job)
+
 
 def setup_shift_type(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
The auto-attendance job is pretty fast as is. Takes less than 30 seconds to process a few day's attendance for a thousand employees, in an ideal situation. Although if there's any custom code that then does some other operations while submitting attendance, the time can add up, specially if something goes wrong and the whole month's attendance is attempted to process at the end of the month to process payroll.
For these cases, it's best to hand that job over to a background worker instead of trying to process it in realtime and being greeted with a timeout error. Hence this attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual trigger for shift attendance processing from Shift Type settings.
  * Large attendance batches (1000+ records) now enqueue for background processing with job/status links.

* **Behavior Changes**
  * Notifications now display dynamic, response-driven messages.
  * Processing is skipped when shift configuration is invalid and shows clearer status/error handling.

* **Tests**
  * Added test to verify background job creation for large attendance batches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->