### PR TITLE
fix: check_app_permission returns False for Website Users

### DIFF
--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -1000,6 +1000,12 @@ def check_app_permission():
 	if frappe.session.user == "Administrator":
 		return True
 
+	# Website Users cannot access desk routes, so don't show the app to them
+	# This prevents redirect to /desk/people followed by 403 Forbidden
+	user_type = frappe.get_cached_value("User", frappe.session.user, "user_type")
+	if user_type == "Website User":
+		return False
+
 	if frappe.has_permission("Employee", ptype="read"):
 		return True
 


### PR DESCRIPTION
### **Title**
fix: check_app_permission returns False for Website Users

### **Description**
**Issue**
Website Users with the Employee role are redirected to /desk/people after login, but receive a 403 Forbidden error because Website Users cannot access desk routes.

### **Root Cause**
The check_app_permission() function only checked if the user has read permission on the Employee doctype. It did not verify whether the user can actually access the app's route (/desk/people).

### **Flow Before Fix**

1. Website User with Employee role logs in. 
2. get_default_path() calls get_apps()
3. check_app_permission() returns True (user can read Employee doctype)
4. HRMS is added to visible apps with route /desk/people
5. home_page is set to /desk/people
6. User is redirected to /desk/people
7. 403 Forbidden - Website Users cannot access /desk/*

### **Solution**
Added a check for Website Users before returning True. Since Website Users cannot access desk routes, the function now returns False for them, preventing HRMS from appearing in their apps list.

```
# Website Users cannot access desk routes, so don't show the app to them
user_type = frappe.get_cached_value("User", frappe.session.user, "user_type")
if user_type == "Website User":
    return False
```
### Testing

<img width="616" height="216" alt="Screenshot from 2026-01-24 16-36-31" src="https://github.com/user-attachments/assets/78018629-5008-4bad-a45e-3d14802d6393" />


### Type of change
 Bug fix (non-breaking change which fixes an issue)

### Related Issues
None found - this is a new bug report.

### Checklist

-  My code follows the style guidelines of this project
-  I have performed a self-review of my own code
-  I have commented my code where necessary
-  My changes generate no new warnings