### PR TITLE
fix: add patch to delete old workspaces

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -35,3 +35,4 @@ hrms.patches.v15_0.update_advance_payment_ledger_amount #2025-09-23
 hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
+hrms.patches.v16_0.delete_old_workspaces

--- a/hrms/patches/v16_0/delete_old_workspaces.py
+++ b/hrms/patches/v16_0/delete_old_workspaces.py
@@ -7,9 +7,15 @@ def execute():
 		"Salary Payout",
 		"Employee Lifecycle",
 		"Overview",
-		"Shift & Attendance",
+		"Attendance",
 	]
 
 	for workspace in old_workspaces:
-		if frappe.db.exists("Workspace", {"name": workspace, "public": 1, "for_user": ""}):
+		if frappe.db.exists("Workspace", {"name": workspace, "public": 1, "for_user": ("is", "Not Set")}):
 			frappe.delete_doc("Workspace", workspace, force=True)
+		if sidebar := frappe.db.exists(
+			"Workspace Sidebar", {"name": workspace, "for_user": ("is", "Not Set")}
+		):
+			frappe.delete_doc("Workspace Sidebar", sidebar)
+		if icon := frappe.db.exists("Desktop Icon", {"link_type": "Workspace", "link_to": workspace}):
+			frappe.delete_doc("Desktop Icon", icon)

--- a/hrms/patches/v16_0/delete_old_workspaces.py
+++ b/hrms/patches/v16_0/delete_old_workspaces.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+	old_workspaces = [
+		"Expense Claims",
+		"Salary Payout",
+		"Employee Lifecycle",
+		"Overview",
+		"Shift & Attendance",
+	]
+
+	for workspace in old_workspaces:
+		if frappe.db.exists("Workspace", {"name": workspace, "public": 1, "for_user": ""}):
+			frappe.delete_doc("Workspace", workspace, force=True)


### PR DESCRIPTION
Fixes #3832

## Summary
Adds a migration patch to delete deprecated workspaces that persist on existing sites after PR #3740 renamed them.

## Workspaces deleted
- Expense Claims (renamed to Expenses)
- Salary Payout (renamed to Payroll)
- Employee Lifecycle (renamed to Tenure)
- Overview (renamed to HR)
- Attendance (removed)

## Implementation
- Uses `public=1` and `for_user=''` filter to only delete standard workspaces
- Preserves any custom user workspaces with the same names

## Testing
Tested locally with Docker - verified Shift & Attendance workspace deletion after running patch.

 Picture of before and after:

-- Before :

![before](https://github.com/user-attachments/assets/fc5a08df-955d-4ce2-9d5f-663ae37564eb)

-- After:

<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/0aaa6272-c17b-4db7-ba9e-930fcd4207d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a maintenance patch to remove legacy public workspaces during upgrade, including their associated sidebar entries and desktop icons, to clean up deprecated UI elements and prevent leftover artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->