### PR TITLE
fix: Handle Receivable/Payable accounts in Payroll Entry deductions

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -373,7 +373,10 @@ class PayrollEntry(Document):
 				for cost_center, percentage in employee_cost_centers.items():
 					amount_against_cost_center = flt(item.amount) * percentage / 100
 
-					if employee_advance:
+					account = self.get_salary_component_account(item.salary_component)
+					account_type = frappe.get_cached_value("Account", account, "account_type")
+
+					if employee_advance or account_type in ("Receivable", "Payable"):
 						self.add_advance_deduction_entry(
 							item, amount_against_cost_center, cost_center, employee_advance
 						)
@@ -452,6 +455,7 @@ class PayrollEntry(Document):
 				precision,
 				entry_type="credit",
 				accounts=accounts,
+				party_type="Employee",
 				party=entry.get("employee"),
 				reference_type="Employee Advance",
 				reference_name=entry.get("reference_name"),
@@ -762,6 +766,7 @@ class PayrollEntry(Document):
 		accounting_dimensions,
 		precision,
 		entry_type="credit",
+		party_type=None,
 		party=None,
 		accounts=None,
 		reference_type=None,
@@ -778,6 +783,7 @@ class PayrollEntry(Document):
 			"cost_center": cost_center,
 			"project": self.project,
 		}
+
 
 		if entry_type == "debit":
 			payable_amount += flt(amount, precision)
@@ -805,7 +811,7 @@ class PayrollEntry(Document):
 		if party:
 			row.update(
 				{
-					"party_type": "Employee",
+					"party_type": party_type or "Employee",
 					"party": party,
 				}
 			)


### PR DESCRIPTION
**Problem**
When a Salary Component is linked to a **Receivable** or **Payable** account (like "Employee Receivables") but is not linked to a specific Employee Advance document (manual deduction), the `Payroll Entry` aggregates these amounts by Cost Center.

This leads to a loss of the Employee (Party) reference. Since ERPNext requires a Party for all Receivable/Payable accounts, submitting the Payroll Entry fails with:
`ValidationError: Row X: Party Type and Party is required for Receivable / Payable account`

**Fix**
1. Updated [get_salary_component_total] (payroll_entry.py:354) to check account types. If an account is **Receivable** or **Payable**, it now skips aggregation.
2. These entries now use the [add_advance_deduction_entry] (payroll_entry.py:418) flow, which generates a separate Journal Entry row for each employee.
3. Updated [get_accounting_entries_and_payable_amount] (payroll_entry.py:757) to explicitly pass `party_type="Employee"` and the `party` ID to the Journal Entry.

**Result**
Journal Entries created from Payroll now effectively handle manual deductions against Receivable/Payable accounts, ensuring the Employee reference is preserved and validation passes.