### PR TITLE
fix: use singular/plural forms for 'years' in employee reminders

### DIFF
--- a/hrms/controllers/employee_reminders.py
+++ b/hrms/controllers/employee_reminders.py
@@ -238,8 +238,8 @@ def get_work_anniversary_reminder_text(anniversary_persons: list) -> str:
 	if len(anniversary_persons) == 1:
 		anniversary_person = anniversary_persons[0]["name"]
 		completed_years = getdate().year - anniversary_persons[0]["date_of_joining"].year
-		return _("Today {0} completed {1} year(s) at our Company! 🎉").format(
-			_(anniversary_person), completed_years
+		return _("Today {0} completed {1} {2} at our Company! 🎉").format(
+			_(anniversary_person), completed_years, get_year_label(completed_years)
 		)
 
 	names_grouped_by_years = {}
@@ -250,13 +250,19 @@ def get_work_anniversary_reminder_text(anniversary_persons: list) -> str:
 		names_grouped_by_years.setdefault(completed_years, []).append(person["name"])
 
 	person_names_with_years = [
-		_("{0} completed {1} year(s)").format(comma_sep(person_names, _("{0} & {1}"), False), years)
+		_("{0} completed {1} {2}").format(
+			comma_sep(person_names, _("{0} & {1}"), False), years, get_year_label(years)
+		)
 		for years, person_names in names_grouped_by_years.items()
 	]
 
 	# converts ["Jim", "Rim", "Dim"] to Jim, Rim & Dim
 	anniversary_person = comma_sep(person_names_with_years, _("{0} & {1}"), False)
 	return _("Today {0} at our Company! 🎉").format(_(anniversary_person))
+
+
+def get_year_label(years: int) -> str:
+	return _("year") if years == 1 else _("years")
 
 
 def send_work_anniversary_reminder(


### PR DESCRIPTION
The "year(s)" part is okay in validation messages but doesn't look good in such emails

<img width="651" height="419" alt="image" src="https://github.com/user-attachments/assets/a7b8e176-afe9-48e4-868f-d451d491222a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Work anniversary reminder messages now correctly display singular/plural year labels (e.g., "1 year" vs "2 years"), improving message clarity and grammar consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->