### PR TITLE
fix: show income tax computation report for employees of all statuses

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.js
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.js
@@ -40,7 +40,7 @@ frappe.query_reports["Income Tax Computation"] = {
 			fieldname: "employee_status",
 			label: __("Employee Status"),
 			fieldtype: "Select",
-			options: "Active\nInactive\nSuspended\nLeft",
+			options: "\nActive\nInactive\nSuspended\nLeft",
 			default: "Active",
 			width: "90px",
 		},


### PR DESCRIPTION
<img width="1360" height="561" alt="image" src="https://github.com/user-attachments/assets/f902928e-9e02-4f91-9938-b5cbc9d2c7f9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Employee Status selector in income tax report with improved selection experience

* **Tests**
  * Added test coverage for income tax computation report to verify accurate results across multiple employees with company and payroll period filtering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->