### PR TITLE
fix: remove Invalid salary_component Query Filter from Employee Advance

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -25,7 +25,6 @@ frappe.ui.form.on("Employee Advance", {
 				},
 			};
 		});
-
 	},
 
 	refresh: function (frm) {

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -26,13 +26,6 @@ frappe.ui.form.on("Employee Advance", {
 			};
 		});
 
-		frm.set_query("salary_component", function () {
-			return {
-				filters: {
-					type: "Deduction",
-				},
-			};
-		});
 	},
 
 	refresh: function (frm) {


### PR DESCRIPTION
removes the `frm.set_query("salary_component")` block from `employee_advance.js` because the **Employee Advance** Doctype does not contain a **field** named `salary_component`.

backport version-15-hotfix
backport version-16-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the available salary component options in employee advance forms by removing a previous restriction that limited selections to "Deduction", so users can now choose from the full set of salary components.
  
<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->