### PR TITLE
fix: set default dimension in expense claim

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -59,6 +59,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		self.calculate_total_amount()
 		self.validate_advances()
 		self.set_expense_account(validate=True)
+		self.set_default_accounting_dimension()
 		self.calculate_taxes()
 		self.set_status()
 		self.validate_company_and_department()
@@ -338,6 +339,26 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				)
 			)
 
+	def set_default_accounting_dimension(self):
+		from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+			get_checks_for_pl_and_bs_accounts,
+		)
+
+		for dim in get_checks_for_pl_and_bs_accounts():
+			if dim.company != self.company:
+				continue
+
+			field = frappe.scrub(dim.fieldname)
+
+			if self.meta.get_field(field):
+				if not self.get(field) and dim.mandatory_for_bs:
+					self.set(field, dim.default_dimension)
+
+			for row in self.get("expenses") or []:
+				if row.meta.get_field(field):
+					if not row.get(field) and dim.mandatory_for_pl:
+						row.set(field, dim.default_dimension)
+
 	def create_exchange_gain_loss_je(self):
 		if not self.advances:
 			return
@@ -429,7 +450,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			if doc.get(f):
 				val = flt(
 					flt(doc.get(f), doc.precision(f))
-					* (exchange_rate if exchange_rate else self.exchange_rate),
+					* flt(exchange_rate if exchange_rate else self.exchange_rate),
 					doc.precision("base_" + f),
 				)
 				doc.set("base_" + f, val)


### PR DESCRIPTION
**Issue:** The default dimension is not set in the child table of the expense claim, even if the default dimension is added in the accounting dimension. Only the Cost Center and Projects are auto-fetched, and also handled for PWA. When adding a custom Accounting Dimension, the default dimension does not appear in Expense Claim.

**Ref:** [54639](https://support.frappe.io/helpdesk/tickets/54639)


**Issue in Base Field Amount**:
The Exchange Rate is returned as a String while saving the expense claim in PWA, it throws an error


<img width="1920" height="1080" alt="expense claim" src="https://github.com/user-attachments/assets/4b03e485-b795-44b0-b434-16d82fdd889f" />


**Before:**

[Screencast from 2025-12-05 17-36-03.webm](https://github.com/user-attachments/assets/96644555-0cdb-4ea8-876c-c3fb84eee476)


**After:**

[Screencast from 2025-12-05 17-33-31.webm](https://github.com/user-attachments/assets/c5ffc8f2-6fe8-464d-9ec2-39b371d71e98)


Backport needed for v15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expense claims now automatically apply default accounting dimensions to all required fields and their line items during validation, reducing manual input and ensuring completeness.

* **Bug Fixes**
  * Improved numeric handling for exchange rates to ensure consistent and accurate base-amount calculations across expense conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->