### PR TITLE
feat(job-opening-template): auto fetch template values

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -48,8 +48,6 @@ frappe.ui.form.on("Job Opening", {
 
 		frappe.db.get_doc("Job Opening Template", frm.doc.job_opening_template).then((doc) => {
 			frm.set_value({
-				job_title: doc.job_title,
-				designation: doc.designation,
 				department: doc.department,
 				employment_type: doc.employment_type,
 				location: doc.location,

--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -42,4 +42,21 @@ frappe.ui.form.on("Job Opening", {
 	company: function (frm) {
 		frm.set_value("designation", "");
 	},
+
+	job_opening_template: function (frm) {
+		if (!frm.doc.job_opening_template) return;
+
+		frappe.db.get_doc("Job Opening Template", frm.doc.job_opening_template).then((doc) => {
+			frm.set_value({
+				job_title: doc.job_title,
+				designation: doc.designation,
+				department: doc.department,
+				employment_type: doc.employment_type,
+				location: doc.location,
+				description: doc.description,
+			});
+
+			frm.refresh_fields();
+		});
+	},
 });

--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -10,6 +10,7 @@
  "engine": "InnoDB",
  "field_order": [
   "job_details_section",
+  "job_opening_template",
   "job_title",
   "designation",
   "column_break_5",
@@ -251,6 +252,12 @@
    "fieldname": "publish_applications_received",
    "fieldtype": "Check",
    "label": "Publish Applications Received"
+  },
+  {
+   "fieldname": "job_opening_template",
+   "fieldtype": "Link",
+   "label": "Job Opening Template",
+   "options": "Job Opening Template"
   }
  ],
  "has_web_view": 1,
@@ -258,7 +265,7 @@
  "idx": 1,
  "is_published_field": "publish",
  "links": [],
- "modified": "2025-02-11 22:41:14.873299",
+ "modified": "2025-12-11 19:18:36.145062",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Opening",
@@ -277,6 +284,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": [

--- a/hrms/hr/doctype/job_opening_template/job_opening_template.js
+++ b/hrms/hr/doctype/job_opening_template/job_opening_template.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Job Opening Template", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hrms/hr/doctype/job_opening_template/job_opening_template.json
+++ b/hrms/hr/doctype/job_opening_template/job_opening_template.json
@@ -1,0 +1,96 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:template_title",
+ "creation": "2025-12-11 18:04:50.413169",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "template_title",
+  "job_title",
+  "designation",
+  "department",
+  "employment_type",
+  "location",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "job_title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Job Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Designation",
+   "options": "Designation",
+   "reqd": 1
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Department",
+   "options": "Department",
+   "reqd": 1
+  },
+  {
+   "fieldname": "employment_type",
+   "fieldtype": "Link",
+   "label": "Employment Type",
+   "options": "Employment Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Link",
+   "label": "Location",
+   "options": "Branch"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description"
+  },
+  {
+   "fieldname": "template_title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Template Title",
+   "reqd": 1,
+   "unique": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-12-11 19:15:14.081402",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Job Opening Template",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/job_opening_template/job_opening_template.json
+++ b/hrms/hr/doctype/job_opening_template/job_opening_template.json
@@ -7,28 +7,14 @@
  "engine": "InnoDB",
  "field_order": [
   "template_title",
-  "job_title",
-  "designation",
   "department",
+  "column_break_wkcr",
   "employment_type",
   "location",
+  "section_break_dwfh",
   "description"
  ],
  "fields": [
-  {
-   "fieldname": "job_title",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Job Title",
-   "reqd": 1
-  },
-  {
-   "fieldname": "designation",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Designation",
-   "options": "Designation"
-  },
   {
    "fieldname": "department",
    "fieldtype": "Link",
@@ -49,24 +35,31 @@
    "options": "Branch"
   },
   {
-   "fieldname": "description",
-   "fieldtype": "Text Editor",
-   "label": "Description",
-   "reqd": 1
-  },
-  {
    "fieldname": "template_title",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Template Title",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "column_break_wkcr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_dwfh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-12 00:41:25.323063",
+ "modified": "2025-12-12 12:52:12.217926",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Opening Template",

--- a/hrms/hr/doctype/job_opening_template/job_opening_template.json
+++ b/hrms/hr/doctype/job_opening_template/job_opening_template.json
@@ -27,23 +27,20 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Designation",
-   "options": "Designation",
-   "reqd": 1
+   "options": "Designation"
   },
   {
    "fieldname": "department",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Department",
-   "options": "Department",
-   "reqd": 1
+   "options": "Department"
   },
   {
    "fieldname": "employment_type",
    "fieldtype": "Link",
    "label": "Employment Type",
-   "options": "Employment Type",
-   "reqd": 1
+   "options": "Employment Type"
   },
   {
    "fieldname": "location",
@@ -54,7 +51,8 @@
   {
    "fieldname": "description",
    "fieldtype": "Text Editor",
-   "label": "Description"
+   "label": "Description",
+   "reqd": 1
   },
   {
    "fieldname": "template_title",
@@ -68,7 +66,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-11 19:15:14.081402",
+ "modified": "2025-12-12 00:41:25.323063",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Opening Template",

--- a/hrms/hr/doctype/job_opening_template/job_opening_template.py
+++ b/hrms/hr/doctype/job_opening_template/job_opening_template.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class JobOpeningTemplate(Document):
+	pass

--- a/hrms/hr/doctype/job_opening_template/test_job_opening_template.py
+++ b/hrms/hr/doctype/job_opening_template/test_job_opening_template.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestJobOpeningTemplate(IntegrationTestCase):
+	"""
+	Integration tests for JobOpeningTemplate.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
**Issue:** [3780](https://github.com/frappe/hrms/issues/3780)

**Ref:**  [54400](https://support.frappe.io/helpdesk/tickets/54400?view=VIEW-HD+Ticket-781)

**Feature Details**

- Added Job Opening Template 

- Fetch the values from the job opening Template for the fields Designation, Employment Type, Location, and Description in Job Opening

[Screencast from 2025-12-12 13-33-27.webm](https://github.com/user-attachments/assets/60b3b6d7-eb96-4d36-bbfa-bafe6c0f1b84)


Backport Needed for v-15



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Job Opening Template to streamline creating job openings.
  * Job Opening form can auto-populate key fields (department, employment type, location, description) from a selected template.

* **Tests**
  * Added an integration test scaffold for Job Opening Template.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->