### PR TITLE
docs: update local setup - switch example --site from .local to .localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Use the following credentials to log in:
 	```
 2. In a separate terminal window, run the following commands
 	```sh
-	$ bench new-site hrms.local
+	$ bench new-site hrms.localhost
 	$ bench get-app erpnext
 	$ bench get-app hrms
-	$ bench --site hrms.local install-app hrms
-	$ bench --site hrms.local add-to-hosts
+	$ bench --site hrms.localhost install-app hrms
+	$ bench --site hrms.localhost add-to-hosts
 	```
-3. You can access the site at `http://hrms.local:8080`
+3. You can access the site at `http://hrms.localhost:8080`
 
 ## Learning and Community
 


### PR DESCRIPTION
The current README uses `hrms.local` which can conflict with mDNS and is not recommended for local development.

This PR updates the local setup --site examples to use `hrms.localhost`, avoiding DNS issues on macOS/Linux.

  * `.localhost` is reserved for loopback and guaranteed to resolve without conflicting with real TLDs or mDNS services.
  * The rest of Frappe docs use `*.localhost` for local sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup documentation with revised example commands and local access URLs.
  * Changes include modernized domain configuration for local development environments.
  * Updated application installation, site creation, and host configuration examples to reflect current standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->