### PR TITLE
fix: allow backdated leave application after creating expiry ledger entries

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -291,6 +291,10 @@ frappe.ui.form.on("Leave Application", {
 		});
 		$(".form-message").prop("hidden", true);
 	},
+	posting_date: function (frm) {
+		frm.trigger("make_dashboard");
+		frm.trigger("get_leave_balance");
+	},
 });
 
 frappe.tour["Leave Application"] = [

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -972,7 +972,6 @@ def get_leave_balance_on(
 
 	allocation_records = get_leave_allocation_records(employee, date, leave_type)
 	allocation = allocation_records.get(leave_type, frappe._dict())
-
 	end_date = (
 		allocation.to_date if (allocation and cint(consider_all_leaves_in_the_allocation_period)) else date
 	)
@@ -1141,8 +1140,7 @@ def get_manually_expired_leaves(
 	employee: str, leave_type: str, from_date: datetime.date, end_date: datetime.date, date: datetime.date
 ):
 	ledger = frappe.qb.DocType("Leave Ledger Entry")
-	if date < end_date:
-		end_date = date
+
 	leaves = (
 		frappe.qb.from_(ledger)
 		.select(ledger.leaves)
@@ -1151,7 +1149,7 @@ def get_manually_expired_leaves(
 			& (ledger.employee == employee)
 			& (ledger.leave_type == leave_type)
 			& (ledger.from_date >= from_date)
-			& (ledger.to_date <= end_date)
+			& (ledger.to_date < end_date)
 			& (ledger.transaction_type == "Leave Allocation")
 			& ((ledger.is_expired == 1) & (ledger.is_carry_forward == 0))
 		)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -979,7 +979,7 @@ def get_leave_balance_on(
 
 	leaves_taken = get_leaves_for_period(employee, leave_type, allocation.from_date, end_date)
 	manually_expired_leaves = get_manually_expired_leaves(
-		employee, leave_type, allocation.from_date, end_date, date
+		employee, leave_type, allocation.from_date, end_date
 	)
 
 	remaining_leaves = get_remaining_leaves(
@@ -1137,7 +1137,7 @@ def get_remaining_leaves(
 
 
 def get_manually_expired_leaves(
-	employee: str, leave_type: str, from_date: datetime.date, end_date: datetime.date, date: datetime.date
+	employee: str, leave_type: str, from_date: datetime.date, end_date: datetime.date
 ):
 	ledger = frappe.qb.DocType("Leave Ledger Entry")
 

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1427,6 +1427,28 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		self.assertEqual(leave_balance, 0)
 
+	def test_backdated_application_after_expiry(self):
+		employee = get_employee().name
+		previous_month_start = get_first_day(add_months(getdate(), -1))
+		previous_month_end = get_last_day(previous_month_start)
+		leave_type = create_leave_type(leave_type_name="_Test_backdated_application").name
+		allocation = make_allocation_record(
+			employee, leave_type, previous_month_start, previous_month_end, leaves=10
+		)
+		expire_allocation(allocation, expiry_date=previous_month_end)
+		doc = frappe.new_doc(
+			"Leave Application",
+			employee=employee,
+			leave_type=leave_type,
+			from_date=previous_month_start,
+			to_date=previous_month_start,
+			posting_date=add_days(previous_month_end, -1),
+			status="Approved",
+		)
+		doc.save()
+		doc.submit()
+		self.assertEqual(get_leave_balance_on(employee, leave_type, add_days(previous_month_end, -1)), 9)
+
 	def test_status_on_discard(self):
 		make_allocation_record()
 		application = self.get_application(self.leave_applications[0])

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1422,7 +1422,10 @@ class TestLeaveApplication(HRMSTestSuite):
 		expire_allocation(leave_allocation, expiry_date=getdate())
 
 		leave_balance = get_leave_balance_on(
-			employee=employee.name, leave_type=leave_type.name, date=getdate()
+			employee=employee.name,
+			leave_type=leave_type.name,
+			date=getdate(),
+			consider_all_leaves_in_the_allocation_period=True,
 		)
 
 		self.assertEqual(leave_balance, 0)
@@ -1442,12 +1445,12 @@ class TestLeaveApplication(HRMSTestSuite):
 			leave_type=leave_type,
 			from_date=previous_month_start,
 			to_date=previous_month_start,
-			posting_date=add_days(previous_month_end, -1),
+			posting_date=previous_month_end,
 			status="Approved",
 		)
 		doc.save()
 		doc.submit()
-		self.assertEqual(get_leave_balance_on(employee, leave_type, add_days(previous_month_end, -1)), 9)
+		self.assertEqual(get_leave_balance_on(employee, leave_type, previous_month_end), 9)
 
 	def test_status_on_discard(self):
 		make_allocation_record()


### PR DESCRIPTION
- Get leave balance already considers leaves that expire on the end date of the allocation, `get_manually_expired_leaves` should exclude that record in such case to avoid counting expired leaves twice which leads to negative balances on end date of the allocation. And prevented backdated leave applications.  
Improved the where clause to accommodate this.
#### Before
<img width="1465" height="413" alt="Screenshot From 2026-01-05 11-59-09" src="https://github.com/user-attachments/assets/1bb16ec3-91db-42c2-8158-150aa112cb3e" />


#### After
<img width="1465" height="413" alt="Screenshot From 2026-01-05 11-58-42" src="https://github.com/user-attachments/assets/bddff051-1bf7-4a7d-bde9-2207f1190780" />

- Re triggered leave type dashboard on change of posting date to be able to see correct leave balances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Posting date changes now automatically update leave balance and dashboard information.

* **Bug Fixes**
  * Fixed incorrect leave balance calculations when processing backdated applications after leave allocation expiry.
  * Improved handling of manually expired leave allocations during balance computation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->