### PR TITLE
fix: consider holiday list assignments while marking attendance in bulk

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -19,10 +19,10 @@ from frappe.utils import (
 import hrms
 from hrms.hr.doctype.shift_assignment.shift_assignment import has_overlapping_timings
 from hrms.hr.utils import (
-	get_holiday_dates_for_employee,
 	get_holidays_for_employee,
 	validate_active_employee,
 )
+from hrms.utils.holiday_list import get_holiday_dates_between_range
 
 
 class DuplicateAttendanceError(frappe.ValidationError):
@@ -384,7 +384,7 @@ def get_unmarked_days(employee, from_date, to_date, exclude_holidays=0):
 	marked_days = [getdate(record.attendance_date) for record in records]
 
 	if cint(exclude_holidays):
-		holiday_dates = get_holiday_dates_for_employee(employee, from_date, to_date)
+		holiday_dates = get_holiday_dates_between_range(employee, from_date, to_date)
 		holidays = [getdate(record) for record in holiday_dates]
 		marked_days.extend(holidays)
 

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -384,7 +384,9 @@ def get_unmarked_days(employee, from_date, to_date, exclude_holidays=0):
 	marked_days = [getdate(record.attendance_date) for record in records]
 
 	if cint(exclude_holidays):
-		holiday_dates = get_holiday_dates_between_range(employee, from_date, to_date)
+		holiday_dates = get_holiday_dates_between_range(
+			employee, from_date, to_date, raise_exception_for_holiday_list=False
+		)
 		holidays = [getdate(record) for record in holiday_dates]
 		marked_days.extend(holidays)
 

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -26,6 +26,7 @@ from hrms.hr.doctype.attendance.attendance import (
 	mark_attendance,
 )
 from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	assign_holiday_list,
 	create_holiday_list_assignment,
 )
 from hrms.tests.test_utils import get_first_sunday
@@ -174,6 +175,7 @@ class TestAttendance(IntegrationTestCase):
 		# holiday considered in unmarked days
 		self.assertIn(first_sunday, unmarked_days)
 
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_unmarked_days_excluding_holidays(self):
 		first_sunday = get_first_sunday(self.holiday_list, for_date=get_last_day(add_months(getdate(), -1)))
 		attendance_date = add_days(first_sunday, 1)

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -25,6 +25,9 @@ from hrms.hr.doctype.attendance.attendance import (
 	get_unmarked_days,
 	mark_attendance,
 )
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	create_holiday_list_assignment,
+)
 from hrms.tests.test_utils import get_first_sunday
 
 
@@ -192,6 +195,28 @@ class TestAttendance(IntegrationTestCase):
 		self.assertIn(getdate(add_days(attendance_date, 1)), unmarked_days)
 		# holidays not considered in unmarked days
 		self.assertNotIn(first_sunday, unmarked_days)
+
+	def test_unmarked_days_excluding_holidays_across_two_holiday_list_assignments(self):
+		from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
+
+		employee = make_employee("test_unmarked_days_exclude_holidays@example.com", company="_Test Company")
+		start_date = get_first_day(getdate())
+		mid_date = add_days(start_date, 15)
+		end_date = get_last_day(getdate())
+		holiday_list_1 = make_holiday_list(
+			"First Holiday List", from_date=start_date, to_date=add_days(mid_date, -1)
+		)
+		holiday_list_2 = make_holiday_list("Second Holiday List", from_date=mid_date, to_date=end_date)
+		create_holiday_list_assignment("Employee", employee, holiday_list=holiday_list_1)
+		create_holiday_list_assignment("Employee", employee, holiday_list=holiday_list_2)
+
+		unmarked_days = get_unmarked_days(employee, start_date, end_date, exclude_holidays=True)
+		unmarked_days = [getdate(date) for date in unmarked_days]
+		sunday_in_holiday_list_1 = get_first_sunday(holiday_list=holiday_list_1, for_date=start_date)
+		sunday_in_holiday_list_2 = get_first_sunday(holiday_list=holiday_list_2, for_date=end_date)
+
+		self.assertNotIn(sunday_in_holiday_list_1, unmarked_days)
+		self.assertNotIn(sunday_in_holiday_list_2, unmarked_days)
 
 	def test_unmarked_days_as_per_joining_and_relieving_dates(self):
 		first_sunday = get_first_sunday(self.holiday_list, for_date=get_last_day(add_months(getdate(), -1)))

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -36,11 +36,23 @@ def get_holiday_dates_between_range(
 	end_date: str,
 	skip_weekly_offs: bool = False,
 	select_weekly_offs: bool = False,
+	raise_exception_for_holiday_list: bool = True,
 ) -> list:
 	start_date = getdate(start_date)
 	end_date = getdate(end_date)
-	from_holiday_list = get_holiday_list_for_employee(assigned_to, as_on=start_date, as_dict=True) or {}
-	to_holiday_list = get_holiday_list_for_employee(assigned_to, as_on=end_date, as_dict=True) or {}
+
+	from_holiday_list = (
+		get_holiday_list_for_employee(
+			assigned_to, as_on=start_date, as_dict=True, raise_exception=raise_exception_for_holiday_list
+		)
+		or {}
+	)
+	to_holiday_list = (
+		get_holiday_list_for_employee(
+			assigned_to, as_on=end_date, as_dict=True, raise_exception=raise_exception_for_holiday_list
+		)
+		or {}
+	)
 
 	if (
 		from_holiday_list


### PR DESCRIPTION
#### Problem
`get_unmarked_days` which fetches all unmarked days for marking attendance in bulk, would consider holiday list assigned on the current date instead of considering start and end dates specified, leading to incorrect unmarked days when `exclude holidays` is checked.

#### Fix

- This is now fixed by replacing `get_holiday_dates_for_employee` with `get_holiday_dates_between_range`, the same function used to get holidays across lists while calculating holidays in leave applications.
- Exception for unassigned list is silenced for this particular case, but the function continues to raise exception by default as before ( <s>or maybe this should be on, since exclude holidays check is explicit?</s> the default exception wouldn't be all that helpful since it doesn't show the date for which the assignment doesn't exist )

There is one problem caught by [this test](https://github.com/frappe/hrms/blob/23f3a4e4e000cbb94f6ed78865def1c61029b44c/hrms/hr/doctype/attendance/test_attendance.py#L174), the setup modifies from and to date of the holiday list after original assignment and not as the test feature (I think :sweat_smile: ), but this doesn't change assignment starts from date in HLA, the test itself was fixed by reassigning the list with context manager but this could still be a problem in some use cases.
