### PR TITLE
fix(expense-claim): inclusion of tax and charges in allocated amount

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -346,7 +346,7 @@ frappe.ui.form.on("Expense Claim", {
 
 	update_employee_advance_claimed_amount: function (frm) {
 		let amount_to_be_allocated =
-			frm.doc.total_sanctioned_amount + flt(frm.doc.total_taxes_and_charges);
+			flt(frm.doc.total_sanctioned_amount) + flt(frm.doc.total_taxes_and_charges);
 		$.each(frm.doc.advances || [], function (i, advance) {
 			if (amount_to_be_allocated >= advance.unclaimed_amount - advance.return_amount) {
 				advance.allocated_amount =

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -345,7 +345,8 @@ frappe.ui.form.on("Expense Claim", {
 	},
 
 	update_employee_advance_claimed_amount: function (frm) {
-		let amount_to_be_allocated = frm.doc.total_sanctioned_amount;
+		let amount_to_be_allocated =
+			frm.doc.total_sanctioned_amount + flt(frm.doc.total_taxes_and_charges);
 		$.each(frm.doc.advances || [], function (i, advance) {
 			if (amount_to_be_allocated >= advance.unclaimed_amount - advance.return_amount) {
 				advance.allocated_amount =


### PR DESCRIPTION
**Issue:** The Allocated amount in advances table does not inclued tax and charges

**Ref:** [57821](https://support.frappe.io/helpdesk/tickets/57821?view=VIEW-HD+Ticket-781)

**Before:**

[Screencast from 2026-01-23 16-14-40.webm](https://github.com/user-attachments/assets/c0db568a-2e4d-4429-94a9-650aec0f4aa5)


**After:**

[Screencast from 2026-01-23 16-17-37.webm](https://github.com/user-attachments/assets/ee95c55e-5cfb-4b34-8f12-298f7a88580e)


Backport needed for v-15. v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expense claim allocation now includes taxes and charges when calculating the pool for applying employee advances. This increases the amount available for allocation, reducing instances of unallocated advances and ensuring displayed allocation totals on expense claims are more accurate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->