### PR TITLE
fix: leave approver shouldn't have amend permission on leave application

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.json
+++ b/hrms/hr/doctype/leave_application/leave_application.json
@@ -255,7 +255,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2024-04-08 13:56:03.818019",
+ "modified": "2026-01-27 12:02:51.679025",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Application",
@@ -307,7 +307,6 @@
    "write": 1
   },
   {
-   "amend": 1,
    "cancel": 1,
    "delete": 1,
    "email": 1,
@@ -345,6 +344,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee,employee_name,leave_type,from_date,to_date,total_leave_days",
  "sort_field": "creation",
  "sort_order": "DESC",


### PR DESCRIPTION
To avoid this exception while creating new site, introduced with frappe/frappe#35640
`frappe.exceptions.ValidationError: For Leave Approver at level 0 in Leave Application in row 5: The 'Amend' permission cannot be granted without the 'Create' permission.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Leave Approver permissions to remove amendment capability.

* **Changes**
  * Updated Leave Application form display format for improved layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->