### PR TITLE
feat: Add global HRMS mobile app controls for employee requests

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -23,39 +23,51 @@ import LeaveIcon from "@/components/icons/LeaveIcon.vue"
 import ExpenseIcon from "@/components/icons/ExpenseIcon.vue"
 import EmployeeAdvanceIcon from "@/components/icons/EmployeeAdvanceIcon.vue"
 import SalaryIcon from "@/components/icons/SalaryIcon.vue"
+import { createResource } from "frappe-ui"
+import { computed } from "vue"
 
 const __ = inject("$translate")
 
-const quickLinks = [
-	{
-		icon: markRaw(AttendanceIcon),
-		title: __("Request Attendance"),
-		route: "AttendanceRequestFormView",
-	},
-	{
-		icon: markRaw(ShiftIcon),
-		title: __("Request a Shift"),
-		route: "ShiftRequestFormView",
-	},
-	{
-		icon: markRaw(LeaveIcon),
-		title: __("Request Leave"),
-		route: "LeaveApplicationFormView",
-	},
-	{
-		icon: markRaw(ExpenseIcon),
-		title: __("Claim an Expense"),
-		route: "ExpenseClaimFormView",
-	},
-	{
-		icon: markRaw(EmployeeAdvanceIcon),
-		title: __("Request an Advance"),
-		route: "EmployeeAdvanceFormView",
-	},
-	{
-		icon: markRaw(SalaryIcon),
-		title: __("View Salary Slips"),
-		route: "SalarySlipsDashboard",
-	},
-]
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
+})
+
+const quickLinks = computed(() => {
+	if (!settings.data) return []
+
+	return [
+		settings.data.allow_attendance_request_from_mobile_app && {
+			icon: markRaw(AttendanceIcon),
+			title: __("Request Attendance"),
+			route: "AttendanceRequestFormView",
+		},
+		settings.data.allow_shift_request_from_mobile_app && {
+			icon: markRaw(ShiftIcon),
+			title: __("Request a Shift"),
+			route: "ShiftRequestFormView",
+		},
+		settings.data.allow_leave_application_from_mobile_app && {
+			icon: markRaw(LeaveIcon),
+			title: __("Request Leave"),
+			route: "LeaveApplicationFormView",
+		},
+		settings.data.allow_expense_claim_from_mobile_app && {
+			icon: markRaw(ExpenseIcon),
+			title: __("Claim an Expense"),
+			route: "ExpenseClaimFormView",
+		},
+		settings.data.allow_employee_advance_from_mobile_app && {
+			icon: markRaw(EmployeeAdvanceIcon),
+			title: __("Request an Advance"),
+			route: "EmployeeAdvanceFormView",
+		},
+		{
+			icon: markRaw(SalaryIcon),
+			title: __("View Salary Slips"),
+			route: "SalarySlipsDashboard",
+		},
+	].filter(Boolean)
+})
+
 </script>

--- a/frontend/src/views/attendance/AttendanceRequestForm.vue
+++ b/frontend/src/views/attendance/AttendanceRequestForm.vue
@@ -2,7 +2,7 @@
 	<ion-page>
 		<ion-content :fullscreen="true">
 			<FormView
-				v-if="formFields.data"
+				v-if="formFields.data && settings.data?.allow_attendance_request_from_mobile_app"
 				doctype="Attendance Request"
 				v-model="attendanceRequest"
 				:isSubmittable="true"
@@ -18,6 +18,8 @@
 import { IonPage, IonContent } from "@ionic/vue"
 import { createResource } from "frappe-ui"
 import { ref, watch, inject } from "vue"
+import { useRouter } from "vue-router"
+import { toast } from "frappe-ui"
 
 import FormView from "@/components/FormView.vue"
 
@@ -29,6 +31,14 @@ const props = defineProps({
 		type: String,
 		required: false,
 	},
+})
+
+const router = useRouter()
+
+// Fetch HR settings
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
 })
 
 // reactive object to store form data
@@ -48,6 +58,21 @@ const formFields = createResource({
 })
 
 // form scripts
