### PR TITLE
fix: link to holiday list assignment in the message

### DIFF
--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe import _
-from frappe.utils import add_days, getdate
+from frappe.utils import add_days, get_link_to_form, getdate
 
 
 def get_holiday_dates_between(
@@ -90,7 +90,11 @@ def get_holiday_list_for_employee(
 
 	if not holiday_list and raise_exception:
 		frappe.throw(
-			_("Please assign Holiday List for Employee {0} or their company {1}").format(employee, company)
+			_("Please assign Holiday List for Employee {0} or their company {1} through {2}").format(
+				employee,
+				company,
+				get_link_to_form("Holiday List Assignment", label="Holiday List Assignment"),
+			)
 		)
 	return holiday_list
 


### PR DESCRIPTION
#### Before

<img width="1458" height="698" alt="Screenshot From 2026-01-15 14-42-46" src="https://github.com/user-attachments/assets/70cbd63c-c28b-410c-8b84-1a4149cda30e" />

#### After

https://github.com/user-attachments/assets/91c11bf2-8055-4a93-a178-3ea83d10d3b6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for holiday list-related issues by including direct links to the Holiday List Assignment form, enabling users to quickly navigate to relevant configuration pages and resolve assignment issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->