### PR TITLE
build(ci): use python 3.14 and node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Check for valid Python & Merge Conflicts
         run: |
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
 
       - name: Add to Hosts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10.6
+        image: mariadb:11.8
         env:
           MARIADB_ROOT_PASSWORD: 'root'
         ports:
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           check-latest: true
@@ -131,7 +131,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/docs_checker.yml
+++ b/.github/workflows/docs_checker.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: 'Setup Environment'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
       - name: 'Clone repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Validate Docs
         env:

--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v5
           with:
-            python-version: "3.12"
+            python-version: "3.14"
 
         - name: Run script to update POT file
           run: |

--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             ref: ${{ matrix.branch }}
 
         - name: Setup Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
             python-version: "3.14"
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 200
       - uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
 
       - name: Check commit titles
@@ -31,10 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Install and Run Pre-commit
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,10 +10,10 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 200
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           check-latest: true
@@ -29,10 +29,10 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Entire Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup dependencies


### PR DESCRIPTION
- use python 3.14, node 24 and mariadb 11.8
- update action versions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized continuous integration workflows with upgraded toolchain versions: MariaDB database service (v11.8), Python runtime (v3.14), Node.js runtime (v24), and GitHub Actions utilities to latest versions. Updates applied across all CI/CD pipelines including testing, documentation checks, linting, and release procedures for enhanced compatibility and build reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->