### PR TITLE
fix(organizational-chart): show empty state when no data is available

### DIFF
--- a/hrms/hr/page/organizational_chart/organizational_chart.js
+++ b/hrms/hr/page/organizational_chart/organizational_chart.js
@@ -1,3 +1,153 @@
+hrms.organizational_chart = hrms.organizational_chart || {};
+
+Object.assign(hrms.organizational_chart, {
+	get_employee_count(company) {
+		const args = {
+			doctype: "Employee",
+		};
+
+		if (company) {
+			args.filters = { company };
+		}
+
+		return frappe
+			.call({
+				method: "frappe.client.get_count",
+				args,
+			})
+			.then((r) => Number(r.message) || 0);
+	},
+
+	clear_empty_state(page) {
+		page.body.find("#hierarchy-empty-root").remove();
+	},
+
+	render_empty_state({ page, doctype, company, device_type }) {
+		this.clear_empty_state(page);
+
+		const empty = frappe.render_template("hierarchy_empty_state", {
+			doctype,
+			company: company || __("the selected company"),
+			can_create: frappe.model.can_create(doctype),
+			device_type,
+		});
+
+		page.main.append(empty);
+
+		page.body
+			.find("#add-doc-btn")
+			.off("click")
+			.on("click", () => {
+				frappe.route_options = { company };
+				frappe.new_doc(doctype);
+			});
+	},
+
+	set_main_state(page, state) {
+		const state_classes =
+			"hierarchy-main-chart hierarchy-main-empty hierarchy-main-export hierarchy-main-mobile-chart hierarchy-main-mobile-empty";
+		page.main.removeClass(state_classes);
+
+		if (state) {
+			page.main.addClass(state);
+		}
+	},
+
+	get_state_config(device_type) {
+		const state_class_map = {
+			desktop: {
+				empty: "hierarchy-main-empty",
+				non_empty: "hierarchy-main-chart",
+				remove_selectors: ["#hierarchy-chart-wrapper", ".hierarchy", "#arrows"],
+			},
+			mobile: {
+				empty: "hierarchy-main-mobile-empty",
+				non_empty: "hierarchy-main-mobile-chart",
+				remove_selectors: [".hierarchy-mobile", ".sibling-group", "#arrows"],
+			},
+		};
+
+		return state_class_map[device_type] || state_class_map.desktop;
+	},
+
+	apply_empty_state({ chart, company, device_type, state_config }) {
+		return this.get_employee_count(company).then((employee_count) => {
+			if (employee_count > 0) {
+				this.clear_empty_state(chart.page);
+				this.set_main_state(chart.page, state_config.non_empty);
+				return false;
+			}
+
+			(state_config.remove_selectors || []).forEach((selector) => {
+				chart.page.main.find(selector).remove();
+			});
+
+			this.set_main_state(chart.page, state_config.empty);
+			this.render_empty_state({
+				page: chart.page,
+				doctype: chart.doctype,
+				company,
+				device_type,
+			});
+
+			return true;
+		});
+	},
+
+	handle_company_change({ chart, method, device_type }) {
+		const state_config = this.get_state_config(device_type);
+		const company = chart.page.fields_dict.company?.get_value();
+
+		if (!company) {
+			this.clear_empty_state(chart.page);
+			return Promise.resolve();
+		}
+
+		return frappe
+			.call({
+				method,
+				args: { company },
+			})
+			.then((r) => {
+				const has_root_nodes = Boolean(r.message && r.message.length);
+
+				if (has_root_nodes) {
+					this.clear_empty_state(chart.page);
+					this.set_main_state(chart.page, state_config.non_empty);
+					return;
+				}
+
+				return this.apply_empty_state({
+					chart,
+					company,
+					device_type,
+					state_config,
+				});
+			});
+	},
+
+	bind_empty_state_handler(chart, method, device_type) {
+		chart.page.main.addClass("hierarchy-chart-main");
+
+		if (!chart._render_root_nodes_original) {
+			chart._render_root_nodes_original = chart.render_root_nodes.bind(chart);
+			chart.render_root_nodes = (...args) => {
+				return Promise.resolve(chart._render_root_nodes_original(...args)).then(
+					(result) => {
+						chart.page.main
+							.find('[data-fieldname="company"] .link-field')
+							.addClass("hierarchy-company-link-field");
+
+						return Promise.resolve(
+							this.handle_company_change({ chart, method, device_type }),
+						).then(() => result);
+					},
+				);
+			};
+		}
+	},
+});
+
 frappe.pages["organizational-chart"].on_page_load = function (wrapper) {
 	frappe.ui.make_app_page({
 		parent: wrapper,
@@ -9,6 +159,7 @@ frappe.pages["organizational-chart"].on_page_load = function (wrapper) {
 		frappe.require("hierarchy-chart.bundle.js", () => {
 			let organizational_chart;
 			let method = "hrms.hr.page.organizational_chart.organizational_chart.get_children";
+			const device_type = frappe.is_mobile() ? "mobile" : "desktop";
 
 			if (frappe.is_mobile()) {
 				organizational_chart = new hrms.HierarchyChartMobile("Employee", wrapper, method);
@@ -17,6 +168,11 @@ frappe.pages["organizational-chart"].on_page_load = function (wrapper) {
 			}
 
 			frappe.breadcrumbs.add("HR");
+			hrms.organizational_chart.bind_empty_state_handler(
+				organizational_chart,
+				method,
+				device_type,
+			);
 			organizational_chart.show();
 		});
 	});

--- a/hrms/public/js/hierarchy-chart.bundle.js
+++ b/hrms/public/js/hierarchy-chart.bundle.js
@@ -1,3 +1,4 @@
 import "./hierarchy_chart/hierarchy_chart_desktop.js";
 import "./hierarchy_chart/hierarchy_chart_mobile.js";
 import "./templates/node_card.html";
+import "./templates/hierarchy_empty_state.html";

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -12,7 +12,7 @@ hrms.HierarchyChart = class {
 		this.method = method;
 		this.doctype = doctype;
 
-		this.page.main.addClass("frappe-card");
+		this.page.main.addClass("frappe-card hierarchy-chart-main");
 
 		this.nodes = {};
 		this.setup_node_class();
@@ -97,7 +97,16 @@ hrms.HierarchyChart = class {
 
 		company.refresh();
 		$(`[data-fieldname="company"]`).trigger("change");
-		$(`[data-fieldname="company"] .link-field`).css("z-index", 2);
+		$(`[data-fieldname="company"] .link-field`).addClass("hierarchy-company-link-field");
+	}
+
+	set_main_state(state) {
+		const state_classes = "hierarchy-main-chart hierarchy-main-empty hierarchy-main-export";
+		this.page.main.removeClass(state_classes);
+
+		if (state) {
+			this.page.main.addClass(state);
+		}
 	}
 
 	setup_actions() {
@@ -125,14 +134,7 @@ hrms.HierarchyChart = class {
 
 	export_chart() {
 		frappe.dom.freeze(__("Exporting..."));
-		this.page.main.css({
-			"min-height": "",
-			"max-height": "",
-			overflow: "visible",
-			position: "fixed",
-			left: "0",
-			top: "0",
-		});
+		this.set_main_state("hierarchy-main-export");
 
 		$(".node-card").addClass("exported");
 
@@ -151,11 +153,10 @@ hrms.HierarchyChart = class {
 				a.click();
 			})
 			.finally(() => {
+				this.set_main_state("hierarchy-main-chart");
+				$(".node-card").removeClass("exported");
 				frappe.dom.unfreeze();
 			});
-
-		this.setup_page_style();
-		$(".node-card").removeClass("exported");
 	}
 
 	setup_hierarchy() {
@@ -219,13 +220,7 @@ hrms.HierarchyChart = class {
 			.then((r) => {
 				if (r.message.length) {
 					me.page.body.find("#hierarchy-empty-root").remove();
-
-					me.page.main.css({
-						"min-height": "300px",
-						"max-height": "700px",
-						overflow: "auto",
-						position: "relative",
-					});
+					me.set_main_state("hierarchy-main-chart");
 
 					let expand_node;
 					let node;
@@ -254,39 +249,6 @@ hrms.HierarchyChart = class {
 					if (!expanded_view) {
 						me.expand_node(expand_node);
 					}
-				} else {
-					me.page.body.find("#hierarchy-empty-root").remove();
-					const empty_html = frappe.render_template("hierarchy_empty_state", {
-						doctype: me.doctype,
-						company: me.company,
-						can_create: frappe.model.can_create(me.doctype),
-						device_type: "desktop",
-					});
-
-					$("#hierarchy-chart-wrapper").remove();
-					me.page.body.append(empty_html);
-
-					me.page.main.css({
-						"min-height": "100%",
-						"max-height": "100%",
-					});
-
-					(function () {
-						const root = document.getElementById("hierarchy-empty-root");
-						if (!root) return;
-						try {
-							const rect = root.getBoundingClientRect();
-							const windowHeight = window.innerHeight;
-							const height = Math.max(300, Math.floor(windowHeight - rect.top - 20));
-							root.style.height = height + "px";
-							root.style.overflow = "auto";
-							root.style.position = "relative";
-						} catch (e) {}
-					})();
-					me.page.body.find("#add-doc-btn").on("click", () => {
-						frappe.route_options = { company: me.company };
-						frappe.new_doc(me.doctype);
-					});
 				}
 			});
 	}

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -12,20 +12,10 @@ hrms.HierarchyChart = class {
 		this.method = method;
 		this.doctype = doctype;
 
-		this.setup_page_style();
 		this.page.main.addClass("frappe-card");
 
 		this.nodes = {};
 		this.setup_node_class();
-	}
-
-	setup_page_style() {
-		this.page.main.css({
-			"min-height": "300px",
-			"max-height": "700px",
-			overflow: "auto",
-			position: "relative",
-		});
 	}
 
 	setup_node_class() {
@@ -228,6 +218,15 @@ hrms.HierarchyChart = class {
 			})
 			.then((r) => {
 				if (r.message.length) {
+					me.page.body.find("#hierarchy-empty-root").remove();
+
+					me.page.main.css({
+						"min-height": "300px",
+						"max-height": "700px",
+						overflow: "auto",
+						position: "relative",
+					});
+
 					let expand_node;
 					let node;
 
@@ -255,6 +254,39 @@ hrms.HierarchyChart = class {
 					if (!expanded_view) {
 						me.expand_node(expand_node);
 					}
+				} else {
+					me.page.body.find("#hierarchy-empty-root").remove();
+					const empty_html = frappe.render_template("hierarchy_empty_state", {
+						doctype: me.doctype,
+						company: me.company,
+						can_create: frappe.model.can_create("Employee"),
+						device_type: "desktop",
+					});
+
+					$("#hierarchy-chart-wrapper").remove();
+					me.page.body.append(empty_html);
+
+					me.page.main.css({
+						"min-height": "100%",
+						"max-height": "100%",
+					});
+
+					(function () {
+						const root = document.getElementById("hierarchy-empty-root");
+						if (!root) return;
+						try {
+							const rect = root.getBoundingClientRect();
+							const windowHeight = window.innerHeight;
+							const height = Math.max(300, Math.floor(windowHeight - rect.top - 20));
+							root.style.height = height + "px";
+							root.style.overflow = "auto";
+							root.style.position = "relative";
+						} catch (e) {}
+					})();
+					me.page.body.find("#add-doc-btn").on("click", () => {
+						frappe.route_options = { company: me.company };
+						frappe.new_doc(me.doctype);
+					});
 				}
 			});
 	}

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -259,7 +259,7 @@ hrms.HierarchyChart = class {
 					const empty_html = frappe.render_template("hierarchy_empty_state", {
 						doctype: me.doctype,
 						company: me.company,
-						can_create: frappe.model.can_create("Employee"),
+						can_create: frappe.model.can_create(me.doctype),
 						device_type: "desktop",
 					});
 

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -11,7 +11,7 @@ hrms.HierarchyChartMobile = class {
 		this.method = method;
 		this.doctype = doctype;
 
-		this.page.main.addClass("frappe-card");
+		this.page.main.addClass("frappe-card hierarchy-chart-main");
 
 		this.nodes = {};
 		this.setup_node_class();
@@ -95,6 +95,16 @@ hrms.HierarchyChartMobile = class {
 
 		company.refresh();
 		$(`[data-fieldname="company"]`).trigger("change");
+		$(`[data-fieldname="company"] .link-field`).addClass("hierarchy-company-link-field");
+	}
+
+	set_main_state(state) {
+		const state_classes = "hierarchy-main-mobile-chart hierarchy-main-mobile-empty";
+		this.page.main.removeClass(state_classes);
+
+		if (state) {
+			this.page.main.addClass(state);
+		}
 	}
 
 	make_svg_markers() {
@@ -150,13 +160,7 @@ hrms.HierarchyChartMobile = class {
 			.then((r) => {
 				if (r.message.length) {
 					me.page.body.find("#hierarchy-empty-root").remove();
-
-					me.page.main.css({
-						"min-height": "300px",
-						"max-height": "600px",
-						overflow: "auto",
-						position: "relative",
-					});
+					me.set_main_state("hierarchy-main-mobile-chart");
 
 					let root_level = me.$hierarchy.find(".root-level");
 					root_level.empty();
@@ -173,40 +177,6 @@ hrms.HierarchyChartMobile = class {
 							connections: data.connections,
 							is_root: true,
 						});
-					});
-				} else {
-					me.page.body.find("#hierarchy-empty-root").remove();
-					me.page.main.css({
-						"min-height": "100%",
-						"max-height": "100%",
-						overflow: "auto",
-						position: "relative",
-					});
-
-					const empty = frappe.render_template("hierarchy_empty_state", {
-						doctype: me.doctype,
-						company: me.company,
-						can_create: frappe.model.can_create(me.doctype),
-						device_type: "mobile",
-					});
-
-					me.page.main.append(empty);
-
-					(function () {
-						const root = document.getElementById("hierarchy-empty-root");
-						if (!root) return;
-						try {
-							const rect = root.getBoundingClientRect();
-							const windowHeight = window.innerHeight;
-							const height = Math.max(300, Math.floor(windowHeight - rect.top - 20));
-							root.style.height = height + "px";
-							root.style.overflow = "auto";
-							root.style.position = "relative";
-						} catch (e) {}
-					})();
-					me.page.body.find("#add-doc-btn").on("click", () => {
-						frappe.route_options = { company: me.company };
-						frappe.new_doc(me.doctype);
 					});
 				}
 			});

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -11,12 +11,6 @@ hrms.HierarchyChartMobile = class {
 		this.method = method;
 		this.doctype = doctype;
 
-		this.page.main.css({
-			"min-height": "300px",
-			"max-height": "600px",
-			overflow: "auto",
-			position: "relative",
-		});
 		this.page.main.addClass("frappe-card");
 
 		this.nodes = {};
@@ -155,6 +149,15 @@ hrms.HierarchyChartMobile = class {
 			})
 			.then((r) => {
 				if (r.message.length) {
+					me.page.body.find("#hierarchy-empty-root").remove();
+
+					me.page.main.css({
+						"min-height": "300px",
+						"max-height": "600px",
+						overflow: "auto",
+						position: "relative",
+					});
+
 					let root_level = me.$hierarchy.find(".root-level");
 					root_level.empty();
 
@@ -170,6 +173,40 @@ hrms.HierarchyChartMobile = class {
 							connections: data.connections,
 							is_root: true,
 						});
+					});
+				} else {
+					me.page.body.find("#hierarchy-empty-root").remove();
+					me.page.main.css({
+						"min-height": "100%",
+						"max-height": "100%",
+						overflow: "auto",
+						position: "relative",
+					});
+
+					const empty = frappe.render_template("hierarchy_empty_state", {
+						doctype: me.doctype,
+						company: me.company,
+						can_create: frappe.model.can_create(me.doctype),
+						device_type: "mobile",
+					});
+
+					me.page.main.append(empty);
+
+					(function () {
+						const root = document.getElementById("hierarchy-empty-root");
+						if (!root) return;
+						try {
+							const rect = root.getBoundingClientRect();
+							const windowHeight = window.innerHeight;
+							const height = Math.max(300, Math.floor(windowHeight - rect.top - 20));
+							root.style.height = height + "px";
+							root.style.overflow = "auto";
+							root.style.position = "relative";
+						} catch (e) {}
+					})();
+					me.page.body.find("#add-doc-btn").on("click", () => {
+						frappe.route_options = { company: me.company };
+						frappe.new_doc(me.doctype);
 					});
 				}
 			});

--- a/hrms/public/js/templates/hierarchy_empty_state.html
+++ b/hrms/public/js/templates/hierarchy_empty_state.html
@@ -1,0 +1,32 @@
+
+<div id="hierarchy-empty-root" class="text-muted flex flex-1 items-center justify-center align-center text-center">
+  <div class="">
+    <div class="empty-apps-state">
+      <svg class="icon icon-xl" style="stroke: var(--text-light);">
+        <use href="#icon-small-file"></use>
+      </svg>
+      <div class="mt-4 mb-2">
+        {{ __("You haven't created a {0} for {1} yet.", [__(doctype), __(company)]) }}
+      </div>
+
+      {% if can_create %}
+        {% if device_type == "desktop" %}
+          <button
+            class="btn btn-default btn-sm btn-new-doc hidden-xs"
+            id="add-doc-btn"
+          >
+            {{ __("Create a new {0}", [__(doctype)]) }}
+          </button>
+        {% else %}
+          <button
+            class="btn btn-primary btn-new-doc visible-xs"
+            id="add-doc-btn"
+          >
+            {{ __("Create {0}", [__(doctype)]) }}
+          </button>
+        {% endif %}
+      {% endif %}
+
+    </div>
+  </div>
+</div>

--- a/hrms/public/scss/hierarchy_chart.scss
+++ b/hrms/public/scss/hierarchy_chart.scss
@@ -23,6 +23,54 @@
 	box-shadow: none;
 }
 
+.hierarchy-chart-main {
+	&.hierarchy-main-chart {
+		min-height: 300px;
+		max-height: 700px;
+		overflow: auto;
+		position: relative;
+	}
+
+	&.hierarchy-main-export {
+		min-height: auto;
+		max-height: none;
+		overflow: visible;
+		position: fixed;
+		left: 0;
+		top: 0;
+	}
+
+	&.hierarchy-main-mobile-chart {
+		min-height: 300px;
+		max-height: 600px;
+		overflow: auto;
+		position: relative;
+	}
+
+	&.hierarchy-main-empty {
+		overflow: auto;
+		position: relative;
+	}
+
+	&.hierarchy-main-mobile-empty {
+		overflow: auto;
+		position: relative;
+	}
+
+	&.hierarchy-main-empty #hierarchy-empty-root,
+	&.hierarchy-main-mobile-empty #hierarchy-empty-root {
+		min-height: max(320px, calc(100vh - 240px));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+	}
+}
+
+[data-fieldname="company"] .link-field.hierarchy-company-link-field {
+	z-index: 2;
+}
+
 .node-image {
 	width: 3rem;
 	height: 3rem;


### PR DESCRIPTION
What does this PR do?
Adds a proper empty state to the Organizational Chart when no employees or reporting relationships are available.
Fixes #3940 

What problem does it solve?
Prevents a blank or broken-looking Organizational Chart when data is missing

Screenshots
<img width="2916" height="2068" alt="image" src="https://github.com/user-attachments/assets/04090d56-c7ac-476b-8915-02733ad851a4" />
<img width="856" height="1852" alt="image" src="https://github.com/user-attachments/assets/47507d47-c05d-4ff1-aa8f-db617cb5585c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing empty-state for the hierarchy with localized messaging and a contextual "create" call-to-action; template now bundled.

* **Improvements**
  * Better desktop and mobile responsiveness: constrained heights, improved scrolling, and consistent empty vs populated views.
  * Smoother export flow with reduced layout disruption.
  * Company link controls now layer correctly for reliable interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->