### PR TITLE
fix(expense-claim): add accounting dimension for payment gl

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -270,6 +270,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					"advance_voucher_type": "Employee Advance",
 					"advance_voucher_no": data.employee_advance,
 					"transaction_exchange_rate": self.exchange_rate,
+					"cost_center": self.cost_center,
+					"project": self.project,
 				}
 				if not make_payment_via_je:
 					gl_dict.update(
@@ -294,6 +296,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 						"credit_in_transaction_currency": self.grand_total,
 						"against": self.employee,
 						"transaction_exchange_rate": self.exchange_rate,
+						"cost_center": self.cost_center,
+						"project": self.project,
 					},
 					account_currency=self.currency,
 					item=self,
@@ -313,6 +317,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 						"against_voucher": self.name,
 						"against_voucher_type": self.doctype,
 						"transaction_exchange_rate": self.exchange_rate,
+						"cost_center": self.cost_center,
+						"project": self.project,
 					},
 					account_currency=self.currency,
 					item=self,


### PR DESCRIPTION
Issue: Accounting Dimension is not tagged in GL entry for payment side causing inconsistency.

Ref: [55332](https://support.frappe.io/helpdesk/tickets/55332)

**Steps to reproduce:**

- Create an Employee Advance for ₹100.
- Create a Payment Entry against the Employee Advance.
- Create an Expense Claim against the Employee Advance using the "Create -> Expense Claim" button.
- Submit the Expense Claim after filling in the cost center at both the header level and in the child table.
- Check View  ->  Accounting Ledger: the cost center is not populated on the credit side.

Before:

<img width="1624" height="536" alt="image" src="https://github.com/user-attachments/assets/7e11af96-7149-475c-b0ba-d32ad7de4856" />

<img width="1641" height="812" alt="image" src="https://github.com/user-attachments/assets/cd6599b4-62e3-4f79-a522-6c130105709b" />


After:

<img width="1844" height="630" alt="image" src="https://github.com/user-attachments/assets/439ca949-41f5-4af2-90bc-69589e30910f" />



**Backport Neede: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cost center and project dimensions are now properly recorded across all expense claim accounting entries—including payable, expense, advance, and payment records—ensuring complete and accurate financial tracking in reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->