+watch(
+	() => settings.data,
+	(settingsData) => {
+		if (settingsData && !settingsData.allow_attendance_request_from_mobile_app) {
+			toast({
+				title: __("Access Denied"),
+				text: __("Attendance requests are disabled from the mobile app"),
+				icon: "alert-circle",
+			})
+			router.replace("/") // go back to home
+		}
+	},
+	{ immediate: true }
+)
+
 watch(
 	() => attendanceRequest.value.employee,
 	(employee_id) => {

--- a/frontend/src/views/attendance/ShiftRequestForm.vue
+++ b/frontend/src/views/attendance/ShiftRequestForm.vue
@@ -2,7 +2,7 @@
 	<ion-page>
 		<ion-content :fullscreen="true">
 			<FormView
-				v-if="formFields.data"
+				v-if="formFields.data && settings.data?.allow_shift_request_from_mobile_app"
 				doctype="Shift Request"
 				v-model="shiftRequest"
 				:isSubmittable="true"
@@ -16,12 +16,15 @@
 
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
-import { createResource } from "frappe-ui"
+import { createResource, toast } from "frappe-ui"
 import { ref, watch, inject } from "vue"
+import { useRouter } from "vue-router"
 
 import FormView from "@/components/FormView.vue"
 
 const employee = inject("$employee")
+const __ = inject("$translate")
+const router = useRouter()
 
 const props = defineProps({
 	id: {
@@ -29,6 +32,26 @@ const props = defineProps({
 		required: false,
 	},
 })
+
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
+})
+
+watch(
+	() => settings.data,
+	(settingsData) => {
+		if (settingsData && !settingsData.allow_shift_request_from_mobile_app) {
+			toast({
+				title: __("Access Denied"),
+				text: __("Shift Requests are disabled from the mobile app"),
+				icon: "alert-circle",
+			})
+			router.replace("/") 
+		}
+	},
+	{ immediate: true }
+)
 
 // reactive object to store form data
 const shiftRequest = ref({})

--- a/frontend/src/views/employee_advance/Form.vue
+++ b/frontend/src/views/employee_advance/Form.vue
@@ -2,7 +2,7 @@
 	<ion-page>
 		<ion-content :fullscreen="true">
 			<FormView
-				v-if="formFields.data"
+				v-if="formFields.data && settings.data?.allow_employee_advance_from_mobile_app"
 				doctype="Employee Advance"
 				v-model="employeeAdvance"
 				:isSubmittable="true"
@@ -19,18 +19,27 @@
 import { IonPage, IonContent } from "@ionic/vue"
 import { createResource } from "frappe-ui"
 import { ref, watch, inject, computed } from "vue"
+import { useRouter } from "vue-router"
+import { toast } from "frappe-ui"
 
 import FormView from "@/components/FormView.vue"
 
 import { getCompanyCurrency } from "@/data/currencies"
 
 const employee = inject("$employee")
+const __ = inject("$translate")
 
 const props = defineProps({
 	id: {
 		type: String,
 		required: false,
 	},
+})
+
+const router = useRouter()
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
 })
 
 // object to store form data
@@ -85,6 +94,21 @@ const advanceAccount = createResource({
 })
 
 // form scripts
