### PR TITLE
ci: fix generate POT workflow

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -27,6 +27,11 @@ jobs:
           with:
             python-version: "3.14"
 
+        - name: Setup Node
+          uses: actions/setup-node@v6
+          with:
+            node-version: 24
+
         - name: Run script to update POT file
           run: |
             bash ${GITHUB_WORKSPACE}/.github/helper/update_pot_file.sh


### PR DESCRIPTION
This pull request adds a new step to the GitHub Actions workflow to set up Node.js before running the script that updates the POT file. This ensures that Node.js version 24 is available in the environment, which may be required by the script or its dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to support Node.js environment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->