### PR TITLE
feat(Organizational Chart): add Employee role to page permissions

### DIFF
--- a/hrms/hr/page/organizational_chart/organizational_chart.json
+++ b/hrms/hr/page/organizational_chart/organizational_chart.json
@@ -4,7 +4,7 @@
  "docstatus": 0,
  "doctype": "Page",
  "idx": 0,
- "modified": "2021-05-25 10:53:18.201931",
+ "modified": "2026-01-24 18:44:07.197592",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "organizational-chart",
@@ -16,6 +16,9 @@
   },
   {
    "role": "HR Manager"
+  },
+  {
+   "role": "Employee"
   }
  ],
  "script": null,


### PR DESCRIPTION
## Description
Fixes #3731
`no-docs`

Adds the "Employee" role to the Organizational Chart page permissions, allowing standard employees to view the org chart by default.

## Changes
- Added "Employee" role to `hrms/hr/page/organizational_chart/organizational_chart.json`

## Testing
Verified via bench console that users with Employee role now have access:
```python
>>> frappe.set_user("employee@test.com")
>>> user_roles = set(frappe.get_roles())
>>> page_roles = {'Employee', 'HR User', 'HR Manager'}
>>> has_access = bool(user_roles & page_roles)
>>> print("Has access:", has_access)
Has access: True
```

**Before:** Only HR User and HR Manager roles could access the page.
**After:** Employee role users can now access the Organizational Chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an "Employee" role to the organizational chart so it’s available in role options.
  * Updated the organizational chart metadata (modified timestamp) to reflect the latest change.
  * Minor formatting fix to ensure the organizational chart data is properly closed and well-formed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->