### PR TITLE
fix(employee-onboaring): use boarding_status instead of status

### DIFF
--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.json
@@ -70,7 +70,7 @@
    "default": "Pending",
    "fieldname": "boarding_status",
    "fieldtype": "Select",
-   "label": "Status",
+   "label": "Boarding Status",
    "options": "Pending\nIn Process\nCompleted",
    "read_only": 1
   },
@@ -174,11 +174,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:39.939109",
+ "modified": "2026-02-05 13:46:25.874832",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Onboarding",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -209,6 +209,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding_list.js
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding_list.js
@@ -5,7 +5,7 @@ frappe.listview_settings["Employee Onboarding"] = {
 		return [
 			__(doc.boarding_status),
 			frappe.utils.guess_colour(doc.boarding_status),
-			"status,=," + doc.boarding_status,
+			"boarding_status,=," + doc.boarding_status,
 		];
 	},
 };


### PR DESCRIPTION
**Issue:** Navigating from List View to Report View in the Employee Onboarding doctype throws the following error:

frappe.exceptions.DataError:  Field not permitted in query: tabEmployee Onboarding.status

**Ref:** [58376](https://support.frappe.io/helpdesk/tickets/58376?view=VIEW-HD+Ticket-781)


Backport needed for v-15,  v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* Updated the Employee Onboarding status field label to "Boarding Status" for improved clarity.
* Refined list view indicators to properly display boarding status information.
* Enhanced list view layout with dynamic row formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->