### PR TITLE
fix(attendance): use valuewrapper for doctype in calendar view

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+from datetime import date
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -250,12 +252,11 @@ class Attendance(Document):
 
 
 @frappe.whitelist()
-def get_events(start, end, filters=None, user=None):
-	if not user:
-		user = frappe.session.user
-	employee = frappe.db.get_value("Employee", {"user_id": user})
+def get_events(start: date | str, end: date | str, filters: str | list | None = None) -> list[dict]:
+	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
 	if not employee:
 		return []
+
 	if isinstance(filters, str):
 		import json
 
@@ -341,7 +342,7 @@ def mark_attendance(
 
 
 @frappe.whitelist()
-def mark_bulk_attendance(data):
+def mark_bulk_attendance(data: str | dict):
 	import json
 
 	if isinstance(data, str):
@@ -351,11 +352,11 @@ def mark_bulk_attendance(data):
 		frappe.throw(_("Please select a date."))
 		return
 
-	for date in data.unmarked_days:
+	for attendance_date in data.unmarked_days:
 		doc_dict = {
 			"doctype": "Attendance",
 			"employee": data.employee,
-			"attendance_date": get_datetime(date),
+			"attendance_date": get_datetime(attendance_date),
 			"status": data.status,
 			"half_day_status": "Absent" if data.status == "Half Day" else None,
 			"shift": data.shift,

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -251,7 +251,7 @@ class Attendance(Document):
 @frappe.whitelist()
 def get_events(start, end, filters=None):
 	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
-	if not employee:
+	if not employee:	
 		return []
 	if isinstance(filters, str):
 		import json
@@ -270,7 +270,6 @@ def add_attendance(filters):
 		"Attendance",
 		fields=[
 			"name",
-			"'Attendance' as doctype",
 			"attendance_date",
 			"employee_name",
 			"status",
@@ -279,6 +278,7 @@ def add_attendance(filters):
 		filters=filters,
 	)
 	for record in attendance:
+		record["doctype"] = "Attendance"
 		record["title"] = f"{record.employee_name} : {record.status}"
 	return attendance
 

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder.terms import ValueWrapper
 from frappe.utils import (
 	add_days,
 	cint,
@@ -270,6 +271,7 @@ def add_attendance(filters):
 		"Attendance",
 		fields=[
 			"name",
+			ValueWrapper("Attendance").as_("doctype"),
 			"attendance_date",
 			"employee_name",
 			"status",
@@ -278,8 +280,7 @@ def add_attendance(filters):
 		filters=filters,
 	)
 	for record in attendance:
-		record["doctype"] = "Attendance"
-		record["title"] = f"{record.employee_name} : {record.status}"
+		record["title"] = f"{record['employee_name']} : {record['status']}"
 	return attendance
 
 

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -250,8 +250,10 @@ class Attendance(Document):
 
 
 @frappe.whitelist()
-def get_events(start, end, filters=None):
-	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
+def get_events(start, end, filters=None, user=None):
+	if not user:
+		user = frappe.session.user
+	employee = frappe.db.get_value("Employee", {"user_id": user})
 	if not employee:
 		return []
 	if isinstance(filters, str):

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -251,7 +251,7 @@ class Attendance(Document):
 @frappe.whitelist()
 def get_events(start, end, filters=None):
 	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
-	if not employee:	
+	if not employee:
 		return []
 	if isinstance(filters, str):
 		import json

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -22,6 +22,7 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from hrms.hr.doctype.attendance.attendance import (
 	DuplicateAttendanceError,
 	OverlappingShiftAttendanceError,
+	get_events,
 	get_unmarked_days,
 	mark_attendance,
 )
@@ -269,43 +270,28 @@ class TestAttendance(IntegrationTestCase):
 		self.assertEqual(len(attendances), 1)
 
 	def test_get_events_returns_attendance(self):
-		from frappe.utils import today
+		employee = make_employee("calendar.user@example.com", company="_Test Company")
 
-		from hrms.hr.doctype.attendance.attendance import get_events
+		attendance_name = mark_attendance(employee, getdate(), status="Present")
+		attendance = frappe.get_value("Attendance", attendance_name, "status")
 
-		user = frappe.get_doc(
-			{"doctype": "User", "email": "calendar.user@example.com", "first_name": "Calendar", "enabled": 1}
-		).insert(ignore_permissions=True)
+		self.assertEqual(attendance, "Present")
 
-		employee = frappe.get_doc(
-			{
-				"doctype": "Employee",
-				"first_name": "Calendar",
-				"gender": "Male",
-				"date_of_joining": today(),
-				"date_of_birth": "1990-01-01",
-				"status": "Active",
-				"company": "_Test Company",
-				"user_id": user.name,
-			}
-		).insert()
-
-		attendance = frappe.get_doc(
-			{
-				"doctype": "Attendance",
-				"employee": employee.name,
-				"attendance_date": today(),
-				"company": "_Test Company",
-				"status": "Present",
-			}
-		).insert()
-
-		self.assertEqual(attendance.status, "Present")
-
-		events = get_events(start=today(), end=today(), user=user.name)
+		frappe.set_user("calendar.user@example.com")
+		try:
+			events = get_events(start=getdate(), end=getdate())
+		finally:
+			frappe.set_user("Administrator")
 
 		self.assertTrue(events)
-		self.assertTrue(any(e.get("doctype") == "Attendance" for e in events))
+		attendance_events = [e for e in events if e.get("doctype") == "Attendance"]
+		self.assertTrue(attendance_events)
+		self.assertEqual(attendance_events[0].get("status"), "Present")
+		self.assertEqual(
+			attendance_events[0].get("employee_name"),
+			frappe.db.get_value("Employee", employee, "employee_name"),
+		)
+		self.assertEqual(attendance_events[0].get("attendance_date"), getdate())
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -268,5 +268,44 @@ class TestAttendance(IntegrationTestCase):
 		)
 		self.assertEqual(len(attendances), 1)
 
+	def test_get_events_returns_attendance(self):
+		from frappe.utils import today
+
+		from hrms.hr.doctype.attendance.attendance import get_events
+
+		user = frappe.get_doc(
+			{"doctype": "User", "email": "calendar.user@example.com", "first_name": "Calendar", "enabled": 1}
+		).insert(ignore_permissions=True)
+
+		employee = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Calendar",
+				"gender": "Male",
+				"date_of_joining": today(),
+				"date_of_birth": "1990-01-01",
+				"status": "Active",
+				"company": "_Test Company",
+				"user_id": user.name,
+			}
+		).insert()
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee.name,
+				"attendance_date": today(),
+				"company": "_Test Company",
+				"status": "Present",
+			}
+		).insert()
+
+		self.assertEqual(attendance.status, "Present")
+
+		events = get_events(start=today(), end=today(), user=user.name)
+
+		self.assertTrue(events)
+		self.assertTrue(any(e.get("doctype") == "Attendance" for e in events))
+
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
**Issue:** Attendance records are visible in List View but do not appear in the Calendar View in the HRMS app.

**Description:** Attendance was not showing in the Calendar View because an old SQL-style alias was used in the helper function. Newer versions of Frappe do not support this syntax. This caused the calendar query to break and return no events.

**Before:** 

[Before(Calendar View).webm](https://github.com/user-attachments/assets/0ee7fc34-3789-48f4-a70b-82a4067c17c9)


**After:**

[After(Calendar View).webm](https://github.com/user-attachments/assets/0b2c6f0e-bb6d-4e00-a105-796f5adfa070)


Backport needed for V16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attendance entries now show the correct doctype label.
  * Attendance titles consistently display employee names and status values.
  * Event listings default to the current user when no user is specified, and return no events if no matching employee exists.
  * Filters passed as strings are correctly parsed and handled.

* **Refactor**
  * Improved parameter and return-type handling for event retrieval and bulk attendance processing.

* **Tests**
  * Added a test verifying Attendance events are returned and displayed correctly within a date range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->