+watch(
+	() => settings.data,
+	(settingsData) => {
+		if (settingsData && !settingsData.allow_employee_advance_from_mobile_app) {
+			toast({
+				title: __("Access Denied"),
+				text: __("Employee Advance requests are disabled from the mobile app"),
+				icon: "alert-circle",
+			})
+			router.replace("/") // go back to home
+		}
+	},
+	{ immediate: true }
+)
+
 watch(
 	() => employeeAdvance.value.currency,
 	() => setExchangeRate()

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -2,7 +2,7 @@
 	<ion-page>
 		<ion-content :fullscreen="true">
 			<FormView
-				v-if="formFields.data"
+				v-if="formFields.data && settings.data?.allow_expense_claim_from_mobile_app"
 				doctype="Expense Claim"
 				v-model="expenseClaim"
 				:isSubmittable="true"
@@ -52,8 +52,9 @@
 
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
-import { createResource } from "frappe-ui"
+import { createResource, toast } from "frappe-ui"
 import { computed, ref, watch, inject } from "vue"
+import { useRouter } from "vue-router"
 
 import FormView from "@/components/FormView.vue"
 import ExpensesTable from "@/components/ExpensesTable.vue"
@@ -64,6 +65,8 @@ import { getCompanyCurrency } from "@/data/currencies"
 
 
 const dayjs = inject("$dayjs")
+const __ = inject("$translate")
+const router = useRouter()
 
 const today = dayjs().format("YYYY-MM-DD")
 const isReadOnly = ref(false)
@@ -86,7 +89,27 @@ const tabs = [
 	{ name: "Totals", lastField: "cost_center" },
 ]
 
-// object to store form data
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
+})
+
+watch(
+	() => settings.data,
+	(settingsData) => {
+		if (settingsData && !settingsData.allow_expense_claim_from_mobile_app) {
+			toast({
+				title: __("Access Denied"),
+				text: __("Expense Claim requests are disabled from the mobile app"),
+				icon: "alert-circle",
+			})
+			router.replace("/") // go back to home
+		}
+	},
+	{ immediate: true }
+)
+
+// reactive object to store form data
 const expenseClaim = ref({
 	employee: currEmployee,
 	company: employeeCompany,

--- a/frontend/src/views/leave/Form.vue
+++ b/frontend/src/views/leave/Form.vue
@@ -2,7 +2,7 @@
 	<ion-page>
 		<ion-content :fullscreen="true">
 			<FormView
-				v-if="formFields.data"
+				v-if="formFields.data && settings.data?.allow_leave_application_from_mobile_app"
 				doctype="Leave Application"
 				v-model="leaveApplication"
 				:isSubmittable="true"
@@ -17,13 +17,15 @@
 
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
-import { createResource } from "frappe-ui"
+import { createResource, toast } from "frappe-ui"
 import { ref, watch, inject } from "vue"
+import { useRouter } from "vue-router"
 
 import FormView from "@/components/FormView.vue"
 
 const dayjs = inject("$dayjs")
 const __ = inject("$translate")
+const router = useRouter()
 const today = dayjs().format("YYYY-MM-DD")
 
 const props = defineProps({
@@ -35,6 +37,26 @@ const props = defineProps({
 
 const sessionEmployee = inject("$employee")
 const currEmployee = ref(sessionEmployee.data.name)
+
+const settings = createResource({
+	url: "hrms.api.get_hr_settings",
+	auto: true,
+})
+
+watch(
+	() => settings.data,
+	(settingsData) => {
+		if (settingsData && !settingsData.allow_leave_application_from_mobile_app) {
+			toast({
+				title: __("Access Denied"),
+				text: __("Leave Applications are disabled from the mobile app"),
+				icon: "alert-circle",
+			})
+			router.replace("/") // go back to home
+		}
+	},
+	{ immediate: true }
+)
 
 // reactive object to store form data
 const leaveApplication = ref({})

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -85,6 +85,11 @@ def get_hr_settings() -> dict:
 	return frappe._dict(
 		allow_employee_checkin_from_mobile_app=settings.allow_employee_checkin_from_mobile_app,
 		allow_geolocation_tracking=settings.allow_geolocation_tracking,
+		allow_leave_application_from_mobile_app=settings.allow_leave_application_from_mobile_app,
+		allow_employee_advance_from_mobile_app=settings.allow_employee_advance_from_mobile_app,
+		allow_expense_claim_from_mobile_app=settings.allow_expense_claim_from_mobile_app,
+		allow_attendance_request_from_mobile_app=settings.allow_attendance_request_from_mobile_app,
+		allow_shift_request_from_mobile_app=settings.allow_shift_request_from_mobile_app,
 	)
 
 

--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -58,7 +58,13 @@
   "feedback_reminder_notification_template",
   "column_break_4",
   "hiring_sender",
-  "hiring_sender_email"
+  "hiring_sender_email",
+  "mobile_app_settings_section",
+  "allow_attendance_request_from_mobile_app",
+  "allow_shift_request_from_mobile_app",
+  "allow_leave_application_from_mobile_app",
+  "allow_expense_claim_from_mobile_app",
+  "allow_employee_advance_from_mobile_app",
  ],
  "fields": [
   {
@@ -374,6 +380,41 @@
    "fieldname": "employee_exit_settings_section",
    "fieldtype": "Section Break",
    "label": "Employee Exit Settings"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_leave_application_from_mobile_app",
+   "fieldtype": "Check",
+   "label": "Allow Leave Application from Mobile App"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_employee_advance_from_mobile_app",
+   "fieldtype": "Check",
+   "label": "Allow Employee Advance from Mobile App"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_expense_claim_from_mobile_app",
+   "fieldtype": "Check",
+   "label": "Allow Expense Claim from Mobile App"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_shift_request_from_mobile_app",
+   "fieldtype": "Check",
+   "label": "Allow Shift Request from Mobile App"
+  },
+  {
+   "fieldname": "mobile_app_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Mobile App Settings"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_attendance_request_from_mobile_app",
+   "fieldtype": "Check",
+   "label": "Allow Attendance Request from Mobile App"
   }
  ],
  "icon": "fa fa-cog",


### PR DESCRIPTION
This PR enhances the HRMS mobile app by allowing administrators to control which employee request workflows are available from the mobile app, based on company policy.

It introduces HR Settings–based controls to enable or disable mobile access for key HR workflows such as Leave, Shift, Attendance, Expense Claims, and Employee Advances.

**Issues**

Feat: HRMS Mobile App – Global Controls for Employee Requests https://github.com/frappe/hrms/issues/3956

Support Ticket https://support.frappe.io/helpdesk/my-tickets/56703

**Solution**
This PR introduces a centralized and configurable way to control which HR workflows are available from the HRMS mobile app.

The following changes were made:

- Added new Mobile App Settings in HR Settings to enable or disable:
  - Leave Application
  - Shift Request
  - Attendance Request
  - Expense Claim
  - Employee Advance
- Exposed these settings via hrms.api.get_hr_settings for mobile consumption.
- Updated the mobile home screen so Quick Links are dynamically shown or hidden based on these settings.
- Added runtime validation on each mobile request form (Leave, Shift, Attendance, Expense, Employee Advance) to:
  - Block access when the feature is disabled
  - Show an “Access Denied” message
  - Redirect the user back to the home screen

This ensures users cannot submit requests even if they directly navigate to a disabled form.
**After**
<img width="1834" height="802" alt="image" src="https://github.com/user-attachments/assets/d3863174-9dc2-4cc5-88d5-87423f29eb9d" />

https://github.com/user-attachments/assets/a93fd6a4-4f95-47ee-b68f-f904a48ecb55



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile app access controls: admins can enable/disable leave, expense claims, attendance requests, shift requests, and employee advances via HR Settings (defaults enabled).
  * Dynamic quick links: Home quick links now adapt to HR Settings.
  * Access enforcement UX: when a mobile feature is disabled, users see an "Access Denied" notification and are redirected to the home screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->