### PR TITLE
fix: Allow any host in vite dev servers for frontends

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
 	server: {
 		port: 8080,
 		proxy: getProxyOptions(),
+		allowedHosts: true,
 	},
 	plugins: [
 		vue(),

--- a/roster/vite.config.js
+++ b/roster/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
 	server: {
 		port: 8081,
 		proxy: getProxyOptions(),
+		allowedHosts: true,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
Changes Done
- Enabled allowedHosts config to enable the development server in local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server configuration to support additional host access in proxy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->