### PR TITLE
fix(Bulk Salary Structure Assignment): use untranslated id to filter for column being updated

### DIFF
--- a/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js
+++ b/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js
@@ -208,7 +208,7 @@ frappe.ui.form.on("Bulk Salary Structure Assignment", {
 						primary_action_label: __("Update"),
 						primary_action(values) {
 							const col_idx = frm.employees_datatable.datamanager.columns.find(
-								(col) => col.content === d,
+								(col) => col.id === d.toLowerCase(),
 							).colIndex;
 							frm.checked_rows_indexes.forEach((row_idx) => {
 								frm.employees_datatable.cellmanager.updateCell(


### PR DESCRIPTION
Closes #3927

#### Problem

Client script in Bulk Salary Structure Assignment Tool used column name string to filter for the column being updated, which changes with language translation.

#### Fix

Switched column name content to column id which remains untranslated.

#### After

https://github.com/user-attachments/assets/c3d0354d-e8f1-4428-bbb9-a912ff480a05



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column identification in bulk salary structure assignment to ensure reliable updates across selected records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->