### PR TITLE
fix: unsupported string alias in get_all

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -6,6 +6,7 @@ import datetime
 import frappe
 from frappe import _
 from frappe.model.workflow import get_workflow_name
+from frappe.query_builder import Field
 from frappe.query_builder.functions import Max, Min, Sum
 from frappe.utils import (
 	add_days,
@@ -1335,8 +1336,6 @@ def add_leaves(events, start, end, filters=None):
 		"docstatus",
 		"employee_name",
 		"leave_type",
-		"(1) as allDay",
-		"'Leave Application' as doctype",
 	]
 
 	show_leaves_of_all_members = frappe.db.get_single_value(
@@ -1346,9 +1345,10 @@ def add_leaves(events, start, end, filters=None):
 		leave_applications = frappe.get_all("Leave Application", filters=filters, fields=fields)
 	else:
 		leave_applications = frappe.get_list("Leave Application", filters=filters, fields=fields)
-
 	for d in leave_applications:
 		d["title"] = f"{d['employee_name']} ({d['leave_type']})"
+		d["allDay"] = 1
+		d["doctype"] = "Leave Application"
 		del d["employee_name"]
 		del d["leave_type"]
 		if d not in events:

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -6,7 +6,6 @@ import datetime
 import frappe
 from frappe import _
 from frappe.model.workflow import get_workflow_name
-from frappe.query_builder import Field
 from frappe.query_builder.functions import Max, Min, Sum
 from frappe.utils import (
 	add_days,


### PR DESCRIPTION
This pops up in leave application calendar, because of incorrect select field format
<img width="1526" height="444" alt="image" src="https://github.com/user-attachments/assets/1b326140-930d-439c-ae3b-bc22b455b772" />

Fixed the query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Calendar event data for leave applications streamlined; events are now explicitly marked as all-day and tagged by type.
  * Employee name and leave type are no longer included in the calendar event payload; calendar display and behavior remain unchanged for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->