### PR TITLE
test: set mandatory field in loan product

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -1192,6 +1192,7 @@ def setup_lending():
 			penalty_income_account="Penalty Income Account - _TC",
 			repayment_schedule_type="Monthly as per repayment start date",
 			collection_offset_sequence_for_standard_asset="Test EMI Based Standard Loan Demand Offset Order",
+			collection_offset_sequence_for_sub_standard_asset="Test EMI Based Standard Loan Demand Offset Order",
 		)
 
 	return (


### PR DESCRIPTION
`collection_offset_sequence_for_sub_standard_asset` field was made mandatory in loan product without a default value and wasn't being set from our tests either, which made them fail with validation error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test data configuration for loan product setup with additional asset classification parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->