### PR TITLE
fix: update leave balance while cancelling the compensatory leave request

### DIFF
--- a/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py
@@ -112,7 +112,7 @@ class CompensatoryLeaveRequest(Document):
 			leave_allocation = frappe.get_doc("Leave Allocation", self.leave_allocation)
 			if leave_allocation:
 				leave_allocation.new_leaves_allocated -= date_difference
-				if leave_allocation.new_leaves_allocated - date_difference <= 0:
+				if leave_allocation.new_leaves_allocated < 0:
 					leave_allocation.new_leaves_allocated = 0
 				leave_allocation.validate()
 				leave_allocation.db_set("new_leaves_allocated", leave_allocation.total_leaves_allocated)

--- a/hrms/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
@@ -49,6 +49,25 @@ class TestCompensatoryLeaveRequest(HRMSTestSuite):
 			before + 1,
 		)
 
+	def test_leave_balance_on_cancel(self):
+		"""check leave balance update on cancellation of compensatory leave request"""
+		employee = get_employee()
+		mark_attendance(employee, date=add_days(today(), -1))
+
+		request_1 = get_compensatory_leave_request(employee.name, leave_date=add_days(today(), -1))
+
+		request_1.submit()
+		mark_attendance(employee)
+		request_2 = get_compensatory_leave_request(employee.name)
+
+		request_2.submit()
+		# cancel today's compensatory leave request
+		request_2.cancel()
+		self.assertEqual(
+			get_leave_balance_on(employee.name, request_2.leave_type, today()),
+			1,
+		)
+
 	def test_allocation_update_on_submit(self):
 		employee = get_employee()
 		mark_attendance(employee, date=add_days(today(), -1))


### PR DESCRIPTION
**Issue:**
While cancelling a Compensatory Leave Request, the system incorrectly recalculates the Leave Allocation, causing valid compensatory leaves to be reduced to zero when multiple compensatory leave requests exist for the same employee and leave period.

Fixes: https://github.com/frappe/hrms/issues/3985

**Before:**

[beforeScreencast from 27-01-26 06:15:35 PM IST.webm](https://github.com/user-attachments/assets/d665e653-676c-4921-aabe-169d4df25f8b)

**After:**

[Screencast from 27-01-26 06:17:57 PM IST.webm](https://github.com/user-attachments/assets/79f826b3-154b-4851-8e96-2b6545b9c3cc)

Backport needed for : v15, v16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leave balance recalculation when canceling compensatory leave so balances cannot become negative and are floored to zero when appropriate.

* **Tests**
  * Added automated test to verify leave balances are correctly updated after canceling compensatory leave requests, including same-day cancellation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->