### PR TITLE
fix: add missing translation

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -286,7 +286,7 @@ frappe.ui.form.on("Leave Application", {
 		}
 	},
 	show_save_button: function (frm) {
-		frm.page.set_primary_action("Save", () => {
+		frm.page.set_primary_action(__("Save"), () => {
 			frm.save();
 		});
 		$(".form-message").prop("hidden", true);


### PR DESCRIPTION
In **Leave Application** DocType
### Before
<img width="2278" height="468" alt="Before" src="https://github.com/user-attachments/assets/9a128edc-9858-4396-8039-c062f1e171b5" />

### After
<img width="2305" height="465" alt="After" src="https://github.com/user-attachments/assets/3b8175ef-7789-47bf-9b22-7a5f79518979" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled localization support for the Leave Application interface, allowing button text to be translated into multiple languages based on user locale settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->