### PR TITLE
fix(naming): use function appropriately to avoid double naming

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.py
+++ b/hrms/hr/doctype/job_opening/job_opening.py
@@ -24,7 +24,7 @@ class JobOpening(WebsiteGenerator):
 	)
 
 	def autoname(self):
-		self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
+		set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def validate(self):
 		if not self.route:

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -612,7 +612,6 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		# can only apply on optional holidays
 		self.assertRaises(NotAnOptionalHoliday, leave_application.insert)
-
 		leave_application.from_date = optional_leave_date
 		leave_application.to_date = optional_leave_date
 		leave_application.status = "Approved"
@@ -1476,7 +1475,7 @@ class TestLeaveApplication(HRMSTestSuite):
 			"_Test Application 2", from_date=getdate(), to_date=add_days(getdate(), 10), add_weekly_offs=False
 		)
 		add_date_to_holiday_list(getdate(), "_Test Application 2")
-		employee = get_employee().name
+		employee = make_employee("test_leave_days@example.com", company="_Test Company")
 		create_holiday_list_assignment("Employee", employee, "_Test Application")
 		create_holiday_list_assignment("Employee", employee, "_Test Application 2")
 		leave_type = frappe.get_doc(


### PR DESCRIPTION
closes #4054 and is a part of Ticket #55602

**Before**:
<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/f9e525df-f69b-4dd0-9945-5d28bc155de8" />

**After**:
<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/7b3bf6ac-d350-4f9d-9a2f-c445a2059f01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal job opening naming behavior to rely on updated naming handling.

* **Tests**
  * Updated leave application tests and test setup for leave allocation and holiday handling; adjusted employee creation used in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->