### PR TITLE
fix: employee_wise_accounting_enabled missing positional argument

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -911,7 +911,9 @@ class PayrollEntry(Document):
 				if only_tax_impact != 1 and statistical_component != 1:
 					if is_flexible_benefit == 1 and create_separate_je == 1:
 						self.set_accounting_entries_for_bank_entry(
-							salary_detail.amount, salary_detail.salary_component
+							salary_detail.amount,
+							salary_detail.salary_component,
+							employee_wise_accounting_enabled,
 						)
 					else:
 						if employee_wise_accounting_enabled:


### PR DESCRIPTION
Steps to replicate 

1. In Salary component  enable `Is Flexible Benefit` and `Create Separate Payment Entry Against Benefit Claim`

Process a payroll entry , salary structure should have this updated component

### ERROR

<img width="1440" height="685" alt="Screenshot 2025-12-17 at 4 42 01 PM" src="https://github.com/user-attachments/assets/ec3459ae-701c-4722-bf5e-25e5dddc91fa" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in payroll accounting for flexible benefits where employee-wise accounting settings were not being properly applied during bank entry processing. This correction ensures accurate per-employee accounting records are maintained when processing flexible benefits with separate journal entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->