### PR TITLE
fix: create reverse ledger entry for backdated leave applications

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -113,6 +113,8 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		self.create_leave_ledger_entry()
 		# create a reverse ledger entry for backdated leave applications for whom expiry entry already exists
 		leave_allocation = self.get_leave_allocation()
+		if not leave_allocation:
+			return
 		to_date = leave_allocation.get("to_date")
 		can_expire = not frappe.db.get_value("Leave Type", self.leave_type, "is_carry_forward")
 

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -111,6 +111,17 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self.notify_employee()
 
 		self.create_leave_ledger_entry()
+		# create a reverse ledger entry for backdated leave applications for whom expiry entry already exists
+		leave_allocation = self.get_leave_allocation()
+		to_date = leave_allocation.get("to_date")
+		can_expire = not frappe.db.get_value("Leave Type", self.leave_type, "is_carry_forward")
+
+		if to_date < getdate() and can_expire:
+			args = frappe._dict(
+				leaves=self.total_leave_days, from_date=to_date, to_date=to_date, is_carry_forward=0
+			)
+			create_leave_ledger_entry(self, args)
+
 		self.reload()
 
 	def before_cancel(self):
@@ -249,6 +260,22 @@ class LeaveApplication(Document, PWANotificationsMixin):
 					"Leave cannot be applied/cancelled before {0}, as leave balance has already been carry-forwarded in the future leave allocation record {1}"
 				).format(formatdate(future_allocation[0].from_date), future_allocation[0].name)
 			)
+
+	def get_leave_allocation(self):
+		date = self.posting_date or getdate()
+		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
+		leave_allocation = (
+			frappe.qb.from_(LeaveAllocation)
+			.select(LeaveAllocation.to_date)
+			.where(
+				((LeaveAllocation.from_date <= date) & (date <= LeaveAllocation.to_date))
+				& (LeaveAllocation.docstatus == 1)
+				& (LeaveAllocation.leave_type == self.leave_type)
+				& (LeaveAllocation.employee == self.employee)
+			)
+		).run(as_dict=True)
+
+		return leave_allocation[0] if leave_allocation else None
 
 	def update_attendance(self):
 		if self.status != "Approved":

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -1451,6 +1451,15 @@ class TestLeaveApplication(HRMSTestSuite):
 		doc.save()
 		doc.submit()
 		self.assertEqual(get_leave_balance_on(employee, leave_type, previous_month_end), 9)
+		leave_ledger_entry = frappe.get_all(
+			"Leave Ledger Entry",
+			fields="*",
+			filters={"transaction_name": doc.name},
+			order_by="leaves",
+		)
+		self.assertEqual(len(leave_ledger_entry), 2)
+		self.assertEqual(leave_ledger_entry[0].leaves, doc.total_leave_days * -1)
+		self.assertEqual(leave_ledger_entry[1].leaves, doc.total_leave_days * 1)
 
 	def test_status_on_discard(self):
 		make_allocation_record()


### PR DESCRIPTION
When leave applications are created when expiry entry already exists for the allocation, the negative entry of the application, has to be countered with a reverse entry so that the total sum of leaves is correct.
<img width="2256" height="558" alt="image" src="https://github.com/user-attachments/assets/86ea83b9-08bd-4080-ad04-128383968b4c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backdated leave submissions after allocation expiry now create the additional ledger entry needed to correctly reflect leave usage and restore expired allocation balances, ensuring accurate leave totals and transaction ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->