### PR TITLE
fix: validate dates in additional salary

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -111,6 +111,11 @@ class AdditionalSalary(Document):
 
 		self.validate_from_to_dates("from_date", "to_date")
 
+		if self.is_recurring and not (self.from_date and self.to_date):
+			frappe.throw(_("From and to dates are madatory for recurring type additional salaries."))
+		elif not self.payroll_date:
+			frappe.throw(_("Payroll date is mandatory for non-recurring type additional salaries."))
+
 		if date_of_joining:
 			if self.payroll_date and getdate(self.payroll_date) < getdate(date_of_joining):
 				frappe.throw(_("Payroll date can not be less than employee's joining date."))

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -113,7 +113,7 @@ class AdditionalSalary(Document):
 
 		if self.is_recurring and not (self.from_date and self.to_date):
 			frappe.throw(_("From and to dates are madatory for recurring type additional salaries."))
-		elif not self.payroll_date:
+		elif (not self.is_recurring) and (not self.payroll_date):
 			frappe.throw(_("Payroll date is mandatory for non-recurring type additional salaries."))
 
 		if date_of_joining:


### PR DESCRIPTION
After #3877, additional salary uses either from date or payroll date to fetch applicable salary structure, while these are made mandatory conditionally in the client script, they aren't validated, and result in error while importing additional salaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for additional salary entries: recurring entries now require both start and end dates, while non‑recurring entries require a payroll date. Users will see clearer, descriptive error messages when required date fields are missing, preventing incomplete or ambiguous salary records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->