### PR TITLE
fix: Structure misspelling

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -39,7 +39,7 @@ class AdditionalSalary(Document):
 	def validate_salary_structure(self):
 		if not frappe.db.exists("Salary Structure Assignment", {"employee": self.employee}):
 			frappe.throw(
-				_("There is no Salary Structure assigned to {0}. First assign a Salary Stucture.").format(
+				_("There is no Salary Structure assigned to {0}. First assign a Salary Structure.").format(
 					self.employee
 				)
 			)

--- a/hrms/payroll/doctype/employee_incentive/employee_incentive.py
+++ b/hrms/payroll/doctype/employee_incentive/employee_incentive.py
@@ -17,7 +17,7 @@ class EmployeeIncentive(Document):
 	def validate_salary_structure(self):
 		if not frappe.db.exists("Salary Structure Assignment", {"employee": self.employee}):
 			frappe.throw(
-				_("There is no Salary Structure assigned to {0}. First assign a Salary Stucture.").format(
+				_("There is no Salary Structure assigned to {0}. First assign a Salary Structure.").format(
 					self.employee
 				)
 			)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1066,7 +1066,7 @@ class TestSalarySlip(IntegrationTestCase):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 		salary_structure = make_salary_structure(
-			"Stucture to test tax",
+			"Structure to test tax",
 			"Monthly",
 			other_details={"max_benefits": 100000},
 			test_tax=True,
@@ -1161,7 +1161,7 @@ class TestSalarySlip(IntegrationTestCase):
 		employee = make_employee("test_tax_for_mid_joinee@salary.com", date_of_joining=joining_date)
 
 		salary_structure = make_salary_structure(
-			"Stucture to test tax",
+			"Structure to test tax",
 			"Monthly",
 			test_tax=True,
 			from_date=joining_date,
@@ -1199,7 +1199,7 @@ class TestSalarySlip(IntegrationTestCase):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 		salary_structure = make_salary_structure(
-			"Stucture to test tax",
+			"Structure to test tax",
 			"Monthly",
 			other_details={"max_benefits": 100000},
 			test_tax=True,

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -115,12 +115,12 @@ class TestSalaryStructure(IntegrationTestCase):
 		salary_structure = make_salary_structure(
 			"Salary Structure Sample", "Monthly", currency=company_currency
 		)
-		employee = "test_assign_stucture@salary.com"
+		employee = "test_assign_structure@salary.com"
 		employee_doc_name = make_employee(employee)
-		# clear the already assigned stuctures
+		# clear the already assigned structures
 		frappe.db.sql(
 			"""delete from `tabSalary Structure Assignment` where employee=%s and salary_structure=%s """,
-			("test_assign_stucture@salary.com", salary_structure.name),
+			("test_assign_structure@salary.com", salary_structure.name),
 		)
 		# test structure_assignment
 		salary_structure.assign_salary_structure(

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -204,7 +204,7 @@ def get_employee_currency(employee):
 	employee_currency = frappe.db.get_value("Salary Structure Assignment", {"employee": employee}, "currency")
 	if not employee_currency:
 		frappe.throw(
-			_("There is no Salary Structure assigned to {0}. First assign a Salary Stucture.").format(
+			_("There is no Salary Structure assigned to {0}. First assign a Salary Structure.").format(
 				employee
 			)
 		)


### PR DESCRIPTION
Correct the spelling error: "Structure" should be "Structure"
Because it may cause translation problems
backport version-15-hotfix