### PR TITLE
fix: employee advance account's account type should be receivable

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -80,8 +80,11 @@ class EmployeeAdvance(Document):
 		hrms.refetch_resource("hrms:employee_advance_balance", employee_user)
 
 	def validate_advance_account_type(self):
+		if not self.advance_account:
+			return
+
 		account_type = frappe.db.get_value("Account", self.advance_account, "account_type")
-		if account_type and (account_type != "Receivable"):
+		if not account_type or (account_type != "Receivable"):
 			frappe.throw(
 				_("Employee advance account {0} should be of type {1}.").format(
 					get_link_to_form("Account", self.advance_account), frappe.bold(_("Receivable"))


### PR DESCRIPTION
Added preventive fix for https://support.frappe.io/helpdesk/tickets/57086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now requires an advance account to have an explicit account type of "Receivable", preventing submission when an invalid or missing account type is supplied.
  * When no advance account is provided, account-type checks are skipped to avoid unnecessary errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->