### PR TITLE
feat(salary-structure-assignmet): leave encashment amount field added

### DIFF
--- a/hrms/hr/doctype/leave_encashment/leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.py
@@ -181,9 +181,27 @@ class LeaveEncashment(AccountsController):
 		if not hasattr(self, "_salary_structure"):
 			self.set_salary_structure()
 
-		per_day_encashment = frappe.db.get_value(
-			"Salary Structure", self._salary_structure, "leave_encashment_amount_per_day"
+		per_day_encashment = frappe.get_value(
+			"Salary Structure Assignment",
+			filters={
+				"employee": self.employee,
+				"salary_structure": self._salary_structure,
+				"docstatus": 1,
+				"from_date": ["<=", self.encashment_date],
+			},
+			fieldname=["leave_encashment_amount_per_day"],
+			order_by="from_date desc",
 		)
+
+		if not per_day_encashment:
+			per_day_encashment = frappe.db.get_value(
+				"Salary Structure",
+				self._salary_structure,
+				"leave_encashment_amount_per_day",
+			)
+
+		per_day_encashment = per_day_encashment or 0
+
 		self.encashment_amount = self.encashment_days * per_day_encashment if per_day_encashment > 0 else 0
 
 	def set_status(self, update=False):

--- a/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
+++ b/hrms/hr/doctype/leave_encashment/test_leave_encashment.py
@@ -426,6 +426,33 @@ class TestLeaveEncashment(IntegrationTestCase):
 		encashment.reload()
 		self.assertEqual(encashment.status, "Cancelled")
 
+	def test_leave_encashment_based_on_salary_structure_assignment(self):
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+			create_salary_structure_assignment,
+		)
+
+		salary_structure = make_salary_structure(
+			"Salary Structure for Encashment Amount",
+			"Monthly",
+			self.employee,
+		)
+
+		create_salary_structure_assignment(
+			employee=self.employee,
+			salary_structure=salary_structure.name,
+			company="_Test Company",
+			currency="INR",
+			leave_encashment_amount_per_day=50,
+		)
+
+		leave_encashment = self.create_test_leave_encashment(encashment_date=getdate())
+		leave_encashment.submit()
+
+		self.assertEqual(leave_encashment.leave_balance, 10)
+		self.assertTrue(leave_encashment.actual_encashable_days, 5)
+		self.assertTrue(leave_encashment.encashment_days, 5)
+		self.assertEqual(leave_encashment.encashment_amount, 250)
+
 
 def create_leave_encashment(**args):
 	if args:

--- a/hrms/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/test_salary_structure.py
@@ -252,6 +252,7 @@ def create_salary_structure_assignment(
 	base=None,
 	allow_duplicate=False,
 	include_flexi_benefits=False,
+	leave_encashment_amount_per_day=None,
 ):
 	if not currency:
 		currency = erpnext.get_default_currency()
@@ -288,6 +289,8 @@ def create_salary_structure_assignment(
 	salary_structure_assignment.payroll_payable_account = get_payable_account(company)
 	salary_structure_assignment.company = company or erpnext.get_default_company()
 	salary_structure_assignment.income_tax_slab = income_tax_slab
+	if leave_encashment_amount_per_day:
+		salary_structure_assignment.leave_encashment_amount_per_day = leave_encashment_amount_per_day
 	for benefit in employee_benefits:
 		salary_structure_assignment.append("employee_benefits", benefit)
 	salary_structure_assignment.save(ignore_permissions=True)

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -25,6 +25,8 @@
   "column_break_9",
   "variable",
   "amended_from",
+  "column_break_kjvm",
+  "leave_encashment_amount_per_day",
   "opening_balances_section",
   "taxable_earnings_till_date",
   "column_break_20",
@@ -104,7 +106,7 @@
   {
    "fieldname": "section_break_7",
    "fieldtype": "Section Break",
-   "label": "Base & Variable"
+   "label": "Base, Variable & Leave Encashment"
   },
   {
    "fetch_from": "grade.default_base_pay",
@@ -227,15 +229,27 @@
    "fieldname": "max_benefits",
    "fieldtype": "Currency",
    "label": "Maximum Benefit Amount"
+  },
+  {
+   "fieldname": "column_break_kjvm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "salary_structure.leave_encashment_amount_per_day",
+   "fetch_if_empty": 1,
+   "fieldname": "leave_encashment_amount_per_day",
+   "fieldtype": "Currency",
+   "label": "Leave Encashment Amount Per Day",
+   "options": "currency"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-03 17:06:42.296943",
+ "modified": "2026-01-09 11:52:07.106968",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
**Issue:** #3879 ,  #3880 

**Description:** Currently, Leave Encashment Amount per Day is configured in the Salary Structure.
This value is applied uniformly to all employees who are assigned to that Salary Structure.

In real scenarios, the Leave Encashment Amount per Day differs for each employee, even when they share the same Salary Structure.

**Ref:** [56858](https://support.frappe.io/helpdesk/tickets/56858?view=VIEW-HD+Ticket-781)

[Screencast from 2026-01-09 00-11-04.webm](https://github.com/user-attachments/assets/e318c905-8a16-4189-955e-8fe2e76a3b70)



Backport needed for v-15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-day leave encashment rate can be set on Salary Structure Assignments via a "Leave Encashment Amount Per Day" field; pay section label updated. Rate falls back to the Salary Structure when not set. Falsy rates are treated as 0 and encashment amount is applied only when rate > 0.

* **Tests**
  * Added a test validating encashment calculations respect the assignment-level per-day rate and expected totals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->