### PR TITLE
fix: Leaves workspace settings link should point to Leaves tab of HR Settings

### DIFF
--- a/hrms/workspace_sidebar/leaves.json
+++ b/hrms/workspace_sidebar/leaves.json
@@ -216,11 +216,12 @@
    "label": "Settings",
    "link_to": "HR Settings",
    "link_type": "DocType",
+   "navigate_to_tab": "leaves_tab",
    "show_arrow": 0,
    "type": "Link"
   }
  ],
- "modified": "2026-01-10 15:13:33.783255",
+ "modified": "2026-01-12 14:12:08.828397",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leaves",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Leaves workspace sidebar navigation configuration to streamline access to leaves settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->