### PR TITLE
fix: set correct total positions in staffing plan

### DIFF
--- a/hrms/hr/doctype/staffing_plan/staffing_plan.py
+++ b/hrms/hr/doctype/staffing_plan/staffing_plan.py
@@ -39,11 +39,10 @@ class StaffingPlan(Document):
 
 		for detail in self.get("staffing_details"):
 			# Set readonly fields
-			self.set_number_of_positions(detail)
 			designation_counts = get_designation_counts(detail.designation, self.company)
 			detail.current_count = designation_counts["employee_count"]
 			detail.current_openings = designation_counts["job_openings"]
-
+			self.set_number_of_positions(detail)
 			detail.total_estimated_cost = 0
 			if detail.number_of_positions > 0:
 				if detail.vacancies and detail.estimated_cost_per_position:
@@ -181,12 +180,14 @@ class StaffingPlan(Document):
 
 			self.staffing_details = []
 			for req in requisitions:
+				current_count = get_designation_counts(req.designation, self.company)["employee_count"]
 				self.append(
 					"staffing_details",
 					{
 						"designation": req.designation,
 						"vacancies": req.no_of_positions,
 						"estimated_cost_per_position": req.expected_compensation,
+						"number_of_positions": cint(current_count) + cint(req.no_of_positions),
 					},
 				)
 


### PR DESCRIPTION
closes #3810 (refer for before)


#### After

https://github.com/user-attachments/assets/26304f13-2897-456f-bd60-8dee7c795637


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed staffing plan calculations so number of positions and estimated budgets correctly include existing employees plus open vacancies; job requisition-derived entries now incorporate current staff when computing totals.

* **Tests**
  * Added and expanded tests (including setup and a job-requisition scenario) to validate staffing details, vacancies, current counts, and total positions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->