### PR TITLE
fix(user-type): add leave type read permission for employee self service

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -34,6 +34,7 @@ hrms.patches.v15_0.fix_timesheet_status
 hrms.patches.v15_0.update_advance_payment_ledger_amount #2025-09-23 
 hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim
+hrms.patches.v15_0.add_leave_type_permission_for_ess.py
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
 hrms.patches.v16_0.delete_old_workspaces #2026-01-09
 hrms.patches.v16_0.create_holiday_list_assignments

--- a/hrms/patches/v15_0/add_leave_type_permission_for_ess.py
+++ b/hrms/patches/v15_0/add_leave_type_permission_for_ess.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def execute():
+	doc = frappe.get_doc("User Type", "Employee Self Service")
+
+	existing = {d.document_type for d in doc.user_doctypes}
+
+	if "Leave Type" not in existing:
+		doc.append(
+			"user_doctypes",
+			{
+				"document_type": "Leave Type",
+				"read": 1,
+			},
+		)
+		doc.save()

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -557,7 +557,6 @@ def get_post_install_patches():
 		"create_country_fixtures",
 		"update_allocate_on_in_leave_type",
 		"update_performance_module_changes",
-		"add_leave_type_permission_for_ess",
 	)
 
 

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -557,6 +557,7 @@ def get_post_install_patches():
 		"create_country_fixtures",
 		"update_allocate_on_in_leave_type",
 		"update_performance_module_changes",
+		"add_leave_type_permission_for_ess",
 	)
 
 
@@ -646,6 +647,7 @@ def get_user_types_data():
 				"Expense Claim Type": ["read"],
 				"Employee Advance": ["read", "write", "create", "delete"],
 				# leave and attendance
+				"Leave Type": ["read"],
 				"Leave Application": ["read", "write", "create", "delete"],
 				"Attendance Request": ["read", "write", "create", "delete"],
 				"Compensatory Leave Request": ["read", "write", "create", "delete"],


### PR DESCRIPTION
**Issue:** The Employee Self Service user type does not have the permission for Leave Type

**Ref:** [57831](https://support.frappe.io/helpdesk/tickets/57831?view=VIEW-HD+Ticket-781)

**Before:**

[Screencast from 2026-01-22 17-05-20.webm](https://github.com/user-attachments/assets/c4d569d4-04e8-4719-9abf-8764265ad493)


**After:**

[Screencast from 2026-01-22 17-02-08.webm](https://github.com/user-attachments/assets/0392518b-07b9-4591-83c3-8a16c4cb97ef)


Backport needed for v-15, v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Employee Self Service users now have read access to Leave Type information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->