### PR TITLE
fix: update attendance status mapping to include "Half Day" and adjus…

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -134,7 +134,7 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 		if (!summarized_view) {
 			if ((group_by && column.colIndex > 3) || (!group_by && column.colIndex > 2)) {
 				if (value == "HD/P") value = "<span style='color:#914EE3'>" + value + "</span>";
-				else if (value == "HD/A")
+				else if (value == "HD/A" || value == "HD")
 					value = "<span style='color:orange'>" + value + "</span>";
 				else if (value == "P" || value == "WFH")
 					value = "<span style='color:green'>" + value + "</span>";

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -23,6 +23,7 @@ Filters = frappe._dict
 status_map = {
 	"Present": "P",
 	"Absent": "A",
+	"Half Day": "HD",
 	"Half Day/Other Half Absent": "HD/A",
 	"Half Day/Other Half Present": "HD/P",
 	"Work From Home": "WFH",
@@ -82,6 +83,7 @@ def get_message() -> str:
 	colors = [
 		"green",
 		"red",
+		"orange",
 		"orange",
 		"#914EE3",
 		"green",


### PR DESCRIPTION
Ensure that **Half Day (HD)** is shown in the **Monthly Attendance Sheet** when `Status for Other Half` is empty in **Attendance** DocType, instead of leaving the day blank, which could mislead users into assuming the day is **unmarked**.

### Before
<img width="2218" height="968" alt="image" src="https://github.com/user-attachments/assets/d5836012-5260-4b6b-86bc-32b37de2265d" />

### After
<img width="2219" height="982" alt="image" src="https://github.com/user-attachments/assets/273fd690-f981-4316-ad7c-317d02af44f7" />

backport-version-15-hotfix
backport-version-16-hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Half-day attendance entries now display with proper color formatting in the monthly attendance sheet, ensuring consistent visual identification across the report.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->