### PR TITLE
fix(Leave Application): remove invalid amend permission from Leave Approver

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.json
+++ b/hrms/hr/doctype/leave_application/leave_application.json
@@ -307,7 +307,6 @@
    "write": 1
   },
   {
-   "amend": 1,
    "cancel": 1,
    "delete": 1,
    "email": 1,


### PR DESCRIPTION
## Description
Fixes #3991
no-docs

The Leave Approver role had `amend` permission without `create` permission, which violates Frappe's permission dependency rules and blocks fresh HRMS installations.

## Root Cause
In `leave_application.json`, Row 5 (Leave Approver at level 0) had `amend: 1` but no `create` permission. Frappe requires `create` when `amend` is granted (amending creates a new document version).

## Fix
Removed the invalid `amend` permission from Leave Approver role.

## Verification
CI passing will confirm the fix - the installation that was previously failing should now succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Leave Approver role permissions to prevent amending leave applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->