### PR TITLE
fix(gratuity): consider default amount

### DIFF
--- a/hrms/payroll/doctype/gratuity/gratuity.py
+++ b/hrms/payroll/doctype/gratuity/gratuity.py
@@ -264,16 +264,11 @@ class Gratuity(AccountsController):
 		if not salary_slip:
 			frappe.throw(_("No Salary Slip found for Employee: {0}").format(bold(self.employee)))
 
-		# consider full payment days for calculation as last month's salary slip
-		# might have less payment days as per attendance, making it non-deterministic
-		salary_slip.payment_days = salary_slip.total_working_days
-		salary_slip.calculate_net_pay()
-
 		total_amount = 0
 		component_found = False
 		for row in salary_slip.earnings:
 			if row.salary_component in applicable_earning_components:
-				total_amount += flt(row.amount)
+				total_amount += flt(row.default_amount)
 				component_found = True
 
 		if not component_found:


### PR DESCRIPTION
**Issue:**  While creating Gratuity for a relieving employee who has an outstanding loan repayment balance, the system throws an error when the full loan amount is adjusted through Full & Final settlement.

**Ref:** [56591](https://support.frappe.io/helpdesk/tickets/56591?view=VIEW-HD+Ticket-781)

**Before:**

[Screencast from 2026-01-06 15-30-06.webm](https://github.com/user-attachments/assets/f2699c77-f7ab-4650-83c7-2b3c6c7e71c5)


**After:**


https://github.com/user-attachments/assets/3e167a0e-e0fa-40f7-b355-b26a0c679692




Backport needed for v-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined gratuity calculation: uses default earning values for aggregation and removed the forced recalculation step on the final payslip, improving determinism and simplifying payout computation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->