### PR TITLE
feat: add return amount column in employee advance summary report

### DIFF
--- a/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
+++ b/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
@@ -2,6 +2,8 @@
 # For license information, please see license.txt
 
 
+from pypika import Order
+
 import frappe
 from frappe import _, msgprint
 
@@ -100,31 +102,42 @@ def get_columns():
 	]
 
 
-def get_conditions(filters):
-	conditions = ""
+def get_advances(filters):
+	EmployeeAdvance = frappe.qb.DocType("Employee Advance")
+
+	query = (
+		frappe.qb.from_(EmployeeAdvance)
+		.select(
+			EmployeeAdvance.name,
+			EmployeeAdvance.employee,
+			EmployeeAdvance.paid_amount,
+			EmployeeAdvance.status,
+			EmployeeAdvance.advance_amount,
+			EmployeeAdvance.claimed_amount,
+			EmployeeAdvance.return_amount,
+			EmployeeAdvance.company,
+			EmployeeAdvance.posting_date,
+			EmployeeAdvance.purpose,
+			EmployeeAdvance.currency,
+		)
+		.where(EmployeeAdvance.docstatus < 2)
+	)
 
 	if filters.get("employee"):
-		conditions += "and employee = %(employee)s"
+		query = query.where(EmployeeAdvance.employee == filters.employee)
+
 	if filters.get("company"):
-		conditions += " and company = %(company)s"
+		query = query.where(EmployeeAdvance.company == filters.company)
+
 	if filters.get("status"):
-		conditions += " and status = %(status)s"
+		query = query.where(EmployeeAdvance.status == filters.status)
+
 	if filters.get("from_date"):
-		conditions += " and posting_date>=%(from_date)s"
+		query = query.where(EmployeeAdvance.posting_date >= filters.from_date)
+
 	if filters.get("to_date"):
-		conditions += " and posting_date<=%(to_date)s"
+		query = query.where(EmployeeAdvance.posting_date <= filters.to_date)
 
-	return conditions
-
-
-def get_advances(filters):
-	conditions = get_conditions(filters)
-	return frappe.db.sql(
-		"""select name, employee, paid_amount, status, advance_amount, claimed_amount, return_amount, company,
-		posting_date, purpose, currency
-		from `tabEmployee Advance`
-		where docstatus<2 %s order by posting_date, name desc"""
-		% conditions,
-		filters,
-		as_dict=1,
+	return query.orderby(EmployeeAdvance.posting_date, EmployeeAdvance.name, order=Order.desc).run(
+		as_dict=True
 	)

--- a/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
+++ b/hrms/hr/report/employee_advance_summary/employee_advance_summary.py
@@ -27,6 +27,7 @@ def execute(filters=None):
 			advance.advance_amount,
 			advance.paid_amount,
 			advance.claimed_amount,
+			advance.return_amount,
 			advance.status,
 			advance.currency,
 		]
@@ -80,6 +81,13 @@ def get_columns():
 			"options": "currency",
 			"width": 120,
 		},
+		{
+			"label": _("Returned Amount"),
+			"fieldname": "return_amount",
+			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 120,
+		},
 		{"label": _("Status"), "fieldname": "status", "fieldtype": "Data", "width": 120},
 		{
 			"label": _("Currency"),
@@ -112,7 +120,7 @@ def get_conditions(filters):
 def get_advances(filters):
 	conditions = get_conditions(filters)
 	return frappe.db.sql(
-		"""select name, employee, paid_amount, status, advance_amount, claimed_amount, company,
+		"""select name, employee, paid_amount, status, advance_amount, claimed_amount, return_amount, company,
 		posting_date, purpose, currency
 		from `tabEmployee Advance`
 		where docstatus<2 %s order by posting_date, name desc"""


### PR DESCRIPTION
**Issue:** 

Currently, Employee Advance Summary report does not have a Column for Returned Amount. If a user wants to see this amount then they have to add this Column manually.

Fixes: https://github.com/frappe/hrms/issues/3662

**Before:**

<img width="1468" height="726" alt="before" src="https://github.com/user-attachments/assets/022c26f6-5fc6-4e5e-952e-cdce8023cc0a" />


**After:**

<img width="1468" height="726" alt="after" src="https://github.com/user-attachments/assets/583df427-b647-4ae8-8074-968e81c7d5c6" />


Bakport needed for: v15, v16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Returned Amount" column to the Employee Advance Summary report with currency formatting.

* **Improvements**
  * Enhanced report filtering (employee, company, status, date range) for more accurate results.
  * Improved query execution and ordering for more consistent, reliably ordered report results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->