### PR TITLE
fix(salary_register): show Loan Repayment column only when Lending app is installed

### DIFF
--- a/hrms/payroll/report/salary_register/salary_register.py
+++ b/hrms/payroll/report/salary_register/salary_register.py
@@ -227,15 +227,19 @@ def get_columns(earning_types, ded_types):
 			}
 		)
 
-	columns.extend(
-		[
+	if "lending" in frappe.get_installed_apps():
+		columns.append(
 			{
 				"label": _("Loan Repayment"),
 				"fieldname": "total_loan_repayment",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,
-			},
+			}
+		)
+
+	columns.extend(
+		[
 			{
 				"label": _("Total Deduction"),
 				"fieldname": "total_deduction",


### PR DESCRIPTION
In the **Salary Register report**, the **Loan Repayment** column is sourced from the `total_loan_repayment` field in **Salary Slip**, which is populated only when the **Lending** app is installed.

In environments where the **Lending** app is not installed, this column is still always displayed but remains empty for all records, resulting in an unnecessary and misleading column in the report.

<img width="1110" height="285" alt="Loan Repayment Column" src="https://github.com/user-attachments/assets/eae6ec32-8e7e-495c-a19d-bdf2faf35138" />


This **PR** updates the report to add the **Loan Repayment** column only when the **Lending** app is installed, ensuring the report reflects the active modules in the system and improves overall clarity and usability.

backport version-15-hotfix
backport version-16-hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved salary register report to conditionally display the Loan Repayment column based on system configuration, ensuring proper data alignment and eliminating unnecessary fields when not applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->