### PR TITLE
fix: use boarding_status instead of status in Employee Separation

### DIFF
--- a/hrms/hr/doctype/employee_separation/employee_separation_list.js
+++ b/hrms/hr/doctype/employee_separation/employee_separation_list.js
@@ -5,7 +5,7 @@ frappe.listview_settings["Employee Separation"] = {
 		return [
 			__(doc.boarding_status),
 			frappe.utils.guess_colour(doc.boarding_status),
-			"status,=," + doc.boarding_status,
+			"boarding_status,=," + doc.boarding_status,
 		];
 	},
 };


### PR DESCRIPTION
**Issue :**

Navigating from List View to Report View in the **Employee Separation** doctype throws the following error:

`frappe.exceptions.DataError:  Field not permitted in query: tabEmployee Separation.status`

**Issue :** [#3922 ](https://github.com/frappe/hrms/issues/3922)

**Backport needed for v-15. v-16**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the status indicator field for employee separations to accurately display boarding status information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->