### PR TITLE
chore: update v15 patch for add_leave_type_permission_for_ess

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -34,7 +34,7 @@ hrms.patches.v15_0.fix_timesheet_status
 hrms.patches.v15_0.update_advance_payment_ledger_amount #2025-09-23 
 hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim
-hrms.patches.v15_0.add_leave_type_permission_for_ess.py
+hrms.patches.v15_0.add_leave_type_permission_for_ess
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
 hrms.patches.v16_0.delete_old_workspaces #2026-01-09
 hrms.patches.v16_0.create_holiday_list_assignments


### PR DESCRIPTION
The patch reference for add_leave_type_permission_for_ess included a .py extension. This has been removed to align with the expected patch format
**regression from:** https://github.com/frappe/hrms/pull/4020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated patch module reference format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->