### PR TITLE
fix(salary-slip): overwrite structure value with zero value

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1739,7 +1739,7 @@ class SalarySlip(TransactionBase):
 			):
 				component_row.set(attr, component_data.get(attr))
 
-		if additional_salary:
+		if additional_salary and amount:
 			if additional_salary.overwrite:
 				component_row.additional_amount = flt(
 					flt(amount) - flt(component_row.get("default_amount", 0)),


### PR DESCRIPTION
**Issue:** #3889

**Description:**
When an Additional Salary is created with overwrite_salary_structure_amount=1 and amount=0 to nullify a salary structure component, the salary slip incorrectly shows a negative earning instead of 0. This was working earlier but it is no longer working.

**Before:**

[Screencast from 2025-12-30 13-03-29.webm](https://github.com/user-attachments/assets/67abeff8-cfad-4e66-9ff3-8913e39294be)


**After:**

[Screencast from 2025-12-30 13-05-57.webm](https://github.com/user-attachments/assets/1b19b49d-afc8-4f86-9814-f981c48e89c2)


Backport needed for v-15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced additional salary component calculation to properly validate both amount and salary data before applying overwrite operations.

* **Tests**
  * Added test coverage validating salary component behavior with zero payment days.
  * Added test validation for additional salary components with zero-valued amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->