### PR TITLE
feat: add Mongolian (mn) translation

### DIFF
--- a/hrms/locale/mn.po
+++ b/hrms/locale/mn.po
@@ -1,0 +1,14267 @@
+# Translations template for Frappe HR.
+# Copyright (C) 2025 Frappe Technologies Pvt. Ltd.
+# This file is distributed under the same license as the Frappe HR project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+msgid ""
+msgstr ""
+"Project-Id-Version: Frappe HR VERSION\n"
+"Report-Msgid-Bugs-To: contact@frappe.io\n"
+"POT-Creation-Date: 2026-02-01 09:43+0000\n"
+"PO-Revision-Date: 2026-02-07 11:14+0800\n"
+"Last-Translator: \n"
+"Language-Team: Mongolian\n"
+"Language: mn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"Generated-By: Babel 2.13.1\n"
+"X-Generator: Poedit 3.8\n"
+"X-Loco-Version: 2.6.14; wp-6.7.1\n"
+
+#. Description of the 'Arrear Start Date' (Date) field in DocType 'Arrear'
+#: hrms/payroll/doctype/arrear/arrear.json
+#| msgid ""
+#| "If enabled, Tax Exemption Declaration will be considered for income tax "
+#| "calculation."
+msgid ""
+" Salary slips starting on or after this date will be considered for arrear "
+"calculations"
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол орлогын албан татварыг тооцохдоо Татвараас чөлөөлөх "
+"тухай мэдэгдлийг авч үзнэ."
+
+#. Label of the unlink_payment_on_cancellation_of_employee_advance (Check)
+#. field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid " Unlink Payment on Cancellation of Employee Advance"
+msgstr " Ажилтны урьдчилгааг цуцалсны төлбөрийг салга"
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.py:23
+msgid "\"From Date\" can not be greater than or equal to \"To Date\""
+msgstr "\"Одоогоос\" нь \"Одоог хүртэл\"-ээс их эсвэл тэнцүү байж болохгүй."
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:86
+msgid "% Utilization (B + NB) / T"
+msgstr "% ашиглалт (B + NB) / T"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:92
+msgid "% Utilization (B / T)"
+msgstr "Ашиглалтын % (B / T)"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:157
+msgid "'employee_field_value' and 'timestamp' are required."
+msgstr "'ажилтны_талбайн_үнэ' болон 'цаг хугацааны тамга' шаардлагатай."
+
+#: hrms/hr/utils.py:254
+#: hrms/payroll/doctype/payroll_period/payroll_period.py:53
+msgid ") for {0}"
+msgstr ") {0}-д"
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:54
+#| msgid "Fetching Employees"
+msgid "...Fetching Employees"
+msgstr "Ажилчдыг татах"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "0.25"
+msgstr "0.25"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "0.5"
+msgstr "0.5"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "00:00"
+msgstr "00:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "01:00"
+msgstr "01:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "02:00"
+msgstr "02:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "03:00"
+msgstr "03:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "04:00"
+msgstr "04:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "05:00"
+msgstr "05:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "06:00"
+msgstr "06:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "07:00"
+msgstr "07:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "08:00"
+msgstr "08:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "09:00"
+msgstr "09:00"
+
+#. Option for the 'Rounding' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "1.0"
+msgstr "1.0"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "10:00"
+msgstr "10:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "11:00"
+msgstr "11:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "12:00"
+msgstr "12:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "13:00"
+msgstr "13:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "14:00"
+msgstr "14:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "15:00"
+msgstr "15:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "16:00"
+msgstr "16:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "17:00"
+msgstr "17:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "18:00"
+msgstr "18:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "19:00"
+msgstr "19:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "20:00"
+msgstr "20:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "21:00"
+msgstr "21:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "22:00"
+msgstr "22:00"
+
+#. Option for the 'Send Emails At' (Select) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "23:00"
+msgstr "23:00"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:272
+msgid "<b>Base</b> amount has not been set for the following employee(s): {0}"
+msgstr "Дараах ажилчдад <b>суурь</b> хэмжээг тогтоогоогүй байна: {0}"
+
+#. Description of the 'Password Policy' (Data) field in DocType 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"<b>Example:</b> SAL-{first_name}-{date_of_birth.year} <br>This will generate"
+" a password like SAL-Jane-1972"
+msgstr ""
+"<b>Жишээ нь:</b> SAL-{first_name}-{date_of_birth.year} <br>Энэ нь SAL-"
+"Jane-1972 шиг нууц үг үүсгэх болно"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:280
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:288
+msgid ""
+"<b>Total Leaves Allocated</b> are more than the number of days in the "
+"allocation period"
+msgstr ""
+"<b>Хуваарилагдсан нийт навч</b> нь хуваарилалтын үеийн өдрүүдийн тооноос их "
+"байна"
+
+#. Content of the 'Help' (HTML) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"<h3>Help</h3>\n"
+"\n"
+"<p>Notes:</p>\n"
+"\n"
+"<ol>\n"
+"<li>Use field <code>base</code> for using base salary of the Employee</li>\n"
+"<li>Use Salary Component abbreviations in conditions and formulas. <code>BS = Basic Salary</code></li>\n"
+"<li>Use field name for employee details in conditions and formulas. <code>Employment Type = employment_type</code><code>Branch = branch</code></li>\n"
+"<li>Use field name from Salary Slip in conditions and formulas. <code>Payment Days = payment_days</code><code>Leave without pay = leave_without_pay</code></li>\n"
+"<li>Direct Amount can also be entered based on Condition. See example 3</li></ol>\n"
+"\n"
+"<h4>Examples</h4>\n"
+"<ol>\n"
+"<li>Calculating Basic Salary based on <code>base</code>\n"
+"<pre><code>Condition: base &lt; 10000</code></pre>\n"
+"<pre><code>Formula: base * .2</code></pre></li>\n"
+"<li>Calculating HRA based on Basic Salary<code>BS</code> \n"
+"<pre><code>Condition: BS &gt; 2000</code></pre>\n"
+"<pre><code>Formula: BS * .1</code></pre></li>\n"
+"<li>Calculating TDS based on Employment Type<code>employment_type</code> \n"
+"<pre><code>Condition: employment_type==\"Intern\"</code></pre>\n"
+"<pre><code>Amount: 1000</code></pre></li>\n"
+"</ol>"
+msgstr ""
+"<h3>Туслаач</h3><p> Тэмдэглэл:</p><ol><li> Ажилтны үндсэн цалинг ашиглахын "
+"тулд талбайн <code>base</code> ашиглана</li><li> Нөхцөл ба томъёонд "
+"Цалингийн бүрэлдэхүүн хэсгийн товчлолыг ашигла. <code>BS = Basic "
+"Salary</code></li><li> Нөхцөл байдал, томъёонд ажилтны дэлгэрэнгүй "
+"мэдээллийг авахын тулд талбарын нэрийг ашиглана уу. <code>Employment Type = "
+"employment_type</code> <code>Branch = branch</code></li><li> Нөхцөл ба "
+"томъёонд Цалингийн хуудасны талбарын нэрийг ашиглана уу. <code>Payment Days "
+"= payment_days</code> <code>Leave without pay = "
+"leave_without_pay</code></li><li> Нөхцөлд үндэслэн шууд дүнг оруулах "
+"боломжтой. Жишээ 3-ыг үзнэ үү</li></ol><h4> Жишээ</h4><ol><li> Үндсэн цалинг"
+" <code>base</code> дээр үндэслэн тооцно<pre> <code>Condition: base &lt; "
+"10000</code></pre><pre> <code>Formula: base * .2</code></pre></li><li> "
+"Үндсэн цалингийн <code>BS</code> дээр үндэслэн HRA тооцох<pre> "
+"<code>Condition: BS &gt; 2000</code></pre><pre> <code>Formula: BS * "
+".1</code></pre></li><li> Хөдөлмөр <code>employment_type</code> төрөл дээр "
+"үндэслэн TDS-ийг тооцоолох<pre> <code>Condition: "
+"employment_type==&quot;Intern&quot;</code></pre><pre> <code>Amount: "
+"1000</code></pre></li></ol>"
+
+#. Content of the 'html_6' (HTML) field in DocType 'Taxable Salary Slab'
+#: hrms/payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid ""
+"<h4>Condition Examples</h4>\n"
+"<ol>\n"
+"<li>Applying tax if employee born between 31-12-1937 and 01-01-1958 (Employees aged 60 to 80)<br>\n"
+"<code>Condition: date_of_birth&gt;date(1937, 12, 31) and date_of_birth&lt;date(1958, 01, 01)</code></li><br><li>Applying tax by employee gender<br>\n"
+"<code>Condition: gender==\"Male\"</code></li><br>\n"
+"<li>Applying tax by Salary Component<br>\n"
+"<code>Condition: base &gt; 10000</code></li></ol>"
+msgstr ""
+"<h4>Нөхцөл байдлын жишээ</h4><ol><li> 1937 оны 31 сарын 12-оос 1958 оны 01 "
+"сарын 1-ний хооронд төрсөн ажилтан (60-80 насны ажилтан) бол татвар "
+"ногдуулах<br> <code>Condition: date_of_birth&gt;date(1937, 12, 31) and "
+"date_of_birth&lt;date(1958, 01, 01)</code></li><br><li> Ажилчдын хүйсээр "
+"татвар ногдуулах<br> <code>Condition: "
+"gender==&quot;Male&quot;</code></li><br><li> Цалингийн бүрэлдэхүүнээр татвар"
+" ногдуулах<br> <code>Condition: base &gt; 10000</code></li></ol>"
+
+#. Content of the 'Half Day Marked Employee Header' (HTML) field in DocType
+#. 'Employee Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#| msgid "Employee {0} on Half day on {1}"
+msgid "<h5>Employees on Half Day</h5>"
+msgstr "Ажилтан хагас өдөр "
+
+#. Content of the 'Unmarked Employee Header' (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "<h5>Unmarked Employees</h5>"
+msgstr "<h5>Тэмдэглэгдээгüй ажилтнууд</h5>"
+
+#. Content of the 'Horizontal Break' (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "<hr>"
+msgstr "<hr>"
+
+#. Header text in the Payroll Workspace
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "<span class=\"h4\"><b>Transactions &amp; Reports</b></span>"
+msgstr "<span class=\"h4\"><b>Гүйлгээ ба тайлан</b></span>"
+
+#. Header text in the Shift & Attendance Workspace
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "<span style=\"font-size: 18px;\"><b>Masters &amp; Reports</b></span>"
+msgstr "<span style=\"font-size: 18px;\"><b>Магистр ба тайлан</b></span>"
+
+#: hrms/public/js/utils/index.js:166
+msgid "<table class='table table-bordered'><tr><th>{0}</th><th>{1}</th></tr>"
+msgstr ""
+"<table class='table table-bordered'><tr><th>{0}</th><th> {1}</th></tr>"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.py:30
+msgid "A Job Requisition for {0} requested by {1} already exists: {2}"
+msgstr ""
+"{1}-н хүссэн {0}-д зориулсан ажлын байрны захиалга аль хэдийн байна: {2}"
+
+#: hrms/controllers/employee_reminders.py:123
+#: hrms/controllers/employee_reminders.py:216
+msgid "A friendly reminder of an important date for our team."
+msgstr "Манай багийн хувьд чухал болзооны тухай нөхөрсөг сануулга."
+
+#: hrms/hr/utils.py:250
+#: hrms/payroll/doctype/payroll_period/payroll_period.py:49
+msgid "A {0} exists between {1} and {2} ("
+msgstr "{1} болон {2} хооронд {0} байна ("
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#. Option for the 'Status for Other Half' (Select) field in DocType
+#. 'Attendance'
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance
+#. Tool'
+#. Option for the 'Status for Other Half' (Select) field in DocType 'Employee
+#. Attendance Tool'
+#. Option for the 'Attendance' (Select) field in DocType 'Training Event
+#. Employee'
+#. Option for the 'Consider Unmarked Attendance As' (Select) field in DocType
+#. 'Payroll Settings'
+#: frontend/src/components/AttendanceCalendar.vue:80
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:732
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Absent"
+msgstr "Байхгүй"
+
+#. Label of the absent_days (Float) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/report/salary_register/salary_register.py:185
+msgid "Absent Days"
+msgstr "Эзгүй өдрүүд"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:174
+msgid "Absent Records"
+msgstr "Байгаагүй бүртгэл"
+
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:56
+msgid "Account No"
+msgstr "Дансны дугаар"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:115
+#| msgid ""
+#| "Account type cannot be set for payroll payable account {0}, please remove "
+#| "and try again"
+msgid ""
+"Account type should be set {0} for payroll payable account {1}, please set "
+"and try again"
+msgstr ""
+"Цалингийн төлбөрийн данс {1}-д дансны төрлийг {0} болгож тохируулна уу, "
+"тохируулаад дахин оролдоно уу"
+
+#: hrms/hr/doctype/expense_claim_type/expense_claim_type.py:29
+msgid "Account {0} does not match with Company {1}"
+msgstr "{0} бүртгэл нь {1} компанитай таарахгүй байна"
+
+#. Label of the accounting_dimensions_tab (Tab Break) field in DocType
+#. 'Payroll
+#. Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Accounting & Payment"
+msgstr "Нягтлан бодох бүртгэл ба төлбөр"
+
+#. Label of a Card Break in the Expenses Workspace
+#. Label of a Card Break in the Payroll Workspace
+#: hrms/hr/workspace/expenses/expenses.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Accounting Reports"
+msgstr "Нягтлан бодох бүртгэлийн тайлан"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:59
+msgid "Accounts not set for Salary Component {0}"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг {0}-д данс тохируулаагүй байна"
+
+#. Option for the 'Transaction Type' (Select) field in DocType 'Employee
+#. Benefit Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+msgid "Accrual"
+msgstr "Хуримтлал"
+
+#. Label of the accrual_arrears (Table) field in DocType 'Arrear'
+#. Label of the accrual_arrears (Table) field in DocType 'Payroll Correction'
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid "Accrual Arrears"
+msgstr "Хуримтлалын нөхөн олговор"
+
+#. Label of the accrual_component (Check) field in DocType 'Salary Component'
+#. Label of the accrual_component (Check) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+#| msgid "Salary Component"
+msgid "Accrual Component"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:66
+#| msgid "Accounts not set for Salary Component {0}"
+msgid "Accrual Component can only be set for Earning Salary Components."
+msgstr "Цалингийн бүрэлдэхүүн хэсэг -д данс тохируулаагүй байна"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:86
+msgid ""
+"Accrual Component can only be set for Flexible Benefit Salary Components "
+"with accrual payout methods."
+msgstr ""
+"Хуримтлалын бүрэлдэхүүн хэсгийг зөвхөн хуримтлалын төлбөрийн аргатай уян "
+"хатан тэтгэмжийн цалингийн бүрэлдэхүүн хэсэгт тохируулж болно."
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:78
+msgid ""
+"Accrual Component must be set for Flexible Benefit Salary Components with "
+"accrual payout methods."
+msgstr ""
+"Хуримтлалын бүрэлдэхүүн хэсгийг хуримтлалын төлбөрийн аргатай уян хатан "
+"тэтгэмжийн цалингийн бүрэлдэхүүн хэсэгт заавал тохируулах ёстой."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:627
+msgid "Accrual Journal Entry for salaries from {0} to {1}"
+msgstr "{0}-с {1} хүртэлх цалингийн хуримтлалын журналын бичилт"
+
+#. Option for the 'Payout Method' (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Accrue and payout at end of payroll period"
+msgstr "Цалингийн хугацааны эцэст хуримтлуулж төлөх"
+
+#. Option for the 'Payout Method' (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Accrue per cycle, pay only on claim"
+msgstr "Мөчлөг бүрт хуримтлуулж, зөвхөн нэхэмжлэлээр төлөх"
+
+#. Label of the accrued_benefits (Table) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#| msgid "Benefits"
+msgid "Accrued Benefits"
+msgstr "Ашиг тус"
+
+#. Name of a report
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.json
+#| msgid "Accounting Reports"
+msgid "Accrued Earnings Report"
+msgstr "Нягтлан бодох бүртгэлийн тайлан"
+
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.py:99
+msgid ""
+"Accrued amount {0} is less than paid amount {1} for Benefit {2} in payroll "
+"period {3}"
+msgstr ""
+"Хуримтлагдсан дүн {0} нь {3} цалингийн хугацааны {2} тэтгэмжийн төлсөн дүн "
+"{1}-с бага байна"
+
+#: hrms/hr/doctype/attendance_request/attendance_warnings.html:8
+msgid "Action on Submission"
+msgstr "Өргөдөл гаргах арга хэмжээ"
+
+#. Label of the activity_name (Data) field in DocType 'Employee Boarding
+#. Activity'
+#: hrms/hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgid "Activity Name"
+msgstr "Үйл ажиллагааны нэр"
+
+#. Label of the amount (Currency) field in DocType 'Employee Tax Exemption
+#. Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Actual Amount"
+msgstr "Бодит дүн"
+
+#. Label of the actual_encashable_days (Float) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:131
+msgid "Actual Encashable Days"
+msgstr "Бодит бэлэн мөнгө авах өдрүүд"
+
+#. Label of the actual_overtime_duration (Float) field in DocType 'Attendance'
+#: hrms/hr/doctype/attendance/attendance.json
+msgid "Actual Overtime Duration"
+msgstr "Бодит илүү цагийн хугацаа"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:452
+msgid ""
+"Actual balances aren't available because the leave application spans over "
+"different leave allocations. You can still apply for leaves which would be "
+"compensated during the next allocation."
+msgstr ""
+"Амралтын өргөдөл нь өөр өөр амралтын хуваарилалтаас хамаарч байгаа тул бодит"
+" үлдэгдэл байхгүй байна. Та дараагийн хуваарилалтын үеэр нөхөн олговор авах "
+"навч авах хүсэлт гаргаж болно."
+
+#. Label of the add_day_wise_dates (Button) field in DocType 'Leave Block
+#. List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Add Day-wise Dates"
+msgstr "Өдрийн огноог нэмнэ үү"
+
+#: hrms/hr/employee_property_update.js:43
+msgid "Add Employee Property"
+msgstr "Ажилтны өмчийг нэмнэ үү"
+
+#: frontend/src/components/ExpensesTable.vue:123
+msgid "Add Expense"
+msgstr "Зардал нэмэх"
+
+#: hrms/public/js/performance/performance_feedback.js:95
+msgid "Add Feedback"
+msgstr "Санал хүсэлт нэмэх"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:118
+msgid "Add Tax"
+msgstr "Татвар нэмэх"
+
+#: hrms/hr/employee_property_update.js:116
+msgid "Add to Details"
+msgstr "Дэлгэрэнгүй мэдээлэлд нэмнэ үү"
+
+#. Label of the carry_forward (Check) field in DocType 'Leave Allocation'
+#. Label of the carry_forward (Check) field in DocType 'Leave Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Add unused leaves from previous allocations"
+msgstr "Өмнөх хуваарилалтаас ашиглагдаагүй навчийг нэмнэ"
+
+#. Description of the 'Carry Forward' (Check) field in DocType 'Leave Control
+#. Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid ""
+"Add unused leaves from previous leave period's allocation to this allocation"
+msgstr ""
+"Өмнөх амралтын хугацааны ашиглагдаагүй навчийг энэ хуваарилалтад нэмнэ"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1597
+msgid ""
+"Added tax components from the Salary Component master as the salary "
+"structure didn't have any tax component."
+msgstr ""
+"Цалингийн бүтцэд татварын бүрэлдэхүүн байхгүй байсан тул Цалингийн "
+"бүрэлдэхүүн хэсгийн мастераас татварын бүрэлдэхүүн хэсгүүдийг нэмсэн."
+
+#: hrms/hr/employee_property_update.js:193
+msgid "Added to details"
+msgstr "Дэлгэрэнгүй мэдээлэлд нэмсэн"
+
+#. Label of the additional_amount (Currency) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Additional Amount"
+msgstr "Нэмэлт дүн"
+
+#. Label of the additional_information_section (Section Break) field in
+#. DocType
+#. 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Additional Information "
+msgstr "Нэмэлт мэдээлэл "
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:46
+msgid "Additional PF"
+msgstr "Нэмэлт PF"
+
+#. Label of the additional_salary (Link) field in DocType 'Leave Encashment'
+#. Label of a Link in the Expenses Workspace
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/workspace/expenses/expenses.json
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Additional Salary"
+msgstr "Нэмэлт цалин"
+
+#. Label of the additional_salary (Link) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Additional Salary "
+msgstr "Нэмэлт цалин "
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:150
+msgid ""
+"Additional Salary for referral bonus can only be created against Employee "
+"Referral with status {0}"
+msgstr ""
+"Урамшууллын урамшууллын нэмэлт цалинг зөвхөн {0} статустай ажилтны "
+"лавлагааны эсрэг үүсгэж болно."
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:185
+msgid ""
+"Additional Salary for this salary component with {0} enabled already exists "
+"for this date"
+msgstr ""
+"{0}-г идэвхжүүлсэн энэ цалингийн бүрэлдэхүүн хэсгийн нэмэлт цалин энэ өдөр "
+"аль хэдийн байна"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:97
+msgid ""
+"Additional Salary: {0} already exist for Salary Component: {1} for period "
+"{2} and {3}"
+msgstr ""
+"Нэмэлт цалин: Цалингийн бүрэлдэхүүн хэсэгт {0} аль хэдийн байгаа: {2} ба {3}"
+" хугацаанд {1}"
+
+#. Label of the address_of_organizer (Data) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Address of Organizer"
+msgstr "Зохион байгуулагчийн хаяг"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:51
+#| msgid "Annual Allocation"
+msgid "Adjust Allocation"
+msgstr "Жилийн хуваарилалт"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:412
+#| msgid "{0} created successfully!"
+msgid "Adjustment Created Successfully"
+msgstr " амжилттай үүсгэгдсэн!"
+
+#. Label of the adjustment_type (Select) field in DocType 'Leave Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Associated Document Type"
+msgid "Adjustment Type"
+msgstr "Холбоотой баримт бичгийн төрөл"
+
+#. Option for the 'Level' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Advance"
+msgstr "Урьдчилгаа"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:52
+#| msgid "Advance Account"
+msgid "Advance Account Required"
+msgstr "Урьдчилсан данс"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:56
+msgid ""
+"Advance Account is mandatory. Please set the {0} in the Company {1} and "
+"submit this document."
+msgstr ""
+"Урьдчилгааны данс заавал байх ёстой. {1} компанид {0}-г тохируулаад энэ "
+"баримтыг батална уу."
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:99
+msgid ""
+"Advance Account {} currency should be same as Salary Currency of Employee "
+"{}. Please select same currency Advance Account"
+msgstr ""
+"Урьдчилгааны данс {}-ийн валют нь {} ажилтны цалингийн валюттай ижил байх "
+"ёстой. Ижил валюттай урьдчилгааны данс сонгоно уу"
+
+#. Label of the base_advance_paid (Currency) field in DocType 'Expense Claim
+#. Advance'
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+#| msgid "Net Pay (Company Currency)"
+msgid "Advance Paid (Company Currency)"
+msgstr "Цэвэр төлбөр (Компанийн валют)"
+
+#. Label of the advanced_filters_section (Section Break) field in DocType
+#. 'Leave Control Panel'
+#. Label of the advanced_filters_section (Section Break) field in DocType
+#. 'Shift Assignment Tool'
+#. Label of the advanced_filters_section (Section Break) field in DocType
+#. 'Bulk
+#. Salary Structure Assignment'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+msgid "Advanced Filters"
+msgstr "Нарийвчилсан шүүлтүүрүүд"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:422
+msgid "All Exchange Gain/Loss amount of {0} has been booked through {1}"
+msgstr "{0}-ийн бүх ханшийн зөрүүний олз/алдагдлын дүнг {1}-ээр бүртгэсэн"
+
+#: hrms/hr/doctype/goal/goal_tree.js:215
+msgid "All Goals"
+msgstr "Бүх зорилго"
+
+#: hrms/hr/doctype/job_opening/job_opening.py:102
+msgid "All Jobs"
+msgstr "Бүх ажлын байр"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:70
+msgid "All allocated assets should be returned before submission"
+msgstr "Бүх хуваарилагдсан хөрөнгийг мэдүүлэхээс өмнө буцааж өгөх ёстой"
+
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.py:48
+msgid "All the mandatory tasks for employee creation are not completed yet."
+msgstr ""
+"Ажилтныг бий болгох зайлшгүй шаардлагатай бүх ажлууд хараахан дуусаагүй "
+"байна."
+
+#. Label of the allocate_based_on_leave_policy (Check) field in DocType 'Leave
+#. Control Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "Allocate Based On Leave Policy"
+msgstr "Амралтын бодлогод үндэслэн хуваарилна"
+
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.js:176
+msgid "Allocate Leave"
+msgstr "Амралт хуваарилах"
+
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.js:192
+msgid "Allocate leaves to {0} employee(s)?"
+msgstr "{0} ажилтанд чөлөө олгох уу?"
+
+#. Label of the allocate_on_day (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Allocate on Day"
+msgstr "Өдөрт хуваарилна"
+
+#. Label of the base_allocated_amount (Currency) field in DocType 'Expense
+#. Claim Advance'
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+#| msgid "Rounded Total (Company Currency)"
+msgid "Allocated Amount (Company Currency)"
+msgstr "Дугуйлсан нийт (Компанийн валют)"
+
+#. Label of the allocated_leaves (Float) field in DocType 'Leave Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#: hrms/hr/doctype/leave_application/leave_application.js:75
+msgid "Allocated Leaves"
+msgstr "Хуваарилагдсан навч"
+
+#. Label of the allocated_via (Select) field in DocType 'Earned Leave
+#. Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Allocated Leaves"
+msgid "Allocated Via"
+msgstr "Хуваарилагдсан навч"
+
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.js:205
+msgid "Allocating Leave"
+msgstr "Амралт хуваарилах"
+
+#. Label of the allocation_date (Date) field in DocType 'Earned Leave
+#. Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Allocation"
+msgid "Allocation Date"
+msgstr "Хуваарилалт"
+
+#. Label of the section_break_etvg (Section Break) field in DocType 'Leave
+#. Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Allocate on Day"
+msgid "Allocation Details"
+msgstr "Өдөрт хуваарилна"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:119
+msgid "Allocation Expired!"
+msgstr "Хуваарилалтын хугацаа дууссан!"
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.py:60
+msgid "Allocation is greater than the maximum allowed {0} for leave type {1}"
+msgstr ""
+"Хуваарилалт нь {1} чөлөөний төрлийн зөвшөөрөгдсөн дээд хэмжээ {0}-с хэтэрсэн"
+
+#. Label of the leave_allocation (Link) field in DocType 'Leave Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Allocation"
+msgid "Allocation to Adjust"
+msgstr "Хуваарилалт"
+
+#: hrms/hr/utils.py:440
+msgid ""
+"Allocation was skipped due to exceeding annual allocation set in leave "
+"policy"
+msgstr ""
+"Чөлөөний бодлогод тогтоосон жилийн хуваарилалтаас хэтэрсэн тул хуваарилалтыг"
+" алгассан"
+
+#: hrms/hr/utils.py:430
+msgid ""
+"Allocation was skipped due to maximum leave allocation limit set in leave "
+"type. Please increase the limit and retry failed allocation."
+msgstr ""
+"Чөлөөний төрөлд тогтоосон хуваарилалтын дээд хэмжээнээс хэтэрсэн тул "
+"хуваарилалтыг алгассан. Хязгаарыг нэмэгдүүлж амжилтгүй хуваарилалтыг дахин "
+"оролдоно уу."
+
+#. Label of the allow_employee_checkin_from_mobile_app (Check) field in
+#. DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Allow Employee Checkin from Mobile App"
+msgstr "Мобайл програмаас ажилчдаа бүртгүүлэхийг зөвшөөрөх"
+
+#. Label of the allow_encashment (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Allow Encashment"
+msgstr "Бэлэн мөнгө авахыг зөвшөөрөх"
+
+#. Label of the allow_geolocation_tracking (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Allow Geolocation Tracking"
+msgstr "Газарзүйн байршлыг хянахыг зөвшөөрөх"
+
+#. Label of the applicable_after (Int) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Allow Leave Application After (Working Days)"
+msgstr "(Ажлын өдрүүд) дараа өргөдөл гаргахыг зөвшөөрөх"
+
+#. Label of the allow_multiple_shift_assignments (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:105
+msgid "Allow Multiple Shift Assignments for Same Date"
+msgstr "Ижил огноогоор олон ээлжийн даалгавар хийхийг зөвшөөрөх"
+
+#. Label of the allow_negative (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Allow Negative Balance"
+msgstr "Сөрөг үлдэгдлийг зөвшөөрөх"
+
+#. Label of the allow_over_allocation (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Allow Over Allocation"
+msgstr "Хэт хуваарилалтыг зөвшөөрөх"
+
+#. Label of the allow_tax_exemption (Check) field in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Allow Tax Exemption"
+msgstr "Татвараас чөлөөлөхийг зөвшөөрөх"
+
+#. Label of the allow_user (Link) field in DocType 'Leave Block List Allow'
+#: hrms/hr/doctype/leave_block_list_allow/leave_block_list_allow.json
+msgid "Allow User"
+msgstr "Хэрэглэгчийг зөвшөөрөх"
+
+#. Label of the allow_list (Section Break) field in DocType 'Leave Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Allow Users"
+msgstr "Хэрэглэгчдийг зөвшөөрөх"
+
+#. Label of the allow_check_out_after_shift_end_time (Int) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Allow check-out after shift end time (in minutes)"
+msgstr "Ээлж дуусах цагийн дараа гарахыг зөвшөөрөх (минутаар)"
+
+#. Option for the 'Payout Method' (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Allow claim for full benefit amount"
+msgstr "Тэтгэмжийн бүрэн дүнг нэхэмжлэхийг зөвшөөрөх"
+
+#. Description of the 'Allow Users' (Section Break) field in DocType 'Leave
+#. Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid ""
+"Allow the following users to approve Leave Applications for block days."
+msgstr ""
+"Дараах хэрэглэгчдэд блокийн өдрүүдээр өргөдөл гаргахыг зөвшөөрөхийг "
+"зөвшөөрнө үү."
+
+#. Description of the 'Allow Over Allocation' (Check) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid ""
+"Allows allocating more leaves than the number of days in the allocation "
+"period."
+msgstr ""
+"Хуваарилалтын хугацааны өдрийн тооноос илүү навч хуваарилахыг зөвшөөрдөг."
+
+#. Option for the 'Determine Check-in and Check-out' (Select) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Alternating entries as IN and OUT during the same shift"
+msgstr "Нэг ээлжийн үед IN болон OUT гэж ээлжлэн оруулах"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:49
+msgid "Amount Based on Formula"
+msgstr "Формула дээр үндэслэсэн дүн"
+
+#. Label of the amount_based_on_formula (Check) field in DocType 'Salary
+#. Component'
+#. Label of the amount_based_on_formula (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:108
+msgid "Amount based on formula"
+msgstr "Томъёонд үндэслэсэн хэмжээ"
+
+#. Description of the 'Claimed Amount' (Currency) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Amount claimed via Expense Claim"
+msgstr "Зардлын нэхэмжлэлээр нэхэмжилсэн дүн"
+
+#. Description of the 'Advance Amount' (Currency) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Amount of expense"
+msgstr "Зардлын хэмжээ"
+
+#. Description of the 'Paid Amount' (Currency) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#| msgid "Amount that has been paid against this advance"
+msgid "Amount paid against this encashment"
+msgstr "Энэ урьдчилгаа төлбөрт төлсөн дүн"
+
+#. Description of the 'Returned Amount' (Currency) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Amount scheduled for deduction via salary"
+msgstr "Цалингаар суутгах төлөвлөсөн дүн"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:37
+msgid "Amount should not be less than zero"
+msgstr "Дүн нь тэгээс бага байж болохгүй"
+
+#. Description of the 'Paid Amount (Company Currency)' (Currency) field in
+#. DocType 'Employee Advance'
+#. Description of the 'Paid Amount' (Currency) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Amount that has been paid against this advance"
+msgstr "Энэ урьдчилгаа төлбөрт төлсөн дүн"
+
+#: hrms/payroll/doctype/arrear/arrear.py:92
+#| msgid "{0} already exists for employee {1} and period {2}"
+msgid ""
+"An Arrear document already exists for employee {0} with salary structure {1}"
+" in payroll period {2}"
+msgstr "{1} ажилтан болон {2} хугацаанд {0} аль хэдийн байна"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:56
+msgid ""
+"An attendance record is linked to this checkin. Please cancel the attendance"
+" before modifying time."
+msgstr ""
+"Энэ бүртгэлтэй холбоотой ирцийн бүртгэл байна. Цагийг өөрчлөхийн өмнө ирцийг"
+" цуцална уу."
+
+#. Label of the annual_allocation (Float) field in DocType 'Leave Policy
+#. Detail'
+#: hrms/hr/doctype/leave_policy_detail/leave_policy_detail.json
+msgid "Annual Allocation"
+msgstr "Жилийн хуваарилалт"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:372
+msgid "Annual Allocation Exceeded"
+msgstr "Жилийн хуваарилалт хэтэрсэн"
+
+#: hrms/setup.py:404
+msgid "Annual Salary"
+msgstr "Жилийн цалин"
+
+#. Label of the annual_taxable_amount (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Annual Taxable Amount"
+msgstr "Жилийн татвар ногдох хэмжээ"
+
+#. Label of the description (Small Text) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Any other details"
+msgstr "Бусад дэлгэрэнгүй мэдээлэл"
+
+#. Description of the 'Remarks' (Text) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Any other remarks, noteworthy effort that should go in the records"
+msgstr ""
+"Бусад тэмдэглэл, анхаарал татахуйц хүчин чармайлтыг бүртгэлд оруулах ёстой"
+
+#. Label of the applicable_earnings_component (Table MultiSelect) field in
+#. DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Applicable Earnings Component"
+msgstr "Холбогдох орлогын бүрэлдэхүүн хэсэг"
+
+#. Label of the applicable_salary_component (Table MultiSelect) field in
+#. DocType 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Applicable Earnings Component"
+msgid "Applicable Salary Components"
+msgstr "Холбогдох орлогын бүрэлдэхүүн хэсэг"
+
+#. Description of the 'Required for Employee Creation' (Check) field in
+#. DocType
+#. 'Employee Boarding Activity'
+#: hrms/hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgid "Applicable in the case of Employee Onboarding"
+msgstr "Ажилтныг ажилд авах тохиолдолд хамаарна"
+
+#. Label of the applicant_email (Data) field in DocType 'Job Offer'
+#: hrms/hr/doctype/job_offer/job_offer.json
+msgid "Applicant Email Address"
+msgstr "Өргөдөл гаргагчийн имэйл хаяг"
+
+#. Label of the applicant_name (Data) field in DocType 'Appointment Letter'
+#. Label of the applicant_name (Data) field in DocType 'Job Applicant'
+#. Label of the applicant_name (Data) field in DocType 'Job Offer'
+#. Label of a field in the job-application Web Form
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_offer/job_offer.json
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Applicant Name"
+msgstr "Өргөдөл гаргагчийн нэр"
+
+#. Label of the applicant_rating (Rating) field in DocType 'Job Applicant'
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+msgid "Applicant Rating"
+msgstr "Өргөдөл гаргагчийн үнэлгээ"
+
+#. Description of a DocType
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+msgid "Applicant for a Job"
+msgstr "Ажилд орох өргөдөл гаргагч"
+
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:44
+msgid "Applicant name"
+msgstr "Өргөдөл гаргагчийн нэр"
+
+#. Label of a Card Break in the Leaves Workspace
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Application"
+msgstr "Өргөдөл"
+
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:46
+msgid "Application Status"
+msgstr "Хэрэглээний статус"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:224
+msgid "Application period cannot be across two allocation records"
+msgstr "Өргөдөл гаргах хугацаа нь хуваарилалтын хоёр бүртгэлд байж болохгүй"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:221
+msgid "Application period cannot be outside leave allocation period"
+msgstr ""
+"Өргөдөл гаргах хугацаа нь чөлөө олгох хугацаанаас гадуур байж болохгүй"
+
+#: hrms/templates/generators/job_opening.html:162
+msgid "Applications Received"
+msgstr "Хүлээн авсан өргөдөл"
+
+#: hrms/www/jobs/index.html:235
+msgid "Applications received:"
+msgstr "Хүлээн авсан өргөдөл:"
+
+#. Label of the applies_to_all_departments (Check) field in DocType 'Leave
+#. Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Applies to Company"
+msgstr "Компанид хамаарна"
+
+#. Description of a DocType
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Apply / Approve Leaves"
+msgstr "Навч хэрэглэх / батлах"
+
+#: hrms/templates/generators/job_opening.html:29
+#: hrms/templates/generators/job_opening.html:209
+msgid "Apply Now"
+msgstr "Одоо өргөдөл гаргана уу"
+
+#. Label of the applicable_for_public_holiday (Check) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Apply for Public Holiday"
+msgstr "Нийтийн баярын өдөр хүсэлт гаргах"
+
+#. Label of the applicable_for_weekend (Check) field in DocType 'Overtime
+#. Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Apply for Weekend"
+msgstr "Амралтын өдөр хүсэлт гаргах"
+
+#. Label of the appointment_date (Date) field in DocType 'Appointment Letter'
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+msgid "Appointment Date"
+msgstr "Уулзалтын огноо"
+
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Appointment Letter"
+msgstr "Томилох бичиг"
+
+#. Label of the appointment_letter_template (Link) field in DocType
+#. 'Appointment Letter'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+#: hrms/hr/doctype/appointment_letter_template/appointment_letter_template.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Appointment Letter Template"
+msgstr "Томилгооны захидлын загвар"
+
+#. Name of a DocType
+#: hrms/hr/doctype/appointment_letter_content/appointment_letter_content.json
+msgid "Appointment Letter content"
+msgstr "Томилгооны захидлын агуулга"
+
+#. Name of a DocType
+#. Label of the appraisal (Link) field in DocType 'Employee Performance
+#. Feedback'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:44
+msgid "Appraisal"
+msgstr "Үнэлгээ"
+
+#. Label of the appraisal_cycle (Link) field in DocType 'Appraisal'
+#. Name of a DocType
+#. Label of the appraisal_cycle (Link) field in DocType 'Employee Performance
+#. Feedback'
+#. Label of the appraisal_cycle (Link) field in DocType 'Goal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hrms/hr/doctype/goal/goal.json hrms/hr/doctype/goal/goal_tree.js:17
+#: hrms/hr/doctype/goal/goal_tree.js:105
+#: hrms/hr/report/appraisal_overview/appraisal_overview.js:18
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:37
+msgid "Appraisal Cycle"
+msgstr "Үнэлгээний мөчлөг"
+
+#. Name of a DocType
+#: hrms/hr/doctype/appraisal_goal/appraisal_goal.json
+msgid "Appraisal Goal"
+msgstr "Үнэлгээний зорилго"
+
+#. Name of a DocType
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+msgid "Appraisal KRA"
+msgstr "Үнэлгээний KRA"
+
+#. Label of the section_break_cycle (Section Break) field in DocType 'Goal'
+#: hrms/hr/doctype/goal/goal.json hrms/hr/doctype/goal/goal_tree.js:96
+msgid "Appraisal Linking"
+msgstr "Үнэлгээний холболт"
+
+#. Name of a report
+#. Label of a chart in the Performance Workspace
+#: hrms/hr/report/appraisal_overview/appraisal_overview.json
+#: hrms/hr/workspace/performance/performance.json
+msgid "Appraisal Overview"
+msgstr "Үнэлгээний тойм"
+
+#. Label of the appraisal_template (Link) field in DocType 'Appraisal'
+#. Name of a DocType
+#. Label of the appraisal_template (Link) field in DocType 'Appraisee'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/appraisal_template/appraisal_template.json
+#: hrms/hr/doctype/appraisee/appraisee.json hrms/setup.py:162
+msgid "Appraisal Template"
+msgstr "Үнэлгээний загвар"
+
+#. Name of a DocType
+#: hrms/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgid "Appraisal Template Goal"
+msgstr "Үнэлгээний загварын зорилго"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:142
+msgid "Appraisal Template Missing"
+msgstr "Үнэлгээний загвар байхгүй"
+
+#. Label of the template_title (Data) field in DocType 'Appraisal Template'
+#: hrms/hr/doctype/appraisal_template/appraisal_template.json
+msgid "Appraisal Template Title"
+msgstr "Үнэлгээний загварын гарчиг"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:135
+msgid "Appraisal Template not found for some designations."
+msgstr "Зарим тэмдэглэгээний үнэлгээний загвар олдсонгүй."
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:125
+msgid "Appraisal creation is queued. It may take a few minutes."
+msgstr ""
+"Үнэлгээ үүсгэх дараалалд байна. Үүнд хэдэн минут зарцуулагдаж магадгүй."
+
+#: hrms/hr/doctype/appraisal/appraisal.py:58
+msgid ""
+"Appraisal {0} already exists for Employee {1} for this Appraisal Cycle or "
+"overlapping period"
+msgstr ""
+"Энэ Үнэлгээний мөчлөг эсвэл давхцах хугацаанд {1} ажилтанд {0} үнэлгээ аль "
+"хэдийн байгаа"
+
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.py:45
+msgid "Appraisal {0} does not belong to Employee {1}"
+msgstr "Үнэлгээ {0} нь {1} ажилтанд хамаарахгүй"
+
+#. Name of a DocType
+#: hrms/hr/doctype/appraisee/appraisee.json
+msgid "Appraisee"
+msgstr "Үнэлгээчин"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:159
+msgid "Appraisees: {0}"
+msgstr "Үнэлгээчид: {0}"
+
+#: hrms/setup.py:396
+msgid "Apprentice"
+msgstr "Дагалдан"
+
+#. Label of the section_break_7 (Section Break) field in DocType 'Leave
+#. Application'
+#: frontend/src/components/RequestActionSheet.vue:290
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Approval"
+msgstr "Зөвшөөрөл"
+
+#. Label of the approval_status (Select) field in DocType 'Expense Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Approval Status"
+msgstr "Зөвшөөрлийн статус"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:148
+msgid "Approval Status must be 'Approved' or 'Rejected'"
+msgstr "Зөвшөөрлийн статус нь \"Батлагдсан\" эсвэл \"Татгалзсан\" байх ёстой"
+
+#: frontend/src/components/RequestActionSheet.vue:108
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:119
+msgid "Approve"
+msgstr "Зөвшөөрөх"
+
+#. Option for the 'Approval Status' (Select) field in DocType 'Expense Claim'
+#. Option for the 'Status' (Select) field in DocType 'Leave Application'
+#. Option for the 'Status' (Select) field in DocType 'Shift Request'
+#: frontend/src/components/ExpenseClaimSummary.vue:36
+#: frontend/src/views/leave/List.vue:30
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#: hrms/hr/doctype/leave_application/leave_application.json
+#: hrms/hr/doctype/shift_request/shift_request.json
+msgid "Approved"
+msgstr "Зөвшөөрсөн"
+
+#. Label of the approver (Link) field in DocType 'Department Approver'
+#. Label of the approver (Link) field in DocType 'Shift Assignment Tool'
+#. Label of the approver (Link) field in DocType 'Shift Request'
+#: hrms/hr/doctype/department_approver/department_approver.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/doctype/shift_request/shift_request.json
+msgid "Approver"
+msgstr "Зөвшөөрөгч"
+
+#: hrms/setup.py:133 hrms/setup.py:235
+msgid "Approvers"
+msgstr "Зөвшөөрөгчид"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:39
+#: hrms/public/js/salary_slip_deductions_report_filters.js:22
+msgid "Apr"
+msgstr "4-р сар"
+
+#: frontend/src/components/FileUploaderView.vue:53
+msgid "Are you sure you want to delete the attachment"
+msgstr "Та хавсралтыг устгахдаа итгэлтэй байна уу"
+
+#: frontend/src/components/FormView.vue:228
+msgid "Are you sure you want to delete the {0}"
+msgstr "Та {0}-г устгахдаа итгэлтэй байна уу"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip_list.js:19
+msgid "Are you sure you want to email the selected salary slips?"
+msgstr "Та сонгосон цалингийн хуудсыг имэйлээр явуулахдаа итгэлтэй байна уу?"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.js:9
+msgid "Are you sure you want to reject the Employee Referral?"
+msgstr "Та ажилтны саналаас татгалзахдаа итгэлтэй байна уу?"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/arrear/arrear.json
+msgid "Arrear"
+msgstr "Нөхөн олговор"
+
+#. Label of the arrear_component (Check) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#| msgid "Salary Component"
+msgid "Arrear Component"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:95
+msgid ""
+"Arrear Component cannot be set for Salary Components based on taxable "
+"salary."
+msgstr ""
+"Нөхөн олговрын бүрэлдэхүүн хэсгийг татварт ногдох цалин дээр суурилсан "
+"цалингийн бүрэлдэхүүн хэсэгт тохируулах боломжгүй."
+
+#. Label of the arrear_start_date (Date) field in DocType 'Arrear'
+#: hrms/payroll/doctype/arrear/arrear.json
+#| msgid "Start Date"
+msgid "Arrear Start Date"
+msgstr "Эхлэх огноо"
+
+#. Label of the arrears_tab (Tab Break) field in DocType 'Arrear'
+#: hrms/payroll/doctype/arrear/arrear.json
+msgid "Arrears"
+msgstr "Нөхөн олговрууд"
+
+#. Label of the arrival_date (Datetime) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Arrival Datetime"
+msgstr "Ирэх огноо"
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:23
+msgid "As per your assigned Salary Structure you cannot apply for benefits"
+msgstr ""
+"Таны томилсон Цалингийн бүтцийн дагуу та тэтгэмж авах хүсэлт гаргах "
+"боломжгүй"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:101
+msgid "Asset Recovery Cost for {0}: {1}"
+msgstr "{0}-н хөрөнгийг нөхөн сэргээх зардал: {1}"
+
+#. Label of the section_break_15 (Section Break) field in DocType 'Full and
+#. Final Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Assets Allocated"
+msgstr "Хуваарилагдсан хөрөнгө"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:283
+msgid "Assign Salary Structure to {0} employee(s)?"
+msgstr "{0} ажилтанд цалингийн бүтцийг хуваарилах уу?"
+
+#. Option for the 'Action' (Select) field in DocType 'Shift Assignment Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:110
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Assign Shift"
+msgstr "Shift оноо"
+
+#. Option for the 'Action' (Select) field in DocType 'Shift Assignment Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:114
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Assign Shift Schedule"
+msgstr "Ээлжийн хуваарийг томилох"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:53
+msgid "Assign Structure"
+msgstr "Бүтэц хуваарилах"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:298
+msgid "Assigning Salary Structure"
+msgstr "Цалингийн бүтцийг хуваарилах"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.py:113
+msgid "Assigning Structure..."
+msgstr "Бүтэц оноож байна..."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:257
+msgid "Assigning Structures..."
+msgstr "Бүтэц оноож байна..."
+
+#. Label of the from_date (Date) field in DocType 'Holiday List Assignment'
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+#| msgid "Assignment based on"
+msgid "Assignment Starts From"
+msgstr "Даалгаврыг үндэслэнэ"
+
+#. Label of the assignment_based_on (Select) field in DocType 'Leave Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Assignment based on"
+msgstr "Даалгаврыг үндэслэнэ"
+
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.py:48
+msgid "Assignment start date cannot be outside holiday list dates"
+msgstr "Томилгооны эхлэх огноо нь баярын жагсаалтын огноос гарч болохгүй"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.js:50
+#: hrms/hr/doctype/job_requisition/job_requisition.js:74
+msgid "Associate Job Opening"
+msgstr "Хамтарсан ажлын байрны нээлт"
+
+#. Label of the associated_document (Dynamic Link) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Associated Document"
+msgstr "Холбоотой баримт бичиг"
+
+#. Label of the associated_document_type (Link) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Associated Document Type"
+msgstr "Холбоотой баримт бичгийн төрөл"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:108
+msgid "At least one interview has to be selected."
+msgstr "Дор хаяж нэг ярилцлага сонгогдсон байх ёстой."
+
+#. Label of the attach_proof (Attach) field in DocType 'Employee Tax Exemption
+#. Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Attach Proof"
+msgstr "Нотлох баримтыг хавсаргана уу"
+
+#. Label of the attempted (Check) field in DocType 'Earned Leave Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Accepted"
+msgid "Attempted"
+msgstr "Хүлээн зөвшөөрсөн"
+
+#. Name of a DocType
+#. Label of the attendance (Select) field in DocType 'Training Event Employee'
+#. Label of a Card Break in the People Workspace
+#. Label of a Link in the People Workspace
+#. Label of a Card Break in the Shift & Attendance Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#. Option for the 'Calculate Payroll Working Days Based On' (Select) field in
+#. DocType 'Payroll Settings'
+#: frontend/src/components/BottomTabs.vue:48
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+#: hrms/overrides/dashboard_overrides.py:10
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#: hrms/templates/emails/training_event.html:9
+msgid "Attendance"
+msgstr "Ирц"
+
+#: frontend/src/components/AttendanceCalendar.vue:3
+#| msgid "Attendance Marked"
+msgid "Attendance Calendar"
+msgstr "Ирцийг тэмдэглэсэн"
+
+#. Label of a chart in the Shift & Attendance Workspace
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Attendance Count"
+msgstr "Ирцийн тоо"
+
+#. Label of the attendance_date (Date) field in DocType 'Attendance'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/report/shift_attendance/shift_attendance.py:43
+msgid "Attendance Date"
+msgstr "Ирсэн огноо"
+
+#. Label of the att_fr_date (Date) field in DocType 'Upload Attendance'
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+msgid "Attendance From Date"
+msgstr "Огнооноос ирц"
+
+#: hrms/hr/doctype/upload_attendance/upload_attendance.js:20
+msgid "Attendance From Date and Attendance To Date is mandatory"
+msgstr "Огнооноос өнөөг хүртэлх ирц заавал байх ёстой"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:123
+msgid "Attendance ID"
+msgstr "Ирцийн ID"
+
+#. Label of the attendance (Link) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/attendance/attendance_list.js:122
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:102
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Attendance Marked"
+msgstr "Ирцийг тэмдэглэсэн"
+
+#. Label of the attendance_request (Link) field in DocType 'Attendance'
+#. Name of a DocType
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/attendance/attendance.js:18
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Attendance Request"
+msgstr "Ирцийн хүсэлт"
+
+#: frontend/src/views/attendance/AttendanceRequestList.vue:5
+msgid "Attendance Request History"
+msgstr "Ирцийн хүсэлтийн түүх"
+
+#. Label of the attendance_settings_section (Section Break) field in DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Attendance Settings"
+msgstr "Ирцийн тохиргоо"
+
+#. Label of the att_to_date (Date) field in DocType 'Upload Attendance'
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+msgid "Attendance To Date"
+msgstr "Өнөөдрийг хүртэл ирц"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:121
+msgid "Attendance Updated"
+msgstr "Ирц шинэчлэгдсэн"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.js:19
+msgid "Attendance Warnings"
+msgstr "Ирцийн сэрэмжлүүлэг"
+
+#: hrms/hr/doctype/attendance/attendance.py:60
+msgid ""
+"Attendance date {0} can not be less than employee {1}'s joining date: {2}"
+msgstr "Оролцох огноо {0} ажилтны {1} элссэн өдрөөс бага байж болохгүй: {2}"
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:99
+msgid ""
+"Attendance for all the employees under this criteria has been marked "
+"already."
+msgstr "Энэ шалгуурын дагуу бүх ажилчдын ирцийг аль хэдийн тэмдэглэсэн байна."
+
+#: hrms/hr/doctype/attendance/attendance.py:118
+msgid ""
+"Attendance for employee {0} is already marked for an overlapping shift {1}: "
+"{2}"
+msgstr ""
+"{0} ажилтны ирцийг аль хэдийн давхцаж буй ээлжийн {1} гэж тэмдэглэсэн байна:"
+" {2}"
+
+#: hrms/hr/doctype/attendance/attendance.py:72
+msgid "Attendance for employee {0} is already marked for the date {1}: {2}"
+msgstr "{0} ажилтны ирцийг {1} огноогоор тэмдэглэсэн байна: {2}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:617
+#| msgid ""
+#| "Attendance for employee {0} is already marked for the date {1}: {2}"
+msgid ""
+"Attendance for employee {0} is already marked for the following dates: {1}"
+msgstr "{0} ажилтны ирцийг {1} огноогоор тэмдэглэсэн байна: "
+
+#: hrms/hr/doctype/attendance_request/attendance_warnings.html:2
+msgid ""
+"Attendance for the following dates will be skipped/overwritten on submission"
+msgstr "Дараах огнооны ирцийг илгээхдээ алгасах/давж бичих болно"
+
+#: hrms/hr/doctype/attendance/attendance_list.js:102
+msgid ""
+"Attendance from {0} to {1} has already been marked for the Employee {2}"
+msgstr ""
+"{0}-с {1} хүртэлх ирцийг {2} ажилтны хувьд аль хэдийн тэмдэглэсэн байна"
+
+#: hrms/public/js/templates/employees_with_unmarked_attendance.html:36
+msgid ""
+"Attendance has been marked for all the employees between the selected "
+"payroll dates."
+msgstr "Сонгосон цалингийн өдрүүдийн хооронд бүх ажилчдын ирцийг тэмдэглэсэн."
+
+#: hrms/public/js/templates/employees_with_unmarked_attendance.html:6
+msgid ""
+"Attendance is pending for these employees between the selected payroll "
+"dates. Mark attendance to proceed. Refer {0} for details."
+msgstr ""
+"Сонгосон цалингийн өдрүүдийн хооронд эдгээр ажилчдын ирц хүлээгдэж байна. "
+"Үргэлжлүүлэхийн тулд ирцийг тэмдэглэ. Дэлгэрэнгүйг {0}-с үзнэ үү."
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:291
+msgid "Attendance marked successfully"
+msgstr "Ирцийг амжилттай тэмдэглэв"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:140
+msgid "Attendance not submitted for {0} as it is a Holiday."
+msgstr "Амралтын өдөр тул {0}-д ирц бүрдүүлээгүй."
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:149
+msgid "Attendance not submitted for {0} as {1} is on leave."
+msgstr "{1} амралттай байгаа тул {0}-н ирцийг ирүүлээгүй."
+
+#. Description of the 'Process Attendance After' (Date) field in DocType
+#. 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Attendance will be marked automatically only after this date."
+msgstr "Зөвхөн энэ өдрөөс хойш ирцийг автоматаар тэмдэглэнэ."
+
+#: frontend/src/views/attendance/Dashboard.vue:19
+msgid "AttendanceRequestListView"
+msgstr "Оролцох ХүсэлтЖагсаалт харах"
+
+#. Label of the section_break_18 (Section Break) field in DocType 'Training
+#. Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Attendees"
+msgstr "Оролцогчид"
+
+#: hrms/hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py:56
+msgid "Attrition Count"
+msgstr "Элэгдлийн тоо"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:43
+#: hrms/public/js/salary_slip_deductions_report_filters.js:26
+msgid "Aug"
+msgstr "Наймдугаар сар"
+
+#. Label of the auto_attendance_settings_section (Section Break) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Auto Attendance Settings"
+msgstr "Автомат ирцийн тохиргоо"
+
+#. Label of the auto_leave_encashment (Check) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Auto Leave Encashment"
+msgstr "Автоматаар чөлөөлөх мөнгөн хураамж"
+
+#. Option for the 'KRA Evaluation Method' (Select) field in DocType 'Appraisal
+#. Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Automated Based on Goal Progress"
+msgstr "Зорилгодоо тулгуурлан автоматжуулсан"
+
+#: hrms/hr/utils.py:484
+msgid ""
+"Automatic Leave Allocation has failed for the following Earned Leaves: {0}. "
+"Please check {1} for more details."
+msgstr ""
+"Дараах олгогдсон чөлөөнүүдэд автомат чөлөөний хуваарилалт амжилтгүй болсон: "
+"{0}. Дэлгэрэнгүйг {1}-с харна уу."
+
+#. Description of the 'Assets Allocated' (Section Break) field in DocType
+#. 'Full
+#. and Final Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Automatically fetches all assets allocated to the employee, if any"
+msgstr ""
+"Хэрэв байгаа бол ажилтанд хуваарилагдсан бүх хөрөнгийг автоматаар татаж "
+"авдаг"
+
+#. Label of the auto_update_last_sync (Check) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+#| msgid "Last Sync of Checkin"
+msgid "Automatically update Last Sync of Checkin"
+msgstr "Бүртгэлийн сүүлчийн синк"
+
+#. Label of the available_leaves (Float) field in DocType 'Salary Slip Leave'
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Available Leave(s)"
+msgstr "Боломжтой чөлөө(үүд)"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:11
+msgid "Available Leaves"
+msgstr "Боломжтой навчнууд"
+
+#. Label of the avg_feedback_score (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:84
+msgid "Average Feedback Score"
+msgstr "Санал хүсэлтийн дундаж оноо"
+
+#. Label of the average_rating (Rating) field in DocType 'Interview Feedback'
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/public/js/templates/feedback_summary.html:5
+msgid "Average Rating"
+msgstr "Дундаж үнэлгээ"
+
+#. Description of the 'Final Score' (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#| msgid ""
+#| "Average of Goal Score, Feedback Score, and Self Appraisal Score (out of 5)"
+msgid "Average of Goal Score, Feedback Score, and Self Appraisal Score"
+msgstr ""
+"Зорилгын оноо, санал хүсэлтийн оноо, өөрийгөө үнэлэх үнэлгээний дундаж "
+"(5-аас)"
+
+#: hrms/public/js/templates/interview_feedback.html:16
+msgid "Average rating of demonstrated skills"
+msgstr "Үзүүлсэн ур чадварын дундаж үнэлгээ"
+
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:52
+msgid "Avg Feedback Score"
+msgstr "Санал хүсэлтийн дундаж оноо"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:218
+msgid "Avg Utilization"
+msgstr "Дундаж ашиглалт"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:224
+msgid "Avg Utilization (Billed Only)"
+msgstr "Дундаж ашиглалт (Зөвхөн тооцоотой)"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Offer'
+#: hrms/hr/doctype/job_offer/job_offer.json
+msgid "Awaiting Response"
+msgstr "Хариулт хүлээж байна"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:184
+msgid "Backdated Leave Application is restricted. Please set the {} in {}"
+msgstr ""
+"Хугацаа хоцрогдсон чөлөө авах хүсэлтийг хязгаарласан. {}-д {}-г тохируулна "
+"уу"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.js:285
+msgid "Bank Entries"
+msgstr "Банкны бүртгэл"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/bank_remittance/bank_remittance.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Bank Remittance"
+msgstr "Банкны мөнгөн гуйвуулга"
+
+#. Label of the base (Currency) field in DocType 'Salary Structure Assignment'
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:180
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Base"
+msgstr "Суурь"
+
+#. Label of the section_break_7 (Section Break) field in DocType 'Salary
+#. Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#| msgid "Leave Encashment"
+msgid "Base, Variable & Leave Encashment"
+msgstr "Бэлэн мөнгө үлдээх"
+
+#. Label of the begin_check_in_before_shift_start_time (Int) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Begin check-in before shift start time (in minutes)"
+msgstr "Ээлж эхлэхээс өмнө бүртгүүлж эхлэх (минутаар)"
+
+#: hrms/controllers/employee_reminders.py:75
+msgid "Below is the list of upcoming holidays for you:"
+msgstr "Танд удахгүй болох амралтын өдрүүдийн жагсаалтыг доор харуулав."
+
+#: hrms/overrides/dashboard_overrides.py:35
+msgid "Benefit"
+msgstr "Ашиг тус"
+
+#. Label of the amount (Currency) field in DocType 'Employee Benefit Detail'
+#: hrms/payroll/doctype/employee_benefit_detail/employee_benefit_detail.json
+#| msgid "Max Benefit Amount"
+msgid "Benefit Amount"
+msgstr "Тэтгэмжийн дээд хэмжээ"
+
+#. Label of the employee_benefit_details_section (Section Break) field in
+#. DocType 'Employee Benefit Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#| msgid "Event Details"
+msgid "Benefit Details"
+msgstr "Үйл явдлын дэлгэрэнгүй мэдээлэл"
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:36
+#| msgid "Maximum benefit amount of component {0} exceeds {1}"
+msgid "Benefit amount of component {0} exceeds {1}"
+msgstr "{0} бүрэлдэхүүн хэсгийн ашиг тусын дээд хэмжээ {1}-ээс хэтэрсэн байна"
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:30
+#| msgid "Maximum benefit amount of component {0} exceeds {1}"
+msgid "Benefit amount of component {0} should be greater than 0"
+msgstr "{0} бүрэлдэхүүн хэсгийн ашиг тусын дээд хэмжээ -ээс хэтэрсэн байна"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:451
+msgid ""
+"Benefit amount {0} for Salary Component {1} should not be greater than "
+"maximum benefit amount {2} set in {3}"
+msgstr ""
+"Цалингийн бүрэлдэхүүн хэсэг {1}-ийн тэтгэмжийн дүн {0} нь {3}-д тогтоосон "
+"дээд тэтгэмжийн дүн {2}-с хэтрэх ёсгүй"
+
+#. Label of the section_break_4 (Section Break) field in DocType 'Employee
+#. Benefit Application'
+#. Label of the benefit_type_and_amount (Section Break) field in DocType
+#. 'Employee Benefit Claim'
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Benefits"
+msgstr "Ашиг тус"
+
+#: hrms/hr/report/project_profitability/project_profitability.py:169
+msgid "Bill Amount"
+msgstr "Тооцооны дүн"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:249
+msgid "Billed Hours"
+msgstr "Тооцоотой цаг"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:68
+msgid "Billed Hours (B)"
+msgstr "Тооцоотой цаг (B)"
+
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Payroll
+#. Entry'
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary Slip'
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Structure'
+#. Option for the 'Payroll Frequency' (Select) field in DocType 'Salary
+#. Withholding'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Bimonthly"
+msgstr "Хоёр сар тутам"
+
+#: hrms/controllers/employee_reminders.py:134
+msgid "Birthday Reminder"
+msgstr "Төрсөн өдрийн сануулагч"
+
+#: hrms/controllers/employee_reminders.py:141
+msgid "Birthday Reminder 🎂"
+msgstr "Төрсөн өдрийн сануулагч 🎂"
+
+#. Label of the send_birthday_reminders (Check) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Birthdays"
+msgstr "Төрсөн өдрүүд"
+
+#. Label of the block_date (Date) field in DocType 'Leave Block List Date'
+#: hrms/hr/doctype/leave_block_list_date/leave_block_list_date.json
+msgid "Block Date"
+msgstr "Блоклох огноо"
+
+#. Label of the block_days (Section Break) field in DocType 'Leave Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Block Days"
+msgstr "Блок өдрүүд"
+
+#. Description of a DocType
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Block Holidays on important days."
+msgstr "Чухал өдрүүдэд амралтын өдрүүдийг хоригло."
+
+#. Label of the bonus_section (Section Break) field in DocType 'Retention
+#. Bonus'
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.json
+msgid "Bonus"
+msgstr "Бонус"
+
+#. Label of the bonus_amount (Currency) field in DocType 'Retention Bonus'
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.json
+msgid "Bonus Amount"
+msgstr "Урамшууллын хэмжээ"
+
+#. Label of the bonus_payment_date (Date) field in DocType 'Retention Bonus'
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.json
+msgid "Bonus Payment Date"
+msgstr "Бонус төлөх огноо"
+
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.py:17
+msgid "Bonus Payment Date cannot be a past date"
+msgstr "Бонус төлөх огноо нь өнгөрсөн огноо байж болохгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:233
+msgid "Branch: {0}"
+msgstr "Салбар: {0}"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:131
+msgid "Bulk Assignments"
+msgstr "Бөөн даалгавар"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment_list.js:3
+msgid "Bulk Leave Policy Assignment"
+msgstr "Бөөнөөр чөлөөлөх бодлогын даалгавар"
+
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+#: hrms/payroll/doctype/salary_structure/salary_structure_list.js:3
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Bulk Salary Structure Assignment"
+msgstr "Бөөн цалингийн бүтцийн даалгавар"
+
+#. Description of the 'Calculate Final Score based on Formula' (Check) field
+#. in
+#. DocType 'Appraisal Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid ""
+"By default, the Final Score is calculated as the average of Goal Score, "
+"Feedback Score, and Self Appraisal Score. Enable this to set a different "
+"formula"
+msgstr ""
+"Анхдагч байдлаар эцсийн оноог Зорилго, Санал хүсэлт, Өөрийгөө Үнэлгээний "
+"онооны дундажаар тооцдог. Өөр томьёо тохируулахын тулд үүнийг идэвхжүүлнэ үү"
+
+#. Label of the ctc (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "CTC"
+msgstr "CTC"
+
+#. Label of the calculate_final_score_based_on_formula (Check) field in
+#. DocType
+#. 'Appraisal Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Calculate Final Score based on Formula"
+msgstr "Формула дээр үндэслэн эцсийн оноог тооцоол"
+
+#. Label of the calculate_gratuity_amount_based_on (Select) field in DocType
+#. 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Calculate Gratuity Amount Based On"
+msgstr "Тэтгэлгийн хэмжээг үндэслэн тооцоолно уу"
+
+#. Label of the payroll_based_on (Select) field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Calculate Payroll Working Days Based On"
+msgstr "Цалингийн ажлын өдрүүдийг үндэслэн тооцоол"
+
+#. Description of the 'Expire Carry Forwarded Leaves (Days)' (Int) field in
+#. DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Calculated in days"
+msgstr "Өдөрт тооцсон"
+
+#: hrms/setup.py:332
+msgid "Calls"
+msgstr "Дуудлага"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:149
+msgid "Cancellation Queued"
+msgstr "Цуцлах дараалалд орсон"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:55
+msgid "Cannot Modify Time"
+msgstr "Цагийг өөрчлөх боломжгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:323
+msgid "Cannot allocate leaves outside the allocation period {0} - {1}"
+msgstr ""
+"Хуваарилалтын хугацаанаас гадуур навчийг хуваарилах боломжгүй {0} - {1}"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:446
+#| msgid ""
+#| "Total allocated leaves are more than maximum allocation allowed for {0} "
+#| "leave type for employee {1} in the period"
+msgid ""
+"Cannot allocate more leaves due to maximum leave allocation limit of {0} in "
+"leave policy assignment"
+msgstr ""
+"Хуваарилагдсан нийт чөлөө нь тухайн хугацаанд {0} ажилтны амралтын төрөлд "
+"зөвшөөрөгдсөн дээд хэмжээнээс их байна"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:438
+msgid ""
+"Cannot allocate more leaves due to maximum leaves allowed limit of {0} in "
+"{1} leave type."
+msgstr ""
+"{1} чөлөөний төрлийн зөвшөөрөгдсөн дээд чөлөөний хязгаар {0} тул илүү чөлөө "
+"хуваарилах боломжгүй."
+
+#: hrms/api/roster.py:139
+msgid "Cannot break shift after end date"
+msgstr "Дуусах огнооноос хойш ээлжийг таслах боломжгүй"
+
+#: hrms/api/roster.py:141
+msgid "Cannot break shift before start date"
+msgstr "Эхлэх өдрөөс өмнө ээлжийг таслах боломжгүй"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:70
+msgid "Cannot cancel Shift Assignment: {0} as it is linked to Attendance: {1}"
+msgstr "Ээлжийн даалгавар: {0} ирцтэй холбогдсон тул цуцлах боломжгүй: {1}"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:53
+msgid ""
+"Cannot cancel Shift Assignment: {0} as it is linked to Employee Checkin: {1}"
+msgstr ""
+"Ажилтны бүртгэлтэй холбогдсон тул ээлжийн даалгавар: {0}-г цуцлах боломжгүй:"
+" {1}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:306
+msgid "Cannot create Salary Slip for Employee joining after Payroll Period"
+msgstr ""
+"Цалингийн хугацааны дараа ажилд орсон ажилтны цалингийн хуудас үүсгэх "
+"боломжгүй"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:309
+msgid ""
+"Cannot create Salary Slip for Employee who has left before Payroll Period"
+msgstr ""
+"Цалингийн хугацаанаас өмнө гарсан ажилтны цалингийн хуудас үүсгэх боломжгүй"
+
+#: hrms/hr/doctype/job_applicant/job_applicant.py:49
+msgid "Cannot create a Job Applicant against a closed Job Opening"
+msgstr "Хаалттай нээлттэй ажлын байрны эсрэг ажилд горилогч үүсгэх боломжгүй"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:201
+msgid ""
+"Cannot create or change transactions against an Appraisal Cycle with status "
+"{0}."
+msgstr ""
+"{0} статустай Үнэлгээний мөчлөгийн эсрэг гүйлгээ үүсгэх эсвэл өөрчлөх "
+"боломжгүй."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:634
+msgid "Cannot find active Leave Period"
+msgstr "Идэвхтэй чөлөө авах хугацааг олж чадсангүй"
+
+#: hrms/hr/doctype/attendance/attendance.py:152
+msgid "Cannot mark attendance for an Inactive employee {0}"
+msgstr "Идэвхгүй ажилтны ирцийг тэмдэглэх боломжгүй {0}"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:72
+msgid "Cannot submit. Attendance is not marked for some employees."
+msgstr "Илгээх боломжгүй. Зарим ажилчдын ирцийг тэмдэглээгүй."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:140
+msgid "Cannot update allocation for {0} after submission"
+msgstr "Илгээсний дараа {0}-н хуваарилалтыг шинэчлэх боломжгүй"
+
+#: hrms/hr/doctype/goal/goal_list.js:101
+msgid "Cannot update status of Goal groups"
+msgstr "Зорилгын бүлгүүдийн статусыг шинэчлэх боломжгүй"
+
+#. Label of the carry_forward (Check) field in DocType 'Leave Control Panel'
+#. Label of the carry_forward_section (Section Break) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Carry Forward"
+msgstr "Урагшаа"
+
+#. Label of the carry_forwarded_leaves_count (Float) field in DocType 'Leave
+#. Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+msgid "Carry Forwarded Leaves"
+msgstr "Ургасан навчийг авч явах"
+
+#: hrms/setup.py:347 hrms/setup.py:348
+msgid "Casual Leave"
+msgstr "Энгийн чөлөө"
+
+#. Label of the cause_of_grievance (Text) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Cause of Grievance"
+msgstr "Гомдлын шалтгаан"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:105
+#| msgid "changed the status from {0} to {1} via Attendance Request"
+msgid ""
+"Changed the status from {0} to {1} and Status for Other Half to {2} via "
+"Attendance Request"
+msgstr ""
+"Ирцийн хүсэлтээр {0}-с {1} болгож, нөгөө хагас өдрийн төлөвийг {2} болгож "
+"өөрчилсөн"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:109
+#| msgid "changed the status from {0} to {1} via Attendance Request"
+msgid "Changed the status from {0} to {1} via Attendance Request"
+msgstr "Ирцийн хүсэлтээр {0} байсныг {1} болгож өөрчилсөн"
+
+#: hrms/hr/doctype/leave_application/leave_application.js:187
+#| msgid "Importing {0} of {1}"
+msgid "Changing '{0}' to {1}."
+msgstr "{1}-с {0}-г импортлож байна"
+
+#: hrms/hr/doctype/goal/goal.js:112
+msgid ""
+"Changing KRA in this parent goal will align all the child goals to the same "
+"KRA, if any."
+msgstr ""
+"Энэхүү эцэг эхийн зорилгод KRA-г өөрчлөх нь хүүхдийн бүх зорилгыг хэрэв "
+"байгаа бол ижил KRA-тай нийцүүлнэ."
+
+#: hrms/public/js/utils/index.js:147
+msgid ""
+"Check <a href='/app/List/Error Log?reference_doctype={0}'>{1}</a> for more "
+"details"
+msgstr ""
+"Дэлгэрэнгүй мэдээллийг <a href='/app/List/Error "
+"Log?reference_doctype={0}'>{1}-г</a> шалгана уу"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1537
+msgid "Check Error Log {0} for more details."
+msgstr "Дэлгэрэнгүй мэдээллийг {0} алдааны бүртгэлээс шалгана уу."
+
+#: frontend/src/components/CheckInPanel.vue:123
+msgid "Check In"
+msgstr "Бүртгүүлэх"
+
+#: frontend/src/components/CheckInPanel.vue:122
+msgid "Check Out"
+msgstr "Гарах"
+
+#. Label of the check_vacancies (Check) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Check Vacancies On Job Offer Creation"
+msgstr "Ажлын санал бий болгох сул орон тоог шалгана уу"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:467
+#: hrms/hr/utils.py:937
+msgid "Check {0} for more details"
+msgstr "Дэлгэрэнгүй мэдээллийг {0}-г шалгана уу"
+
+#: frontend/src/components/CheckInPanel.vue:159
+msgid "Check-in"
+msgstr "Бүртгүүлэх"
+
+#. Label of the check_in_date (Date) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Check-in Date"
+msgstr "Бүртгүүлэх огноо"
+
+#: frontend/src/components/CheckInPanel.vue:159
+msgid "Check-out"
+msgstr "Гарах"
+
+#. Label of the check_out_date (Date) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Check-out Date"
+msgstr "Гарах огноо"
+
+#. Label of the checkin_radius (Int) field in DocType 'Shift Location'
+#: hrms/hr/doctype/shift_location/shift_location.json
+msgid "Checkin Radius"
+msgstr "Бүртгүүлэх радиус"
+
+#: hrms/hr/doctype/goal/goal_tree.js:52
+msgid "Child nodes can only be created under 'Group' type nodes"
+msgstr "Хүүхдийн зангилааг зөвхөн \"Бүлэг\" төрлийн зангилааны доор үүсгэж болно"
+
+#. Description of the 'Overtime Amount Calculation' (Select) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Choose how the hourly overtime amount is calculated:\n"
+"<ol style=\"padding-left:15px;\"><li>Fixed Hourly Rate: A fixed, manually entered hourly rate.</li>\n"
+"<li>Salary Component-Based:\n"
+"\n"
+"(Sum of selected component amounts) ÷ (Payment Days) ÷ (Standard Daily Hours)</li></ol>"
+msgstr ""
+"Цагийн илүү цагийн дүнг хэрхэн тооцоолохыг сонгоно уу:\n"
+"<ol style=\"padding-left:15px;\"><li>Тогтмол цагийн ханш: Тогтмол, гараар оруулсан цагийн ханш.</li>\n"
+"<li>Цалингийн бүрэлдэхүүн хэсэгт суурилсан:\n"
+"\n"
+"(Сонгосон бүрэлдэхүүн хэсгүүдийн дүнгийн нийлбэр) ÷ (Төлбөрийн өдрүүд) ÷ (Стандарт өдрийн цаг)</li></ol>"
+
+#. Description of the 'Payroll Date' (Date) field in DocType 'Payroll
+#. Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid ""
+"Choose the date on which you want to create these components as arrears."
+msgstr ""
+"Эдгээр бүрэлдэхүүн хэсгүүдийг нөхөн олговор болгон үүсгэх огноог сонгоно уу."
+
+#. Label of the earning_component (Link) field in DocType 'Employee Benefit
+#. Claim'
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgid "Claim Benefit For"
+msgstr "Нэхэмжлэлийн тэтгэмж"
+
+#: frontend/src/views/Home.vue:47
+#: frontend/src/views/expense_claim/Dashboard.vue:17
+msgid "Claim an Expense"
+msgstr "Зардал нэхэмжлэх"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: frontend/src/views/employee_advance/List.vue:42
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Claimed"
+msgstr "Нэхэмжлэгдсэн"
+
+#. Label of the claimed_amount (Currency) field in DocType 'Employee Advance'
+#. Label of the claimed_amount (Currency) field in DocType 'Employee Benefit
+#. Claim'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+#: hrms/hr/report/employee_advance_summary/employee_advance_summary.py:77
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgid "Claimed Amount"
+msgstr "Нэхэмжлэгдсэн дүн"
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:34
+#| msgid "Maximum benefit amount of employee {0} exceeds {1}"
+msgid ""
+"Claimed amount of employee {0} exceeds maximum amount eligible for claim {1}"
+msgstr "Ажилтны тэтгэмжийн дээд хэмжээ {0} {1}-ээс хэтэрсэн байна"
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:30
+#| msgid "Maximum benefit amount of employee {0} exceeds {1}"
+msgid "Claimed amount of employee {0} should be greater than 0"
+msgstr "Ажилтны тэтгэмжийн дээд хэмжээ {0} -ээс хэтэрсэн байна"
+
+#. Label of a Card Break in the Expenses Workspace
+#: hrms/hr/workspace/expenses/expenses.json
+#: hrms/overrides/dashboard_overrides.py:84
+msgid "Claims"
+msgstr "Нэхэмжлэл"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#. Option for the 'Result' (Select) field in DocType 'Interview Feedback'
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+msgid "Cleared"
+msgstr "Цэвэрлэсэн"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.js:292
+msgid "Click {0} to change the configuration and then resave salary slip"
+msgstr ""
+"Тохиргоог өөрчлөхийн тулд {0} дээр товшоод цалингийн хуудсыг дахин хадгална "
+"уу"
+
+#. Label of the closed_on (Date) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/templates/generators/job_opening.html:187
+msgid "Closed On"
+msgstr "Хаалттай"
+
+#. Label of the closes_on (Date) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/templates/generators/job_opening.html:187
+msgid "Closes On"
+msgstr "Хаалттай"
+
+#: hrms/www/jobs/index.html:243
+msgid "Closes on:"
+msgstr "Хаах:"
+
+#. Label of the closing_notes (Text) field in DocType 'Appointment Letter'
+#. Label of the closing_notes (Text) field in DocType 'Appointment Letter
+#. Template'
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+#: hrms/hr/doctype/appointment_letter_template/appointment_letter_template.json
+msgid "Closing Notes"
+msgstr "Хаалтын тэмдэглэл"
+
+#: frontend/src/views/Profile.vue:177
+msgid "Company Information"
+msgstr "Компанийн мэдээлэл"
+
+#. Name of a DocType
+#. Label of the compensatory_request (Link) field in DocType 'Leave
+#. Allocation'
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/workspace/leaves/leaves.json hrms/hr/workspace/people/people.json
+msgid "Compensatory Leave Request"
+msgstr "Нөхөн олговрын чөлөө авах хүсэлт"
+
+#: hrms/setup.py:356 hrms/setup.py:357
+msgid "Compensatory Off"
+msgstr "Нөхөн олговрыг унтраах"
+
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.js:118
+msgid "Completing onboarding"
+msgstr "Ашиглалтаа дуусгаж байна"
+
+#. Label of the section_break_5 (Section Break) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Component properties and references "
+msgstr "Бүрэлдэхүүн хэсгүүдийн шинж чанарууд ба лавлагаа "
+
+#. Label of the configure_component_tab (Tab Break) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Condition & Formula"
+msgstr "Нөхцөл ба томъёо"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:8
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:12
+msgid "Condition and Formula Help"
+msgstr "Нөхцөл ба томъёоны тусламж"
+
+#. Label of the section_break_2 (Section Break) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Condition and formula"
+msgstr "Нөхцөл ба томъёо"
+
+#. Label of the conditions_and_formula_variable_and_example (HTML) field in
+#. DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Conditions and Formula variable and example"
+msgstr "Нөхцөл ба томъёоны хувьсагч ба жишээ"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Conference"
+msgstr "Бага хурал"
+
+#: frontend/src/components/CheckInPanel.vue:73
+msgid "Confirm {0}"
+msgstr "{0}-г баталгаажуулах"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.js:58
+msgid "Consider Grace Period"
+msgstr "Хөнгөлөлтийн хугацааг авч үзье"
+
+#. Label of the consider_marked_attendance_on_holidays (Check) field in
+#. DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.js:282
+msgid "Consider Marked Attendance on Holidays"
+msgstr "Баярын өдрүүдэд тэмдэглэсэн ирцийг анхаарч үзээрэй"
+
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.js:49
+msgid "Consider Tax Exemption Declaration"
+msgstr "Татвараас чөлөөлөх тухай мэдэгдлийг авч үзье"
+
+#. Label of the consider_unmarked_attendance_as (Select) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.js:282
+msgid "Consider Unmarked Attendance As"
+msgstr "Тэмдэглэгдээгүй ирцийг гэж үзнэ үү"
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.js:53
+msgid "Consolidate Leave Types"
+msgstr "Амралтын төрлүүдийг нэгтгэх"
+
+#. Label of the contact_number (Data) field in DocType 'Training Event'
+#. Label of the contact_number (Data) field in DocType 'Training Program'
+#. Label of the cell_number (Data) field in DocType 'Travel Request'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_program/training_program.json
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Contact Number"
+msgstr "Холбоо барих дугаар"
+
+#. Label of the travel_proof (Attach) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Copy of Invitation/Announcement"
+msgstr "Урилга / Зарын хуулбар"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1600
+msgid "Could not submit some Salary Slips: {}"
+msgstr "Зарим цалингийн хуудсыг илгээж чадсангүй: {}"
+
+#: hrms/hr/doctype/goal/goal_tree.js:292
+msgid "Could not update Goal"
+msgstr "Зорилгоо шинэчилж чадсангүй"
+
+#: hrms/hr/doctype/goal/goal_list.js:133
+msgid "Could not update goals"
+msgstr "Зорилгоо шинэчилж чадсангүй"
+
+#: hrms/overrides/company.py:38
+msgid "Country Fixture Deletion Failed"
+msgstr "Улс орны засварыг устгаж чадсангүй"
+
+#: hrms/overrides/company.py:51
+msgid "Country Setup failed"
+msgstr "Улс орны тохиргоо амжилтгүй боллоо"
+
+#. Label of a field in the job-application Web Form
+#: hrms/hr/web_form/job_application/job_application.json
+#| msgid "Amount of expense"
+msgid "Country of Residence"
+msgstr "Зардлын хэмжээ"
+
+#. Label of the course (Data) field in DocType 'Training Event'
+#. Label of the course (Data) field in DocType 'Training Feedback'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_feedback/training_feedback.json
+msgid "Course"
+msgstr "Мэдээж"
+
+#. Label of the cover_letter (Text) field in DocType 'Job Applicant'
+#. Label of a field in the job-application Web Form
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Cover Letter"
+msgstr "Cover Letter"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.js:40
+msgid "Create Additional Salary"
+msgstr "Нэмэлт цалин бий болгох"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:34
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:38
+msgid "Create Appraisals"
+msgstr "Үнэлгээг бий болгох"
+
+#: hrms/hr/doctype/interview_round/interview_round.js:7
+#: hrms/hr/doctype/job_applicant/job_applicant.js:95
+msgid "Create Interview"
+msgstr "Ярилцлага үүсгэх"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.js:21
+msgid "Create Job Applicant"
+msgstr "Ажилд орох өргөдөл гаргагч үүсгэх"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.js:39
+msgid "Create Job Opening"
+msgstr "Нээлттэй ажлын байр бий болгох"
+
+#. Label of the create_new_employee_id (Check) field in DocType 'Employee
+#. Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Create New Employee Id"
+msgstr "Шинэ ажилтны ID үүсгэх"
+
+#. Label of the create_overtime_slip (Check) field in DocType 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Create Overtime Slip For Eligible Employee(s)"
+msgstr "Тохирох ажилтнуудын илүү цагийн хуудас үүсгэх"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:83
+#| msgid "Create Salary Slips"
+msgid "Create Overtime Slips"
+msgstr "Цалингийн хуудас үүсгэх"
+
+#: hrms/public/js/erpnext/timesheet.js:8
+msgid "Create Salary Slip"
+msgstr "Цалингийн хуудас үүсгэх"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:97
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:175
+msgid "Create Salary Slips"
+msgstr "Цалингийн хуудас үүсгэх"
+
+#. Label of the create_shifts_after (Date) field in DocType 'Shift Schedule
+#. Assignment'
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+msgid "Create Shifts After"
+msgstr "Дараа нь ээлж үүсгэх"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:192
+msgid "Creating Appraisals"
+msgstr "Үнэлгээг бий болгох"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:458
+msgid "Creating Payment Entries......"
+msgstr "Төлбөрийн бичилт үүсгэж байна......"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1560
+msgid "Creating Salary Slips..."
+msgstr "Цалингийн хуудас үүсгэж байна..."
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:246
+msgid "Creating {0}..."
+msgstr "{0} үүсгэж байна..."
+
+#: hrms/hr/report/leave_ledger/leave_ledger.py:41
+msgid "Creation Date"
+msgstr "Үүсгэсэн огноо"
+
+#: hrms/hr/utils.py:946
+msgid "Creation Failed"
+msgstr "Бүтээж чадсангүй"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.py:73
+msgid ""
+"Creation of Salary Structure Assignments has been queued. It may take a few "
+"minutes."
+msgstr ""
+"Цалингийн бүтцийг бий болгох ажлыг дараалалд орууллаа. Үүнд хэдэн минут "
+"зарцуулагдаж магадгүй."
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:200
+msgid "Creation of {0} has been queued. It may take a few minutes."
+msgstr "{0}-г үүсгэх дараалалд орсон. Үүнд хэдэн минут зарцуулагдаж магадгүй."
+
+#. Description of the 'Rating Criteria' (Table) field in DocType 'Appraisal
+#. Template'
+#: hrms/hr/doctype/appraisal_template/appraisal_template.json
+msgid ""
+"Criteria based on which employee should be rated in Performance Feedback and"
+" Self Appraisal"
+msgstr ""
+"Гүйцэтгэлийн санал хүсэлт, өөрийгөө үнэлэх зэрэгт ямар ажилтны үнэлгээ өгөх "
+"ёстойг үндэслэсэн шалгуур"
+
+#. Label of the currency_section (Section Break) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Currency "
+msgstr "Валют "
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:94
+msgid "Currency of selected Income Tax Slab should be {0} instead of {1}"
+msgstr "Сонгосон орлогын албан татварын валют нь {1} биш {0} байх ёстой"
+
+#. Label of the current_ctc (Currency) field in DocType 'Employee Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Current CTC"
+msgstr "Одоогийн CTC"
+
+#. Label of the current_count (Int) field in DocType 'Staffing Plan Detail'
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Current Count"
+msgstr "Одоогийн тоо"
+
+#. Label of the current_employer (Data) field in DocType 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Current Employer "
+msgstr "Одоогийн ажил олгогч "
+
+#. Label of the current_job_title (Data) field in DocType 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Current Job Title"
+msgstr "Одоогийн ажлын байрны нэр"
+
+#. Label of the current_month_income_tax (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Current Month Income Tax"
+msgstr "Тухайн сарын орлогын албан татвар"
+
+#: hrms/hr/doctype/vehicle_log/vehicle_log.py:15
+msgid "Current Odometer Value should be greater than Last Odometer Value {0}"
+msgstr ""
+"Одоо байгаа зай хэмжигчний утга нь сүүлийн зай хэмжигчээс {0} их байх ёстой"
+
+#. Label of the odometer (Int) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Current Odometer value "
+msgstr "Одоогийн Odometer утга "
+
+#. Label of the current_openings (Int) field in DocType 'Staffing Plan Detail'
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Current Openings"
+msgstr "Одоогийн нээлтүүд"
+
+#. Label of the current_payroll_period (Link) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#| msgid "Select Payroll Period"
+msgid "Current Payroll Period"
+msgstr "Цалингийн хугацааг сонгоно уу"
+
+#. Option for the 'Calculate Gratuity Amount Based On' (Select) field in
+#. DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Current Slab"
+msgstr "Одоогийн хавтан"
+
+#. Label of the current_work_experience (Float) field in DocType 'Gratuity'
+#. Label of the gratuity_rule_slabs (Table) field in DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity/gratuity.json
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Current Work Experience"
+msgstr "Одоогийн ажлын туршлага"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:98
+msgid ""
+"Currently, there is no {0} leave period for this date to create/update leave"
+" allocation."
+msgstr ""
+"Одоогоор амралтын хуваарилалтыг үүсгэх/шинэчлэхийн тулд энэ өдөр {0} чөлөө "
+"авах хугацаа байхгүй байна."
+
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "Custom Range"
+msgstr "Тусгай хүрээ"
+
+#. Label of the cycle_name (Data) field in DocType 'Appraisal Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Cycle Name"
+msgstr "Циклийн нэр"
+
+#. Label of the cycles (Table) field in DocType 'Salary Withholding'
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Cycles"
+msgstr "Цикл"
+
+#. Name of a DocType
+#. Label of a Card Break in the Tenure Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/daily_work_summary/daily_work_summary.json
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.js:7
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Daily Work Summary"
+msgstr "Өдөр тутмын ажлын хураангуй"
+
+#. Label of the daily_work_summary_group (Link) field in DocType 'Daily Work
+#. Summary'
+#. Name of a DocType
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/daily_work_summary/daily_work_summary.json
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+#: hrms/hr/page/team_updates/team_updates.js:12
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Daily Work Summary Group"
+msgstr "Өдөр тутмын ажлын тойм бүлэг"
+
+#. Name of a DocType
+#: hrms/hr/doctype/daily_work_summary_group_user/daily_work_summary_group_user.json
+msgid "Daily Work Summary Group User"
+msgstr "Өдөр тутмын ажлын хураангуй бүлгийн хэрэглэгч"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/report/daily_work_summary_replies/daily_work_summary_replies.json
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Daily Work Summary Replies"
+msgstr "Өдөр тутмын ажлын хураангуй хариултууд"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:167
+#| msgid "Date Range"
+msgid "Date Range Exceeded"
+msgstr "Огнооны хүрээ"
+
+#: hrms/hr/doctype/leave_block_list/leave_block_list.py:19
+msgid "Date is repeated"
+msgstr "Огноо давтагдана"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:59
+msgid "Date {0} is repeated in Overtime Details"
+msgstr "Илүү цагийн дэлгэрэнгүйд {0} огноо давтагдсан"
+
+#. Label of the section_break_5 (Section Break) field in DocType 'Leave
+#. Application'
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Dates & Reason"
+msgstr "Огноо ба шалтгаан"
+
+#. Label of the dates_based_on (Select) field in DocType 'Leave Control Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "Dates Based On"
+msgstr "Огноо дээр үндэслэсэн"
+
+#: hrms/setup.py:121
+msgid "Days for which Holidays are blocked for this department."
+msgstr "Энэ хэлтэст амралтын өдрүүдийг хориглосон өдрүүд."
+
+#. Label of the days_to_reverse (Float) field in DocType 'Payroll Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid "Days to Reverse"
+msgstr "Буцаах өдрүүд"
+
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:19
+#| msgid "To Date should be greater than From Date"
+msgid "Days to Reverse must be greater than zero."
+msgstr "To Date нь From Date-аас их байх ёстой"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:19
+msgid "Debit A/C Number"
+msgstr "Дебит A/C дугаар"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:47
+#: hrms/public/js/salary_slip_deductions_report_filters.js:30
+msgid "Dec"
+msgstr "12-р сар"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:193
+msgid "Decision Pending"
+msgstr "Шийдвэр хүлээгдэж байна"
+
+#. Label of the declarations (Table) field in DocType 'Employee Tax Exemption
+#. Declaration'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgid "Declarations"
+msgstr "Тунхаглал"
+
+#. Label of the amount (Currency) field in DocType 'Employee Tax Exemption
+#. Declaration Category'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgid "Declared Amount"
+msgstr "Зарласан дүн"
+
+#. Label of the deduct_full_tax_on_selected_payroll_date (Check) field in
+#. DocType 'Additional Salary'
+#. Label of the deduct_full_tax_on_selected_payroll_date (Check) field in
+#. DocType 'Salary Component'
+#. Label of the deduct_full_tax_on_selected_payroll_date (Check) field in
+#. DocType 'Salary Detail'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Deduct Full Tax on Selected Payroll Date"
+msgstr "Сонгосон цалингийн огнооны татварыг бүрэн хасна"
+
+#. Label of the deduct_tax_for_unsubmitted_tax_exemption_proof (Check) field
+#. in
+#. DocType 'Payroll Entry'
+#. Label of the deduct_tax_for_unsubmitted_tax_exemption_proof (Check) field
+#. in
+#. DocType 'Salary Slip'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Deduct Tax For Unsubmitted Tax Exemption Proof"
+msgstr "Татвараас чөлөөлөгдөөгүй нотлох баримтын хувьд татварыг хасна"
+
+#. Option for the 'Type' (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/report/salary_register/salary_register.py:90
+#: hrms/payroll/report/salary_register/salary_register.py:96
+msgid "Deduction"
+msgstr "Суутгал"
+
+#. Label of the deduction_arrears (Table) field in DocType 'Arrear'
+#. Label of the deduction_arrears (Table) field in DocType 'Payroll
+#. Correction'
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#| msgid "Deduction Reports"
+msgid "Deduction Arrears"
+msgstr "Суутгалын тайлан"
+
+#. Label of a Card Break in the Payroll Workspace
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Deduction Reports"
+msgstr "Суутгалын тайлан"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.js:84
+msgid "Deduction from Salary"
+msgstr "Цалингаас хасах"
+
+#. Label of the deductions (Table) field in DocType 'Salary Slip'
+#. Label of the deductions (Table) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Deductions"
+msgstr "Суутгал"
+
+#. Label of the deductions_before_tax_calculation (Currency) field in DocType
+#. 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Deductions before tax calculation"
+msgstr "Татвар тооцохын өмнөх суутгал"
+
+#. Label of the default_amount (Currency) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Default Amount"
+msgstr "Өгөгдмөл дүн"
+
+#. Description of the 'Account' (Link) field in DocType 'Salary Component
+#. Account'
+#: hrms/payroll/doctype/salary_component_account/salary_component_account.json
+msgid ""
+"Default Bank / Cash account will be automatically updated in Salary Journal "
+"Entry when this mode is selected."
+msgstr ""
+"Энэ горимыг сонгосон үед үндсэн банк / бэлэн мөнгөний данс Цалингийн "
+"журналын бичилтэд автоматаар шинэчлэгдэх болно."
+
+#. Label of the default_base_pay (Currency) field in DocType 'Employee Grade'
+#: hrms/hr/doctype/employee_grade/employee_grade.json
+msgid "Default Base Pay"
+msgstr "Үндсэн төлбөр"
+
+#: hrms/setup.py:81
+msgid "Default Employee Advance Account"
+msgstr "Анхдагч ажилтны урьдчилгаа данс"
+
+#: hrms/setup.py:73
+msgid "Default Expense Claim Payable Account"
+msgstr "Анхдагч зардлын нэхэмжлэлийн өглөгийн данс"
+
+#: hrms/overrides/company.py:133 hrms/setup.py:96
+msgid "Default Payroll Payable Account"
+msgstr "Өгөгдмөл цалингийн данс"
+
+#. Label of the default_salary_structure (Link) field in DocType 'Employee
+#. Grade'
+#: hrms/hr/doctype/employee_grade/employee_grade.json
+msgid "Default Salary Structure"
+msgstr "Үндсэн цалингийн бүтэц"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:204
+#: hrms/setup.py:207
+msgid "Default Shift"
+msgstr "Өгөгдмөл Shift"
+
+#: frontend/src/components/FileUploaderView.vue:49
+msgid "Delete Attachment"
+msgstr "Хавсралтыг устгах"
+
+#: frontend/src/components/FormView.vue:224
+msgid "Delete {0}"
+msgstr "{0}-г устгах"
+
+#. Name of a DocType
+#: hrms/hr/doctype/department_approver/department_approver.json
+msgid "Department Approver"
+msgstr "Хэлтсийн батламжлагч"
+
+#. Label of a chart in the Recruitment Workspace
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Department Wise Openings"
+msgstr "Тэнхимийн ухаалаг нээлтүүд"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:107
+#| msgid "Account {0} does not belong to company: {1}"
+msgid "Department {0} does not belong to company: {1}"
+msgstr "{0} бүртгэл нь компанид харьяалагддаггүй: {1}"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:235
+msgid "Department: {0}"
+msgstr "Газар: {0}"
+
+#. Label of the departure_date (Datetime) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Departure Datetime"
+msgstr "Явах огноо"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:109
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:113
+msgid "Depends On Payment Days"
+msgstr "Төлбөрийн өдрүүдээс хамаарна"
+
+#. Label of the depends_on_payment_days (Check) field in DocType 'Salary
+#. Component'
+#. Label of the depends_on_payment_days (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Depends on Payment Days"
+msgstr "Төлбөрийн өдрүүдээс хамаарна"
+
+#. Description of a DocType
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Description of a Job Opening"
+msgstr "Нээлтийн ажлын байрны тодорхойлолт"
+
+#. Name of a DocType
+#: hrms/hr/doctype/designation_skill/designation_skill.json
+msgid "Designation Skill"
+msgstr "Зориулалтын ур чадвар"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:237
+msgid "Designation: {0}"
+msgstr "Тэмдэглэл: {0}"
+
+#. Label of the details_of_sponsor (Data) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Details of Sponsor (Name, Location)"
+msgstr "Ивээн тэтгэгчийн дэлгэрэнгүй мэдээлэл (Нэр, Байршил)"
+
+#. Label of the determine_check_in_and_check_out (Select) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Determine Check-in and Check-out"
+msgstr "Бүртгүүлэх, гарах хугацааг тодорхойлох"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:111
+msgid ""
+"Disable {0} for the {1} component, to prevent the amount from being deducted"
+" twice, as its formula already uses a payment-days-based component."
+msgstr ""
+"{1} бүрэлдэхүүн хэсгийн томьёо нь төлбөрийн өдөрт суурилсан бүрэлдэхүүнийг "
+"аль хэдийн ашигласан тул дүнг хоёр дахин хасахаас сэргийлэхийн тулд {0}-г "
+"идэвхгүй болго."
+
+#: hrms/hr/doctype/leave_type/leave_type.py:40
+msgid "Disable {0} or {1} to proceed."
+msgstr "Үргэлжлүүлэхийн тулд {0} эсвэл {1}-г идэвхгүй болгоно уу."
+
+#: frontend/src/views/AppSettings.vue:40
+msgid "Disabling Push Notifications..."
+msgstr "Түлхэх мэдэгдлийг идэвхгүй болгож байна..."
+
+#. Label of the do_not_include_in_accounts (Check) field in DocType 'Salary
+#. Component'
+#. Label of the do_not_include_in_accounts (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+#| msgid "Do Not Include in Total"
+msgid "Do Not Include in Accounting Entries"
+msgstr "Нийтэд бүү оруул"
+
+#. Label of the do_not_include_in_total (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Do Not Include in Total"
+msgstr "Нийтэд бүү оруул"
+
+#. Label of the do_not_include_in_total (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Do not include in total"
+msgstr "Нийтдээ оруулахгүй"
+
+#: hrms/hr/doctype/interview/interview.py:68
+msgid ""
+"Do you want to update the Job Applicant {0} as {1} based on this interview "
+"result?"
+msgstr ""
+"Та энэ ярилцлагын үр дүнд үндэслэн ажил горилогчийг {0} {1} болгон "
+"шинэчлэхийг хүсэж байна уу?"
+
+#: frontend/src/components/RequestActionSheet.vue:292
+msgid "Document {0} failed!"
+msgstr "{0} баримт бичиг амжилтгүй боллоо!"
+
+#. Option for the 'Travel Type' (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Domestic"
+msgstr "Дотоодын"
+
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.py:39
+#| msgid "Bulk Assignments"
+msgid "Duplicate Assignment"
+msgstr "Бөөн даалгавар"
+
+#: hrms/hr/doctype/attendance/attendance.py:77
+msgid "Duplicate Attendance"
+msgstr "Давхардсан ирц"
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:57
+#| msgid "Duplicate Attendance"
+msgid "Duplicate Claim Detected"
+msgstr "Давхардсан ирц"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.py:35
+msgid "Duplicate Job Requisition"
+msgstr "Давхардсан ажлын байрны захиалга"
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.py:40
+#| msgid "Duplicate Attendance"
+msgid "Duplicate Leave Adjustment"
+msgstr "Давхардсан ирц"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:192
+msgid "Duplicate Overwritten Salary"
+msgstr "Давхардсан дарж бичсэн цалин"
+
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.py:43
+msgid "Duplicate Salary Withholding"
+msgstr "Давхардсан цалингийн суутгал"
+
+#: hrms/public/js/utils/index.js:210
+msgid "ERROR({0}): {1}"
+msgstr "АЛДАА({0}): {1}"
+
+#. Label of the early_exit (Check) field in DocType 'Attendance'
+#. Label of the early_exit (Check) field in DocType 'Employee Attendance Tool'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/report/shift_attendance/shift_attendance.js:53
+msgid "Early Exit"
+msgstr "Эрт гарах"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:91
+msgid "Early Exit By"
+msgstr "Эрт гарах"
+
+#. Label of the early_exit_grace_period (Int) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Early Exit Grace Period"
+msgstr "Эрт гарах хөнгөлөлтийн хугацаа"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:186
+msgid "Early Exits"
+msgstr "Эрт гарах"
+
+#. Label of the earned_leave (Section Break) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Earned Leave"
+msgstr "Чөлөө авсан"
+
+#. Label of the earned_leave_frequency (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Earned Leave Frequency"
+msgstr "Олсон чөлөө авах давтамж"
+
+#. Name of a DocType
+#. Label of the earned_leave_schedule_section (Section Break) field in DocType
+#. 'Leave Allocation'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#| msgid "Earned Leave Frequency"
+msgid "Earned Leave Schedule"
+msgstr "Олсон чөлөө авах давтамж"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:141
+msgid "Earned Leaves"
+msgstr "Олсон навч"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:35
+msgid ""
+"Earned Leaves are allocated as per the configured frequency via scheduler."
+msgstr ""
+"Олсон навчийг хуваарилагчаар тохируулсан давтамжийн дагуу хуваарилдаг."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:144
+msgid ""
+"Earned Leaves are auto-allocated via scheduler based on the annual "
+"allocation set in the Leave Policy: {0}"
+msgstr ""
+"Амралтын журамд заасан жилийн хуваарилалт дээр үндэслэн олсон чөлөөг "
+"хуваарьлагчаар автоматаар хуваарилдаг: {0}"
+
+#: hrms/hr/doctype/leave_type/leave_type.js:59
+msgid ""
+"Earned Leaves are leaves earned by an Employee after working with the "
+"company for a certain amount of time. Enabling this will allocate leaves on "
+"pro-rata basis by automatically updating Leave Allocation for leaves of this"
+" type at intervals set by 'Earned Leave Frequency."
+msgstr ""
+"Ажилтан нь тухайн компанитай тодорхой хугацаанд ажилласны дараа олж авсан "
+"чөлөө юм. Үүнийг идэвхжүүлснээр энэ төрлийн навчны Амжилтын хуваарилалтыг "
+"\"Ажилласан чөлөөний давтамж\"-аар тохируулсан интервалаар автоматаар "
+"шинэчлэх замаар навчийг хувь тэнцүүлэн хуваарилах болно."
+
+#. Option for the 'Type' (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/report/salary_register/salary_register.py:90
+#: hrms/payroll/report/salary_register/salary_register.py:96
+msgid "Earning"
+msgstr "Орлого"
+
+#. Label of the earning_arrears (Table) field in DocType 'Arrear'
+#. Label of the earning_arrears (Table) field in DocType 'Payroll Correction'
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#| msgid "Earnings"
+msgid "Earning Arrears"
+msgstr "Орлого"
+
+#. Label of the earning_component (Link) field in DocType 'Leave Type'
+#. Label of the salary_component (Link) field in DocType 'Employee Benefit
+#. Application Detail'
+#. Label of the salary_component (Link) field in DocType 'Employee Benefit
+#. Detail'
+#: hrms/hr/doctype/leave_type/leave_type.json
+#: hrms/payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+#: hrms/payroll/doctype/employee_benefit_detail/employee_benefit_detail.json
+msgid "Earning Component"
+msgstr "Орлогын бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:146
+msgid "Earning Salary Component is required for Employee Referral Bonus."
+msgstr ""
+"Ажилтны урамшууллын урамшуулалд Цалингийн Орлогын бүрэлдэхүүн хэсэг "
+"шаардлагатай."
+
+#. Label of the earnings (Table) field in DocType 'Salary Slip'
+#. Label of the earnings (Table) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Earnings"
+msgstr "Орлого"
+
+#. Label of the earnings_and_deductions_tab (Tab Break) field in DocType
+#. 'Salary Slip'
+#. Label of the earning_deduction (Tab Break) field in DocType 'Salary
+#. Structure'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Earnings & Deductions"
+msgstr "Орлого, суутгал"
+
+#: frontend/src/components/ExpensesTable.vue:213
+msgid "Edit Expense Item"
+msgstr "Зардлын зүйлийг засах"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:221
+msgid "Edit Expense Tax"
+msgstr "Зардлын татварыг засах"
+
+#. Label of the effective_from (Date) field in DocType 'Leave Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Effective From"
+msgstr "-аас хүчинтэй"
+
+#. Label of the effective_to (Date) field in DocType 'Leave Policy Assignment'
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Effective To"
+msgstr "Үр дүнтэй"
+
+#. Label of the effective_from (Date) field in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Effective from"
+msgstr "-аас хүчинтэй"
+
+#. Label of the email_salary_slip_to_employee (Check) field in DocType
+#. 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Email Salary Slip to Employee"
+msgstr "Цалингийн хуудсыг ажилтан руу имэйлээр илгээнэ үү"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip_list.js:13
+msgid "Email Salary Slips"
+msgstr "Цалингийн хуудсыг цахим шуудангаар илгээнэ үү"
+
+#. Label of the email_sent_to (Code) field in DocType 'Daily Work Summary'
+#: hrms/hr/doctype/daily_work_summary/daily_work_summary.json
+msgid "Email Sent To"
+msgstr "Имэйлийг илгээсэн"
+
+#. Description of the 'Email Salary Slip to Employee' (Check) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"Emails salary slip to employee based on preferred email selected in Employee"
+msgstr ""
+"Ажилтны сонгосон имэйлд үндэслэн цалингийн хуудсыг ажилчид руу илгээнэ"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:40
+msgid "Employee A/C Number"
+msgstr "Ажилтны A/C дугаар"
+
+#: hrms/patches/v16_0/create_custom_field_for_employee_advance_in_employee_master.py:11
+#: hrms/setup.py:267
+#| msgid "Default Employee Advance Account"
+msgid "Employee Advance Account"
+msgstr "Анхдагч ажилтны урьдчилгаа данс"
+
+#: frontend/src/views/expense_claim/Dashboard.vue:35
+msgid "Employee Advance Balance"
+msgstr "Ажилчдын урьдчилгаа тэнцэл"
+
+#. Name of a report
+#. Label of a Link in the Expenses Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/report/employee_advance_summary/employee_advance_summary.json
+#: hrms/hr/workspace/expenses/expenses.json
+#: hrms/hr/workspace/people/people.json
+msgid "Employee Advance Summary"
+msgstr "Ажилчдын урьдчилгаа хураангуй"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/report/employee_analytics/employee_analytics.json
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Analytics"
+msgstr "Ажилтны аналитик"
+
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employee Attendance Tool"
+msgstr "Ажилчдын ирцийн хэрэгсэл"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Benefit Application"
+msgstr "Ажилчдын тэтгэмжийн өргөдөл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgid "Employee Benefit Application Detail"
+msgstr "Ажилтны тэтгэмжийн өргөдлийн дэлгэрэнгүй"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Benefit Claim"
+msgstr "Ажилтны тэтгэмжийн нэхэмжлэл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_benefit_detail/employee_benefit_detail.json
+#| msgid "Employee Benefit Claim"
+msgid "Employee Benefit Detail"
+msgstr "Ажилтны тэтгэмжийн нэхэмжлэл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#| msgid "Employee Benefits"
+msgid "Employee Benefit Ledger"
+msgstr "Ажилчдын тэтгэмж"
+
+#. Label of the employee_benefits_section (Section Break) field in DocType
+#. 'Salary Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/setup.py:406
+msgid "Employee Benefits"
+msgstr "Ажилчдын тэтгэмж"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/report/employee_birthday/employee_birthday.json
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Birthday"
+msgstr "Ажилтны төрсөн өдөр"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgid "Employee Boarding Activity"
+msgstr "Ажилчдын дотуур байрны үйл ажиллагаа"
+
+#. Name of a DocType
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employee Checkin"
+msgstr "Ажилтны бүртгэл"
+
+#: frontend/src/views/attendance/EmployeeCheckinList.vue:5
+msgid "Employee Checkin History"
+msgstr "Ажилтны бүртгэлийн түүх"
+
+#. Label of the employee_company (Link) field in DocType 'Holiday List
+#. Assignment'
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+#| msgid "Employee Loan"
+msgid "Employee Company"
+msgstr "Ажилчдын зээл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_cost_center/employee_cost_center.json
+msgid "Employee Cost Center"
+msgstr "Ажилчдын зардлын төв"
+
+#. Label of the details_section (Section Break) field in DocType 'Employee
+#. Onboarding'
+#. Label of the employee_details_tab (Tab Break) field in DocType 'Employee
+#. Performance Feedback'
+#. Label of the employee_details_section (Section Break) field in DocType
+#. 'Exit
+#. Interview'
+#. Label of the employee_details_section (Section Break) field in DocType
+#. 'Full
+#. and Final Statement'
+#. Label of the employee_details_section (Section Break) field in DocType
+#. 'Shift Assignment'
+#. Label of the shift_details_section (Section Break) field in DocType 'Shift
+#. Schedule Assignment'
+#. Label of the employee_details (Section Break) field in DocType 'Travel
+#. Request'
+#. Label of the employee_section (Section Break) field in DocType 'Employee
+#. Other Income'
+#. Label of the section_break_24 (Section Break) field in DocType 'Payroll
+#. Entry'
+#: frontend/src/views/Profile.vue:165
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+#: hrms/hr/doctype/travel_request/travel_request.json
+#: hrms/payroll/doctype/employee_other_income/employee_other_income.json
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Employee Details"
+msgstr "Ажилтны дэлгэрэнгүй мэдээлэл"
+
+#. Label of the employee_emails (Small Text) field in DocType 'Training Event'
+#. Label of the employee_emails (Small Text) field in DocType 'Training
+#. Result'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_result/training_result.json
+msgid "Employee Emails"
+msgstr "Ажилчдын имэйл"
+
+#. Label of the employee_exit_settings_section (Section Break) field in
+#. DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Employee Exit Settings"
+msgstr "Ажилтнаас гарах тохиргоо"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/report/employee_exits/employee_exits.json
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Exits"
+msgstr "Ажилтан гарах"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_feedback_criteria/employee_feedback_criteria.json
+msgid "Employee Feedback Criteria"
+msgstr "Ажилтны санал хүсэлтийн шалгуур"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgid "Employee Feedback Rating"
+msgstr "Ажилчдын санал хүсэлтийн үнэлгээ"
+
+#. Label of the employee_grade (Link) field in DocType 'Employee Attendance
+#. Tool'
+#. Name of a DocType
+#. Label of the employee_grade (Link) field in DocType 'Employee Onboarding'
+#. Label of the employee_grade (Link) field in DocType 'Employee Onboarding
+#. Template'
+#. Label of the employee_grade (Link) field in DocType 'Employee Separation'
+#. Label of the employee_grade (Link) field in DocType 'Employee Separation
+#. Template'
+#. Label of the employee_grade (Link) field in DocType 'Leave Control Panel'
+#. Label of the grade (Link) field in DocType 'Shift Assignment Tool'
+#. Label of a Link in the People Workspace
+#. Label of the grade (Link) field in DocType 'Bulk Salary Structure
+#. Assignment'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/doctype/employee_grade/employee_grade.json
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+#: hrms/hr/doctype/employee_separation_template/employee_separation_template.json
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+msgid "Employee Grade"
+msgstr "Ажилтны зэрэг"
+
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Grievance"
+msgstr "Ажилчдын гомдол"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_health_insurance/employee_health_insurance.json
+msgid "Employee Health Insurance"
+msgstr "Ажилтны эрүүл мэндийн даатгал"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employee Hours Utilization Based On Timesheet"
+msgstr "Цагийн хүснэгтэд үндэслэн ажилчдын цагийн ашиглалт"
+
+#. Label of the employee_image (Attach Image) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Employee Image"
+msgstr "Ажилтны зураг"
+
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Employee Incentive"
+msgstr "Ажилчдын урамшуулал"
+
+#. Label of the section_break_6 (Section Break) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Employee Info"
+msgstr "Ажилтны мэдээлэл"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/report/employee_information/employee_information.json
+#: hrms/hr/workspace/people/people.json hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Information"
+msgstr "Ажилтны мэдээлэл"
+
+#. Name of a report
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.json
+#: hrms/hr/workspace/leaves/leaves.json hrms/hr/workspace/people/people.json
+msgid "Employee Leave Balance"
+msgstr "Ажилтны чөлөөний үлдэгдэл"
+
+#. Name of a report
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.json
+#: hrms/hr/workspace/leaves/leaves.json hrms/hr/workspace/people/people.json
+msgid "Employee Leave Balance Summary"
+msgstr "Ажилтны чөлөөний үлдэгдлийн хураангуй"
+
+#: hrms/setup.py:780
+msgid "Employee Loan"
+msgstr "Ажилчдын зээл"
+
+#. Label of the emp_created_by (Select) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Employee Naming By"
+msgstr "Ажилтны нэрлэсэн нэр"
+
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Onboarding"
+msgstr "Ажилтныг элсүүлэх"
+
+#. Label of the employee_onboarding_template (Link) field in DocType 'Employee
+#. Onboarding'
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/employee_onboarding_template/employee_onboarding_template.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Onboarding Template"
+msgstr "Ажилтны ажилд авах загвар"
+
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.py:32
+msgid "Employee Onboarding: {0} already exists for Job Applicant: {1}"
+msgstr "Ажилтныг элсүүлэх: Ажил горилогчийн хувьд {0} аль хэдийн байна: {1}"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_other_income/employee_other_income.json
+msgid "Employee Other Income"
+msgstr "Ажилтны бусад орлого"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Employee Performance Feedback"
+msgstr "Ажилчдын гүйцэтгэлийн талаархи санал хүсэлт"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Employee Promotion"
+msgstr "Ажилтны албан тушаал ахих"
+
+#. Label of the details_section (Section Break) field in DocType 'Employee
+#. Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Employee Promotion Details"
+msgstr "Ажилтны албан тушаал ахих тухай мэдээлэл"
+
+#: hrms/hr/doctype/employee_promotion/employee_promotion.py:20
+msgid "Employee Promotion cannot be submitted before Promotion Date"
+msgstr "Ажилтны дэвшлийг албан тушаал ахих өдрөөс өмнө гаргаж болохгүй"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_property_history/employee_property_history.json
+msgid "Employee Property History"
+msgstr "Ажилчдын өмчийн түүх"
+
+#. Name of a DocType
+#. Label of the employee_referral (Link) field in DocType 'Job Applicant'
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_requisition/job_requisition.js:18
+#: hrms/hr/workspace/recruitment/recruitment.json hrms/setup.py:400
+msgid "Employee Referral"
+msgstr "Ажилтны лавлагаа"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.py:26
+#| msgid ""
+#| "Employee Onboarding: {0} already exists for Job Applicant: {1}"
+msgid "Employee Referral {0} already exists for email: {1}"
+msgstr "Ажилтныг элсүүлэх: Ажил горилогчийн хувьд {0} аль хэдийн байна: {1}"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:142
+msgid "Employee Referral {0} is not applicable for referral bonus."
+msgstr "Ажилтны лавлагаа {0} нь лавлагааны урамшуулалд хамаарахгүй."
+
+#: hrms/hr/doctype/job_requisition/job_requisition.js:15
+msgid "Employee Referrals"
+msgstr "Ажилчдын лавлагаа"
+
+#. Label of the employee_responsible (Link) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Employee Responsible "
+msgstr "Хариуцлагатай ажилтан "
+
+#. Option for the 'Final Decision' (Select) field in DocType 'Exit Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+msgid "Employee Retained"
+msgstr "Ажилтан хэвээр үлдсэн"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+msgid "Employee Separation"
+msgstr "Ажилтныг тусгаарлах"
+
+#. Label of the employee_separation_template (Link) field in DocType 'Employee
+#. Separation'
+#. Name of a DocType
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+#: hrms/hr/doctype/employee_separation_template/employee_separation_template.json
+msgid "Employee Separation Template"
+msgstr "Ажилтныг тусгаарлах загвар"
+
+#. Label of the employee_settings_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Employee Settings"
+msgstr "Ажилтны тохиргоо"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_skill/employee_skill.json
+msgid "Employee Skill"
+msgstr "Ажилчдын ур чадвар"
+
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/employee_skill_map/employee_skill_map.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Employee Skill Map"
+msgstr "Ажилчдын ур чадварын зураг"
+
+#. Label of the employee_skills (Table) field in DocType 'Employee Skill Map'
+#: hrms/hr/doctype/employee_skill_map/employee_skill_map.json
+msgid "Employee Skills"
+msgstr "Ажилчдын ур чадвар"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:194
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.js:40
+#: hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:36
+#: hrms/hr/report/leave_ledger/leave_ledger.js:34
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.js:41
+msgid "Employee Status"
+msgstr "Ажилтны статус"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Tax Exemption Category"
+msgstr "Ажилтны татвараас чөлөөлөх ангилал"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Tax Exemption Declaration"
+msgstr "Ажилтны татвараас чөлөөлөх тухай мэдэгдэл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgid "Employee Tax Exemption Declaration Category"
+msgstr "Ажилтны татвараас чөлөөлөх тухай мэдүүлгийн ангилал"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Tax Exemption Proof Submission"
+msgstr "Ажилтныг татвараас чөлөөлөх тухай нотлох баримтыг ирүүлэх"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Employee Tax Exemption Proof Submission Detail"
+msgstr ""
+"Ажилтны татвараас чөлөөлөгдсөнийг нотлох баримтын дэлгэрэнгүй мэдээлэл"
+
+#. Name of a DocType
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Employee Tax Exemption Sub Category"
+msgstr "Ажилтны татвараас чөлөөлөх дэд ангилал"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_training/employee_training.json
+msgid "Employee Training"
+msgstr "Ажилтны сургалт"
+
+#. Name of a DocType
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Employee Transfer"
+msgstr "Ажилтныг шилжүүлэх"
+
+#. Label of the transfer_details (Table) field in DocType 'Employee Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Employee Transfer Detail"
+msgstr "Ажилтныг шилжүүлэх дэлгэрэнгүй мэдээлэл"
+
+#. Label of the details_section (Section Break) field in DocType 'Employee
+#. Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Employee Transfer Details"
+msgstr "Ажилтныг шилжүүлэх дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/doctype/employee_transfer/employee_transfer.py:17
+msgid "Employee Transfer cannot be submitted before Transfer Date"
+msgstr "Ажилтны шилжүүлгийг шилжүүлэх өдрөөс өмнө гаргаж өгөх боломжгүй"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:89
+#: hrms/hr/doctype/employee_advance/employee_advance.py:159
+msgid "Employee advance account {0} should be of type {1}."
+msgstr "Ажилтны урьдчилгааны данс {0} нь {1} төрлийнх байх ёстой."
+
+#: hrms/hr/doctype/hr_settings/hr_settings.js:27
+msgid ""
+"Employee can be named by Employee ID if you assign one, or via Naming "
+"Series. Select your preference here."
+msgstr ""
+"Ажилтныг нэрлэсэн бол ажилтны ID-аар, эсвэл нэрлэх цувралаар нэрлэж болно. "
+"Эндээс сонголтоо сонгоно уу."
+
+#. Label of the employee_name (Data) field in DocType 'Leave Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Employee name"
+msgstr "Ажилтны нэр"
+
+#. Description of the 'Employee Naming By' (Select) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Employee records are created using the selected option"
+msgstr "Сонгосон сонголтыг ашиглан ажилчдын бүртгэлийг үүсгэнэ"
+
+#: hrms/hr/doctype/shift_type/shift_type.py:285
+msgid "Employee was marked Absent due to missing Employee Checkins."
+msgstr "Ажилтны бүртгэл дутуу байсан тул ажилтныг байхгүй гэж тэмдэглэсэн."
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:248
+msgid ""
+"Employee was marked Absent for not meeting the working hours threshold."
+msgstr "Ажилтан нь ажлын цагийн босгыг хангаагүй тул ажилгүй гэж тэмдэглэсэн."
+
+#: hrms/hr/doctype/shift_type/shift_type.py:414
+#| msgid "Employee was marked Absent due to missing Employee Checkins."
+msgid ""
+"Employee was marked Absent for other half due to missing Employee Checkins."
+msgstr "Ажилтны бүртгэл дутуу байсан тул ажилтныг байхгүй гэж тэмдэглэсэн."
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:456
+#| msgid "Employee {0} is on Leave on {1}"
+msgid "Employee {0} : {1}"
+msgstr "Ажилтан {0} {1}-д амарна"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:67
+msgid ""
+"Employee {0} already has an Attendance Request {1} that overlaps with this "
+"period"
+msgstr "Ажилтан {0} энэ хугацаатай давхцаж буй ирцийн хүсэлт {1}-тэй байна."
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:140
+msgid ""
+"Employee {0} already has an active Shift {1}: {2} that overlaps within this "
+"period."
+msgstr ""
+"{0} ажилтан аль хэдийн идэвхтэй ээлжийн {1}-тэй байна: {2} энэ хугацаанд "
+"давхцаж байна."
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:56
+msgid ""
+"Employee {0} already submitted an application {1} for the payroll period {2}"
+msgstr ""
+"Ажилтан {0} аль хэдийн {2} цалингийн хугацаанд {1} өргөдөл гаргасан байна"
+
+#: hrms/hr/doctype/shift_request/shift_request.py:128
+msgid ""
+"Employee {0} has already applied for Shift {1}: {2} that overlaps within "
+"this period"
+msgstr ""
+"Ажилтан {0} аль хэдийн энэ хугацаанд давхцаж буй {1} ээлжинд хүсэлт "
+"гаргасан: {2}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:506
+msgid "Employee {0} has already applied for {1} between {2} and {3} : {4}"
+msgstr ""
+"{0} ажилтан аль хэдийн {2}-с {3} хооронд {1}-д өргөдөл гаргасан байна : {4}"
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:48
+msgid ""
+"Employee {0} has already claimed the benefit '{1}' for {2} ({3}).<br>To "
+"prevent overpayments, only one claim per benefit type is allowed in each "
+"payroll cycle."
+msgstr ""
+"{0} ажилтан {2} ({3})-д '{1}' тэтгэмжийг аль хэдийн нэхэмжилсэн.<br>Илүүдэл "
+"төлбөрөөс сэргийлэхийн тулд цалингийн мөчлөг бүрт тэтгэмжийн төрөл бүрт "
+"зөвхөн нэг нэхэмжлэл зөвшөөрнө."
+
+#: hrms/hr/doctype/attendance/attendance.py:211
+msgid "Employee {0} is not active or does not exist"
+msgstr "Ажилтан {0} идэвхгүй эсвэл байхгүй байна"
+
+#: hrms/hr/doctype/attendance/attendance.py:187
+msgid "Employee {0} is on Leave on {1}"
+msgstr "Ажилтан {0} {1}-д амарна"
+
+#: hrms/hr/doctype/training_feedback/training_feedback.py:25
+msgid "Employee {0} not found in Training Event Participants."
+msgstr "Ажилтан {0} Сургалтын арга хэмжээнд оролцогчдоос олдсонгүй."
+
+#: hrms/hr/doctype/attendance/attendance.py:180
+msgid "Employee {0} on Half day on {1}"
+msgstr "Ажилтан {0} хагас өдөр {1}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:648
+msgid "Employee {0} relieved on {1} must be set as 'Left'"
+msgstr "{1}-д чөлөөлөгдсөн {0} ажилтныг \"Зүүн\" гэж тохируулах ёстой"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:161
+msgid "Employee: {0} have to complete minimum {1} years for gratuity"
+msgstr "Ажилтан: {0} тэтгэлэг авахын тулд доод тал нь {1} жил ажиллах ёстой"
+
+#. Label of the employees_html (HTML) field in DocType 'Leave Control Panel'
+#. Label of the employees_html (HTML) field in DocType 'Shift Assignment Tool'
+#. Label of the employees_html (HTML) field in DocType 'Bulk Salary Structure
+#. Assignment'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+msgid "Employees HTML"
+msgstr "Ажилчдын HTML"
+
+#. Label of a Link in the People Workspace
+#: hrms/hr/workspace/people/people.json
+msgid "Employees Working on a Holiday"
+msgstr "Баярын өдрөөр ажиллаж буй ажилчид"
+
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.py:32
+msgid "Employees cannot give feedback to themselves. Use {0} instead: {1}"
+msgstr ""
+"Ажилтнууд өөрсөддөө хариу өгөх боломжгүй. Оронд нь {0}-г ашиглана уу: {1}"
+
+#. Label of the half_marked_employees_html (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#| msgid "Employee {0} on Half day on {1}"
+msgid "Employees on Half Day HTML"
+msgstr "Ажилтан хагас өдөр "
+
+#. Label of a number card in the Leaves Workspace
+#: hrms/hr/workspace/leaves/leaves.json
+#| msgid "Employee {0} is on Leave on {1}"
+msgid "Employees on leave this month"
+msgstr "Ажилтан -д амарна"
+
+#. Label of a number card in the Leaves Workspace
+#: hrms/hr/workspace/leaves/leaves.json
+#| msgid "Employees Working on a Holiday"
+msgid "Employees on leave today"
+msgstr "Баярын өдрөөр ажиллаж буй ажилчид"
+
+#: hrms/hr/doctype/hr_settings/hr_settings.py:81
+msgid ""
+"Employees will miss holiday reminders from {} until {}. <br> Do you want to "
+"proceed with this change?"
+msgstr ""
+"Ажилтнууд {}-с {} хүртэл амралтын өдрүүдийн сануулга өгөхгүй байх болно. "
+"<br> Та энэ өөрчлөлтийг үргэлжлүүлэхийг хүсэж байна уу?"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:167
+msgid "Employees without Feedback: {0}"
+msgstr "Санал хүсэлтгүй ажилчид: {0}"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:171
+msgid "Employees without Goals: {0}"
+msgstr "Зорилгогүй ажилчид: {0}"
+
+#. Name of a report
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/report/employees_working_on_a_holiday/employees_working_on_a_holiday.json
+#: hrms/hr/workspace/leaves/leaves.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Employees working on a holiday"
+msgstr "Амралтын өдрөөр ажилладаг ажилчид"
+
+#. Label of the employment_type (Link) field in DocType 'Employee Attendance
+#. Tool'
+#. Name of a DocType
+#. Label of the employee_type_name (Data) field in DocType 'Employment Type'
+#. Label of the employment_type (Link) field in DocType 'Job Opening'
+#. Label of the employment_type (Link) field in DocType 'Job Opening Template'
+#. Label of the employment_type (Link) field in DocType 'Leave Control Panel'
+#. Label of the employment_type (Link) field in DocType 'Shift Assignment
+#. Tool'
+#. Label of the employment_type (Link) field in DocType 'Bulk Salary Structure
+#. Assignment'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/doctype/employment_type/employment_type.json
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/job_opening_template/job_opening_template.json
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+#: hrms/setup.py:186 hrms/templates/generators/job_opening.html:141
+msgid "Employment Type"
+msgstr "Хөдөлмөр эрхлэлтийн төрөл"
+
+#. Label of the enable_auto_attendance (Check) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Enable Auto Attendance"
+msgstr "Автомат ирцийг идэвхжүүлэх"
+
+#. Label of the enable_early_exit_marking (Check) field in DocType 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Enable Early Exit Marking"
+msgstr "Эрт гарах тэмдэглэгээг идэвхжүүлнэ үү"
+
+#. Label of the enable_late_entry_marking (Check) field in DocType 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Enable Late Entry Marking"
+msgstr "Хожуу нэвтрэх тэмдэглэгээг идэвхжүүлэх"
+
+#: frontend/src/views/AppSettings.vue:25
+msgid "Enable Push Notifications"
+msgstr "Түлхэх мэдэгдлийг идэвхжүүлнэ үү"
+
+#. Description of the 'Apply for Public Holiday' (Check) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Enable this to use a specific multiplier for public holidays. If unchecked, "
+"the standard multiplier will be used instead."
+msgstr ""
+"Нийтийн баярын өдөрт тусгай үржүүлэгч ашиглахын тулд идэвхжүүлнэ үү. "
+"Сонгоогүй бол стандарт үржүүлэгч ашиглагдана."
+
+#. Description of the 'Apply for Weekend' (Check) field in DocType 'Overtime
+#. Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Enable this to use a specific multiplier for weekends. If unchecked, the "
+"standard multiplier will be used instead."
+msgstr ""
+"Амралтын өдөрт тусгай үржүүлэгч ашиглахын тулд идэвхжүүлнэ үү. Сонгоогүй бол"
+" стандарт үржүүлэгч ашиглагдана."
+
+#. Description of the 'Flexible Benefit' (Check) field in DocType 'Employee
+#. Benefit Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+msgid ""
+"Enabled only for Employee Benefit components from Salary Structure "
+"Assignment"
+msgstr ""
+"Зөвхөн Цалингийн бүтцийн томилгооны Ажилтны тэтгэмжийн бүрэлдэхүүн хэсгүүдэд"
+" идэвхжүүлсэн"
+
+#: frontend/src/views/AppSettings.vue:40
+msgid "Enabling Push Notifications..."
+msgstr "Түлхэх мэдэгдлийг идэвхжүүлж байна..."
+
+#. Label of the encashment (Section Break) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Encashment"
+msgstr "Бэлэн мөнгө авах"
+
+#. Label of the encashment_amount (Currency) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+msgid "Encashment Amount"
+msgstr "Бэлэн мөнгөний хэмжээ"
+
+#. Label of the encashment_days (Float) field in DocType 'Leave Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+msgid "Encashment Days"
+msgstr "Бэлэн мөнгө авах өдрүүд"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:130
+msgid "Encashment Days cannot exceed {0} {1} as per Leave Type settings"
+msgstr ""
+"Амралтын төрлийн тохиргооны дагуу мөнгө авах өдрүүд {0} {1}-ээс хэтрэхгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:120
+msgid "Encashment Limit Applied"
+msgstr "Бэлэн мөнгөний хязгаарыг ашигласан"
+
+#. Label of the encrypt_salary_slips_in_emails (Check) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Encrypt Salary Slips in Emails"
+msgstr "Цалингийн хуудсыг цахим шуудангаар шифрлэх"
+
+#: frontend/src/views/attendance/ShiftAssignmentForm.vue:75
+msgid "End Date cannot be before Start Date"
+msgstr "Дуусах огноо нь эхлэх огнооноос өмнө байж болохгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:241
+msgid "End date: {0}"
+msgstr "Дуусах огноо: {0}"
+
+#: hrms/hr/doctype/training_event/training_event.py:26
+msgid "End time cannot be before start time"
+msgstr "Дуусах цаг нь эхлэх цагаас өмнө байж болохгүй"
+
+#: hrms/hr/doctype/job_applicant/job_applicant.js:86
+#| msgid "Interview Round"
+msgid "Enter Interview Round"
+msgstr "Ярилцлагын тойрог"
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.py:48
+msgid "Enter a non-zero value to adjust."
+msgstr "Тохируулахын тулд тэгээс ялгаатай утга оруулна уу."
+
+#: hrms/hr/doctype/hr_settings/hr_settings.js:34
+msgid ""
+"Enter the Standard Working Hours for a normal work day. These hours will be "
+"used in calculations of reports such as Employee Hours Utilization and "
+"Project Profitability analysis."
+msgstr ""
+"Ердийн ажлын өдрийн стандарт ажлын цагийг оруулна уу. Эдгээр цагийг Ажилчдын"
+" цагийн ашиглалт, Төслийн ашигт ажиллагааны шинжилгээ зэрэг тайлангийн "
+"тооцоонд ашиглана."
+
+#. Description of the 'Days to Reverse' (Float) field in DocType 'Payroll
+#. Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid ""
+"Enter the number of Leave Without Pay (LWP) days you want to reverse. This "
+"value cannot exceed the total LWP days recorded for the selected month"
+msgstr ""
+"Буцаахыг хүсэж буй цалингүй чөлөөний (ЦЧ) өдрийн тоог оруулна уу. Энэ утга "
+"нь сонгосон сарын нийт ЦЧ өдрөөс хэтрэх ёсгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:259
+msgid "Enter the number of leaves you want to allocate for the period."
+msgstr "Тухайн хугацаанд хуваарилахыг хүсч буй навчны тоог оруулна уу."
+
+#. Description of the 'Flexible Benefits' (Table) field in DocType 'Salary
+#. Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#| msgid "Max Benefit Amount"
+msgid "Enter yearly benefit amounts"
+msgstr "Тэтгэмжийн дээд хэмжээ"
+
+#: frontend/src/components/FormField.vue:42
+msgid "Enter {0}"
+msgstr "{0}-г оруулна уу"
+
+#: frontend/src/components/FormView.vue:543
+msgid "Error creating {0}"
+msgstr "{0}-г үүсгэхэд алдаа гарлаа"
+
+#: frontend/src/components/FormView.vue:592
+msgid "Error deleting {0}"
+msgstr "{0}-г устгахад алдаа гарлаа"
+
+#: frontend/src/utils/commonUtils.js:46
+#| msgid "Download PDF"
+msgid "Error downloading PDF"
+msgstr "PDF татаж авах"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1324
+msgid "Error in formula or condition"
+msgstr "Томъёо эсвэл нөхцөлийн алдаа"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2540
+msgid "Error in formula or condition: {0} in Income Tax Slab"
+msgstr "Томъёо эсвэл нөхцөлийн алдаа: Орлогын татварын хавтан дахь {0}"
+
+#: hrms/hr/doctype/upload_attendance/upload_attendance.js:57
+msgid "Error in some rows"
+msgstr "Зарим мөрөнд алдаа гарсан"
+
+#: frontend/src/components/FormView.vue:570
+msgid "Error updating {0}"
+msgstr "{0}-г шинэчлэхэд алдаа гарлаа"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2619
+msgid ""
+"Error while evaluating the {doctype} {doclink} at row {row_id}. <br><br> "
+"<b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
+msgstr ""
+"{row_id} мөрөнд {doctype} {doclink}-г тооцоолоход алдаа гарлаа. <br><br> "
+"<b>Алдаа:</b> {error} <br><br> <b>Зөвлөмж:</b> {description}"
+
+#. Label of the estimated_cost_per_position (Currency) field in DocType
+#. 'Staffing Plan Detail'
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Estimated Cost Per Position"
+msgstr "Нэг албан тушаалд ногдох тооцоолсон зардал"
+
+#: hrms/overrides/dashboard_overrides.py:52
+msgid "Evaluation"
+msgstr "Үнэлгээ"
+
+#. Label of the evaluation_date (Date) field in DocType 'Employee Skill'
+#: hrms/hr/doctype/employee_skill/employee_skill.json
+msgid "Evaluation Date"
+msgstr "Үнэлгээний огноо"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:25
+msgid ""
+"Evaluation Method cannot be changed as there are existing appraisals created"
+" for this cycle"
+msgstr ""
+"Үнэлгээний аргыг өөрчлөх боломжгүй, учир нь энэ мөчлөгт одоо байгаа үнэлгээ "
+"бий"
+
+#. Label of the event_details (Section Break) field in DocType 'Travel
+#. Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Event Details"
+msgstr "Үйл явдлын дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/notification/training_scheduled/training_scheduled.html:37
+msgid "Event Link"
+msgstr "Үйл явдлын холбоос"
+
+#: hrms/hr/notification/training_scheduled/training_scheduled.html:23
+#: hrms/templates/emails/training_event.html:6
+msgid "Event Location"
+msgstr "Үйл явдлын байршил"
+
+#. Label of the event_name (Data) field in DocType 'Training Event'
+#. Label of the event_name (Data) field in DocType 'Training Feedback'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_feedback/training_feedback.json
+#: hrms/templates/emails/training_event.html:5
+msgid "Event Name"
+msgstr "Үйл явдлын нэр"
+
+#. Label of the event_status (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Event Status"
+msgstr "Үйл явдлын байдал"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Shift Schedule'
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+msgid "Every 2 Weeks"
+msgstr "2 долоо хоног тутамд"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Shift Schedule'
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+msgid "Every 3 Weeks"
+msgstr "3 долоо хоног тутамд"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Shift Schedule'
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+msgid "Every 4 Weeks"
+msgstr "4 долоо хоног тутамд"
+
+#. Option for the 'Working Hours Calculation Based On' (Select) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Every Valid Check-in and Check-out"
+msgstr "Хүчин төгөлдөр бүртгэл, гарах бүр"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Shift Schedule'
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+msgid "Every Week"
+msgstr "Долоо хоног бүр"
+
+#: hrms/controllers/employee_reminders.py:218
+msgid "Everyone, let’s congratulate them on their work anniversary!"
+msgstr "Бүгдээрээ, тэдний ажлын ойн баярын мэнд хүргэе!"
+
+#: hrms/controllers/employee_reminders.py:125
+msgid "Everyone, let’s congratulate {0} on their birthday."
+msgstr "Бүгдээрээ, {0}-д төрсөн өдрийн мэнд хүргэе."
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Exam"
+msgstr "Шалгалт"
+
+#. Description of the 'Exchange Rate' (Float) field in DocType 'Expense Claim
+#. Advance'
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+#| msgid " Unlink Payment on Cancellation of Employee Advance"
+msgid "Exchange rate of Payment Entry against Employee Advance"
+msgstr " Ажилтны урьдчилгааг цуцалсны төлбөрийг салга"
+
+#: hrms/hr/doctype/attendance/attendance_list.js:85
+msgid "Exclude Holidays"
+msgstr "Баярын өдрүүдийг оруулахгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:106
+msgid "Excluded {0} Non-Encashable Leaves for {1}"
+msgstr "{1}-д мөнгө авах боломжгүй {0} навчийг хассан"
+
+#. Label of the exempted_from_income_tax (Check) field in DocType 'Salary
+#. Component'
+#. Label of the exempted_from_income_tax (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Exempted from Income Tax"
+msgstr "Орлогын албан татвараас чөлөөлөгдсөн"
+
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Exemption"
+msgstr "Чөлөөлөлт"
+
+#. Label of the exemption_category (Link) field in DocType 'Employee Tax
+#. Exemption Declaration Category'
+#. Label of the exemption_category (Read Only) field in DocType 'Employee Tax
+#. Exemption Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Exemption Category"
+msgstr "Чөлөөлөлтийн ангилал"
+
+#. Label of the exemption_proofs_details_tab (Tab Break) field in DocType
+#. 'Employee Tax Exemption Proof Submission'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Exemption Proofs"
+msgstr "Чөлөөлөх баталгаа"
+
+#. Label of the exemption_sub_category (Link) field in DocType 'Employee Tax
+#. Exemption Declaration Category'
+#. Label of the exemption_sub_category (Link) field in DocType 'Employee Tax
+#. Exemption Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Exemption Sub Category"
+msgstr "Чөлөөлөлтийн дэд ангилал"
+
+#: hrms/hr/doctype/attendance_request/attendance_warnings.html:10
+msgid "Existing Record"
+msgstr "Одоо байгаа бичлэг"
+
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py:37
+#| msgid "Multiple Shift Assignments"
+msgid "Existing Shift Assignments"
+msgstr "Олон ээлжийн даалгавар"
+
+#. Option for the 'Final Decision' (Select) field in DocType 'Exit Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/report/employee_exits/employee_exits.py:193
+msgid "Exit Confirmed"
+msgstr "Гарах Баталгаажсан"
+
+#. Label of the exit_details_section (Section Break) field in DocType 'Salary
+#. Withholding'
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Exit Details"
+msgstr "Дэлгэрэнгүй мэдээлэлээс гарах"
+
+#. Name of a DocType
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/report/employee_exits/employee_exits.py:39
+msgid "Exit Interview"
+msgstr "Ярилцлагаас гарах"
+
+#: hrms/hr/report/employee_exits/employee_exits.js:63
+msgid "Exit Interview Pending"
+msgstr "Ярилцлагаас гарах хүлээгдэж байна"
+
+#. Label of the exit_interview (Text Editor) field in DocType 'Employee
+#. Separation'
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+msgid "Exit Interview Summary"
+msgstr "Ярилцлагын хураангуй"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:33
+msgid "Exit Interview {0} already exists for Employee: {1}"
+msgstr "Ярилцлагаас гарах {0} ажилтны хувьд аль хэдийн байна: {1}"
+
+#. Label of the exit_questionnaire_section (Section Break) field in DocType
+#. 'Exit Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/doctype/exit_interview/exit_interview.py:143
+msgid "Exit Questionnaire"
+msgstr "Санал асуулгаас гарах"
+
+#: hrms/hr/doctype/exit_interview/test_exit_interview.py:116
+#: hrms/hr/doctype/exit_interview/test_exit_interview.py:126
+#: hrms/hr/doctype/exit_interview/test_exit_interview.py:128 hrms/setup.py:481
+#: hrms/setup.py:483 hrms/setup.py:504
+msgid "Exit Questionnaire Notification"
+msgstr "Санал асуулгын мэдэгдлээс гарах"
+
+#. Label of the exit_questionnaire_notification_template (Link) field in
+#. DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Exit Questionnaire Notification Template"
+msgstr "Санал асуулгын мэдэгдлийн загвараас гарах"
+
+#: hrms/hr/report/employee_exits/employee_exits.js:68
+msgid "Exit Questionnaire Pending"
+msgstr "Хүлээгдэж буй асуулгаас гарах"
+
+#. Label of the exit_questionnaire_web_form (Link) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/exit_interview/exit_interview.py:124
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Exit Questionnaire Web Form"
+msgstr "Санал асуулгын вэб маягтаас гарах"
+
+#. Label of a quick_list in the Tenure Workspace
+#: hrms/hr/workspace/tenure/tenure.json
+#| msgid "Holidays this Month."
+msgid "Exits (This Month)"
+msgstr "Энэ сард амралтын өдрүүд."
+
+#. Label of the expected_average_rating (Rating) field in DocType 'Interview'
+#. Label of the expected_average_rating (Rating) field in DocType 'Interview
+#. Round'
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_round/interview_round.json
+msgid "Expected Average Rating"
+msgstr "Хүлээгдэж буй дундаж үнэлгээ"
+
+#. Label of the expected_by (Date) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Expected By"
+msgstr "Хүлээгдэж буй"
+
+#. Label of the expected_compensation (Currency) field in DocType 'Job
+#. Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Expected Compensation"
+msgstr "Хүлээгдэж буй нөхөн төлбөр"
+
+#. Label of a field in the job-application Web Form
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Expected Salary Range per month"
+msgstr "Сард хүлээгдэж буй цалингийн хүрээ"
+
+#. Name of a DocType
+#: hrms/hr/doctype/expected_skill_set/expected_skill_set.json
+msgid "Expected Skill Set"
+msgstr "Хүлээгдэж буй ур чадварын багц"
+
+#. Label of the expected_skill_set (Table) field in DocType 'Interview Round'
+#: hrms/hr/doctype/interview_round/interview_round.json
+msgid "Expected Skillset"
+msgstr "Хүлээгдэж буй ур чадварын багц"
+
+#. Name of a role
+#. Label of the expense_approver (Link) field in DocType 'Expense Claim'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+#: hrms/hr/doctype/expense_claim/expense_claim.json hrms/setup.py:153
+#: hrms/setup.py:241
+msgid "Expense Approver"
+msgstr "Зардал батлагч"
+
+#. Label of the expense_approver_mandatory_in_expense_claim (Check) field in
+#. DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Expense Approver Mandatory In Expense Claim"
+msgstr "Зардлын батламжлагч Зардлын нэхэмжлэлд заавал байх ёстой"
+
+#. Name of a DocType
+#: hrms/hr/doctype/expense_claim_account/expense_claim_account.json
+msgid "Expense Claim Account"
+msgstr "Зардлын нэхэмжлэлийн данс"
+
+#. Name of a DocType
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgid "Expense Claim Advance"
+msgstr "Зардлын нэхэмжлэлийн урьдчилгаа"
+
+#. Name of a DocType
+#: hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgid "Expense Claim Detail"
+msgstr "Зардлын нэхэмжлэлийн дэлгэрэнгүй"
+
+#: frontend/src/components/ExpenseClaimSummary.vue:3
+msgid "Expense Claim Summary"
+msgstr "Зардлын нэхэмжлэлийн хураангуй"
+
+#. Label of the expense_type (Link) field in DocType 'Expense Claim Detail'
+#. Name of a DocType
+#. Label of the expense_type (Data) field in DocType 'Expense Claim Type'
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/doctype/expense_claim/expense_claim.py:685
+#: hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+#: hrms/hr/doctype/expense_claim_type/expense_claim_type.json
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Expense Claim Type"
+msgstr "Зардлын нэхэмжлэлийн төрөл"
+
+#: hrms/hr/doctype/vehicle_log/vehicle_log.py:48
+msgid "Expense Claim for Vehicle Log {0}"
+msgstr "Тээврийн хэрэгслийн бүртгэлийн зардлын нэхэмжлэл {0}"
+
+#: hrms/hr/doctype/vehicle_log/vehicle_log.py:36
+msgid "Expense Claim {0} already exists for the Vehicle Log"
+msgstr "Тээврийн хэрэгслийн бүртгэлд зардлын нэхэмжлэл {0} байна"
+
+#. Label of a chart in the Expenses Workspace
+#: frontend/src/views/expense_claim/Dashboard.vue:2
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Expense Claims"
+msgstr "Зардлын нэхэмжлэл"
+
+#. Label of the expense_date (Date) field in DocType 'Expense Claim Detail'
+#: hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+msgid "Expense Date"
+msgstr "Зардлын огноо"
+
+#: frontend/src/components/ExpensesTable.vue:211
+msgid "Expense Item"
+msgstr "Зардлын зүйл"
+
+#. Label of the section_break_9 (Section Break) field in DocType 'Employee
+#. Benefit Claim'
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+msgid "Expense Proof"
+msgstr "Зардлын баталгаа"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:219
+msgid "Expense Tax"
+msgstr "Зардлын татвар"
+
+#. Label of the taxes (Table) field in DocType 'Expense Claim'
+#. Name of a DocType
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#: hrms/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+msgid "Expense Taxes and Charges"
+msgstr "Зардлын татвар, хураамж"
+
+#. Label of the expense_type (Link) field in DocType 'Travel Request Costing'
+#: hrms/hr/doctype/travel_request_costing/travel_request_costing.json
+msgid "Expense Type"
+msgstr "Зардлын төрөл"
+
+#. Label of the expenses_and_advances_tab (Tab Break) field in DocType
+#. 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Expenses & Advances"
+msgstr "Зардал ба урьдчилгаа"
+
+#. Label of the expenses_settings_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#| msgid "Employee Settings"
+msgid "Expenses Settings"
+msgstr "Ажилтны тохиргоо"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:42
+msgid "Expire Allocation"
+msgstr "Хуваарилалтын хугацаа дуусах"
+
+#. Label of the expire_carry_forwarded_leaves_after_days (Int) field in
+#. DocType
+#. 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Expire Carry Forwarded Leaves (Days)"
+msgstr "Дуусах хугацаа нь зуусан навч (өдөр)"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:568
+#| msgid "Expired Leaves"
+msgid "Expire Leaves"
+msgstr "Хугацаа нь дууссан навчнууд"
+
+#. Label of the expired_leaves (Float) field in DocType 'Salary Slip Leave'
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Expired Leave(s)"
+msgstr "Хугацаа нь дууссан чөлөө(үүд)"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:8
+msgid "Expired Leaves"
+msgstr "Хугацаа нь дууссан навчнууд"
+
+#. Label of the explanation (Small Text) field in DocType 'Attendance Request'
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+msgid "Explanation"
+msgstr "Тайлбар"
+
+#: hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js:137
+msgid "Exporting..."
+msgstr "Экспорт хийж байна..."
+
+#: hrms/hr/utils.py:934
+msgid "Failed to create/submit {0} for employees:"
+msgstr "Ажилчдын хувьд {0}-г үүсгэж/илгээж чадсангүй:"
+
+#: hrms/overrides/company.py:36
+msgid "Failed to delete defaults for country {0}."
+msgstr "{0} улсын өгөгдмөлүүдийг устгаж чадсангүй."
+
+#: hrms/api/__init__.py:769
+#| msgid "Failed to download Salary Slip PDF"
+msgid "Failed to download PDF: {0}"
+msgstr "PDF татахад алдаа гарлаа: {0}"
+
+#: hrms/hr/doctype/interview/interview.py:117
+msgid ""
+"Failed to send the Interview Reschedule notification. Please configure your "
+"email account."
+msgstr ""
+"Ярилцлагыг дахин төлөвлөх тухай мэдэгдлийг илгээж чадсангүй. Имэйл бүртгэлээ"
+" тохируулна уу."
+
+#: hrms/overrides/company.py:49
+msgid "Failed to setup defaults for country {0}."
+msgstr "{0} улсын өгөгдмөл тохиргоог хийж чадсангүй."
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:464
+msgid "Failed to submit some leave policy assignments:"
+msgstr "Зарим чөлөө олгох бодлогын даалгаврыг илгээж чадсангүй:"
+
+#: hrms/hr/doctype/interview/interview.py:208
+msgid "Failed to update the Job Applicant status"
+msgstr "Ажил горилогчийн статусыг шинэчилж чадсангүй"
+
+#: hrms/public/js/utils/index.js:143
+msgid "Failed to {0} {1} for employees:"
+msgstr "Ажилчдын хувьд {0} {1} амжилтгүй боллоо:"
+
+#. Label of the failure_details_section (Tab Break) field in DocType 'Payroll
+#. Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Failure Details"
+msgstr "Алдаа дутагдлын дэлгэрэнгүй мэдээлэл"
+
+#. Label of the failure_reason (Small Text) field in DocType 'Earned Leave
+#. Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Failure Details"
+msgid "Failure Reason"
+msgstr "Алдаа дутагдлын дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/utils.py:483
+msgid "Failure of Automatic Allocation of Earned Leaves"
+msgstr "Олгогдсон чөлөөний автомат хуваарилалт амжилтгүй болсон"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:37
+#: hrms/public/js/salary_slip_deductions_report_filters.js:20
+msgid "Feb"
+msgstr "Хоёрдугаар сар"
+
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:48
+msgid "Feedback Count"
+msgstr "Санал хүсэлтийн тоо"
+
+#. Label of the feedback_html (HTML) field in DocType 'Appraisal'
+#. Label of the feedback_html (HTML) field in DocType 'Interview'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/interview/interview.json
+msgid "Feedback HTML"
+msgstr "Санал хүсэлтийн HTML"
+
+#. Label of the feedback_ratings (Table) field in DocType 'Employee
+#. Performance
+#. Feedback'
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Feedback Ratings"
+msgstr "Санал хүсэлтийн үнэлгээ"
+
+#. Label of the feedback_reminder_notification_template (Link) field in
+#. DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Feedback Reminder Notification Template"
+msgstr "Сануулах санал хүсэлтийн мэдэгдлийн загвар"
+
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:124
+msgid "Feedback Score"
+msgstr "Санал хүсэлтийн оноо"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+msgid "Feedback Submitted"
+msgstr "Санал хүсэлт илгээсэн"
+
+#: hrms/public/js/templates/interview_feedback.html:14
+msgid "Feedback Summary"
+msgstr "Санал хүсэлтийн хураангуй"
+
+#: hrms/hr/doctype/interview_feedback/interview_feedback.py:52
+msgid ""
+"Feedback already submitted for the Interview {0}. Please cancel the previous"
+" Interview Feedback {1} to continue."
+msgstr ""
+"Ярилцлагад санал хүсэлтээ аль хэдийн илгээсэн {0}. Үргэлжлүүлэхийн тулд "
+"өмнөх ярилцлагын санал хүсэлтийг {1} цуцална уу."
+
+#: hrms/hr/doctype/training_feedback/training_feedback.py:31
+msgid "Feedback cannot be recorded for an absent Employee."
+msgstr "Эзгүй байгаа ажилтны санал хүсэлтийг бүртгэх боломжгүй."
+
+#: hrms/public/js/performance/performance_feedback.js:120
+msgid "Feedback {0} added successfully"
+msgstr "Санал хүсэлтийг {0} амжилттай нэмсэн"
+
+#. Label of the fetch_geolocation (Button) field in DocType 'Employee Checkin'
+#. Label of the fetch_geolocation (Button) field in DocType 'Shift Location'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+#: hrms/hr/doctype/shift_location/shift_location.json
+msgid "Fetch Geolocation"
+msgstr "Газарзүйн байршлыг татах"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.js:7
+#| msgid "Other Details"
+msgid "Fetch Overtime Details"
+msgstr "Бусад дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.js:33
+msgid "Fetch Shift"
+msgstr "Шилжилтийг татах"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin_list.js:9
+msgid "Fetch Shifts"
+msgstr "Шилжилтүүдийг татах"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:109
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:136
+msgid "Fetching Employees"
+msgstr "Ажилчдыг татах"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.js:38
+msgid "Fetching Shift"
+msgstr "Shift дуудаж байна"
+
+#: hrms/public/js/utils/index.js:193
+msgid "Fetching your geolocation"
+msgstr "Таны газарзүйн байршлыг дуудаж байна"
+
+#: frontend/src/components/FilePreviewModal.vue:4
+msgid "File Preview"
+msgstr "Файлыг урьдчилан харах"
+
+#: hrms/hr/doctype/leave_application/leave_application.js:99
+#: hrms/hr/doctype/leave_encashment/leave_encashment.js:50
+msgid "Fill the form and save it"
+msgstr "Маягтыг бөглөж хадгална уу"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Filled"
+msgstr "Дүүрсэн"
+
+#. Label of the section_break_17 (Section Break) field in DocType 'Payroll
+#. Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Filter Employees"
+msgstr "Ажилчдыг шүүх"
+
+#. Label of the filter_by_shift (Check) field in DocType 'Employee Attendance
+#. Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#| msgid "Filter List"
+msgid "Filter by Shift"
+msgstr "Шүүлтүүрийн жагсаалт"
+
+#. Label of the employee_status (Select) field in DocType 'Exit Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/report/employee_exits/employee_exits.js:57
+#: hrms/hr/report/employee_exits/employee_exits.py:52
+msgid "Final Decision"
+msgstr "Эцсийн шийдвэр"
+
+#. Label of the final_score (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:57
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:125
+msgid "Final Score"
+msgstr "Эцсийн оноо"
+
+#. Label of the final_score_formula (Code) field in DocType 'Appraisal Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Final Score Formula"
+msgstr "Эцсийн онооны томъёо"
+
+#. Option for the 'Working Hours Calculation Based On' (Select) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "First Check-in and Last Check-out"
+msgstr "Эхний бүртгэл, сүүлчийн бүртгэл"
+
+#. Option for the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "First Day"
+msgstr "Эхний өдөр"
+
+#. Label of the first_name (Data) field in DocType 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "First Name "
+msgstr "Нэр "
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1520
+msgid "Fiscal Year {0} not found"
+msgstr "Санхүүгийн жил {0} олдсонгүй"
+
+#. Option for the 'Overtime Amount Calculation' (Select) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Hour Rate"
+msgid "Fixed Hourly Rate"
+msgstr "Цагийн ханш"
+
+#. Label of a Card Break in the Expenses Workspace
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Fleet Management"
+msgstr "Флотын удирдлага"
+
+#. Label of the flexible_benefit (Check) field in DocType 'Employee Benefit
+#. Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.js:90
+#| msgid "Flexible Benefits"
+msgid "Flexible Benefit"
+msgstr "Уян хатан ашиг тус"
+
+#. Label of the employee_benefits (Table) field in DocType 'Employee Benefit
+#. Application'
+#. Label of the flexible_benefits_tab (Tab Break) field in DocType 'Salary
+#. Component'
+#. Label of the employee_benefits (Table) field in DocType 'Salary Structure'
+#. Label of the employee_benefits (Table) field in DocType 'Salary Structure
+#. Assignment'
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Flexible Benefits"
+msgstr "Уян хатан ашиг тус"
+
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:64
+#| msgid "Flexible Benefits"
+msgid "Flexible Component"
+msgstr "Уян хатан ашиг тус"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Flight"
+msgstr "Нислэг"
+
+#: hrms/hr/report/employee_exits/employee_exits.js:73
+msgid "FnF Pending"
+msgstr "FnF Хүлээгдэж байна"
+
+#. Label of the follow_via_email (Check) field in DocType 'Leave Application'
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Follow via Email"
+msgstr "Имэйлээр дагаарай"
+
+#: hrms/setup.py:333
+msgid "Food"
+msgstr "Хоол хүнс"
+
+#. Label of the for_designation (Link) field in DocType 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "For Designation "
+msgstr "Зориулалтын зориулалтаар "
+
+#. Label of the employee (Link) field in DocType 'Employee Performance
+#. Feedback'
+#: hrms/hr/doctype/attendance/attendance_list.js:29
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "For Employee"
+msgstr "Ажилтны хувьд"
+
+#. Description of the 'Fraction of Daily Salary per Leave' (Float) field in
+#. DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid ""
+"For a day of leave taken, if you still pay (say) 50% of the daily salary, "
+"then enter 0.50 in this field."
+msgstr ""
+"Амралт авсан өдрийн хувьд, хэрэв та өдрийн цалингийн 50% -ийг төлж байгаа "
+"бол энэ талбарт 0.50-ыг оруулна уу."
+
+#. Label of the formula (Code) field in DocType 'Salary Component'
+#. Label of the formula (Code) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Formula"
+msgstr "Томъёо"
+
+#. Label of the fraction_of_applicable_earnings (Float) field in DocType
+#. 'Gratuity Rule Slab'
+#: hrms/payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgid "Fraction of Applicable Earnings "
+msgstr "Холбогдох ашгийн хэсэг "
+
+#. Label of the daily_wages_fraction_for_half_day (Float) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Fraction of Daily Salary for Half Day"
+msgstr "Хагас өдрийн цалингийн нэг хэсэг"
+
+#. Label of the fraction_of_daily_salary_per_leave (Float) field in DocType
+#. 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Fraction of Daily Salary per Leave"
+msgstr "Амралтанд ногдох өдрийн цалингийн хэсэг"
+
+#: hrms/hr/report/project_profitability/project_profitability.py:191
+msgid "Fractional Cost"
+msgstr "Бутархай зардал"
+
+#: frontend/src/components/BaseLayout.vue:9
+msgid "Frappe HR"
+msgstr "Frappe HR"
+
+#. Label of the from_amount (Currency) field in DocType 'Taxable Salary Slab'
+#: hrms/payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid "From Amount"
+msgstr "Тоо хэмжээнээс"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:30
+msgid "From Date must come before To Date"
+msgstr "From Date нь To Date-аас өмнө байх ёстой"
+
+#: hrms/payroll/doctype/arrear/arrear.py:47
+#| msgid "From Date {0} cannot be after employee's relieving Date {1}"
+msgid "From Date {0} cannot be after Payroll Period end date {1}"
+msgstr "Ажилтан чөлөөлөгдсөн огноо {1}-ээс хойш {0} байх боломжгүй."
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:59
+msgid "From Date {0} cannot be after employee's relieving Date {1}"
+msgstr "Ажилтан чөлөөлөгдсөн огноо {1}-ээс хойш {0} байх боломжгүй."
+
+#: hrms/payroll/doctype/arrear/arrear.py:41
+#| msgid "From Date {0} cannot be before employee's joining Date {1}"
+msgid "From Date {0} cannot be before Payroll Period start date {1}"
+msgstr "Огнооноос {0} нь ажилтны нэгдсэн огноо {1}-ээс өмнө байж болохгүй"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:51
+msgid "From Date {0} cannot be before employee's joining Date {1}"
+msgstr "Огнооноос {0} нь ажилтны нэгдсэн огноо {1}-ээс өмнө байж болохгүй"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:115
+msgid "From and to dates are madatory for recurring type additional salaries."
+msgstr ""
+"Давтагдах нэмэлт цалингийн хувьд эхлэх болон дуусах огноо заавал байх ёстой."
+
+#: hrms/hr/utils.py:199
+msgid "From date can not be less than employee's joining date"
+msgstr "Энэ өдрөөс эхлэн ажилтны ажилд орсон өдрөөс бага байж болохгүй"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:123
+msgid "From date can not be less than employee's joining date."
+msgstr "Энэ өдрөөс эхлэн ажилтны ажилд орсон өдрөөс бага байж болохгүй."
+
+#: hrms/hr/doctype/leave_type/leave_type.js:54
+msgid "From here, you can enable encashment for the balance leaves."
+msgstr "Эндээс та үлдэгдлийн үлдэгдэл төлбөрийг идэвхжүүлэх боломжтой."
+
+#: hrms/payroll/report/salary_register/salary_register.html:8
+#| msgid "{0}: From {0} of type {1}"
+msgid "From {0} to {1}"
+msgstr "{0}-с {1} хүртэл"
+
+#. Label of the from_year (Int) field in DocType 'Gratuity Rule Slab'
+#: hrms/payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgid "From(Year)"
+msgstr "(Жи)"
+
+#. Option for the 'Roster Color' (Select) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Fuchsia"
+msgstr "Фуксия"
+
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:45
+msgid "Fuel Expense"
+msgstr "Шатахууны зардал"
+
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:165
+msgid "Fuel Expenses"
+msgstr "Шатахууны зардал"
+
+#. Label of the price (Currency) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:44
+msgid "Fuel Price"
+msgstr "Шатахууны үнэ"
+
+#. Label of the fuel_qty (Float) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:43
+msgid "Fuel Qty"
+msgstr "Шатахууны тоо"
+
+#. Name of a DocType
+#: hrms/hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgid "Full and Final Asset"
+msgstr "Бүрэн ба эцсийн хөрөнгө"
+
+#. Name of a DocType
+#: hrms/hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgid "Full and Final Outstanding Statement"
+msgstr "Бүрэн болон эцсийн үлдэгдэлтэй мэдэгдэл"
+
+#: hrms/setup.py:389
+msgid "Full-time"
+msgstr "Бүтэн цагийн"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Fully Sponsored"
+msgstr "Бүрэн ивээн тэтгэсэн"
+
+#. Label of the funded_amount (Currency) field in DocType 'Travel Request
+#. Costing'
+#: hrms/hr/doctype/travel_request_costing/travel_request_costing.json
+msgid "Funded Amount"
+msgstr "Санхүүжүүлсэн дүн"
+
+#. Label of the future_income_tax_deductions (Currency) field in DocType
+#. 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Future Income Tax"
+msgstr "Ирээдүйн орлогын албан татвар"
+
+#: hrms/hr/utils.py:197
+msgid "Future dates not allowed"
+msgstr "Ирээдүйн огноог зөвшөөрөхгүй"
+
+#. Label of the gain_loss_account (Link) field in DocType 'Expense Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#| msgid "Bank Account"
+msgid "Gain Loss Account"
+msgstr "Банкны данс"
+
+#: hrms/public/js/utils/index.js:186 hrms/public/js/utils/index.js:214
+msgid "Geolocation Error"
+msgstr "Газарзүйн байршлын алдаа"
+
+#: frontend/src/components/CheckInPanel.vue:143
+#: hrms/public/js/utils/index.js:185
+msgid "Geolocation is not supported by your current browser"
+msgstr "Газарзүйн байршлыг таны одоогийн хөтөч дэмждэггүй"
+
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js:47
+msgid "Get Details From Declaration"
+msgstr "Тунхаглалаас дэлгэрэнгүй мэдээлэл аваарай"
+
+#. Label of the get_employees (Button) field in DocType 'Appraisal Cycle'
+#. Label of the section_break_ackd (Section Break) field in DocType 'Employee
+#. Attendance Tool'
+#. Label of the get_employees (Button) field in DocType 'Employee Attendance
+#. Tool'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:69
+msgid "Get Employees"
+msgstr "Ажилчдыг авах"
+
+#. Label of the get_job_requisitions (Button) field in DocType 'Staffing Plan'
+#: hrms/hr/doctype/staffing_plan/staffing_plan.json
+msgid "Get Job Requisitions"
+msgstr "Ажлын байрны захиалга авах"
+
+#. Label of the get_template (Button) field in DocType 'Upload Attendance'
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+msgid "Get Template"
+msgstr "Загвар авах"
+
+#: frontend/src/components/InstallPrompt.vue:8
+msgid "Get the app on your device for easy access & a better experience!"
+msgstr ""
+"Хялбар хандаж, илүү сайн ашиглахын тулд төхөөрөмж дээрээ апп суулгаарай!"
+
+#: frontend/src/components/InstallPrompt.vue:41
+msgid "Get the app on your iPhone for easy access & a better experience"
+msgstr ""
+"Хялбар хандаж, илүү сайн ашиглахын тулд iPhone дээрээ програмыг суулгаарай"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Gluten Free"
+msgstr "Цавуулаггүй"
+
+#: frontend/src/views/InvalidEmployee.vue:12
+msgid "Go to Login"
+msgstr "Нэвтрэх хэсэгт очно уу"
+
+#: frontend/src/views/Login.vue:72
+msgid "Go to Reset Password page"
+msgstr "Нууц үг шинэчлэх хуудас руу очно уу"
+
+#. Label of the goal_completion (Percent) field in DocType 'Appraisal KRA'
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+msgid "Goal Completion (%)"
+msgstr "Зорилгоо биелүүлэх (%)"
+
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:55
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:122
+msgid "Goal Score"
+msgstr "Гоолын оноо"
+
+#. Label of the goal_score_percentage (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Goal Score (%)"
+msgstr "Зорилго (%)"
+
+#. Label of the goal_score (Float) field in DocType 'Appraisal KRA'
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+msgid "Goal Score (weighted)"
+msgstr "Гоолын оноо (жин)"
+
+#: hrms/hr/doctype/goal/goal.py:81
+msgid "Goal progress percentage cannot be more than 100."
+msgstr "Зорилгын ахицын хувь 100-аас их байж болохгүй."
+
+#: hrms/hr/doctype/goal/goal.py:71
+msgid "Goal should be aligned with the same KRA as its parent goal."
+msgstr "Зорилго нь үндсэн зорилттойгоо ижил KRA-тай нийцсэн байх ёстой."
+
+#: hrms/hr/doctype/goal/goal.py:67
+msgid "Goal should be owned by the same employee as its parent goal."
+msgstr "Зорилго нь үндсэн зорилттой ижил ажилтанд байх ёстой."
+
+#: hrms/hr/doctype/goal/goal.py:75
+msgid "Goal should belong to the same Appraisal Cycle as its parent goal."
+msgstr ""
+"Зорилго нь үндсэн зорилттойгоо ижил Үнэлгээний мөчлөгт хамаарах ёстой."
+
+#: hrms/hr/doctype/goal/goal_tree.js:288
+msgid "Goal updated successfully"
+msgstr "Зорилгоо амжилттай шинэчилсэн"
+
+#: hrms/hr/doctype/goal/goal_list.js:129
+msgid "Goals updated successfully"
+msgstr "Зорилгоо амжилттай шинэчилсэн"
+
+#. Label of the grade (Data) field in DocType 'Training Result Employee'
+#. Label of the grade (Link) field in DocType 'Payroll Entry'
+#. Label of the grade (Link) field in DocType 'Salary Structure Assignment'
+#: hrms/hr/doctype/training_result_employee/training_result_employee.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:173
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/setup.py:200
+msgid "Grade"
+msgstr "Зэрэг"
+
+#. Name of a DocType
+#. Label of the details_tab (Tab Break) field in DocType 'Gratuity'
+#. Label of the gratuity_details_tab (Section Break) field in DocType
+#. 'Gratuity
+#. Rule'
+#: hrms/payroll/doctype/gratuity/gratuity.json
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule_dashboard.py:7
+msgid "Gratuity"
+msgstr "Өргөдөл"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/gratuity_applicable_component/gratuity_applicable_component.json
+msgid "Gratuity Applicable Component"
+msgstr "Бэлэглэлийн холбогдох бүрэлдэхүүн хэсэг"
+
+#. Label of the gratuity_rule (Link) field in DocType 'Gratuity'
+#. Name of a DocType
+#: hrms/payroll/doctype/gratuity/gratuity.json
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Gratuity Rule"
+msgstr "Тэтгэлгийн дүрэм"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgid "Gratuity Rule Slab"
+msgstr "Бэлэглэлийн дүрмийн хавтан"
+
+#. Label of a Card Break in the Tenure Workspace
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Grievance"
+msgstr "Гомдол"
+
+#. Label of the grievance_against (Dynamic Link) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Grievance Against"
+msgstr "Гомдлын эсрэг"
+
+#. Label of the grievance_against_party (Link) field in DocType 'Employee
+#. Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Grievance Against Party"
+msgstr "Намын эсрэг гомдол"
+
+#. Label of the grievance_details_section (Section Break) field in DocType
+#. 'Employee Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Grievance Details"
+msgstr "Гомдлын дэлгэрэнгүй мэдээлэл"
+
+#. Label of the grievance_type (Link) field in DocType 'Employee Grievance'
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+#: hrms/hr/doctype/grievance_type/grievance_type.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Grievance Type"
+msgstr "Гомдлын төрөл"
+
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.py:630
+#| msgid "Earnings"
+msgid "Gross Earnings"
+msgstr "Орлого"
+
+#. Label of the gross_pay (Currency) field in DocType 'Salary Slip'
+#: frontend/src/components/SalarySlipItem.vue:13
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/report/income_tax_deductions/income_tax_deductions.py:54
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:42
+#: hrms/payroll/report/salary_register/salary_register.py:211
+msgid "Gross Pay"
+msgstr "Нийт цалин"
+
+#. Label of the base_gross_pay (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Gross Pay (Company Currency)"
+msgstr "Нийт цалин (Компанийн валют)"
+
+#. Label of the gross_year_to_date (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Gross Year To Date"
+msgstr "Өнөөдрийг хүртэлх нийт жил"
+
+#. Label of the base_gross_year_to_date (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Gross Year To Date(Company Currency)"
+msgstr "Өнөөдрийг хүртэлх нийт жил (Компанийн мөнгөн тэмдэгт)"
+
+#: hrms/hr/doctype/goal/goal.js:13
+msgid "Group goal's progress is auto-calculated based on the child goals."
+msgstr ""
+"Бүлгийн зорилгын ахиц дэвшлийг хүүхдийн зорилгод үндэслэн автоматаар "
+"тооцдог."
+
+#: hrms/setup.py:322
+msgid "HR"
+msgstr "Хүний нөөц"
+
+#: hrms/setup.py:59
+msgid "HR & Payroll"
+msgstr "Хүний нөөц ба цалин"
+
+#: hrms/setup.py:65
+msgid "HR & Payroll Settings"
+msgstr "Хүний нөөц ба цалингийн тохиргоо"
+
+#. Name of a DocType
+#. Label of a Link in the People Workspace
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/doctype/leave_application/leave_application.py:186
+#: hrms/hr/workspace/people/people.json
+msgid "HR Settings"
+msgstr "Хүний нөөцийн тохиргоо"
+
+#: hrms/config/desktop.py:5
+msgid "HRMS"
+msgstr "HRMS"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#. Label of the half_day (Check) field in DocType 'Attendance Request'
+#. Label of the half_day (Check) field in DocType 'Compensatory Leave Request'
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance
+#. Tool'
+#. Label of the half_day (Check) field in DocType 'Leave Application'
+#: frontend/src/components/AttendanceCalendar.vue:80
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Half Day"
+msgstr "Хагас өдөр"
+
+#. Label of the half_day_date (Date) field in DocType 'Attendance Request'
+#. Label of the half_day_date (Date) field in DocType 'Compensatory Leave
+#. Request'
+#. Label of the half_day_date (Date) field in DocType 'Leave Application'
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Half Day Date"
+msgstr "Хагас өдрийн огноо"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:27
+msgid "Half Day Date is mandatory"
+msgstr "Хагас өдрийн огноо нь заавал байх ёстой"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:208
+msgid "Half Day Date should be between From Date and To Date"
+msgstr "Хагас өдрийн огноо нь огнооноос хойшхи хооронд байх ёстой"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:29
+msgid "Half Day Date should be in between Work From Date and Work End Date"
+msgstr ""
+"Хагас өдрийн огноо нь ажлын өдрөөс хойш, ажил дуусах огнооны хооронд байх "
+"ёстой"
+
+#. Label of the half_day_marked_employee_header (HTML) field in DocType
+#. 'Employee Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Half Day Marked Employee Header"
+msgstr "Хагас өдрөөр тэмдэглэгдсэн ажилтны толгой хэсэг"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:168
+msgid "Half Day Records"
+msgstr "Хагас өдрийн бичлэгүүд"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:31
+msgid "Half day date should be in between from date and to date"
+msgstr "Хагас өдрийн огноо нь өдрөөс хойш өнөөг хүртэл байх ёстой"
+
+#. Label of the has_certificate (Check) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Has Certificate"
+msgstr "Сертификаттай"
+
+#: hrms/setup.py:215
+msgid "Health Insurance"
+msgstr "Эрүүл мэндийн даатгал"
+
+#. Label of the health_insurance_name (Data) field in DocType 'Employee Health
+#. Insurance'
+#: hrms/hr/doctype/employee_health_insurance/employee_health_insurance.json
+msgid "Health Insurance Name"
+msgstr "Эрүүл мэндийн даатгалын нэр"
+
+#: hrms/setup.py:229
+msgid "Health Insurance No"
+msgstr "Эрүүл мэндийн даатгалын дугаар"
+
+#: hrms/setup.py:221
+msgid "Health Insurance Provider"
+msgstr "Эрүүл мэндийн даатгал үзүүлэгч"
+
+#: hrms/controllers/employee_reminders.py:72
+msgid "Hey {}! This email is to remind you about the upcoming holidays."
+msgstr ""
+"Хөөе {}! Энэ имэйл нь удахгүй болох амралтын талаар танд сануулах зорилготой"
+" юм."
+
+#: frontend/src/components/CheckInPanel.vue:4
+msgid "Hey, {0} 👋"
+msgstr "Хөөе, {0} 👋"
+
+#: hrms/hr/dashboard_chart_source/hiring_vs_attrition_count/hiring_vs_attrition_count.py:55
+msgid "Hiring Count"
+msgstr "Ажилд авах Count"
+
+#. Label of the hiring_settings_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Hiring Settings"
+msgstr "Ажилд авах тохиргоо"
+
+#. Name of a DocType
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+#| msgid "Holiday List"
+msgid "Holiday List Assignment"
+msgstr "Амралтын жагсаалт"
+
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.py:33
+#| msgid ""
+#| "Attendance for employee {0} is already marked for the date {1}: {2}"
+msgid "Holiday List Assignment for {0} already exists for date {1}: {2}"
+msgstr "{0} ажилтны ирцийг {1} огноогоор тэмдэглэсэн байна: {2}"
+
+#. Label of the holiday_list_end (Date) field in DocType 'Holiday List
+#. Assignment'
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+#| msgid "Holiday List"
+msgid "Holiday List End"
+msgstr "Амралтын жагсаалт"
+
+#. Label of the holiday_list_start (Date) field in DocType 'Holiday List
+#. Assignment'
+#: hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+#| msgid "Holiday List"
+msgid "Holiday List Start"
+msgstr "Амралтын жагсаалт"
+
+#. Label of the optional_holiday_list (Link) field in DocType 'Leave Period'
+#: hrms/hr/doctype/leave_period/leave_period.json
+msgid "Holiday List for Optional Leave"
+msgstr "Нэмэлт чөлөө авах амралтын жагсаалт"
+
+#. Label of a number card in the Leaves Workspace
+#: hrms/hr/workspace/leaves/leaves.json
+#| msgid "Holidays this Month."
+msgid "Holidays in this month"
+msgstr "Энэ сард амралтын өдрүүд."
+
+#: hrms/controllers/employee_reminders.py:65
+msgid "Holidays this Month."
+msgstr "Энэ сард амралтын өдрүүд."
+
+#: hrms/controllers/employee_reminders.py:65
+msgid "Holidays this Week."
+msgstr "Энэ долоо хоногийн амралтын өдрүүд."
+
+#. Label of the horizontal_break (HTML) field in DocType 'Employee Attendance
+#. Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Horizontal Break"
+msgstr "Хэвтээ тусгаарлагч"
+
+#. Label of the base_hour_rate (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Hour Rate (Company Currency)"
+msgstr "Цагийн ханш (Компанийн валют)"
+
+#. Label of the hourly_rate (Currency) field in DocType 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Hour Rate"
+msgid "Hourly Rate"
+msgstr "Цагийн ханш"
+
+#: hrms/regional/india/utils.py:184
+msgid "House rent paid days overlapping with {0}"
+msgstr "Байрны түрээсийн төлбөртэй өдрүүд {0}-тэй давхцаж байна"
+
+#: hrms/regional/india/utils.py:162
+msgid "House rented dates required for exemption calculation"
+msgstr "Чөлөөлөлтийг тооцоход шаардлагатай байшин түрээслэх хугацаа"
+
+#: hrms/regional/india/utils.py:165
+msgid "House rented dates should be atleast 15 days apart"
+msgstr "Байшин түрээслэх хугацаа нь дор хаяж 15 хоногийн зайтай байх ёстой"
+
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:60
+msgid "IFSC"
+msgstr "IFSC"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:48
+msgid "IFSC Code"
+msgstr "IFSC код"
+
+#. Option for the 'Log Type' (Select) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "IN"
+msgstr "IN"
+
+#. Label of the personal_id_number (Data) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Identification Document Number"
+msgstr "Иргэний үнэмлэхний дугаар"
+
+#. Name of a DocType
+#. Label of the identification_document_type (Data) field in DocType
+#. 'Identification Document Type'
+#. Label of the personal_id_type (Link) field in DocType 'Travel Request'
+#: hrms/hr/doctype/identification_document_type/identification_document_type.json
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Identification Document Type"
+msgstr "Тодорхойлох баримт бичгийн төрөл"
+
+#. Description of the 'Process Payroll Accounting Entry based on Employee'
+#. (Check) field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "If checked, Payroll Payable will be booked against each employee"
+msgstr "Хэрэв шалгасан бол цалингийн өрийг ажилтан тус бүрээр тооцно"
+
+#. Description of the 'Mandatory Benefit Application' (Check) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"If checked, flexible benefits are considered only if benefit application "
+"exists"
+msgstr ""
+"Сонгосон бол зөвхөн уян хатан тэтгэмжийн хүсэлт байгаа тохиолдолд л тэтгэмж "
+"тооцогдоно"
+
+#. Description of the 'Disable Rounded Total' (Check) field in DocType
+#. 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "If checked, hides and disables Rounded Total field in Salary Slips"
+msgstr ""
+"Хэрэв чагтсан бол Цалингийн хуудасны дугуйрсан нийт талбарыг нууж, идэвхгүй "
+"болгоно"
+
+#. Description of the 'Create Overtime Slip For Eligible Employee(s)' (Check)
+#. field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"If checked, overtime slip creation can be handled as part of payroll "
+"processing"
+msgstr ""
+"Сонгосон бол илүү цагийн хуудас үүсгэлтийг цалингийн боловсруулалтын хэсэг "
+"болгон зохицуулж болно"
+
+#. Description of the 'Exempted from Income Tax' (Check) field in DocType
+#. 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If checked, the full amount will be deducted from taxable income before "
+"calculating income tax without any declaration or proof submission."
+msgstr ""
+"Шалгасан тохиолдолд орлогын албан татварыг тооцохоос өмнө ямар нэгэн "
+"мэдүүлэг, нотлох баримтгүйгээр татвар ногдох орлогоос бүрэн хэмжээгээр "
+"хасна."
+
+#. Description of the 'Allow Tax Exemption' (Check) field in DocType 'Income
+#. Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid ""
+"If enabled, Tax Exemption Declaration will be considered for income tax "
+"calculation."
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол орлогын албан татварыг тооцохдоо Татвараас чөлөөлөх "
+"тухай мэдэгдлийг авч үзнэ."
+
+#. Description of the 'Mark Auto Attendance on Holidays' (Check) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"If enabled, auto attendance will be marked on holidays if Employee Checkins "
+"exist"
+msgstr ""
+"Идэвхжүүлсэн бол ажилчдын бүртгэл байгаа тохиолдолд амралтын өдрүүдэд "
+"автомат ирцийг тэмдэглэнэ"
+
+#. Description of the 'Consider Marked Attendance on Holidays' (Check) field
+#. in
+#. DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"If enabled, deducts payment days for absent attendance on holidays. By "
+"default, holidays are considered as paid"
+msgstr ""
+"Идэвхжүүлсэн бол амралтын өдрүүдэд ирц тасалсны төлбөрийн хоногийг хасна. "
+"Анхдагч байдлаар, амралтын өдрүүдийг төлбөртэй гэж үздэг"
+
+#. Description of the 'Do Not Include in Accounting Entries' (Check) field in
+#. DocType 'Salary Component'
+#. Description of the 'Do Not Include in Accounting Entries' (Check) field in
+#. DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid ""
+"If enabled, the amount will be excluded from accounting entries during "
+"Journal Entry creation."
+msgstr ""
+"Идэвхжүүлсэн тохиолдолд журналын бичилт үүсгэх үед нягтлан бодох бүртгэлийн "
+"бичилтэд дүнг оруулахгүй."
+
+#. Description of the 'Variable Based On Taxable Salary' (Check) field in
+#. DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If enabled, the component will be considered as a tax component and the "
+"amount will be auto-calculated as per the configured income tax slabs"
+msgstr ""
+"Идэвхжүүлсэн тохиолдолд уг бүрэлдэхүүн хэсгийг татварын бүрэлдэхүүн хэсэг "
+"гэж үзэх бөгөөд орлогын албан татварын тохируулгын дагуу дүнг автоматаар "
+"тооцох болно."
+
+#. Description of the 'Is Income Tax Component' (Check) field in DocType
+#. 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If enabled, the component will be considered in the Income Tax Deductions "
+"report"
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол бүрэлдэхүүн хэсгийг Орлогын татварын хөнгөлөлтийн "
+"тайланд авч үзэх болно"
+
+#. Description of the 'Remove if Zero Valued' (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If enabled, the component will not be displayed in the salary slip if the "
+"amount is zero"
+msgstr ""
+"Идэвхжүүлсэн бол хэмжээ нь тэг бол цалингийн хуудас дээр бүрэлдэхүүн хэсэг "
+"харагдахгүй"
+
+#. Description of the 'Publish Applications Received' (Check) field in DocType
+#. 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid ""
+"If enabled, the total no. of applications received for this opening will be "
+"displayed on the website"
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол нийт дугаар. Энэ нээлтэд хүлээн авсан өргөдлийн "
+"жагсаалтыг вэбсайт дээр харуулах болно"
+
+#. Description of the 'Statistical Component' (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If enabled, the value specified or calculated in this component will not "
+"contribute to the earnings or deductions. However, it's value can be "
+"referenced by other components that can be added or deducted. "
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол энэ бүрэлдэхүүн хэсэгт заасан эсвэл тооцоолсон утга "
+"нь орлого, суутгалд нэмэр болохгүй. Гэсэн хэдий ч түүний үнэ цэнийг нэмж "
+"эсвэл хасаж болох бусад бүрэлдэхүүн хэсгүүдээс иш татна. "
+
+#. Description of the 'Accrual Component' (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If enabled, this component allows to accrue amounts without adding them to "
+"earnings. The accrued balance is tracked in the Employee Benefit Ledger and "
+"can be paid out later as needed."
+msgstr ""
+"Идэвхжүүлсэн тохиолдолд энэ бүрэлдэхүүн хэсэг нь орлогод нэмэхгүйгээр дүнг "
+"хуримтлуулах боломжийг олгоно. Хуримтлагдсан үлдэгдлийг Ажилтны тэтгэмжийн "
+"бүртгэлд хянаж, шаардлагатай үед дараа нь төлнө."
+
+#. Description of the 'Arrear Component' (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#| msgid ""
+#| "If enabled, the component will be considered in the Income Tax Deductions "
+#| "report"
+msgid "If enabled, this component will be included in arrear calculations"
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол бүрэлдэхүүн хэсгийг Орлогын татварын хөнгөлөлтийн "
+"тайланд авч үзэх болно"
+
+#. Description of the 'Include holidays in Total no. of Working Days' (Check)
+#. field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"If enabled, total no. of working days will include holidays, and this will "
+"reduce the value of Salary Per Day"
+msgstr ""
+"Хэрэв идэвхжүүлсэн бол нийт дугаар. Ажлын өдрүүдэд амралтын өдрүүд багтах "
+"бөгөөд энэ нь өдрийн цалингийн үнэ цэнийг бууруулна"
+
+#. Description of the 'Max Benefit Amount (Yearly)' (Currency) field in
+#. DocType
+#. 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid ""
+"If greater than zero, this sets the maximum benefit amount assignable to any"
+" employee"
+msgstr ""
+"Тэгээс их бол ямар нэгэн ажилтанд хуваарилах дээд тэтгэмжийн дүнг тогтооно"
+
+#. Description of the 'Applies to Company' (Check) field in DocType 'Leave
+#. Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid ""
+"If not checked, the list will have to be added to each Department where it "
+"has to be applied."
+msgstr ""
+"Хэрэв шалгаагүй бол уг жагсаалтыг хэрэглэх хэлтэс бүрт нэмэх шаардлагатай."
+
+#. Description of the 'Statistical Component' (Check) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid ""
+"If selected, the value specified or calculated in this component will not "
+"contribute to the earnings or deductions. However, it's value can be "
+"referenced by other components that can be added or deducted. "
+msgstr ""
+"Сонгосон тохиолдолд энэ бүрэлдэхүүн хэсэгт заасан эсвэл тооцсон утга нь "
+"орлого, суутгалд нэмэр болохгүй. Гэсэн хэдий ч түүний үнэ цэнийг нэмж эсвэл "
+"хасаж болох бусад бүрэлдэхүүн хэсгүүдээс лавлаж болно. "
+
+#. Description of the 'Closes On' (Date) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "If set, the job opening will be closed automatically after this date"
+msgstr ""
+"Хэрэв тохируулсан бол энэ өдрөөс хойш нээлттэй ажлын байр автоматаар хаагдах"
+" болно"
+
+#: hrms/patches/v15_0/notify_about_loan_app_separation.py:17
+msgid ""
+"If you are using loans in salary slips, please install the {0} app from "
+"Frappe Cloud Marketplace or GitHub to continue using loan integration with "
+"payroll."
+msgstr ""
+"Хэрэв та цалингийн хуудаст зээл ашиглаж байгаа бол Frappe Cloud Marketplace "
+"эсвэл GitHub-аас {0} програмыг суулгаж, цалинтай зээлийн интеграцчлалыг "
+"үргэлжлүүлэн ашиглана уу."
+
+#. Label of the upload_attendance_data (Section Break) field in DocType
+#. 'Upload
+#. Attendance'
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+msgid "Import Attendance"
+msgstr "Импортын ирц"
+
+#. Label of the in_time (Datetime) field in DocType 'Attendance'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/report/shift_attendance/shift_attendance.py:67
+msgid "In Time"
+msgstr "Цаг хугацаанд"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:143
+msgid ""
+"In case of any error during this background process, the system will add a "
+"comment about the error on this Payroll Entry and revert to the Submitted "
+"status"
+msgstr ""
+"Энэхүү суурь процессын явцад ямар нэгэн алдаа гарсан тохиолдолд систем нь "
+"энэхүү Цалингийн бүртгэл дээрх алдааны талаар тайлбар нэмж, Илгээсэн төлөв "
+"рүү буцах болно."
+
+#. Label of the incentive_section (Section Break) field in DocType 'Employee
+#. Incentive'
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.json
+msgid "Incentive"
+msgstr "Урамшуулал"
+
+#. Label of the incentive_amount (Currency) field in DocType 'Employee
+#. Incentive'
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.json
+msgid "Incentive Amount"
+msgstr "Урамшууллын хэмжээ"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:102
+msgid "Include Company Descendants"
+msgstr "Компанийн үр удамыг оруул"
+
+#. Label of the include_holidays (Check) field in DocType 'Attendance Request'
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+msgid "Include Holidays"
+msgstr "Баярын өдрүүд орно"
+
+#. Label of the include_holidays_in_total_working_days (Check) field in
+#. DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Include holidays in Total no. of Working Days"
+msgstr "Амралтын өдрүүдийг нийт тоонд оруулна. Ажлын өдрүүдийн тухай"
+
+#. Label of the include_holiday (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Include holidays within leaves as leaves"
+msgstr "Навч доторх амралтын өдрүүдийг навч болгон оруулаарай"
+
+#. Label of the income_source_details_section (Section Break) field in DocType
+#. 'Employee Other Income'
+#: hrms/payroll/doctype/employee_other_income/employee_other_income.json
+msgid "Income Source"
+msgstr "Орлогын эх үүсвэр"
+
+#: hrms/payroll/report/income_tax_deductions/income_tax_deductions.py:47
+msgid "Income Tax Amount"
+msgstr "Орлогын татварын хэмжээ"
+
+#. Label of the income_tax_calculation_breakup_section (Tab Break) field in
+#. DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Income Tax Breakup"
+msgstr "Орлогын татварын хуваагдал"
+
+#: hrms/payroll/report/income_tax_deductions/income_tax_deductions.py:45
+msgid "Income Tax Component"
+msgstr "Орлогын татварын бүрэлдэхүүн хэсэг"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.json
+#: hrms/payroll/workspace/payroll/payroll.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Income Tax Computation"
+msgstr "Орлогын татварын тооцоо"
+
+#. Label of the income_tax_deducted_till_date (Currency) field in DocType
+#. 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Income Tax Deducted Till Date"
+msgstr "Орлогын албан татварыг өдөр хүртэл хассан"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/report/income_tax_deductions/income_tax_deductions.json
+#: hrms/payroll/workspace/payroll/payroll.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Income Tax Deductions"
+msgstr "Орлогын албан татварын хөнгөлөлт"
+
+#. Label of the income_tax_slab (Link) field in DocType 'Bulk Salary Structure
+#. Assignment'
+#. Name of a DocType
+#. Label of the income_tax_slab (Link) field in DocType 'Salary Structure
+#. Assignment'
+#. Label of a Link in the Payroll Workspace
+#. Label of a Link in the Tax & Benefits Workspace
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:142
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.py:623
+#: hrms/payroll/workspace/payroll/payroll.json
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Income Tax Slab"
+msgstr "Орлогын татварын хавтан"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgid "Income Tax Slab Other Charges"
+msgstr "Орлогын татварын хавтан Бусад хураамж"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:79
+msgid ""
+"Income Tax Slab is mandatory since the Salary Structure {0} has a tax "
+"component {1}"
+msgstr ""
+"Цалингийн бүтэц {0} нь татварын бүрэлдэхүүн хэсэгтэй {1} тул Орлогын "
+"татварын хавтан заавал байх ёстой."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1874
+msgid ""
+"Income Tax Slab must be effective on or before Payroll Period Start Date: "
+"{0}"
+msgstr ""
+"Орлогын татварын хавтан нь Цалингийн хугацаа эхлэх өдөр эсвэл түүнээс өмнө "
+"хүчинтэй байх ёстой: {0}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1862
+msgid "Income Tax Slab not set in Salary Structure Assignment: {0}"
+msgstr ""
+"Орлогын татварын хавтанг Цалингийн бүтцийн хуваарилалтад тохируулаагүй: {0}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1870
+msgid "Income Tax Slab: {0} is disabled"
+msgstr "Орлогын татварын хавтан: {0} идэвхгүй болсон"
+
+#. Label of the income_from_other_sources (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Income from Other Sources"
+msgstr "Бусад эх үүсвэрээс олох орлого"
+
+#: hrms/hr/doctype/appraisal/appraisal.py:159 hrms/mixins/appraisal.py:20
+msgid "Incorrect Weightage Allocation"
+msgstr "Жингийн буруу хуваарилалт"
+
+#. Description of the 'Non-Encashable Leaves' (Int) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid ""
+"Indicates the number of leaves that cannot be encashed from the leave "
+"balance. E.g. with a leave balance of 10 and 4 Non-Encashable Leaves, you "
+"can encash 6, while the remaining 4 can be carried forward or expired"
+msgstr ""
+"Амралтын үлдэгдэлээс мөнгө авах боломжгүй навчны тоог заана. Жишээ нь: "
+"Үлдэгдэл 10 ба мөнгөн бус 4 навчтай бол та 6 навчийг мөнгөжүүлэх боломжтой "
+"бол үлдсэн 4 навчийг шилжүүлж эсвэл хугацаа нь дууссан байж болно."
+
+#. Option for the 'Type' (Select) field in DocType 'Vehicle Service'
+#: hrms/hr/doctype/vehicle_service/vehicle_service.json
+msgid "Inspection"
+msgstr "Хяналт шалгалт"
+
+#: frontend/src/components/InstallPrompt.vue:13
+msgid "Install"
+msgstr "Суулгах"
+
+#: frontend/src/components/InstallPrompt.vue:5
+#: frontend/src/components/InstallPrompt.vue:28
+msgid "Install Frappe HR"
+msgstr "Frappe HR-г суулгана уу"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:465
+msgid "Insufficient Balance"
+msgstr "Үлдэгдэл хангалтгүй"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:463
+msgid "Insufficient leave balance for Leave Type {0}"
+msgstr "Амралтын төрөл {0}-д үлдээх үлдэгдэл хангалтгүй байна"
+
+#. Label of the interest_amount (Currency) field in DocType 'Salary Slip Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Interest Amount"
+msgstr "Хүүгийн хэмжээ"
+
+#. Label of the interest_income_account (Link) field in DocType 'Salary Slip
+#. Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Interest Income Account"
+msgstr "Хүүгийн орлогын данс"
+
+#: hrms/setup.py:395
+msgid "Intern"
+msgstr "Дадлагажигч"
+
+#. Option for the 'Travel Type' (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "International"
+msgstr "Олон улсын"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Internet"
+msgstr "Интернет"
+
+#. Name of a DocType
+#. Label of the interview (Link) field in DocType 'Interview Feedback'
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/job_applicant/job_applicant.js:25
+#: hrms/hr/doctype/job_applicant/job_applicant_dashboard.html:7
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Interview"
+msgstr "Ярилцлага"
+
+#. Name of a DocType
+#: hrms/hr/doctype/interview_detail/interview_detail.json
+msgid "Interview Detail"
+msgstr "Ярилцлагын дэлгэрэнгүй"
+
+#. Label of the interview_summary_section (Section Break) field in DocType
+#. 'Exit Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+msgid "Interview Details"
+msgstr "Ярилцлагын дэлгэрэнгүй мэдээлэл"
+
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.py:40
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Interview Feedback"
+msgstr "Ярилцлагын санал хүсэлт"
+
+#: hrms/hr/doctype/interview/test_interview.py:312
+#: hrms/hr/doctype/interview/test_interview.py:321
+#: hrms/hr/doctype/interview/test_interview.py:323
+#: hrms/hr/doctype/interview/test_interview.py:330 hrms/setup.py:467
+#: hrms/setup.py:469 hrms/setup.py:502
+msgid "Interview Feedback Reminder"
+msgstr "Ярилцлагын санал хүсэлтийн сануулга"
+
+#: hrms/hr/doctype/interview/interview.py:343
+msgid "Interview Feedback {0} submitted successfully"
+msgstr "Ярилцлагын санал хүсэлтийг {0} амжилттай илгээсэн"
+
+#: hrms/hr/doctype/interview/interview.py:87
+msgid "Interview Not Rescheduled"
+msgstr "Ярилцлагыг дахин товлоогүй"
+
+#: hrms/hr/doctype/interview/test_interview.py:296
+#: hrms/hr/doctype/interview/test_interview.py:305
+#: hrms/hr/doctype/interview/test_interview.py:307
+#: hrms/hr/doctype/interview/test_interview.py:329 hrms/setup.py:455
+#: hrms/setup.py:457 hrms/setup.py:498
+msgid "Interview Reminder"
+msgstr "Ярилцлагын сануулга"
+
+#. Label of the interview_reminder_template (Link) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Interview Reminder Notification Template"
+msgstr "Ярилцлагын сануулагчийн мэдэгдлийн загвар"
+
+#: hrms/hr/doctype/interview/interview.py:122
+msgid "Interview Rescheduled successfully"
+msgstr "Ярилцлагыг амжилттай дахин товлосон"
+
+#. Label of the interview_round (Link) field in DocType 'Interview'
+#. Label of the interview_round (Link) field in DocType 'Interview Feedback'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/interview_round/interview_round.json
+#: hrms/hr/doctype/job_applicant/job_applicant_dashboard.html:8
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Interview Round"
+msgstr "Ярилцлагын тойрог"
+
+#: hrms/hr/doctype/job_applicant/job_applicant.py:72
+msgid "Interview Round {0} is only applicable for the Designation {1}"
+msgstr "Ярилцлагын {0}-р шат нь зөвхөн {1}-д зориулагдсан."
+
+#: hrms/hr/doctype/interview/interview.py:52
+msgid ""
+"Interview Round {0} is only for Designation {1}. Job Applicant has applied "
+"for the role {2}"
+msgstr ""
+"Ярилцлагын {0} шат нь зөвхөн {1}-д зориулагдсан. Ажил горилогч {2} албан "
+"тушаалд ажиллах хүсэлт гаргасан"
+
+#: hrms/hr/doctype/interview_feedback/interview_feedback.py:40
+msgid "Interview Scheduled Date"
+msgstr "Ярилцлагын товлогдсон өдөр"
+
+#: hrms/hr/report/employee_exits/employee_exits.js:51
+#: hrms/hr/report/employee_exits/employee_exits.py:46
+msgid "Interview Status"
+msgstr "Ярилцлагын статус"
+
+#. Label of the interview_summary (Text Editor) field in DocType 'Exit
+#. Interview'
+#. Label of the section_break_13 (Section Break) field in DocType 'Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/job_applicant/job_applicant.js:77
+msgid "Interview Summary"
+msgstr "Ярилцлагын хураангуй"
+
+#. Label of the interview_type (Link) field in DocType 'Interview Round'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/interview_round/interview_round.json
+#: hrms/hr/doctype/interview_type/interview_type.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Interview Type"
+msgstr "Ярилцлагын төрөл"
+
+#: hrms/hr/doctype/interview/interview.py:103
+msgid "Interview: {0} Rescheduled"
+msgstr "Ярилцлага: {0} Төлөвлөсөн"
+
+#. Name of a role
+#. Label of the interviewer (Link) field in DocType 'Interview Detail'
+#. Label of the interviewer (Link) field in DocType 'Interview Feedback'
+#. Name of a DocType
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_detail/interview_detail.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/interview_round/interview_round.json
+#: hrms/hr/doctype/interviewer/interviewer.json
+msgid "Interviewer"
+msgstr "Ярилцагч"
+
+#. Label of the interviewers (Table MultiSelect) field in DocType 'Exit
+#. Interview'
+#. Label of the interview_details (Table) field in DocType 'Interview'
+#. Label of the interviewers (Table MultiSelect) field in DocType 'Interview
+#. Round'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_round/interview_round.json
+msgid "Interviewers"
+msgstr "Ярилцлага авагчид"
+
+#. Label of a Card Break in the Recruitment Workspace
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Interviews"
+msgstr "Ярилцлага"
+
+#. Label of a quick_list in the Recruitment Workspace
+#: hrms/hr/workspace/recruitment/recruitment.json
+#| msgid "Interview Type"
+msgid "Interviews (This Week)"
+msgstr "Ярилцлагын төрөл"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:67
+#: hrms/payroll/doctype/salary_component/salary_component.py:81
+#: hrms/payroll/doctype/salary_component/salary_component.py:89
+#| msgid "Statistical Component"
+msgid "Invalid Accrual Component"
+msgstr "Статистикийн бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:216
+msgid "Invalid Additional Salary"
+msgstr "Хүчингүй нэмэлт цалин"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:96
+#| msgid "Salary Component"
+msgid "Invalid Arrear Component"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:467
+#| msgid "Max Benefit Amount"
+msgid "Invalid Benefit Amounts"
+msgstr "Тэтгэмжийн дээд хэмжээ"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:326
+msgid "Invalid Dates"
+msgstr "Хүчингүй огноо"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2651
+#| msgid "Invalid Dates"
+msgid "Invalid LWP Days Reversed"
+msgstr "Хүчингүй огноо"
+
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py:25
+#| msgid "Leave Ledger Entry"
+msgid "Invalid Leave Ledger Entry"
+msgstr "Бүртгэлийн бүртгэлийг орхи"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:294
+msgid ""
+"Invalid Payroll Payable Account. The account currency must be {0} or {1}"
+msgstr ""
+"Цалингийн өглөгийн данс буруу байна. Дансны валют нь {0} эсвэл {1} байх "
+"ёстой"
+
+#: hrms/hr/doctype/shift_type/shift_type.py:49
+#: hrms/hr/doctype/shift_type/shift_type.py:58
+#| msgid "Invalid Dates"
+msgid "Invalid Shift Times"
+msgstr "Хүчингүй огноо"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:926
+msgid "Invalid parameters provided. Please pass the required arguments."
+msgstr "Буруу параметр өгөгдсөн. Шаардлагатай аргументуудыг дамжуулна уу."
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Investigated"
+msgstr "Шалгасан"
+
+#. Label of the investigation_details_section (Section Break) field in DocType
+#. 'Employee Grievance'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+msgid "Investigation Details"
+msgstr "Мөрдөн байцаалтын дэлгэрэнгүй мэдээлэл"
+
+#. Option for the 'Status' (Select) field in DocType 'Training Event Employee'
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+msgid "Invited"
+msgstr "Урьсан"
+
+#. Label of the invoice (Data) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Invoice Ref"
+msgstr "Нэхэмжлэхийн лавлагаа"
+
+#. Label of the is_allocated (Check) field in DocType 'Earned Leave Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Assets Allocated"
+msgid "Is Allocated"
+msgstr "Хуваарилагдсан хөрөнгө"
+
+#. Label of the is_applicable_for_referral_bonus (Check) field in DocType
+#. 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Is Applicable for Referral Bonus"
+msgstr "Лавлагааны урамшуулалд хамаарна"
+
+#. Label of the is_carry_forward (Check) field in DocType 'Leave Ledger Entry'
+#. Label of the is_carry_forward (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/doctype/leave_type/leave_type.json
+#: hrms/hr/report/leave_ledger/leave_ledger.py:85
+msgid "Is Carry Forward"
+msgstr "Урагшаа урагшлуулах"
+
+#. Label of the is_compensatory (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Is Compensatory"
+msgstr "Нөхөн олговортой"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:41
+msgid "Is Compensatory Leave"
+msgstr "Нөхөн олговрын амралт"
+
+#. Label of the is_earned_leave (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+#: hrms/hr/doctype/leave_type/leave_type.py:41
+msgid "Is Earned Leave"
+msgstr "Чөлөө авсан"
+
+#. Label of the is_expired (Check) field in DocType 'Leave Ledger Entry'
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/report/leave_ledger/leave_ledger.py:91
+msgid "Is Expired"
+msgstr "Хугацаа дууссан"
+
+#. Label of the is_flexible_benefit (Check) field in DocType 'Salary
+#. Component'
+#. Label of the is_flexible_benefit (Check) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Is Flexible Benefit"
+msgstr "Уян хатан ашиг тустай"
+
+#. Label of the is_income_tax_component (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Is Income Tax Component"
+msgstr "Орлогын татварын бүрэлдэхүүн хэсэг юм"
+
+#. Label of the is_lwp (Check) field in DocType 'Leave Ledger Entry'
+#. Label of the is_lwp (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/doctype/leave_type/leave_type.json
+#: hrms/hr/report/leave_ledger/leave_ledger.py:97
+msgid "Is Leave Without Pay"
+msgstr "Цалингүй чөлөө"
+
+#. Label of the is_optional_leave (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Is Optional Leave"
+msgstr "Нэмэлт чөлөө"
+
+#. Label of the is_ppl (Check) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Is Partially Paid Leave"
+msgstr "Хэсэгчилсэн цалинтай чөлөө"
+
+#. Label of the is_recurring (Check) field in DocType 'Additional Salary'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+msgid "Is Recurring"
+msgstr "Дахин давтагдаж байна"
+
+#. Label of the is_recurring_additional_salary (Check) field in DocType
+#. 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Is Recurring Additional Salary"
+msgstr "Тогтмол нэмэгдэл цалинтай"
+
+#. Label of the is_salary_released (Check) field in DocType 'Salary
+#. Withholding
+#. Cycle'
+#: hrms/payroll/doctype/salary_withholding_cycle/salary_withholding_cycle.json
+msgid "Is Salary Released"
+msgstr "Цалин чөлөөлөгдсөн үү"
+
+#. Label of the is_salary_withheld (Check) field in DocType 'Payroll Employee
+#. Detail'
+#: hrms/payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgid "Is Salary Withheld"
+msgstr "Цалин суутгасан уу"
+
+#. Label of the is_tax_applicable (Check) field in DocType 'Salary Component'
+#. Label of the is_tax_applicable (Check) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Is Tax Applicable"
+msgstr "Татвар хэрэглэх боломжтой"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:36
+#: hrms/public/js/salary_slip_deductions_report_filters.js:19
+msgid "Jan"
+msgstr "1-р сар"
+
+#. Label of the job_applicant (Link) field in DocType 'Appointment Letter'
+#. Label of the job_applicant (Link) field in DocType 'Employee Onboarding'
+#. Label of the job_applicant (Link) field in DocType 'Interview'
+#. Label of the job_applicant (Link) field in DocType 'Interview Feedback'
+#. Name of a DocType
+#. Label of the job_applicant (Link) field in DocType 'Job Offer'
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/appointment_letter/appointment_letter.json
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_offer/job_offer.json
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:38
+#: hrms/hr/workspace/recruitment/recruitment.json hrms/setup.py:193
+msgid "Job Applicant"
+msgstr "Ажил горилогч"
+
+#. Name of a DocType
+#: hrms/hr/doctype/job_applicant_source/job_applicant_source.json
+msgid "Job Applicant Source"
+msgstr "Ажил горилогчийн эх сурвалж"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.py:70
+msgid "Job Applicant {0} created successfully."
+msgstr "Ажил горилогч {0} амжилттай үүсгэгдсэн."
+
+#: hrms/hr/doctype/interview/interview.py:39
+msgid ""
+"Job Applicants are not allowed to appear twice for the same Interview round."
+" Interview {0} already scheduled for Job Applicant {1}"
+msgstr ""
+"Ажил горилогчид нэг ярилцлагад хоёр удаа оролцох эрхгүй. Ажил горилогч {1}-д"
+" аль хэдийн товлосон {0} ярилцлага"
+
+#. Title of the job-application Web Form
+#: hrms/hr/web_form/job_application/job_application.json
+#| msgid "Job Applicant"
+msgid "Job Application"
+msgstr "Ажил горилогч"
+
+#. Label of the job_application_route (Data) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Job Application Route"
+msgstr "Ажилд орох өргөдөл гаргах зам"
+
+#. Label of the job_description_tab (Tab Break) field in DocType 'Job
+#. Requisition'
+#. Label of the description (Text Editor) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json hrms/setup.py:410
+msgid "Job Description"
+msgstr "Ажлын байрны тодорхойлолт"
+
+#. Label of the job_offer (Link) field in DocType 'Employee Onboarding'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/job_applicant/job_applicant.js:38
+#: hrms/hr/doctype/job_applicant/job_applicant.js:48
+#: hrms/hr/doctype/job_offer/job_offer.json
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:52
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Job Offer"
+msgstr "Ажлын санал"
+
+#. Name of a DocType
+#: hrms/hr/doctype/job_offer_term/job_offer_term.json
+msgid "Job Offer Term"
+msgstr "Ажлын санал болгох хугацаа"
+
+#. Label of the job_offer_term_template (Link) field in DocType 'Job Offer'
+#. Name of a DocType
+#: hrms/hr/doctype/job_offer/job_offer.json
+#: hrms/hr/doctype/job_offer_term_template/job_offer_term_template.json
+msgid "Job Offer Term Template"
+msgstr "Ажлын саналын хугацааны загвар"
+
+#. Label of the offer_terms (Table) field in DocType 'Job Offer'
+#: hrms/hr/doctype/job_offer/job_offer.json
+msgid "Job Offer Terms"
+msgstr "Ажлын санал болгох нөхцөл"
+
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:61
+msgid "Job Offer status"
+msgstr "Ажлын саналын статус"
+
+#: hrms/hr/doctype/job_offer/job_offer.py:24
+msgid "Job Offer: {0} is already for Job Applicant: {1}"
+msgstr "Ажлын санал: {0} ажил горилогчид аль хэдийн байна: {1}"
+
+#. Label of the job_opening (Link) field in DocType 'Interview'
+#. Label of the job_title (Link) field in DocType 'Job Applicant'
+#. Name of a DocType
+#. Label of a field in the job-application Web Form
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/interview/interview.json
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/job_requisition/job_requisition.js:54
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:31
+#: hrms/hr/web_form/job_application/job_application.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Job Opening"
+msgstr "Ажлын байрны нээлт"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.py:51
+msgid "Job Opening Associated"
+msgstr "Ажлын байр нээх холбоотой"
+
+#. Label of the job_opening_template (Link) field in DocType 'Job Opening'
+#. Name of a DocType
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/job_opening_template/job_opening_template.json
+#| msgid "Job Opening Associated"
+msgid "Job Opening Template"
+msgstr "Ажлын байр нээх холбоотой"
+
+#: hrms/www/jobs/index.html:2 hrms/www/jobs/index.html:5
+msgid "Job Openings"
+msgstr "Ажлын байрны нээлтүүд"
+
+#: hrms/hr/doctype/job_opening/job_opening.py:83
+msgid ""
+"Job Openings for the designation {0} are already open or the hiring is "
+"complete as per the Staffing Plan {1}"
+msgstr ""
+"Ажилтнуудын төлөвлөгөөний {1} дагуу {0} ажлын байрны нээлтүүд аль хэдийн "
+"нээгдсэн эсвэл ажилд авах ажил дууссан байна."
+
+#. Label of the job_requisition (Link) field in DocType 'Job Opening'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Job Requisition"
+msgstr "Ажлын байрны захиалга"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.py:48
+msgid "Job Requisition {0} has been associated with Job Opening {1}"
+msgstr "Ажлын байрны хүсэлт {0} нь ажлын байрны нээлттэй {1} холбоотой байна"
+
+#. Description of the 'Description' (Text Editor) field in DocType 'Job
+#. Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Job profile, qualifications required etc."
+msgstr "Ажлын профайл, шаардагдах ур чадвар гэх мэт."
+
+#. Label of a Card Break in the Recruitment Workspace
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Jobs"
+msgstr "Ажлын байр"
+
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#. Option for the 'Assignment based on' (Select) field in DocType 'Leave
+#. Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Joining Date"
+msgstr "Нэгдсэн огноо"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:42
+#: hrms/public/js/salary_slip_deductions_report_filters.js:25
+msgid "July"
+msgstr "долдугаар сар"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:41
+#: hrms/public/js/salary_slip_deductions_report_filters.js:24
+msgid "June"
+msgstr "Зургадугаар сар"
+
+#. Label of the kra (Link) field in DocType 'Appraisal KRA'
+#. Label of the key_result_area (Link) field in DocType 'Appraisal Template
+#. Goal'
+#. Label of the kra (Link) field in DocType 'Goal'
+#. Name of a DocType
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+#: hrms/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+#: hrms/hr/doctype/goal/goal.json hrms/hr/doctype/goal/goal_tree.js:134
+#: hrms/hr/doctype/kra/kra.json
+msgid "KRA"
+msgstr "KRA"
+
+#. Label of the kra_evaluation_method (Select) field in DocType 'Appraisal
+#. Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "KRA Evaluation Method"
+msgstr "KRA үнэлгээний арга"
+
+#: hrms/hr/doctype/goal/goal.py:99
+msgid "KRA updated for all child goals."
+msgstr "KRA бүх хүүхдийн зорилгод шинэчлэгдсэн."
+
+#. Label of the appraisal_kra (Table) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "KRA vs Goals"
+msgstr "KRA vs Goals"
+
+#. Label of the kra_tab (Tab Break) field in DocType 'Appraisal'
+#. Label of the goals (Table) field in DocType 'Appraisal Template'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/appraisal/appraisal.py:145
+#: hrms/hr/doctype/appraisal_template/appraisal_template.json
+msgid "KRAs"
+msgstr "KRAs"
+
+#. Description of the 'KRA' (Link) field in DocType 'Appraisal KRA'
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+msgid "Key Performance Area"
+msgstr "Гүйцэтгэлийн гол талбар"
+
+#. Description of the 'Goal' (Small Text) field in DocType 'Appraisal Goal'
+#: hrms/hr/doctype/appraisal_goal/appraisal_goal.json
+msgid "Key Responsibility Area"
+msgstr "Хариуцлагын гол хэсэг"
+
+#. Description of the 'KRA' (Link) field in DocType 'Appraisal Template Goal'
+#: hrms/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+msgid "Key Result Area"
+msgstr "Үр дүнгийн гол хэсэг"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2648
+msgid ""
+"LWP Days Reversed ({0}) does not match actual Payroll Corrections total "
+"({1}) for employee {2} from {3} to {4}"
+msgstr ""
+"ЦЧ буцаалтын өдрүүд ({0}) нь {4} хүртэлх {3}-с {2} ажилтны бодит цалингийн "
+"залруулгын нийт дүн ({1})-тэй таарахгүй байна"
+
+#. Option for the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Last Day"
+msgstr "Сүүлийн өдөр"
+
+#. Description of the 'Last Sync of Checkin' (Datetime) field in DocType
+#. 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"Last Known Successful Sync of Employee Checkin. Reset this only if you are "
+"sure that all Logs are synced from all the locations. Please don't modify "
+"this if you are unsure."
+msgstr ""
+"Ажилтны бүртгэлийн хамгийн сүүлд мэдэгдэж байгаа амжилттай синк. Хэрэв та "
+"бүх бүртгэлийг бүх байршлаас синк хийсэн гэдэгт итгэлтэй байгаа бол үүнийг "
+"дахин тохируулна уу. Хэрэв та эргэлзэж байвал үүнийг бүү өөрчил."
+
+#. Label of the last_odometer (Int) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Last Odometer Value "
+msgstr "Сүүлийн зай хэмжигч утга "
+
+#. Label of the last_sync_of_checkin (Datetime) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Last Sync of Checkin"
+msgstr "Бүртгэлийн сүүлчийн синк"
+
+#: frontend/src/components/CheckInPanel.vue:9
+msgid "Last {0} was at {1}"
+msgstr "Сүүлийн {0} {1}-д байсан"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:180
+msgid "Late Entries"
+msgstr "Оруулсан хоцрогдол"
+
+#. Label of the late_entry (Check) field in DocType 'Attendance'
+#. Label of the late_entry (Check) field in DocType 'Employee Attendance Tool'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/report/shift_attendance/shift_attendance.js:48
+msgid "Late Entry"
+msgstr "Орох хоцрогдол"
+
+#. Label of the grace_period_settings_auto_attendance_section (Section Break)
+#. field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Late Entry & Early Exit Settings for Auto Attendance"
+msgstr "Автомат ирцэнд хоцорсон орох, эрт гарах тохиргоо"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:85
+msgid "Late Entry By"
+msgstr "Хожуу нэвтэрсэн"
+
+#. Label of the late_entry_grace_period (Int) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Late Entry Grace Period"
+msgstr "Хожуу нэвтрэх хөнгөлөлтийн хугацаа"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:101
+msgid "Latitude and longitude values are required for checking in."
+msgstr "Бүртгүүлэхийн тулд өргөрөг болон уртрагын утгууд шаардлагатай."
+
+#: frontend/src/components/CheckInPanel.vue:131
+msgid "Latitude: {0}°"
+msgstr "Өргөрөг: {0}°"
+
+#. Option for the 'Calculate Payroll Working Days Based On' (Select) field in
+#. DocType 'Payroll Settings'
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:734
+#: hrms/overrides/dashboard_overrides.py:12
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Leave"
+msgstr "Орхих"
+
+#. Name of a DocType
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Leave Encashment"
+msgid "Leave Adjustment"
+msgstr "Бэлэн мөнгө үлдээх"
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.py:41
+msgid ""
+"Leave Adjustment for this allocation already exists: {0}. Please amend "
+"existing adjustment."
+msgstr ""
+"Энэ хуваарилалтад чөлөөний залруулга аль хэдийн байна: {0}. Одоогийн "
+"залруулгыг засварлана уу."
+
+#. Label of the leave_allocation (Link) field in DocType 'Compensatory Leave
+#. Request'
+#. Name of a DocType
+#. Label of the leave_allocation (Link) field in DocType 'Leave Encashment'
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Allocation"
+msgstr "Хуваарилалтаас гарах"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:68
+#| msgid "Leave Allocations"
+msgid "Leave Allocation Exists"
+msgstr "Хуваарилалтаа орхи"
+
+#. Label of the leave_allocations_section (Section Break) field in DocType
+#. 'Leave Policy'
+#: hrms/hr/doctype/leave_policy/leave_policy.json
+msgid "Leave Allocations"
+msgstr "Хуваарилалтаа орхи"
+
+#. Label of the leave_application (Link) field in DocType 'Attendance'
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/leave_application/leave_application.json
+#: hrms/hr/workspace/leaves/leaves.json hrms/hr/workspace/people/people.json
+msgid "Leave Application"
+msgstr "Өргөдөл гаргах"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:787
+msgid ""
+"Leave Application period cannot be across two non-consecutive leave "
+"allocations {0} and {1}."
+msgstr ""
+"Амралт авах хүсэлтийн хугацаа нь дараалсан бус хоёр амралтын хуваарилалт {0}"
+" болон {1} байж болохгүй."
+
+#: hrms/setup.py:432 hrms/setup.py:434 hrms/setup.py:494
+msgid "Leave Approval Notification"
+msgstr "Зөвшөөрлийн мэдэгдлийг үлдээх"
+
+#. Label of the leave_approval_notification_template (Link) field in DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Leave Approval Notification Template"
+msgstr "Зөвшөөрлийн мэдэгдлийн загварыг үлдээнэ үү"
+
+#. Label of the leave_approver (Link) field in DocType 'Leave Application'
+#. Name of a role
+#: hrms/hr/doctype/leave_application/leave_application.json
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json hrms/setup.py:146
+#: hrms/setup.py:248
+msgid "Leave Approver"
+msgstr "Зөвшөөрөгчийг орхи"
+
+#. Label of the leave_approver_mandatory_in_leave_application (Check) field in
+#. DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Leave Approver Mandatory In Leave Application"
+msgstr "Өргөдөл гаргахдаа зөвшөөрөл авагчийг заавал үлдээх хэрэгтэй"
+
+#. Label of the leave_approver_name (Data) field in DocType 'Leave
+#. Application'
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Leave Approver Name"
+msgstr "Зөвшөөрөгчийн нэрийг үлдээнэ үү"
+
+#. Label of the leave_balance (Float) field in DocType 'Leave Encashment'
+#: frontend/src/components/LeaveBalance.vue:4
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+msgid "Leave Balance"
+msgstr "Үлдэгдэл үлдээх"
+
+#. Label of the leave_balance (Float) field in DocType 'Leave Application'
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Leave Balance Before Application"
+msgstr "Өргөдөл гаргахын өмнө үлдэгдэлээ үлдээнэ үү"
+
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+#: hrms/hr/workspace/leaves/leaves.json hrms/setup.py:125
+msgid "Leave Block List"
+msgstr "Блокийн жагсаалтыг орхи"
+
+#. Name of a DocType
+#: hrms/hr/doctype/leave_block_list_allow/leave_block_list_allow.json
+msgid "Leave Block List Allow"
+msgstr "Блокийн жагсаалтаас гарахыг зөвшөөрөх"
+
+#. Label of the leave_block_list_allowed (Table) field in DocType 'Leave Block
+#. List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Leave Block List Allowed"
+msgstr "Блокийн жагсаалтаас гарахыг зөвшөөрсөн"
+
+#. Name of a DocType
+#: hrms/hr/doctype/leave_block_list_date/leave_block_list_date.json
+msgid "Leave Block List Date"
+msgstr "Блокийн жагсаалтаас гарах огноо"
+
+#. Label of the leave_block_list_dates (Table) field in DocType 'Leave Block
+#. List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Leave Block List Dates"
+msgstr "Блоклох огноог орхи"
+
+#. Label of the leave_block_list_name (Data) field in DocType 'Leave Block
+#. List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Leave Block List Name"
+msgstr "Блок жагсаалтын нэрийг үлдээнэ үү"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:1388
+msgid "Leave Blocked"
+msgstr "Блоклосон орхи"
+
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Control Panel"
+msgstr "Хяналтын самбараас гарна уу"
+
+#. Label of the leave_details (Table) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Leave Details"
+msgstr "Дэлгэрэнгүй мэдээллийг үлдээнэ үү"
+
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Encashment"
+msgstr "Бэлэн мөнгө үлдээх"
+
+#. Label of the leave_encashment_amount_per_day (Currency) field in DocType
+#. 'Salary Structure'
+#. Label of the leave_encashment_amount_per_day (Currency) field in DocType
+#. 'Salary Structure Assignment'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Leave Encashment Amount Per Day"
+msgstr "Өдөрт бэлэн мөнгөний хэмжээг үлдээнэ үү"
+
+#: frontend/src/views/leave/List.vue:5
+msgid "Leave History"
+msgstr "Түүхийг орхи"
+
+#. Name of a report
+#: hrms/hr/report/leave_ledger/leave_ledger.json
+msgid "Leave Ledger"
+msgstr "Ledger-г орхи"
+
+#. Name of a DocType
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/report/leave_ledger/leave_ledger.py:21
+msgid "Leave Ledger Entry"
+msgstr "Бүртгэлийн бүртгэлийг орхи"
+
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py:18
+msgid ""
+"Leave Ledger Entry's To date needs to be after From date. Currently, From "
+"Date is {0} and To Date is {1}"
+msgstr ""
+"Чөлөөний бүртгэлийн бичилтийн Хүртэл огноо нь Эхлэх огнооноос хойш байх "
+"ёстой. Одоогоор Эхлэх огноо нь {0}, Хүртэл огноо нь {1}"
+
+#. Label of the leave_period (Link) field in DocType 'Leave Allocation'
+#. Option for the 'Dates Based On' (Select) field in DocType 'Leave Control
+#. Panel'
+#. Label of the leave_period (Link) field in DocType 'Leave Control Panel'
+#. Label of the leave_period (Link) field in DocType 'Leave Encashment'
+#. Name of a DocType
+#. Option for the 'Assignment based on' (Select) field in DocType 'Leave
+#. Policy
+#. Assignment'
+#. Label of the leave_period (Link) field in DocType 'Leave Policy Assignment'
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/doctype/leave_period/leave_period.json
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Period"
+msgstr "Амрах хугацаа"
+
+#. Label of the leave_policy (Link) field in DocType 'Leave Allocation'
+#. Label of the leave_policy (Link) field in DocType 'Leave Control Panel'
+#. Name of a DocType
+#. Label of the leave_policy (Link) field in DocType 'Leave Policy Assignment'
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/leave_policy/leave_policy.json
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Policy"
+msgstr "Бодлого орхих"
+
+#. Option for the 'Allocated Via' (Select) field in DocType 'Earned Leave
+#. Schedule'
+#. Label of the leave_policy_assignment (Link) field in DocType 'Leave
+#. Allocation'
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+#: hrms/hr/workspace/leaves/leaves.json
+msgid "Leave Policy Assignment"
+msgstr "Бодлогын даалгаврыг орхи"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:70
+msgid "Leave Policy Assignment Overlap"
+msgstr "Бодлогын даалгаврын давхцлыг орхи"
+
+#. Name of a DocType
+#: hrms/hr/doctype/leave_policy_detail/leave_policy_detail.json
+msgid "Leave Policy Detail"
+msgstr "Бодлогын дэлгэрэнгүйг үлдээнэ үү"
+
+#. Label of the leave_policy_details (Table) field in DocType 'Leave Policy'
+#: hrms/hr/doctype/leave_policy/leave_policy.json
+msgid "Leave Policy Details"
+msgstr "Бодлогын дэлгэрэнгүйг үлдээнэ үү"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:64
+msgid ""
+"Leave Policy: {0} already assigned for Employee {1} for period {2} to {3}"
+msgstr ""
+"Амрах журам: {2}-с {3} хүртэлх хугацаанд {1} ажилтанд {0}-г аль хэдийн "
+"оноосон байна."
+
+#. Label of the leave_settings_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#| msgid "Leave Details"
+msgid "Leave Settings"
+msgstr "Дэлгэрэнгүй мэдээллийг үлдээнэ үү"
+
+#: hrms/setup.py:441 hrms/setup.py:443 hrms/setup.py:495
+msgid "Leave Status Notification"
+msgstr "Статусын мэдэгдлийг орхи"
+
+#. Label of the leave_status_notification_template (Link) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Leave Status Notification Template"
+msgstr "Статусын мэдэгдлийн загварыг орхи"
+
+#. Label of the leave_type (Link) field in DocType 'Attendance'
+#. Label of the leave_type (Link) field in DocType 'Compensatory Leave
+#. Request'
+#. Label of the leave_type (Link) field in DocType 'Leave Adjustment'
+#. Label of the leave_type (Link) field in DocType 'Leave Allocation'
+#. Label of the leave_type (Link) field in DocType 'Leave Application'
+#. Label of the leave_type (Link) field in DocType 'Leave Block List'
+#. Label of the leave_type (Link) field in DocType 'Leave Control Panel'
+#. Label of the leave_type (Link) field in DocType 'Leave Encashment'
+#. Label of the leave_type (Link) field in DocType 'Leave Ledger Entry'
+#. Label of the leave_type (Link) field in DocType 'Leave Policy Detail'
+#. Name of a DocType
+#. Label of a Link in the Leaves Workspace
+#. Label of the leave_type (Link) field in DocType 'Salary Slip Leave'
+#: frontend/src/views/leave/List.vue:41
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:179
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#: hrms/hr/doctype/leave_application/leave_application.json
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:6
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/doctype/leave_policy_detail/leave_policy_detail.json
+#: hrms/hr/doctype/leave_type/leave_type.json
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.py:34
+#: hrms/hr/report/leave_ledger/leave_ledger.js:22
+#: hrms/hr/report/leave_ledger/leave_ledger.py:65
+#: hrms/hr/workspace/leaves/leaves.json
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Leave Type"
+msgstr "Орхих төрөл"
+
+#. Label of the leave_type_name (Data) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Leave Type Name"
+msgstr "Төрөл нэрээ үлдээнэ үү"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:34
+msgid "Leave Type can either be compensatory or earned leave."
+msgstr "Амралтын төрөл нь нөхөн олговортой эсвэл цалинтай чөлөө байж болно."
+
+#: hrms/hr/doctype/leave_type/leave_type.py:46
+msgid "Leave Type can either be without pay or partial pay"
+msgstr "Амралтын төрөл нь цалингүй эсвэл хэсэгчилсэн цалинтай байж болно"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:34
+msgid "Leave Type is mandatory"
+msgstr "Амрах төрөл заавал байх ёстой"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:185
+msgid "Leave Type {0} cannot be allocated since it is leave without pay"
+msgstr "Амралтын төрөл {0} нь цалингүй чөлөө тул хуваарилах боломжгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:557
+msgid "Leave Type {0} cannot be carry-forwarded"
+msgstr "Амралтын төрлийг {0} шилжүүлэх боломжгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:96
+msgid "Leave Type {0} is not encashable"
+msgstr "Орхих төрөл {0} мөнгө шилжүүлэх боломжгүй"
+
+#. Label of the leave_without_pay (Float) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/report/salary_register/salary_register.py:179
+#: hrms/setup.py:381 hrms/setup.py:382
+msgid "Leave Without Pay"
+msgstr "Төлбөргүй орхи"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:513
+msgid "Leave Without Pay does not match with approved {} records"
+msgstr "\"Төлбөргүй чөлөө\" нь батлагдсан {} бүртгэлтэй таарахгүй байна"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:130
+msgid ""
+"Leave allocation is skipped for {0}, because number of leaves to be "
+"allocated is 0."
+msgstr ""
+"Хуваарилах чөлөөний тоо 0 тул {0}-ийн чөлөөний хуваарилалтыг алгассан."
+
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py:54
+msgid "Leave allocation {0} is linked with the Leave Application {1}"
+msgstr "Амрах хуваарилалт {0} нь Өргөдөл гаргах {1}-тэй холбогдсон"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:90
+msgid "Leave already have been assigned for this Leave Policy Assignment"
+msgstr "Энэ чөлөө олгох бодлогын даалгаварт аль хэдийн чөлөө олгосон байна"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:27
+msgid ""
+"Leave application is linked with leave allocations {0}. Leave application "
+"cannot be set as leave without pay"
+msgstr ""
+"Амралтаас чөлөө авах хүсэлтийг чөлөө олгохтой {0} холбосон. Амрах өргөдлийг "
+"цалингүй чөлөө гэж тохируулах боломжгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:225
+msgid ""
+"Leave cannot be allocated before {0}, as leave balance has already been "
+"carry-forwarded in the future leave allocation record {1}"
+msgstr ""
+"Ирээдүйн амралтын хуваарилалтын бүртгэлд амралтын үлдэгдэл аль хэдийн "
+"шилжсэн тул {0}-ээс өмнө чөлөө олгох боломжгүй. {1}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:262
+msgid ""
+"Leave cannot be applied/cancelled before {0}, as leave balance has already "
+"been carry-forwarded in the future leave allocation record {1}"
+msgstr ""
+"Ирээдүйн амралтын хуваарилалтын бүртгэлд амралтын үлдэгдэл аль хэдийн "
+"шилжсэн тул {0}-ээс өмнө чөлөө олгох/цуцлах боломжгүй {1}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:533
+msgid "Leave of type {0} cannot be longer than {1}."
+msgstr "{0} төрлийн амралт нь {1}-ээс урт байж болохгүй."
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.py:73
+msgid "Leave(s) Expired"
+msgstr "Амралтын хугацаа дууссан"
+
+#. Label of the pending_leaves (Float) field in DocType 'Salary Slip Leave'
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Leave(s) Pending Approval"
+msgstr "Зөвшөөрөл хүлээгдэж буй чөлөө(үүд)."
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.py:67
+msgid "Leave(s) Taken"
+msgstr "Амралт(ууд) авсан"
+
+#. Label of the leaves_tab (Tab Break) field in DocType 'HR Settings'
+#. Label of the leaves (Float) field in DocType 'Leave Ledger Entry'
+#. Name of a Workspace
+#. Label of a Card Break in the People Workspace
+#. Label of the leave_details_section (Tab Break) field in DocType 'Salary
+#. Slip'
+#: frontend/src/components/BottomTabs.vue:53
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+#: hrms/hr/doctype/leave_policy/leave_policy_dashboard.py:8
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment_dashboard.py:8
+#: hrms/hr/report/leave_ledger/leave_ledger.py:59
+#: hrms/hr/workspace/leaves/leaves.json hrms/hr/workspace/people/people.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Leaves"
+msgstr "Навч"
+
+#: frontend/src/views/leave/Dashboard.vue:2
+msgid "Leaves & Holidays"
+msgstr "Навч, амралтын өдрүүд"
+
+#. Label of the leaves_after_adjustment (Float) field in DocType 'Leave
+#. Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+msgid "Leaves After Adjustment"
+msgstr "Залруулгын дараах чөлөө"
+
+#. Label of the leaves_allocated (Check) field in DocType 'Leave Policy
+#. Assignment'
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+msgid "Leaves Allocated"
+msgstr "Навч хуваарилагдсан"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:562
+#| msgid "Leave(s) Expired"
+msgid "Leaves Expired"
+msgstr "Амралтын хугацаа дууссан"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:10
+msgid "Leaves Pending Approval"
+msgstr "Зөвшөөрөл хүлээгдэж байна"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:83
+msgid ""
+"Leaves for the Leave Type {0} won't be carry-forwarded since carry-"
+"forwarding is disabled."
+msgstr ""
+"Зөөвөрлөлтийг идэвхгүй болгосон тул {0} Амралтын төрлийн навчийг "
+"шилжүүлэхгүй."
+
+#: hrms/setup.py:412
+msgid "Leaves per Year"
+msgstr "Жилд навч"
+
+#. Label of the leaves_to_adjust (Float) field in DocType 'Leave Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Leave Block List"
+msgid "Leaves to Adjust"
+msgstr "Блокийн жагсаалтыг орхи"
+
+#: hrms/hr/doctype/leave_type/leave_type.js:42
+msgid ""
+"Leaves you can avail against a holiday you worked on. You can claim "
+"Compensatory Off Leave using Compensatory Leave Request. Click {0} to know "
+"more"
+msgstr ""
+"Та ажиллаж байсан амралтынхаа үеэр ашиг тустай байх боломжтой. Та нөхөн "
+"олговрын чөлөө авах хүсэлтийг ашиглан нөхөн олговрын чөлөө авах боломжтой. "
+"Илүү ихийг мэдэхийн тулд {0} дээр дарна уу"
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.js:47
+#: hrms/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js:43
+#: hrms/hr/report/leave_ledger/leave_ledger.js:41
+msgctxt "Employee"
+msgid "Left"
+msgstr "Зүүн"
+
+#: hrms/overrides/dashboard_overrides.py:16
+msgid "Lifecycle"
+msgstr "Амьдралын мөчлөг"
+
+#. Option for the 'Roster Color' (Select) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Lime"
+msgstr "Шохой"
+
+#. Description of the 'Appraisal Linking' (Section Break) field in DocType
+#. 'Goal'
+#: hrms/hr/doctype/goal/goal.json hrms/hr/doctype/goal/goal_tree.js:97
+msgid ""
+"Link the cycle and tag KRA to your goal to update the appraisal's goal score"
+" based on the goal progress"
+msgstr ""
+"Зорилгын явц дээр үндэслэн үнэлгээний оноог шинэчлэхийн тулд мөчлөгийг "
+"холбож, KRA-г зорилгодоо тэмдэглэ"
+
+#: hrms/controllers/employee_boarding_controller.py:154
+msgid "Linked Project {} and Tasks deleted."
+msgstr "Холбогдсон төсөл {} болон даалгавруудыг устгасан."
+
+#. Label of the loan_account (Link) field in DocType 'Salary Slip Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Loan Account"
+msgstr "Зээлийн данс"
+
+#. Label of the loan_product (Link) field in DocType 'Salary Slip Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Loan Product"
+msgstr "Зээлийн бүтээгдэхүүн"
+
+#: hrms/payroll/report/salary_register/salary_register.py:233
+#: hrms/setup.py:773
+msgid "Loan Repayment"
+msgstr "Зээлийн эргэн төлөлт"
+
+#. Label of the loan_repayment_entry (Link) field in DocType 'Salary Slip
+#. Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Loan Repayment Entry"
+msgstr "Зээлийн эргэн төлөлтийн бүртгэл"
+
+#: hrms/hr/utils.py:821
+msgid ""
+"Loan cannot be repayed from salary for Employee {0} because salary is "
+"processed in currency {1}"
+msgstr ""
+"Ажилтны {0} цалинг {1} валютаар тооцдог тул зээлийг цалингаас төлөх "
+"боломжгүй."
+
+#: frontend/src/components/CheckInPanel.vue:145
+msgid "Locating..."
+msgstr "Байршуулж байна..."
+
+#. Label of the device_id (Data) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Location / Device ID"
+msgstr "Байршил / Төхөөрөмжийн ID"
+
+#. Label of the lodging_required (Check) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Lodging Required"
+msgstr "Орон байр шаардлагатай"
+
+#: frontend/src/views/Profile.vue:107
+msgid "Log Out"
+msgstr "Гарах"
+
+#. Label of the log_type (Select) field in DocType 'Employee Checkin'
+#: frontend/src/views/attendance/EmployeeCheckinList.vue:25
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Log Type"
+msgstr "Бүртгэлийн төрөл"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:83
+msgid "Log Type is required for check-ins falling in the shift: {0}."
+msgstr "Бүртгэлийн төрөл нь ээлжийн бүртгэлд ороход шаардлагатай: {0}."
+
+#: frontend/src/views/InvalidEmployee.vue:7
+msgid "Login Failed"
+msgstr "Нэвтрэх амжилтгүй боллоо"
+
+#: frontend/src/views/Login.vue:8
+msgid "Login to Frappe HR"
+msgstr "Frappe HR-д нэвтэрнэ үү"
+
+#: frontend/src/components/CheckInPanel.vue:132
+msgid "Longitude: {0}°"
+msgstr "Уртраг: {0}°"
+
+#. Label of the lower_range (Currency) field in DocType 'Job Applicant'
+#. Label of the lower_range (Currency) field in DocType 'Job Opening'
+#. Label of a field in the job-application Web Form
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Lower Range"
+msgstr "Доод хүрээ"
+
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:61
+msgid "MICR"
+msgstr "MICR"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:184
+msgid "Make Bank Entry"
+msgstr "Банкны бүртгэл хийх"
+
+#. Label of the mandatory_benefit_application (Check) field in DocType
+#. 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#| msgid "Employee Benefit Application"
+msgid "Mandatory Benefit Application"
+msgstr "Ажилчдын тэтгэмжийн өргөдөл"
+
+#: hrms/public/js/utils/index.js:37
+msgid "Mandatory fields required for this action:"
+msgstr "Энэ үйлдэлд заавал оруулах шаардлагатай талбарууд:"
+
+#. Option for the 'KRA Evaluation Method' (Select) field in DocType 'Appraisal
+#. Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Manual Rating"
+msgstr "Гарын авлагын үнэлгээ"
+
+#. Option for the 'Allocated Via' (Select) field in DocType 'Earned Leave
+#. Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Manual"
+msgid "Manually"
+msgstr "Гарын авлага"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:38
+#: hrms/public/js/salary_slip_deductions_report_filters.js:21
+msgid "Mar"
+msgstr "Гуравдугаар сар"
+
+#: hrms/hr/doctype/attendance/attendance_list.js:17
+#: hrms/hr/doctype/attendance/attendance_list.js:25
+#: hrms/hr/doctype/attendance/attendance_list.js:135
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:232
+#: hrms/hr/doctype/shift_type/shift_type.js:13
+msgid "Mark Attendance"
+msgstr "Ирцийг тэмдэглэ"
+
+#. Label of the mark_auto_attendance_on_holidays (Check) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Mark Auto Attendance on Holidays"
+msgstr "Баярын өдрүүдэд авто ирцийг тэмдэглэ"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:58
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:62
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.js:67
+#: hrms/hr/doctype/goal/goal_tree.js:257
+msgid "Mark as Completed"
+msgstr "Дууссан гэж тэмдэглэ"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:67
+msgid "Mark as In Progress"
+msgstr "Явж байна гэж тэмдэглэ"
+
+#: hrms/hr/doctype/interview/interview.py:73
+msgid "Mark as {0}"
+msgstr "{0} гэж тэмдэглэх"
+
+#: hrms/hr/doctype/attendance/attendance_list.js:109
+msgid "Mark attendance as {0} for {1} on selected dates?"
+msgstr "Сонгосон огнооны {1}-н ирцийг {0} гэж тэмдэглэх үү?"
+
+#. Description of the 'Enable Auto Attendance' (Check) field in DocType 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"Mark attendance based on 'Employee Checkin' for Employees assigned to this "
+"shift."
+msgstr ""
+"Энэ ээлжинд томилогдсон ажилчдын ирцийг \"Ажилтны бүртгэл\"-д үндэслэн "
+"тэмдэглээрэй."
+
+#: hrms/hr/doctype/shift_type/shift_type.py:98
+msgid ""
+"Mark attendance for existing check-in/out logs before changing shift "
+"settings"
+msgstr ""
+"Ээлжийн тохиргоог өөрчлөхийн өмнө одоогийн бүртгэл/гаралтын бүртгэлийн "
+"ирцийг тэмдэглэнэ үү"
+
+#: hrms/hr/doctype/goal/goal_tree.js:262
+msgid "Mark {0} as Completed?"
+msgstr "{0}-г Дууссан гэж тэмдэглэх үү?"
+
+#: hrms/hr/doctype/goal/goal_list.js:81
+msgid "Mark {0} {1} as {2}?"
+msgstr "{0} {1}-г {2} гэж тэмдэглэх үү?"
+
+#. Label of the marked_attendance_section (Section Break) field in DocType
+#. 'Employee Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Marked Attendance"
+msgstr "Тэмдэглэгдсэн ирц"
+
+#. Label of the marked_attendance_html (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Marked Attendance HTML"
+msgstr "Тэмдэглэгдсэн ирц HTML"
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:286
+msgid "Marking Attendance"
+msgstr "Ирцийг тэмдэглэх"
+
+#. Label of the max_amount_eligible (Currency) field in DocType 'Employee
+#. Benefit Claim'
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#| msgid "Max Amount Eligible"
+msgid "Max Amount Eligible For Claim"
+msgstr "Боломжит дээд хэмжээ"
+
+#. Label of the max_benefit_amount (Currency) field in DocType 'Employee
+#. Benefit Application Detail'
+#: hrms/payroll/doctype/employee_benefit_application_detail/employee_benefit_application_detail.json
+msgid "Max Benefit Amount"
+msgstr "Тэтгэмжийн дээд хэмжээ"
+
+#. Label of the max_benefit_amount (Currency) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Max Benefit Amount (Yearly)"
+msgstr "Тэтгэмжийн дээд хэмжээ (жил бүр)"
+
+#. Label of the max_benefits (Currency) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Max Benefits (Amount)"
+msgstr "Хамгийн их ашиг (хэмжээ)"
+
+#. Label of the max_benefits (Currency) field in DocType 'Employee Benefit
+#. Application'
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgid "Max Benefits (Yearly)"
+msgstr "Хамгийн их ашиг тус (жил бүр)"
+
+#. Label of the max_amount (Currency) field in DocType 'Employee Tax Exemption
+#. Category'
+#. Label of the max_amount (Currency) field in DocType 'Employee Tax Exemption
+#. Sub Category'
+#: hrms/payroll/doctype/employee_tax_exemption_category/employee_tax_exemption_category.json
+#: hrms/payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgid "Max Exemption Amount"
+msgstr "Чөлөөлөлтийн дээд хэмжээ"
+
+#: hrms/payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.py:18
+msgid ""
+"Max Exemption Amount cannot be greater than maximum exemption amount {0} of "
+"Tax Exemption Category {1}"
+msgstr ""
+"Чөлөөлөлтийн дээд хэмжээ нь {1} Татвараас чөлөөлөх ангиллын {0}-аас ихгүй "
+"байж болохгүй."
+
+#. Label of the max_taxable_income (Currency) field in DocType 'Income Tax
+#. Slab
+#. Other Charges'
+#: hrms/payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgid "Max Taxable Income"
+msgstr "Хамгийн их татвар ногдуулах орлого"
+
+#. Label of the max_working_hours_against_timesheet (Float) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Max working hours against Timesheet"
+msgstr "Цагийн хүснэгттэй харьцуулахад хамгийн их ажлын цаг"
+
+#. Label of the max_benefits (Currency) field in DocType 'Salary Structure
+#. Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#| msgid "Max Benefit Amount"
+msgid "Maximum Benefit Amount"
+msgstr "Тэтгэмжийн дээд хэмжээ"
+
+#. Label of the maximum_carry_forwarded_leaves (Float) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Maximum Carry Forwarded Leaves"
+msgstr "Хамгийн их зөөвөрлөгдсөн навч"
+
+#. Label of the max_continuous_days_allowed (Int) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Maximum Consecutive Leaves Allowed"
+msgstr "Хамгийн их дараалсан навчийг зөвшөөрнө"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:543
+msgid "Maximum Consecutive Leaves Exceeded"
+msgstr "Дараалсан навчны дээд хэмжээ хэтэрсэн"
+
+#. Label of the max_encashable_leaves (Int) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Maximum Encashable Leaves"
+msgstr "Хамгийн их мөнгө авах боломжтой навч"
+
+#. Label of the max_amount (Currency) field in DocType 'Employee Tax Exemption
+#. Declaration Category'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration_category/employee_tax_exemption_declaration_category.json
+msgid "Maximum Exempted Amount"
+msgstr "Чөлөөлөгдсөн дээд хэмжээ"
+
+#. Label of the max_amount (Currency) field in DocType 'Employee Tax Exemption
+#. Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Maximum Exemption Amount"
+msgstr "Чөлөөлөлтийн дээд хэмжээ"
+
+#. Label of the max_leaves_allowed (Float) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Maximum Leave Allocation Allowed per Leave Period"
+msgstr "Амралтын хугацаанд зөвшөөрөгдөх дээд хэмжээ"
+
+#. Label of the maximum_overtime_hours_allowed (Float) field in DocType
+#. 'Overtime Details'
+#: hrms/hr/doctype/overtime_details/overtime_details.json
+#| msgid "Maximum Consecutive Leaves Allowed"
+msgid "Maximum Overtime Hours Allowed"
+msgstr "Хамгийн их дараалсан навчийг зөвшөөрнө"
+
+#. Label of the maximum_overtime_hours_allowed (Float) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Maximum Consecutive Leaves Allowed"
+msgid "Maximum Overtime Hours Allowed Per Day"
+msgstr "Хамгийн их дараалсан навчийг зөвшөөрнө"
+
+#. Description of the 'Taxable Income Relief Threshold Limit' (Currency) field
+#. in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid ""
+"Maximum annual taxable income eligible for full tax relief. No tax is "
+"applied if income does not exceed this limit"
+msgstr ""
+"Татварын бүрэн хөнгөлөлт авах жилийн дээд татварт ногдох орлого. Орлого энэ "
+"хязгаараас хэтрэхгүй бол татвар ногдуулахгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:117
+msgid "Maximum encashable leaves for {0} are {1}"
+msgstr "{0}-д олгох хамгийн их хуудас нь {1} байна"
+
+#: hrms/hr/doctype/leave_policy/leave_policy.py:19
+msgid "Maximum leave allowed in the leave type {0} is {1}"
+msgstr "Амралтын төрөлд зөвшөөрөгдөх дээд хэмжээ {0} нь {1}"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:40
+#: hrms/public/js/salary_slip_deductions_report_filters.js:23
+msgid "May"
+msgstr "Тавдугаар сар"
+
+#. Label of the meal_preference (Select) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Meal Preference"
+msgstr "Хоолны давуу тал"
+
+#: hrms/setup.py:334
+msgid "Medical"
+msgstr "Анагаах ухаан"
+
+#. Option for the 'Frequency' (Select) field in DocType 'Vehicle Service'
+#: hrms/hr/doctype/vehicle_service/vehicle_service.json
+msgid "Mileage"
+msgstr "Миль"
+
+#. Label of the min_taxable_income (Currency) field in DocType 'Income Tax
+#. Slab
+#. Other Charges'
+#: hrms/payroll/doctype/income_tax_slab_other_charges/income_tax_slab_other_charges.json
+msgid "Min Taxable Income"
+msgstr "Татвар ногдох хамгийн бага орлого"
+
+#. Label of the minimum_year_for_gratuity (Int) field in DocType 'Gratuity
+#. Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Minimum Year for Gratuity"
+msgstr "Тэтгэлгийн хамгийн бага жил"
+
+#. Description of the 'Allow Leave Application After (Working Days)' (Int)
+#. field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid ""
+"Minimum working days required since Date of Joining to apply for this leave"
+msgstr ""
+"Энэхүү чөлөө авах хүсэлт гаргахын тулд элссэн өдрөөс хойш ажлын хамгийн бага"
+" өдөр шаардлагатай"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:64
+#| msgid "Advance Account"
+msgid "Missing Advance Account"
+msgstr "Урьдчилсан данс"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:85
+msgid "Missing Mandatory Field"
+msgstr "Заавал биелүүлэх талбар дутуу байна"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:167
+msgid "Missing Opening Entries"
+msgstr "Нээлтийн бүртгэл дутуу байна"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:48
+msgid "Missing Relieving Date"
+msgstr "Хөнгөлөх огноо дутуу байна"
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:18
+#| msgid "Salary Component"
+msgid "Missing Salary Components"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1865
+msgid "Missing Tax Slab"
+msgstr "Татварын хавтан алга"
+
+#. Label of the mode_of_travel (Select) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Mode of Travel"
+msgstr "Аяллын горим"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:439
+msgid "Mode of payment is required to make a payment"
+msgstr "Төлбөр хийхдээ төлбөрийн хэлбэр шаардлагатай"
+
+#. Label of the month_to_date (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Month To Date"
+msgstr "Сар хүртэл"
+
+#. Label of the base_month_to_date (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Month To Date(Company Currency)"
+msgstr "Сар хүртэлх (Компанийн валют)"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Monthly Attendance Sheet"
+msgstr "Сар бүрийн ирцийн хуудас"
+
+#: hrms/hr/utils.py:280
+msgid "More than one selection for {0} not allowed"
+msgstr "{0}-н нэгээс олон сонголтыг зөвшөөрөхгүй"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:319
+msgid ""
+"Multiple Additional Salaries with overwrite property exist for Salary "
+"Component {0} between {1} and {2}."
+msgstr ""
+"Цалингийн бүрэлдэхүүн хэсэг {0}-д {1}-с {2} хооронд дарж бичих шинж чанартай"
+" олон нэмэлт цалин байдаг."
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:110
+msgid "Multiple Shift Assignments"
+msgstr "Олон ээлжийн даалгавар"
+
+#. Description of the 'Pay Rate Multipliers' (Section Break) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Multipliers that adjust the hourly overtime amount for specific scenarios\n"
+"\n"
+msgstr ""
+"Тодорхой нөхцөлд цагийн илүү цагийн дүнг тохируулах үржүүлэгчид\n"
+"\n"
+
+#: frontend/src/views/employee_advance/List.vue:19
+msgid "My Advances"
+msgstr "Миний дэвшил"
+
+#: frontend/src/views/expense_claim/List.vue:19
+msgid "My Claims"
+msgstr "Миний нэхэмжлэл"
+
+#: frontend/src/views/leave/List.vue:19
+msgid "My Leaves"
+msgstr "Миний навчнууд"
+
+#: frontend/src/components/RequestPanel.vue:36
+msgid "My Requests"
+msgstr "Миний хүсэлтүүд"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1310
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2535
+msgid "Name error"
+msgstr "Нэрийн алдаа"
+
+#. Label of the name_of_organizer (Data) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Name of Organizer"
+msgstr "Зохион байгуулагчийн нэр"
+
+#. Label of the net_pay (Currency) field in DocType 'Salary Slip'
+#. Label of the net_pay (Currency) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.py:49
+#: hrms/payroll/report/salary_register/salary_register.py:251
+msgid "Net Pay"
+msgstr "Цэвэр төлбөр"
+
+#. Label of the base_net_pay (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Net Pay (Company Currency)"
+msgstr "Цэвэр төлбөр (Компанийн валют)"
+
+#. Label of the net_pay_info (Tab Break) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Net Pay Info"
+msgstr "Цэвэр төлбөрийн мэдээлэл"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:209
+msgid "Net Pay cannot be less than 0"
+msgstr "Цэвэр төлбөр 0-ээс бага байж болохгүй"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:53
+msgid "Net Salary Amount"
+msgstr "Цалингийн цэвэр дүн"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:93
+msgid "Net pay cannot be negative"
+msgstr "Цэвэр цалин сөрөг байж болохгүй"
+
+#. Label of the new_employee_id (Link) field in DocType 'Employee Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "New Employee ID"
+msgstr "Шинэ ажилтны үнэмлэх"
+
+#: frontend/src/components/ExpensesTable.vue:213
+msgid "New Expense Item"
+msgstr "Шинэ зардлын зүйл"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:221
+msgid "New Expense Tax"
+msgstr "Шинэ зардлын татвар"
+
+#: hrms/public/js/templates/performance_feedback.html:26
+msgid "New Feedback"
+msgstr "Шинэ санал хүсэлт"
+
+#. Label of a quick_list in the Tenure Workspace
+#: hrms/hr/workspace/tenure/tenure.json
+#| msgid "Holidays this Month."
+msgid "New Hires (This Month)"
+msgstr "Энэ сард амралтын өдрүүд."
+
+#: hrms/hr/report/employee_leave_balance/employee_leave_balance.py:61
+msgid "New Leave(s) Allocated"
+msgstr "Шинэ чөлөө (үүд) хуваарилагдсан"
+
+#. Label of the new_leaves_allocated (Float) field in DocType 'Leave
+#. Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+msgid "New Leaves Allocated"
+msgstr "Шинэ навч хуваарилагдсан"
+
+#. Label of the no_of_days (Float) field in DocType 'Leave Control Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "New Leaves Allocated (In Days)"
+msgstr "Хуваарилсан шинэ навч (өдөрөөр)"
+
+#. Description of the 'Create Shifts After' (Date) field in DocType 'Shift
+#. Schedule Assignment'
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+msgid "New shift assignments will be created after this date."
+msgstr "Энэ өдрөөс хойш шинэ ээлжийн даалгавар бий болно."
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:395
+msgid ""
+"No Bank/Cash Account found for currency {0}. Please create one under company"
+" {1}."
+msgstr ""
+"{0} валютын Банк/Бэлэн мөнгөний данс олдсонгүй. {1} компанийн дор нэгийг "
+"үүсгэнэ үү."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:218
+msgid "No Employee Found"
+msgstr "Ажилтан олдсонгүй"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:169
+msgid "No Employee found for the given employee field value. '{}': {}"
+msgstr "Өгөгдсөн ажилтны талбарт ямар ч ажилтан олдсонгүй. '{}': {}"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:111 hrms/hr/utils.py:924
+msgid "No Employees Selected"
+msgstr "Ажилтан сонгоогүй"
+
+#: hrms/hr/doctype/job_applicant/job_applicant_dashboard.html:53
+msgid "No Interview has been scheduled."
+msgstr "Ярилцлага товлогдоогүй байна."
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:105
+msgid "No Leave Period Found"
+msgstr "Амрах хугацаа олдсонгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:140
+msgid "No Leaves Allocated to Employee: {0} for Leave Type: {1}"
+msgstr "Ажилтанд ямар ч чөлөө хуваарилагдаагүй: Амралтын төрөлд {0}: {1}"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:265
+msgid "No Salary Slip found for Employee: {0}"
+msgstr "Ажилтны цалингийн хуудас олдсонгүй: {0}"
+
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:81
+#| msgid ""
+#| "No Salary Structure Assignment found for employee {0} on or before {1}"
+msgid ""
+"No Salary Slips with {0} found for employee {1} for payroll period {2}."
+msgstr ""
+"{2} цалингийн хугацааны {1} ажилтны {0}-тай цалингийн хуудас олдсонгүй."
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:69
+#| msgid ""
+#| "No Salary Structure Assignment found for employee {0} on or before {1}"
+msgid "No Salary Structure Assignment found for employee {0} on date {1}"
+msgstr ""
+"{0} ажилтны {1}-д болон түүнээс өмнө цалингийн бүтцийн даалгавар олдсонгүй."
+
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.py:119
+msgid "No Salary Structure Assignment found for employee {0} on or before {1}"
+msgstr ""
+"{0} ажилтны {1}-д болон түүнээс өмнө цалингийн бүтцийн даалгавар олдсонгүй."
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:36
+msgid "No Salary Structure assigned to Employee {0} on the given date {1}"
+msgstr "Өгөгдсөн {1} өдөр {0} ажилтанд цалингийн бүтцийг хуваарилаагүй"
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:115
+msgid "No Salary Structures"
+msgstr "Цалингийн бүтэц байхгүй"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:261
+msgid "No Shift Requests Selected"
+msgstr "Шилжилтийн хүсэлтийг сонгоогүй"
+
+#: hrms/hr/doctype/job_opening/job_opening.js:32
+msgid "No Staffing Plans found for this Designation"
+msgstr "Энэ томилгоонд ажиллах боловсон хүчний төлөвлөгөө олдсонгүй"
+
+#: hrms/payroll/doctype/arrear/arrear.py:71
+#| msgid ""
+#| "No Salary Structure Assignment found for employee {0} on or before {1}"
+msgid ""
+"No active Salary Structure Assignment found for employee {0} with salary "
+"structure {1} on or after arrear start date {2}"
+msgstr ""
+"{2} нөхөн олговрын эхлэх огноо буюу түүнээс хойш {1} цалингийн бүтэцтэй {0} "
+"ажилтны идэвхтэй цалингийн бүтцийн томилгоо олдсонгүй"
+
+#: frontend/src/views/InvalidEmployee.vue:8
+msgid ""
+"No active employee found associated with the email ID {0}. Try logging in "
+"with your employee email ID or contact your HR manager for access."
+msgstr ""
+"{0} имэйл ID-тай холбоотой идэвхтэй ажилтан олдсонгүй. Ажилтны цахим "
+"шуудангийн дугаараар нэвтэрч үзнэ үү эсвэл хүний нөөцийн менежертэйгээ "
+"холбогдоно уу."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:439
+msgid ""
+"No active or default Salary Structure found for employee {0} for the given "
+"dates"
+msgstr ""
+"Өгөгдсөн өдрүүдэд {0} ажилтны идэвхтэй эсвэл өгөгдмөл цалингийн бүтэц "
+"олдсонгүй"
+
+#: hrms/hr/doctype/vehicle_log/vehicle_log.py:43
+msgid "No additional expenses has been added"
+msgstr "Нэмэлт зардал нэмээгүй"
+
+#: frontend/src/components/ExpenseAdvancesTable.vue:63
+#| msgid "No attendance records found."
+msgid "No advances found"
+msgstr "Ирцийн бүртгэл олдсонгүй."
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:276
+msgid ""
+"No applicable Earning component found in last salary slip for Gratuity Rule:"
+" {0}"
+msgstr ""
+"Тэтгэлэгийн журмын сүүлийн цалингийн хуудаснаас Орлогын холбогдох "
+"бүрэлдэхүүн хэсэг олдсонгүй: {0}"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:289
+msgid "No applicable Earning components found for Gratuity Rule: {0}"
+msgstr "Тэтгэлгийн дүрэмд хамаарах Орлогын бүрэлдэхүүн хэсэг олдсонгүй: {0}"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:254
+msgid ""
+"No applicable slab found for the calculation of gratuity amount as per the "
+"Gratuity Rule: {0}"
+msgstr ""
+"Тэтгэлгийн дүрмийн дагуу тэтгэмжийн хэмжээг тооцоолоход тохирох хавтан "
+"олдсонгүй: {0}"
+
+#: hrms/payroll/doctype/arrear/arrear.py:194
+#| msgid ""
+#| "No applicable Earning component found in last salary slip for Gratuity Rule:"
+#| " {0}"
+msgid "No arrear components found in the existing salary slips."
+msgstr ""
+"Тэтгэлэгийн журмын сүүлийн цалингийн хуудаснаас Орлогын холбогдох "
+"бүрэлдэхүүн хэсэг олдсонгүй: "
+
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:160
+msgid ""
+"No arrear components found in the salary slip. Ensure Arrear Component is "
+"checked in the Salary Component master."
+msgstr ""
+"Цалингийн хуудсанд нөхөн олговрын бүрэлдэхүүн хэсэг олдсонгүй. Цалингийн "
+"бүрэлдэхүүн хэсгийн мастерт Нөхөн олговрын бүрэлдэхүүн хэсгийг сонгосон "
+"эсэхийг шалгана уу."
+
+#: hrms/payroll/doctype/arrear/arrear.py:407
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:187
+#| msgid "No record found"
+msgid "No arrear details found"
+msgstr "Ямар ч бичлэг олдсонгүй"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:164
+#| msgid "No leave record found for employee {0} on {1}"
+msgid "No attendance records found for employee {0} between {1} and {2}"
+msgstr "{1} болон {2} хооронд {0} ажилтны ирцийн бүртгэл олдсонгүй"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:71
+msgid "No attendance records found for this criteria."
+msgstr "Энэ шалгуурт ирцийн бүртгэл олдсонгүй."
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:64
+msgid "No attendance records found."
+msgstr "Ирцийн бүртгэл олдсонгүй."
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:40
+#| msgid "No attendance records found."
+msgid "No attendance records to create"
+msgstr "Ирцийн бүртгэл олдсонгүй."
+
+#: hrms/hr/doctype/interview/interview.py:87
+msgid "No changes found in timings."
+msgstr "Цагийн өөрчлөлт олдсонгүй."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:242
+msgid "No employees found"
+msgstr "Ажилтан олдсонгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:225
+msgid ""
+"No employees found for the mentioned criteria:<br>Company: {0}<br> Currency:"
+" {1}<br>Payroll Payable Account: {2}"
+msgstr ""
+"Дээр дурдсан шалгуурт ажилтан олдсонгүй:<br>Компани: {0}<br> Валют: "
+"{1}<br>Цалингийн өглөгийн данс: {2}"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:67
+msgid "No employees found for the selected criteria"
+msgstr "Сонгосон шалгуурт ажилтан олдсонгүй"
+
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.py:71
+msgid "No employees found with selected filters and active salary structure"
+msgstr "Сонгосон шүүлтүүр, идэвхтэй цалингийн бүтэцтэй ажилтан олдсонгүй"
+
+#: frontend/src/components/ExpensesTable.vue:64
+#| msgid "No additional expenses has been added"
+msgid "No expenses added"
+msgstr "Нэмэлт зардал нэмээгүй"
+
+#: hrms/public/js/templates/feedback_history.html:55
+msgid "No feedback has been received yet"
+msgstr "Одоогоор санал хүсэлт ирээгүй байна"
+
+#: hrms/hr/doctype/goal/goal_list.js:94
+msgid "No items selected"
+msgstr "Сонгосон зүйл алга"
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.js:46
+#| msgid ""
+#| "No active or default Salary Structure found for employee {0} for the given "
+#| "dates"
+msgid "No leave allocation found for {0} for {1} on given date."
+msgstr "Өгөгдсөн огноонд {1}-ийн {0} чөлөөний хуваарилалт олдсонгүй."
+
+#: hrms/hr/doctype/attendance/attendance.py:197
+msgid "No leave record found for employee {0} on {1}"
+msgstr "{1}-д {0} ажилтны амралтын бүртгэл олдсонгүй"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:29
+msgid "No leaves have been allocated."
+msgstr "Ямар ч навч хуваарилагдаагүй."
+
+#: frontend/src/views/Login.vue:53
+msgid "No login methods are available. Please contact your administrator."
+msgstr "Нэвтрэх арга байхгүй. Администратортайгаа холбогдоно уу."
+
+#: hrms/hr/page/team_updates/team_updates.js:49
+msgid "No more updates"
+msgstr "Өөр шинэчлэлт байхгүй"
+
+#. Label of the no_of_positions (Int) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "No of. Positions"
+msgstr "Үгүй. Албан тушаал"
+
+#: hrms/hr/doctype/daily_work_summary/daily_work_summary.py:102
+msgid "No replies from"
+msgstr "-аас хариу алга"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1586
+msgid ""
+"No salary slip found to submit for the above selected criteria OR salary "
+"slip already submitted"
+msgstr ""
+"Дээрх сонгосон шалгуурын дагуу өгөх цалингийн хуудас олдсонгүй ЭСВЭЛ "
+"цалингийн хуудас аль хэдийн ирүүлсэн байна"
+
+#: frontend/src/views/salary_slip/Dashboard.vue:50
+#| msgid "Salary Slip Loan"
+msgid "No salary slips found"
+msgstr "Цалингийн хуудасны зээл"
+
+#: hrms/payroll/doctype/arrear/arrear.py:136
+#| msgid "No Salary Slip found for Employee: {0}"
+msgid "No salary slips found for the selected employee from {0}"
+msgstr "Ажилтны цалингийн хуудас олдсонгүй: {0}"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:56
+msgid "No taxes added"
+msgstr "Татвар нэмэгдээгүй"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.js:51
+msgid "No valid shift found for log time"
+msgstr "Бүртгэлийн цагт хүчинтэй ээлж олдсонгүй"
+
+#: hrms/public/js/utils/index.js:48
+msgid "No {0} Selected"
+msgstr "Сонгосон {0} байхгүй"
+
+#: frontend/src/components/SalaryDetailTable.vue:32
+#| msgid "No {0} Selected"
+msgid "No {0} added"
+msgstr "Сонгосон {0} байхгүй"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Non Diary"
+msgstr "Өдрийн тэмдэглэлгүй"
+
+#. Label of the non_taxable_earnings (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Non Taxable Earnings"
+msgstr "Татвар ногдуулахгүй орлого"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:250
+msgid "Non-Billed Hours"
+msgstr "Тооцоогүй цаг"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:74
+msgid "Non-Billed Hours (NB)"
+msgstr "Тооцоогүй цаг (NB)"
+
+#. Label of the non_encashable_leaves (Int) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Non-Encashable Leaves"
+msgstr "Бэлэн мөнгө авах боломжгүй навч"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Non-Vegetarian"
+msgstr "Цагаан хоолтон биш"
+
+#. Description of the 'Shift' (Link) field in DocType 'Attendance Request'
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+msgid "Note: Shift will not be overwritten in existing attendance records"
+msgstr "Жич: Одоо байгаа ирцийн бүртгэлд ээлжийг дарж бичихгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:156
+msgid ""
+"Note: Total allocated leaves {0} shouldn't be less than already approved "
+"leaves {1} for the period"
+msgstr ""
+"Тайлбар: Хуваарилагдсан нийт навч {0} нь тухайн хугацааны аль хэдийн "
+"батлагдсан навчнаас {1} бага байж болохгүй"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2174
+msgid ""
+"Note: Your salary slip is password protected, the password to unlock the PDF"
+" is of the format {0}."
+msgstr ""
+"Жич: Таны цалингийн хуудас нууц үгээр хамгаалагдсан бөгөөд PDF-ийн түгжээг "
+"тайлах нууц үг нь {0} форматтай."
+
+#: hrms/hr/employee_property_update.js:176
+msgid "Nothing to change"
+msgstr "Өөрчлөх зүйл алга"
+
+#: hrms/setup.py:413
+msgid "Notice Period"
+msgstr "Мэдэгдлийн хугацаа"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:125
+msgid "Notification Template"
+msgstr "Мэдэгдэлийн загвар"
+
+#. Label of the notify_users_by_email (Check) field in DocType 'Employee
+#. Onboarding'
+#. Label of the notify_users_by_email (Check) field in DocType 'Employee
+#. Separation'
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+msgid "Notify users by email"
+msgstr "Хэрэглэгчдэд имэйлээр мэдэгдэх"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:46
+#: hrms/public/js/salary_slip_deductions_report_filters.js:29
+msgid "Nov"
+msgstr "11-р сар"
+
+#. Label of the number_of_employees (Int) field in DocType 'Payroll Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Number Of Employees"
+msgstr "Ажилчдын тоо"
+
+#. Label of the number_of_positions (Int) field in DocType 'Staffing Plan
+#. Detail'
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Number Of Positions"
+msgstr "Албан тушаалын тоо"
+
+#. Label of the number_of_leaves (Float) field in DocType 'Earned Leave
+#. Schedule'
+#: hrms/hr/doctype/earned_leave_schedule/earned_leave_schedule.json
+#| msgid "Number Of Employees"
+msgid "Number of Leaves"
+msgstr "Ажилчдын тоо"
+
+#. Label of the number_of_withholding_cycles (Int) field in DocType 'Salary
+#. Withholding'
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Number of Withholding Cycles"
+msgstr "Суутгалын мөчлөгийн тоо"
+
+#. Description of the 'Actual Encashable Days' (Float) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+msgid "Number of leaves eligible for encashment based on leave type settings"
+msgstr ""
+"Амралтын төрлийн тохиргоонд үндэслэн мөнгө авах боломжтой хуудасны тоо"
+
+#: frontend/src/views/Login.vue:88
+msgid "OTP Code"
+msgstr "OTP код"
+
+#: frontend/src/views/Login.vue:79
+#| msgid "PWA Notification"
+msgid "OTP Verification"
+msgstr "PWA мэдэгдэл"
+
+#. Option for the 'Log Type' (Select) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "OUT"
+msgstr "ГАРАХ"
+
+#. Label of the average_rating (Rating) field in DocType 'Interview'
+#: hrms/hr/doctype/interview/interview.json
+msgid "Obtained Average Rating"
+msgstr "Дундаж үнэлгээ авсан"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:45
+#: hrms/public/js/salary_slip_deductions_report_filters.js:28
+msgid "Oct"
+msgstr "Аравдугаар сар"
+
+#. Label of the odometer_reading (Section Break) field in DocType 'Vehicle
+#. Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Odometer Reading"
+msgstr "Одометрийн уншилт"
+
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:41
+msgid "Odometer Value"
+msgstr "Одометрийн утга"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin_list.js:5
+#| msgid "Shift"
+msgid "Off-Shift"
+msgstr "Шилжилт"
+
+#. Label of the offshift (Check) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Off-shift"
+msgstr "Ээлжийн гадна"
+
+#. Label of the offer_term (Link) field in DocType 'Job Offer Term'
+#. Name of a DocType
+#. Label of the offer_term (Data) field in DocType 'Offer Term'
+#: hrms/hr/doctype/job_offer_term/job_offer_term.json
+#: hrms/hr/doctype/offer_term/offer_term.json
+msgid "Offer Term"
+msgstr "Санал болгох хугацаа"
+
+#. Label of the offer_terms (Table) field in DocType 'Job Offer Term Template'
+#: hrms/hr/doctype/job_offer_term_template/job_offer_term_template.json
+msgid "Offer Terms"
+msgstr "Санал болгох нөхцөл"
+
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.js:17
+msgid "On Date"
+msgstr "Огноо"
+
+#. Option for the 'Reason' (Select) field in DocType 'Attendance Request'
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+msgid "On Duty"
+msgstr "Үүрэг дээр"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#: frontend/src/components/AttendanceCalendar.vue:80
+#: hrms/hr/doctype/attendance/attendance.json
+msgid "On Leave"
+msgstr "Амралт дээр"
+
+#. Label of a Card Break in the Tenure Workspace
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Onboarding"
+msgstr "Нэвтрэх"
+
+#. Label of the table_for_activity (Section Break) field in DocType 'Employee
+#. Onboarding'
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+msgid "Onboarding Activities"
+msgstr "Нэвтрэх үйл ажиллагаа"
+
+#. Label of the boarding_begins_on (Date) field in DocType 'Employee
+#. Onboarding'
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.json
+msgid "Onboarding Begins On"
+msgstr "Ашиглалт эхлэх нь"
+
+#: hrms/hr/doctype/shift_request/shift_request.py:95
+msgid "Only Approvers can Approve this Request."
+msgstr "Зөвхөн Зөвшөөрөгчид энэ хүсэлтийг зөвшөөрөх боломжтой."
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:45
+msgid "Only Completed documents can be submitted"
+msgstr "Зөвхөн бөглөсөн бичиг баримтыг илгээх боломжтой"
+
+#: hrms/hr/doctype/employee_grievance/employee_grievance.py:13
+msgid "Only Employee Grievance with status {0} or {1} can be submitted"
+msgstr "Зөвхөн {0} эсвэл {1} статустай ажилтны гомдлыг гаргаж болно"
+
+#: hrms/hr/doctype/interview/interview.py:325
+msgid "Only Interviewer Are allowed to submit Interview Feedback"
+msgstr "Зөвхөн ярилцлага авагч нь ярилцлагын санал хүсэлтийг илгээх эрхтэй"
+
+#: hrms/hr/doctype/interview/interview.py:26
+msgid "Only Interviews with Cleared or Rejected status can be submitted."
+msgstr ""
+"Зөвхөн цэвэрлэгдсэн эсвэл татгалзсан статустай ярилцлага өгөх боломжтой."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:104
+msgid ""
+"Only Leave Applications with status 'Approved' and 'Rejected' can be "
+"submitted"
+msgstr ""
+"Зөвхөн \"Зөвшөөрсөн\" болон \"Татгалзсан\" статустай өргөдлийг үлдээх "
+"боломжтой"
+
+#: hrms/hr/doctype/shift_request/shift_request.py:46
+msgid ""
+"Only Shift Request with status 'Approved' and 'Rejected' can be submitted"
+msgstr ""
+"Зөвхөн \"Зөвшөөрсөн\" болон \"Татгалзсан\" статустай ээлжийн хүсэлтийг "
+"гаргаж болно"
+
+#: hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py:33
+msgid "Only expired allocation can be cancelled"
+msgstr "Зөвхөн хугацаа нь дууссан хуваарилалтыг цуцалж болно"
+
+#: hrms/hr/doctype/interview/interview.js:66
+msgid "Only interviewers can submit feedback"
+msgstr "Зөвхөн ярилцлага авагчид санал хүсэлтээ илгээх боломжтой"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:192
+msgid "Only users with the {0} role can create backdated leave applications"
+msgstr ""
+"Зөвхөн {0} үүрэг бүхий хэрэглэгчид буцаагдсан чөлөөний програм үүсгэх "
+"боломжтой"
+
+#: hrms/hr/doctype/goal/goal_list.js:110
+msgid "Only {0} Goals can be {1}"
+msgstr "Зөвхөн {0} зорилго нь {1} байж болно"
+
+#. Option for the 'Status' (Select) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Open & Approved"
+msgstr "Нээлттэй & Батлагдсан"
+
+#: hrms/public/js/templates/feedback_history.html:44
+msgid "Open Feedback"
+msgstr "Санал хүсэлтийг нээх"
+
+#: hrms/hr/doctype/leave_application/leave_application_email_template.html:30
+msgid "Open Now"
+msgstr "Одоо нээх"
+
+#: hrms/templates/generators/job_opening.html:38
+#: hrms/templates/generators/job_opening.html:218
+msgid "Opening closed."
+msgstr "Нээлт хаалттай."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:640
+msgid "Optional Holiday List not set for leave period {0}"
+msgstr "Амралтын өдрийн жагсаалтыг {0}-д тохируулаагүй"
+
+#: hrms/hr/doctype/leave_type/leave_type.js:35
+msgid ""
+"Optional Leaves are holidays that Employees can choose to avail from a list "
+"of holidays published by the company."
+msgstr ""
+"Нэмэлт чөлөө гэдэг нь ажилчид компаниас нийтэлсэн амралтын өдрүүдийн "
+"жагсаалтаас сонгох боломжтой амралтын өдрүүд юм."
+
+#: hrms/hr/page/organizational_chart/organizational_chart.js:4
+msgid "Organizational Chart"
+msgstr "Байгууллагын схем"
+
+#. Label of the other_taxes_and_charges (Table) field in DocType 'Income Tax
+#. Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Other Taxes and Charges"
+msgstr "Бусад татвар, хураамж"
+
+#. Label of the out_time (Datetime) field in DocType 'Attendance'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/report/shift_attendance/shift_attendance.py:73
+msgid "Out Time"
+msgstr "Гарах цаг"
+
+#. Label of a chart in the Payroll Workspace
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Outgoing Salary"
+msgstr "Гарсан цалин"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:292
+msgid "Over Allocation"
+msgstr "Хэт хуваарилалт"
+
+#: hrms/public/js/templates/interview_feedback.html:4
+msgid "Overall Average Rating"
+msgstr "Нийт дундаж үнэлгээ"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:72
+msgid "Overlapping Attendance Request"
+msgstr "Давхардсан ирцийн хүсэлт"
+
+#: hrms/hr/doctype/attendance/attendance.py:123
+msgid "Overlapping Shift Attendance"
+msgstr "Давхардсан ээлжийн ирц"
+
+#: hrms/hr/doctype/shift_request/shift_request.py:136
+msgid "Overlapping Shift Requests"
+msgstr "Давхардсан ээлжийн хүсэлтүүд"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:147
+msgid "Overlapping Shifts"
+msgstr "Давхардсан ээлж"
+
+#. Label of the overtime_section (Section Break) field in DocType 'Attendance'
+#. Label of the overtime_section (Section Break) field in DocType 'Shift Type'
+#. Label of a Card Break in the Shift & Attendance Workspace
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/shift_type/shift_type.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+#| msgid "Overview"
+msgid "Overtime"
+msgstr "Тойм"
+
+#. Label of the overtime_calculation_method (Select) field in DocType
+#. 'Overtime
+#. Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Over Allocation"
+msgid "Overtime Amount Calculation"
+msgstr "Хэт хуваарилалт"
+
+#. Name of a DocType
+#. Label of the overtime_details (Table) field in DocType 'Overtime Slip'
+#: hrms/hr/doctype/overtime_details/overtime_details.json
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json
+#| msgid "Service Details"
+msgid "Overtime Details"
+msgstr "Үйлчилгээний дэлгэрэнгүй мэдээлэл"
+
+#. Label of the overtime_duration (Float) field in DocType 'Overtime Details'
+#: hrms/hr/doctype/overtime_details/overtime_details.json
+#| msgid "Over Allocation"
+msgid "Overtime Duration"
+msgstr "Хэт хуваарилалт"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:73
+msgid ""
+"Overtime Duration for {0} is greater than Maximum Overtime Hours Allowed"
+msgstr ""
+"{0}-ийн илүү цагийн хугацаа нь зөвшөөрөгдсөн дээд илүү цагаас хэтэрсэн"
+
+#. Name of a DocType
+#. Label of the overtime_salary_component (Link) field in DocType 'Overtime
+#. Type'
+#: hrms/hr/doctype/overtime_salary_component/overtime_salary_component.json
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Salary Component"
+msgid "Overtime Salary Component"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Overtime Slip"
+msgstr "Илүү цагийн хуудас"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:457
+msgid "Overtime Slip Creation Error for {0}"
+msgstr "{0}-ийн илүү цагийн хуудас үүсгэхэд алдаа гарлаа"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:468
+#| msgid "Creation Failed"
+msgid "Overtime Slip Creation Failed"
+msgstr "Бүтээж чадсангүй"
+
+#. Label of the overtime_step (Select) field in DocType 'Payroll Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Overtime Slip Step"
+msgstr "Илүү цагийн хуудасны алхам"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:491
+msgid "Overtime Slip Submission Error for {0}"
+msgstr "{0}-ийн илүү цагийн хуудас батлахад алдаа гарлаа"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:502
+#| msgid "Submission Failed"
+msgid "Overtime Slip Submission Failed"
+msgstr "Илгээж чадсангүй"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:497
+#| msgid "Salary Slips Submitted"
+msgid "Overtime Slip Submitted"
+msgstr "Цалингийн хуудас ирүүлсэн"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:461
+#| msgid "Allocate leaves to {0} employee(s)?"
+msgid "Overtime Slip created for {0} employee(s)"
+msgstr "{0} ажилтанд чөлөө олгох уу?"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1247
+#| msgid "Salary Slip creation is queued. It may take a few minutes"
+msgid "Overtime Slip creation is queued. It may take a few minutes"
+msgstr ""
+"Цалингийн хуудас үүсгэх дараалалд байна. Үүнд хэдэн минут зарцуулагдаж "
+"магадгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1271
+#| msgid "Salary Slip submission is queued. It may take a few minutes"
+msgid "Overtime Slip submission is queued. It may take a few minutes"
+msgstr ""
+"Цалингийн хуудас өгөх дараалалд байна. Үүнд хэдэн минут зарцуулагдаж "
+"магадгүй"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:48
+#| msgid "A {0} exists between {1} and {2} ("
+msgid "Overtime Slip:{0} has been created between {1} and {2}"
+msgstr "{1} болон {2} хооронд {0} байна ("
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:463
+#| msgid "Salary Slips Created"
+msgid "Overtime Slips Created"
+msgstr "Цалингийн хуудас үүсгэсэн"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:495
+#| msgid "Allocate leaves to {0} employee(s)?"
+msgid "Overtime Slips submitted for {0} employee(s)"
+msgstr "{0} ажилтанд чөлөө олгох уу?"
+
+#. Label of the overtime_type (Link) field in DocType 'Attendance'
+#. Label of the overtime_type (Link) field in DocType 'Employee Checkin'
+#. Label of the overtime_type (Link) field in DocType 'Overtime Details'
+#. Name of a DocType
+#. Label of the overtime_type (Link) field in DocType 'Shift Assignment'
+#. Label of the overtime_type (Link) field in DocType 'Shift Type'
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+#: hrms/hr/doctype/overtime_details/overtime_details.json
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_type/shift_type.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+#| msgid "Interview Type"
+msgid "Overtime Type"
+msgstr "Ярилцлагын төрөл"
+
+#. Description of the 'Overtime Salary Component' (Link) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Overtime earnings will be booked under this salary component for payout."
+msgstr "Илүү цагийн орлогыг энэ цалингийн бүрэлдэхүүн хэсгээр төлнө."
+
+#. Label of the overwrite_salary_structure_amount (Check) field in DocType
+#. 'Additional Salary'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:187
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:215
+msgid "Overwrite Salary Structure Amount"
+msgstr "Цалингийн бүтцийн хэмжээг дарж бичнэ үү"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:71
+msgid ""
+"Overwrite Salary Structure Amount is disabled as the Salary Component: {0} "
+"not part of the Salary Structure: {1}"
+msgstr ""
+"Цалингийн дүн дарж бичих идэвхгүй, учир нь {0} цалингийн бүрэлдэхүүн хэсэг "
+"нь {1} цалингийн бүтцийн хэсэг биш"
+
+#: hrms/payroll/report/income_tax_deductions/income_tax_deductions.py:41
+msgid "PAN Number"
+msgstr "PAN дугаар"
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:43
+msgid "PF Account"
+msgstr "PF данс"
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:44
+msgid "PF Amount"
+msgstr "PF-ийн хэмжээ"
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:51
+msgid "PF Loan"
+msgstr "PF зээл"
+
+#. Name of a DocType
+#: hrms/hr/doctype/pwa_notification/pwa_notification.json
+msgid "PWA Notification"
+msgstr "PWA мэдэгдэл"
+
+#. Label of the paid_via_salary_slip (Check) field in DocType 'Full and Final
+#. Outstanding Statement'
+#: hrms/hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgid "Paid via Salary Slip"
+msgstr "Цалингийн хуудсаар төлнө"
+
+#. Label of the parent_goal (Link) field in DocType 'Goal'
+#: hrms/hr/doctype/goal/goal.json
+msgid "Parent Goal"
+msgstr "Эцэг эхийн зорилго"
+
+#: hrms/setup.py:390
+msgid "Part-time"
+msgstr "Хагас цагийн"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Partially Sponsored, Require Partial Funding"
+msgstr "Хэсэгчилсэн ивээн тэтгэсэн, хэсэгчилсэн санхүүжилт шаардлагатай"
+
+#. Option for the 'Status' (Select) field in DocType 'Employee Advance'
+#: frontend/src/views/employee_advance/List.vue:42
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Partly Claimed and Returned"
+msgstr "Хэсэгчилсэн нэхэмжлэл гаргаж, буцаасан"
+
+#. Label of the password_policy (Data) field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Password Policy"
+msgstr "Нууц үгийн бодлого"
+
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.js:25
+msgid ""
+"Password policy cannot contain spaces or simultaneous hyphens. The format "
+"will be restructured automatically"
+msgstr ""
+"Нууц үгийн бодлого нь хоосон зай эсвэл нэгэн зэрэг зураас агуулж болохгүй. "
+"Формат автоматаар өөрчлөгдөнө"
+
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.py:22
+msgid "Password policy for Salary Slips is not set"
+msgstr "Цалингийн хуудасны нууц үгийн бодлогыг тохируулаагүй байна"
+
+#. Label of the pay_rate_multipliers_section (Section Break) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Pay Rate Multipliers"
+msgstr "Төлбөрийн ханшийн үржүүлэгчид"
+
+#. Label of the pay_via_payment_entry (Check) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#| msgid "Payment Entry"
+msgid "Pay Via Payment Entry"
+msgstr "Төлбөрийн бүртгэл"
+
+#. Label of the pay_via_salary_slip (Check) field in DocType 'Gratuity'
+#: hrms/payroll/doctype/gratuity/gratuity.json
+msgid "Pay via Salary Slip"
+msgstr "Цалингийн хуудсаар төлнө"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:137
+msgid "Payable Account is mandatory to submit an Expense Claim"
+msgstr "Өр төлбөрийн данс нь зардлын нэхэмжлэл гаргах шаардлагатай"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:461
+msgid "Payment Account is mandatory"
+msgstr "Төлбөрийн данс заавал байх ёстой"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:26
+msgid "Payment Date"
+msgstr "Төлбөрийн огноо"
+
+#. Label of the payment_days (Float) field in DocType 'Payroll Correction'
+#. Label of the payment_days (Float) field in DocType 'Salary Slip'
+#. Label of the payment_days_tab (Tab Break) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/report/salary_register/salary_register.py:191
+msgid "Payment Days"
+msgstr "Төлбөрийн өдрүүд"
+
+#. Label of the payment_days_calculation_help (HTML) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Payment Days Calculation Help"
+msgstr "Төлбөрийн өдрүүдийг тооцоолох тусламж"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:114
+msgid "Payment Days Dependency"
+msgstr "Төлбөрийн өдрүүдийн хамаарал"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.js:282
+msgid "Payment Days calculations are based on these Payroll Settings"
+msgstr "Төлбөрийн өдрүүдийн тооцоог эдгээр Цалингийн Тохиргоон дээр үндэслэнэ"
+
+#. Label of the section_break_5 (Tab Break) field in DocType 'Gratuity'
+#: hrms/payroll/doctype/gratuity/gratuity.json
+msgid "Payment and Accounting"
+msgstr "Төлбөр, нягтлан бодох бүртгэл"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1097
+msgid "Payment of {0} from {1} to {2}"
+msgstr "{1}-с {2} хүртэлх {0}-н төлбөр"
+
+#. Option for the 'Transaction Type' (Select) field in DocType 'Employee
+#. Benefit Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#| msgid "Salary Payout"
+msgid "Payout"
+msgstr "Цалингийн төлбөр"
+
+#. Label of the payout_method (Select) field in DocType 'Salary Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Payout Method"
+msgstr "Төлбөрийн арга"
+
+#. Label of the final_cycle_accrual_payout (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#| msgid "Repay Unclaimed Amount from Salary"
+msgid "Payout Unclaimed Amount in Final Payroll Cycle"
+msgstr "Цалингаас нэхэмжлээгүй мөнгийг эргүүлэн төлөх"
+
+#. Label of the payroll (Section Break) field in DocType 'Leave Encashment'
+#. Name of a Workspace
+#. Label of a Card Break in the Payroll Workspace
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+#: hrms/overrides/dashboard_overrides.py:37
+#: hrms/overrides/dashboard_overrides.py:77
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Payroll"
+msgstr "Цалин"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.js:282
+msgid "Payroll Based On"
+msgstr "Цалингийн тооцоонд үндэслэнэ"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#| msgid "Payroll Settings"
+msgid "Payroll Correction"
+msgstr "Цалингийн тохиргоо"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/payroll_correction_child/payroll_correction_child.json
+#| msgid "Payroll Period"
+msgid "Payroll Correction Child"
+msgstr "Цалингийн хугацаа"
+
+#: hrms/setup.py:111 hrms/setup.py:281
+msgid "Payroll Cost Center"
+msgstr "Цалингийн зардлын төв"
+
+#. Label of the section_break_17 (Section Break) field in DocType 'Salary
+#. Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Payroll Cost Centers"
+msgstr "Цалингийн зардлын төвүүд"
+
+#. Label of the payroll_date (Date) field in DocType 'Additional Salary'
+#. Label of the payroll_date (Date) field in DocType 'Arrear'
+#. Label of the payroll_date (Date) field in DocType 'Employee Benefit Claim'
+#. Label of the payroll_date (Date) field in DocType 'Employee Incentive'
+#. Label of the payroll_date (Date) field in DocType 'Gratuity'
+#. Label of the payroll_date (Date) field in DocType 'Payroll Correction'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.json
+#: hrms/payroll/doctype/gratuity/gratuity.json
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid "Payroll Date"
+msgstr "Цалингийн огноо"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/payroll_employee_detail/payroll_employee_detail.json
+msgid "Payroll Employee Detail"
+msgstr "Ажилчдын цалингийн дэлгэрэнгүй мэдээлэл"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:141
+msgid "Payroll Entry cancellation is queued. It may take a few minutes"
+msgstr ""
+"Цалингийн бүртгэлийг цуцлах дараалалд байна. Үүнд хэдэн минут зарцуулагдаж "
+"магадгүй"
+
+#. Label of the payroll_frequency (Select) field in DocType 'Payroll Entry'
+#. Label of the payroll_frequency (Select) field in DocType 'Salary Slip'
+#. Label of the payroll_frequency (Select) field in DocType 'Salary Structure'
+#. Label of the payroll_frequency (Select) field in DocType 'Salary
+#. Withholding'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Payroll Frequency"
+msgstr "Цалингийн давтамж"
+
+#. Label of the section_break_gsts (Section Break) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Payroll Info"
+msgstr "Цалингийн мэдээлэл"
+
+#: hrms/payroll/report/bank_remittance/bank_remittance.py:12
+msgid "Payroll Number"
+msgstr "Цалингийн дугаар"
+
+#. Label of the payroll_payable_account (Link) field in DocType 'Bulk Salary
+#. Structure Assignment'
+#. Label of the payroll_payable_account (Link) field in DocType 'Payroll
+#. Entry'
+#. Label of the payroll_payable_account (Link) field in DocType 'Salary
+#. Structure Assignment'
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/setup.py:846
+msgid "Payroll Payable Account"
+msgstr "Цалингийн өглөгийн данс"
+
+#. Label of the payroll_period (Link) field in DocType 'Arrear'
+#. Label of the payroll_period (Link) field in DocType 'Employee Benefit
+#. Application'
+#. Label of the payroll_period (Link) field in DocType 'Employee Benefit
+#. Ledger'
+#. Label of the payroll_period (Link) field in DocType 'Employee Other Income'
+#. Label of the payroll_period (Link) field in DocType 'Employee Tax Exemption
+#. Declaration'
+#. Label of the payroll_period (Link) field in DocType 'Employee Tax Exemption
+#. Proof Submission'
+#. Label of the payroll_period (Link) field in DocType 'Payroll Correction'
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: frontend/src/views/salary_slip/Dashboard.vue:21
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#: hrms/payroll/doctype/employee_other_income/employee_other_income.json
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#: hrms/payroll/doctype/payroll_period/payroll_period.json
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.js:62
+#: hrms/payroll/report/income_tax_computation/income_tax_computation.js:18
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Payroll Period"
+msgstr "Цалингийн хугацаа"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/payroll_period_date/payroll_period_date.json
+msgid "Payroll Period Date"
+msgstr "Цалингийн хугацаа"
+
+#. Label of the section_break_5 (Section Break) field in DocType 'Payroll
+#. Period'
+#. Label of the periods (Table) field in DocType 'Payroll Period'
+#: hrms/payroll/doctype/payroll_period/payroll_period.json
+msgid "Payroll Periods"
+msgstr "Цалингийн хугацаа"
+
+#. Label of a Card Break in the Payroll Workspace
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Payroll Reports"
+msgstr "Цалингийн тайлан"
+
+#. Label of a Link in the People Workspace
+#. Name of a DocType
+#: hrms/hr/workspace/people/people.json
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Payroll Settings"
+msgstr "Цалингийн тохиргоо"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:129
+msgid "Payroll date can not be greater than employee's relieving date."
+msgstr "Цалингийн огноо нь ажилтны чөлөөлөгдсөн өдрөөс илүү байж болохгүй."
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:121
+msgid "Payroll date can not be less than employee's joining date."
+msgstr "Цалингийн огноо нь ажилтны ажилд орсон өдрөөс бага байж болохгүй."
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:24
+msgid ""
+"Payroll date cannot be in the past. This is to ensure that claims are made "
+"for the current or future payroll cycles."
+msgstr ""
+"Цалингийн огноо өнгөрсөн хугацаанд байж болохгүй. Энэ нь нэхэмжлэлүүдийг "
+"одоогийн эсвэл ирэх цалингийн мөчлөгт хийхийг баталгаажуулна."
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:117
+msgid "Payroll date is mandatory for non-recurring type additional salaries."
+msgstr ""
+"Давтагддаггүй нэмэлт цалингийн хувьд цалингийн огноо заавал байх ёстой."
+
+#. Description of the 'Pending Amount' (Currency) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Pending (unpaid) amount from previous advances"
+msgstr "Өмнөх урьдчилгаанаас хүлээгдэж буй (төлөөгүй) дүн"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:73
+msgid "Pending Asset Returns"
+msgstr "Хүлээгдэж буй хөрөнгийн өгөөж"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:227
+msgid "Pending FnF"
+msgstr "Хүлээгдэж буй FnF"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:221
+msgid "Pending Interviews"
+msgstr "Хүлээгдэж буй ярилцлага"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:233
+msgid "Pending Questionnaires"
+msgstr "Хүлээгдэж буй асуулга"
+
+#. Name of a Workspace
+#: hrms/hr/workspace/people/people.json
+msgid "People"
+msgstr "Хүмүүс"
+
+#. Label of the percent_deduction (Percent) field in DocType 'Taxable Salary
+#. Slab'
+#: hrms/payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid "Percent Deduction"
+msgstr "хувийн суутгал"
+
+#. Name of a Workspace
+#: hrms/hr/workspace/performance/performance.json
+msgid "Performance"
+msgstr "Гүйцэтгэл"
+
+#: frontend/src/components/FormView.vue:291
+msgid "Permanently cancel {0}"
+msgstr "{0}-г бүрмөсөн цуцлах"
+
+#: frontend/src/components/FormView.vue:260
+msgid "Permanently submit {0}"
+msgstr "{0}-г бүрмөсөн илгээх"
+
+#: hrms/setup.py:394
+msgid "Piecework"
+msgstr "Хэсэгчилсэн ажил"
+
+#. Label of the planned_vacancies (Int) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Planned number of Positions"
+msgstr "Төлөвлөсөн албан тушаалын тоо"
+
+#: hrms/hr/doctype/shift_type/shift_type.js:16
+msgid "Please Enable Auto Attendance and complete the setup first."
+msgstr "Автомат оролцоог идэвхжүүлж эхлээд тохиргоог гүйцээнэ үү."
+
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.js:8
+msgid "Please Select Company First"
+msgstr "Эхлээд компанийг сонгоно уу"
+
+#: hrms/utils/holiday_list.py:105
+msgid ""
+"Please assign Holiday List for Employee {0} or their company {1} through {2}"
+msgstr ""
+"{0} ажилтан эсвэл тэдний {1} компанид {2}-ээр баярын жагсаалт хуваарилна уу"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:836
+msgid ""
+"Please assign a Salary Structure for Employee {0} applicable from or before "
+"{1} first"
+msgstr ""
+"Ажилтны {0} цалингийн бүтцийг эхлээд {1}-ээс өмнө эсвэл түүнээс өмнө "
+"тохируулна уу."
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:41
+msgid ""
+"Please check if employee is on leave or attendance with the same status "
+"exists for selected day(s)."
+msgstr ""
+"Ажилтан чөлөөтэй эсэх эсвэл сонгосон өдр(үүд)т ижил төлөвтэй ирц байгаа "
+"эсэхийг шалгана уу."
+
+#: hrms/templates/emails/training_event.html:17
+msgid "Please confirm once you have completed your training"
+msgstr "Сургалтаа дуусгасны дараа баталгаажуулна уу"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:101
+msgid "Please create a new {0} for the date {1} first."
+msgstr "Эхлээд {1} огноогоор шинэ {0} үүсгэнэ үү."
+
+#: hrms/hr/doctype/employee_transfer/employee_transfer.py:55
+msgid "Please delete the Employee {0} to cancel this document"
+msgstr "Энэ баримт бичгийг цуцлахын тулд Ажилтныг {0} устгана уу"
+
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.py:20
+msgid ""
+"Please enable default incoming account before creating Daily Work Summary "
+"Group"
+msgstr ""
+"Өдөр тутмын ажлын хураангуй бүлгийг үүсгэхээсээ өмнө өгөгдмөл ирсэн "
+"бүртгэлийг идэвхжүүлнэ үү"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.js:97
+msgid "Please enter the designation"
+msgstr "Тодорхойлолтыг оруулна уу"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.js:11
+msgid ""
+"Please fill in Employee, Posting Date, and Company before fetching overtime "
+"details."
+msgstr ""
+"Илүү цагийн мэдээлэл татахын өмнө Ажилтан, Бичилтийн огноо, Компаниг бөглөнө"
+" үү."
+
+#: hrms/hr/doctype/shift_type/shift_type.py:59
+msgid "Please reduce {0} to avoid shift time overlapping with itself"
+msgstr "Ээлжийн цаг өөртэйгөө давхцахаас зайлсхийхийн тулд {0}-г багасгана уу"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2163
+msgid "Please see attachment"
+msgstr "Хавсралтыг харна уу"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.py:225
+msgid "Please select Company and Designation"
+msgstr "Компани болон нэрийг сонгоно уу"
+
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.js:22
+msgid "Please select Employee"
+msgstr "Ажилтнаа сонгоно уу"
+
+#: hrms/hr/doctype/department_approver/department_approver.py:19
+#: hrms/hr/employee_property_update.js:45
+msgid "Please select Employee first."
+msgstr "Эхлээд Ажилтнаа сонгоно уу."
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:41
+#| msgid "Please select From Date."
+msgid "Please select Filter Based On"
+msgstr "Огнооноос сонгоно уу."
+
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.js:25
+msgid "Please select From Date and Payroll Frequency first"
+msgstr "Эхлээд огноо болон цалингийн давтамжийг сонгоно уу"
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:113
+msgid "Please select From Date."
+msgstr "Огнооноос сонгоно уу."
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:167
+msgid "Please select Shift Schedule and assignment date(s)."
+msgstr "Шилжилтийн хуваарь болон хуваарилалтын огноог сонгоно уу."
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:160
+msgid "Please select Shift Type and assignment date(s)."
+msgstr "Шилжилтийн төрөл болон хуваарилалтын огноог сонгоно уу."
+
+#: hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js:233
+msgid "Please select a company first"
+msgstr "Эхлээд компаниа сонгоно уу"
+
+#: hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js:103
+#: hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js:299
+msgid "Please select a company first."
+msgstr "Эхлээд компаниа сонгоно уу."
+
+#: hrms/hr/doctype/upload_attendance/upload_attendance.py:172
+msgid "Please select a csv file"
+msgstr "csv файл сонгоно уу"
+
+#: hrms/hr/doctype/attendance/attendance.py:348
+msgid "Please select a date."
+msgstr "Огноо сонгоно уу."
+
+#: hrms/hr/utils.py:812
+msgid "Please select an Applicant"
+msgstr "Өргөдөл гаргагчийг сонгоно уу"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:260
+msgid "Please select at least one Shift Request to perform this action."
+msgstr ""
+"Энэ үйлдлийг гүйцэтгэхийн тулд дор хаяж нэг ээлжийн хүсэлтийг сонгоно уу."
+
+#: hrms/hr/utils.py:923
+msgid "Please select at least one employee to perform this action."
+msgstr "Энэ үйлдлийг гүйцэтгэхийн тулд дор хаяж нэг ажилтныг сонгоно уу."
+
+#: hrms/public/js/utils/index.js:47
+msgid "Please select at least one row to perform this action."
+msgstr "Энэ үйлдлийг гүйцэтгэхийн тулд дор хаяж нэг мөр сонгоно уу."
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:55
+msgid "Please select company."
+msgstr "Компани сонгоно уу."
+
+#: hrms/hr/doctype/employee_advance/employee_advance.js:16
+#: hrms/hr/doctype/leave_encashment/leave_encashment.js:30
+msgid "Please select employee first"
+msgstr "Эхлээд ажилтнаа сонгоно уу"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:111
+msgid "Please select employees to create appraisals for"
+msgstr "Үнэлгээ үүсгэх ажилчдаа сонгоно уу"
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:256
+#| msgid "Please select the attendance status."
+msgid "Please select half day attendance status."
+msgstr "Ирцийн төлөвөө сонгоно уу."
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:44
+msgid "Please select month and year."
+msgstr "Сар, жилийг сонгоно уу."
+
+#: hrms/hr/doctype/goal/goal.js:103
+msgid "Please select the Appraisal Cycle first."
+msgstr "Эхлээд үнэлгээний мөчлөгийг сонгоно уу."
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:250
+msgid "Please select the attendance status."
+msgstr "Ирцийн төлөвөө сонгоно уу."
+
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js:243
+msgid "Please select the employees you want to mark attendance for."
+msgstr "Ирцээ тэмдэглэхийг хүсч буй ажилчдаа сонгоно уу."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip_list.js:15
+msgid "Please select the salary slips to email"
+msgstr "Цалингийн хуудсыг сонгон цахим шуудангаар илгээнэ үү"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:286
+msgid "Please set \"Default Payroll Payable Account\" in Company Defaults"
+msgstr "Компанийн өгөгдмөл хэсэгт \"Өгөгдмөл цалингийн данс\"-ыг тохируулна уу"
+
+#: hrms/regional/india/utils.py:18
+msgid "Please set Basic and HRA component in Company {0}"
+msgstr "{0} компанид Үндсэн болон HRA бүрэлдэхүүнийг тохируулна уу"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:162
+msgid "Please set Earning Component for Leave type: {0}."
+msgstr "Амралтын төрөлд Орлогын бүрэлдэхүүн хэсгийг тохируулна уу: {0}."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:497
+msgid "Please set Payroll based on in Payroll settings"
+msgstr "Цалингийн тохиргоонд үндэслэн Цалингийн хэмжээг тохируулна уу"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:173
+msgid "Please set Relieving Date for employee: {0}"
+msgstr "Ажилтныг чөлөөлөх огноог тохируулна уу: {0}"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:166
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:52
+#| msgid "Please select the attendance status."
+msgid "Please set a date range less than 90 days."
+msgstr "Ирцийн төлөвөө сонгоно уу."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:357
+msgid "Please set account in Salary Component {0}"
+msgstr "Цалингийн бүрэлдэхүүн хэсэгт бүртгэл тохируулна уу {0}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:695
+msgid ""
+"Please set default template for Leave Approval Notification in HR Settings."
+msgstr ""
+"Хүний нөөцийн тохиргоонд зөвшөөрөл олгох мэдэгдлийн өгөгдмөл загварыг "
+"тохируулна уу."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:670
+msgid ""
+"Please set default template for Leave Status Notification in HR Settings."
+msgstr ""
+"Хүний нөөцийн тохиргоонд Орхих статусын мэдэгдлийн өгөгдмөл загварыг "
+"тохируулна уу."
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:48
+#| msgid "Please set {0} and {1} in {2}."
+msgid "Please set the Advance Account {0} or in {1}"
+msgstr " дотор {0} болон {1}-г тохируулна уу."
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:137
+msgid ""
+"Please set the Appraisal Template for all the {0} or select the template in "
+"the Employees table below."
+msgstr ""
+"Бүх {0}-д Үнэлгээний загварыг тохируулна уу эсвэл доорх Ажилчдын хүснэгтээс "
+"загварыг сонгоно уу."
+
+#: hrms/hr/doctype/expense_claim/expense_claim.js:522
+msgid "Please set the Company"
+msgstr "Компанийг тохируулна уу"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:302
+msgid "Please set the Date Of Joining for employee {0}"
+msgstr "Ажилтан {0}-д элссэн огноог тохируулна уу"
+
+#: hrms/controllers/employee_boarding_controller.py:110
+msgid "Please set the Holiday List."
+msgstr "Амралтын жагсаалтыг тохируулна уу."
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:48
+#| msgid "Please select a date."
+msgid "Please set the date range."
+msgstr "Огноо сонгоно уу."
+
+#: hrms/hr/doctype/exit_interview/exit_interview.js:21
+#: hrms/hr/doctype/exit_interview/exit_interview.py:21
+msgid "Please set the relieving date for employee {0}"
+msgstr "Ажилтныг чөлөөлөх огноог тохируулна уу {0}"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:123
+msgid "Please set {0} and {1} in {2}."
+msgstr "{2} дотор {0} болон {1}-г тохируулна уу."
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:44
+msgid "Please set {0} for Employee {1}"
+msgstr "{1} ажилтанд {0}-г тохируулна уу"
+
+#: hrms/hr/doctype/department_approver/department_approver.py:84
+msgid "Please set {0} for the Employee: {1}"
+msgstr "Ажилтны хувьд {0}-г тохируулна уу: {1}"
+
+#: hrms/hr/doctype/shift_type/shift_type.js:21
+#: hrms/hr/doctype/shift_type/shift_type.js:26
+msgid "Please set {0}."
+msgstr "{0}-г тохируулна уу."
+
+#: hrms/overrides/employee_master.py:16
+msgid "Please setup Employee Naming System in Human Resource > HR Settings"
+msgstr ""
+"Хүний нөөц > Хүний нөөцийн тохиргоо хэсэгт Ажилтны нэрсийн системийг "
+"тохируулна уу"
+
+#: hrms/hr/doctype/upload_attendance/upload_attendance.py:159
+msgid ""
+"Please setup numbering series for Attendance via Setup > Numbering Series"
+msgstr ""
+"Тохируулах > Дугаарлах цувралаар ирцийг дугаарлах цувралыг тохируулна уу"
+
+#: hrms/hr/notification/training_feedback/training_feedback.html:6
+msgid ""
+"Please share your feedback to the training by clicking on 'Training "
+"Feedback' and then 'New'"
+msgstr ""
+"Сургалтын талаарх санал хүсэлтээ \"Сургалтын санал хүсэлт\" дээр дараад "
+"\"Шинэ\" дээр дарж хуваалцана уу."
+
+#: hrms/hr/doctype/interview/interview.py:194
+msgid "Please specify the job applicant to be updated."
+msgstr "Шинэчлэх ажил горилогчийг зааж өгнө үү."
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:158
+msgid ""
+"Please specify {0} and {1} (if any), for the correct tax calculation in "
+"future salary slips."
+msgstr ""
+"Ирээдүйн цалингийн хуудасны татварыг зөв тооцоолохын тулд {0} болон {1} "
+"(хэрэв байгаа бол)-ыг зааж өгнө үү."
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:157
+msgid "Please submit the {0} before marking the cycle as Completed"
+msgstr "Циклийг дууссан гэж тэмдэглэхийн өмнө {0}-г оруулна уу"
+
+#: hrms/templates/emails/training_event.html:13
+msgid "Please update your status for this training event"
+msgstr "Энэхүү сургалтын арга хэмжээний статусаа шинэчилнэ үү"
+
+#. Label of the posted_on (Datetime) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Posted On"
+msgstr "Нийтэлсэн"
+
+#. Label of the posting_date (Date) field in DocType 'Gratuity'
+#: hrms/payroll/doctype/gratuity/gratuity.json
+msgid "Posting date"
+msgstr "Нийтэлсэн огноо"
+
+#. Label of the preferred_area_for_lodging (Data) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Preferred Area for Lodging"
+msgstr "Зочид буудаллахад тохиромжтой бүс"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#. Option for the 'Status for Other Half' (Select) field in DocType
+#. 'Attendance'
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance
+#. Tool'
+#. Option for the 'Status for Other Half' (Select) field in DocType 'Employee
+#. Attendance Tool'
+#. Option for the 'Attendance' (Select) field in DocType 'Training Event
+#. Employee'
+#. Option for the 'Consider Unmarked Attendance As' (Select) field in DocType
+#. 'Payroll Settings'
+#: frontend/src/components/AttendanceCalendar.vue:80
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:733
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Present"
+msgstr "Одоогийн"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:162
+msgid "Present Records"
+msgstr "Одоогийн бичлэгүүд"
+
+#. Label of the prevent_self_expense_approval (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Prevent self approval for expense claims even if user has permissions"
+msgstr ""
+"Хэрэглэгчид зөвшөөрөл байсан ч зардлын нэхэмжлэлийг өөрөө батлахаас "
+"сэргийлэх"
+
+#. Label of the prevent_self_leave_approval (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Prevent self approval for leaves even if user has permissions"
+msgstr "Хэрэглэгчид зөвшөөрөл байсан ч чөлөөг өөрөө батлахаас сэргийлэх"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:155
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:193
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js:73
+msgid "Preview Salary Slip"
+msgstr "Цалингийн хуудсыг урьдчилан үзэх"
+
+#. Label of the principal_amount (Currency) field in DocType 'Salary Slip
+#. Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Principal Amount"
+msgstr "Үндсэн төлбөрийн хэмжээ"
+
+#: hrms/payroll/report/salary_register/salary_register.html:40
+#| msgid "Printed On"
+msgid "Printed On {0}"
+msgstr "{0}-д хэвлэсэн"
+
+#: hrms/setup.py:373 hrms/setup.py:374
+msgid "Privilege Leave"
+msgstr "Давуу эрх чөлөө"
+
+#: hrms/setup.py:391
+msgid "Probation"
+msgstr "Туршилт"
+
+#: hrms/setup.py:405
+msgid "Probationary Period"
+msgstr "Туршилтын хугацаа"
+
+#. Label of the process_attendance_after (Date) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Process Attendance After"
+msgstr "Дараа нь ирцийг боловсруулах"
+
+#. Label of the process_payroll_accounting_entry_based_on_employee (Check)
+#. field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#: hrms/setup.py:857
+msgid "Process Payroll Accounting Entry based on Employee"
+msgstr "Ажилтан дээр үндэслэн цалингийн бүртгэлийн бичилтийг боловсруул"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:123
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:130
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:132
+msgid "Process Requests"
+msgstr "Хүсэлтийг боловсруулах"
+
+#. Option for the 'Action' (Select) field in DocType 'Shift Assignment Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Process Shift Requests"
+msgstr "Шилжилтийн хүсэлтийг боловсруулах"
+
+#. Description of the 'Pay Via Payment Entry' (Check) field in DocType 'Leave
+#. Encashment'
+#: hrms/hr/doctype/leave_encashment/leave_encashment.json
+msgid ""
+"Process leave encashment via a separate Payment Entry instead of Salary Slip"
+msgstr ""
+"Чөлөөний мөнгөн хөрвүүлэлтийг цалингийн хуудасны оронд тусдаа төлбөрийн "
+"бичилтээр боловсруулах"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:289
+msgid "Process {0} Shift Request(s) as <b>{1}</b>?"
+msgstr "{0} Шифтийн хүсэлтийг <b>{1}</b> байдлаар боловсруулах уу?"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:305
+msgid "Processing Requests"
+msgstr "Хүсэлтийг боловсруулах"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:299
+msgid "Processing Requests..."
+msgstr "Хүсэлтийг боловсруулж байна..."
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py:271
+msgid ""
+"Processing of Shift Requests has been queued. It may take a few minutes."
+msgstr ""
+"Ээлжийн хүсэлтийг боловсруулах дараалалд орлоо. Үүнд хэдэн минут "
+"зарцуулагдаж магадгүй."
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Professional Tax Deductions"
+msgstr "Мэргэжлийн татварын хөнгөлөлт"
+
+#. Label of the proficiency (Rating) field in DocType 'Employee Skill'
+#: hrms/hr/doctype/employee_skill/employee_skill.json
+msgid "Proficiency"
+msgstr "Ур чадвар"
+
+#: hrms/hr/report/project_profitability/project_profitability.py:183
+msgid "Profit"
+msgstr "Ашиг"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/report/project_profitability/project_profitability.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Project Profitability"
+msgstr "Төслийн ашигт ажиллагаа"
+
+#. Label of the promotion_date (Date) field in DocType 'Employee Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Promotion Date"
+msgstr "Сурталчилгааны огноо"
+
+#: hrms/hr/employee_property_update.js:172
+msgid "Property already added"
+msgstr "Өмчийг аль хэдийн нэмсэн"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Provident Fund Deductions"
+msgstr "Сангийн суутгал"
+
+#. Label of the public_holiday_multiplier (Float) field in DocType 'Overtime
+#. Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Public Holiday Multiplier"
+msgstr "Нийтийн баярын үржүүлэгч"
+
+#. Label of the publish_applications_received (Check) field in DocType 'Job
+#. Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Publish Applications Received"
+msgstr "Хүлээн авсан програмуудыг нийтлэх"
+
+#. Label of the publish_salary_range (Check) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Publish Salary Range"
+msgstr "Цалингийн хүрээг нийтлэх"
+
+#. Label of the publish (Check) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Publish on website"
+msgstr "Вэбсайт дээр нийтлэх"
+
+#. Label of the section_break_8 (Section Break) field in DocType 'Employee
+#. Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Purpose & Amount"
+msgstr "Зорилго ба хэмжээ"
+
+#. Name of a DocType
+#. Label of the purpose_of_travel (Data) field in DocType 'Purpose of Travel'
+#. Label of the purpose_of_travel (Link) field in DocType 'Travel Request'
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/doctype/purpose_of_travel/purpose_of_travel.json
+#: hrms/hr/doctype/travel_request/travel_request.json
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Purpose of Travel"
+msgstr "Аяллын зорилго"
+
+#: frontend/src/views/AppSettings.vue:128
+msgid "Push Notification permission denied"
+msgstr "Түлхэх мэдэгдлийн зөвшөөрлийг үгүйсгэв"
+
+#: frontend/src/views/AppSettings.vue:96
+msgid "Push notifications disabled"
+msgstr "Түлхэх мэдэгдлийг идэвхгүй болгосон"
+
+#: frontend/src/views/AppSettings.vue:80
+msgid "Push notifications have been disabled on your site"
+msgstr "Таны сайт дээр түлхэх мэдэгдлийг идэвхгүй болгосон"
+
+#. Label of the questionnaire_email_sent (Check) field in DocType 'Exit
+#. Interview'
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+msgid "Questionnaire Email Sent"
+msgstr "Санал асуулгын цахим шуудан илгээсэн"
+
+#. Label of the quick_filters_section (Section Break) field in DocType 'Leave
+#. Control Panel'
+#. Label of the quick_filters_section (Section Break) field in DocType 'Shift
+#. Assignment Tool'
+#. Label of the quick_filters_section (Section Break) field in DocType 'Bulk
+#. Salary Structure Assignment'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+msgid "Quick Filters"
+msgstr "Түргэн шүүлтүүрүүд"
+
+#: frontend/src/components/QuickLinks.vue:3 frontend/src/views/Home.vue:6
+msgid "Quick Links"
+msgstr "Түргэн холбоосууд"
+
+#. Description of the 'Checkin Radius' (Int) field in DocType 'Shift Location'
+#: hrms/hr/doctype/shift_location/shift_location.json
+msgid "Radius within which check-in is allowed (in meters)"
+msgstr "Бүртгүүлэхийг зөвшөөрдөг радиус (метрээр)"
+
+#. Label of the rate_goals_manually (Check) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Rate Goals Manually"
+msgstr "Зорилгоо гараар үнэлэх"
+
+#. Label of the rating_criteria (Table) field in DocType 'Appraisal Template'
+#: hrms/hr/doctype/appraisal_template/appraisal_template.json
+msgid "Rating Criteria"
+msgstr "Үнэлгээний шалгуур"
+
+#. Label of the section_break_23 (Section Break) field in DocType 'Appraisal'
+#. Label of the ratings_section (Section Break) field in DocType 'Interview'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/interview/interview.json
+msgid "Ratings"
+msgstr "Үнэлгээ"
+
+#. Label of the reallocate_leaves (Check) field in DocType 'Employee Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Re-allocate Leaves"
+msgstr "Навчийг дахин хуваарилах"
+
+#. Label of the reason_for_adjustment (Small Text) field in DocType 'Leave
+#. Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+#| msgid "Reason for Requesting"
+msgid "Reason for Adjustment"
+msgstr "Хүсэлт гаргах шалтгаан"
+
+#. Label of the reason_for_requesting (Text) field in DocType 'Job
+#. Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Reason for Requesting"
+msgstr "Хүсэлт гаргах шалтгаан"
+
+#. Label of the reason_for_withholding_salary (Small Text) field in DocType
+#. 'Salary Withholding'
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Reason for Withholding Salary"
+msgstr "Цалингаа суутгасан шалтгаан"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:444
+msgid "Reason for skipping auto attendance:"
+msgstr "Автомат ирцийг алгасах шалтгаан:"
+
+#: frontend/src/views/attendance/Dashboard.vue:14
+msgid "Recent Attendance Requests"
+msgstr "Сүүлийн үеийн ирцийн хүсэлт"
+
+#: frontend/src/views/expense_claim/Dashboard.vue:23
+msgid "Recent Expenses"
+msgstr "Сүүлийн үеийн зардал"
+
+#: frontend/src/views/leave/Dashboard.vue:21
+msgid "Recent Leaves"
+msgstr "Сүүлийн үеийн навчнууд"
+
+#: frontend/src/views/attendance/Dashboard.vue:40
+msgid "Recent Shift Requests"
+msgstr "Сүүлийн ээлжийн хүсэлтүүд"
+
+#. Description of the 'Automatically update Last Sync of Checkin' (Check)
+#. field
+#. in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Recommended for a single biometric device / checkins via mobile app"
+msgstr ""
+"Нэг биометрийн төхөөрөмж / гар утасны аппликэйшнээр бүртгэл хийхэд "
+"тохиромжтой"
+
+#. Option for the 'Action' (Select) field in DocType 'Full and Final Asset'
+#: hrms/hr/doctype/full_and_final_asset/full_and_final_asset.json
+msgid "Recover Cost"
+msgstr "Зардлаа нөхөх"
+
+#. Label of the recruitment_tab (Tab Break) field in DocType 'HR Settings'
+#. Name of a Workspace
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Recruitment"
+msgstr "Ажилд авах"
+
+#. Name of a report
+#. Label of a Link in the People Workspace
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.json
+#: hrms/hr/workspace/people/people.json
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Recruitment Analytics"
+msgstr "Ажилд авах аналитик"
+
+#. Option for the 'Adjustment Type' (Select) field in DocType 'Leave
+#. Adjustment'
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.json
+msgid "Reduce"
+msgstr "Бууруулах"
+
+#: hrms/hr/doctype/leave_type/leave_type.py:69
+msgid ""
+"Reducing maximum leaves allowed after allocation may cause scheduler to "
+"allocate incorrect number of earned leaves. Proceed with caution."
+msgstr ""
+"Хуваарилалтын дараа зөвшөөрөгдсөн дээд чөлөөг бууруулах нь хуваарьт ажилд "
+"олгогдсон чөлөөг буруу хуваарилахад хүргэж болно. Болгоомжтой үргэлжлүүлнэ "
+"үү."
+
+#: hrms/hr/doctype/leave_adjustment/leave_adjustment.py:75
+msgid ""
+"Reduction is more than {0}'s available leave balance {1} for leave type {2}"
+msgstr ""
+"{2} чөлөөний төрлийн {0}-ийн боломжтой чөлөөний үлдэгдэл {1}-с бууруулга "
+"хэтэрсэн"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:371
+#: hrms/hr/doctype/leave_application/leave_application.py:537
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:189
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:101
+msgid "Reference: {0}"
+msgstr "Лавлагаа: {0}"
+
+#. Label of the referral_payment_status (Select) field in DocType 'Employee
+#. Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Referral Bonus Payment Status"
+msgstr "Лавлагааны урамшууллын төлбөрийн байдал"
+
+#. Label of the referral_details_section (Section Break) field in DocType
+#. 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Referral Details"
+msgstr "Лавлагааны дэлгэрэнгүй мэдээлэл"
+
+#. Label of the referrer_details_section (Section Break) field in DocType
+#. 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Referrer Details"
+msgstr "Илгээгчийн дэлгэрэнгүй мэдээлэл"
+
+#. Label of the referrer_name (Data) field in DocType 'Employee Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Referrer Name"
+msgstr "Илгээгчийн нэр"
+
+#. Label of the reflections_section (Section Break) field in DocType
+#. 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Reflections"
+msgstr "Тусгал"
+
+#. Label of the refuelling_details (Section Break) field in DocType 'Vehicle
+#. Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Refuelling Details"
+msgstr "Шатахуун цэнэглэх дэлгэрэнгүй мэдээлэл"
+
+#: frontend/src/components/RequestActionSheet.vue:96
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:126
+msgid "Reject"
+msgstr "Татгалзах"
+
+#: hrms/hr/doctype/employee_referral/employee_referral.js:7
+msgid "Reject Employee Referral"
+msgstr "Ажилтны саналаас татгалзах"
+
+#: frontend/src/components/RequestActionSheet.vue:290
+msgid "Rejection"
+msgstr "Татгалзах"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:188
+msgid "Release Withheld Salaries"
+msgstr "Суутгасан цалингаа чөлөөл"
+
+#. Option for the 'Status' (Select) field in DocType 'Salary Withholding'
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Released"
+msgstr "Суллагдсан"
+
+#. Label of the relieving_date (Date) field in DocType 'Full and Final
+#. Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Relieving Date "
+msgstr "Тайвшруулах огноо "
+
+#: hrms/hr/doctype/exit_interview/exit_interview.js:28
+#: hrms/hr/doctype/exit_interview/exit_interview.py:24
+msgid "Relieving Date Missing"
+msgstr "Алга болсон огноог арилгах"
+
+#. Label of the remaining_benefit (Currency) field in DocType 'Employee
+#. Benefit
+#. Application'
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+msgid "Remaining Benefits (Yearly)"
+msgstr "Үлдсэн ашиг тус (жил бүр)"
+
+#. Label of the remind_before (Time) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Remind Before"
+msgstr "Өмнө нь сануул"
+
+#. Label of the reminded (Check) field in DocType 'Interview'
+#: hrms/hr/doctype/interview/interview.json
+msgid "Reminded"
+msgstr "Сануулсан"
+
+#. Label of the reminders_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Reminders"
+msgstr "Сануулга"
+
+#. Label of the remove_if_zero_valued (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Remove if Zero Valued"
+msgstr "Хэрэв тэг үнэлэгдсэн бол устгана уу"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Rented Car"
+msgstr "Түрээсийн машин"
+
+#: hrms/setup.py:830 hrms/setup.py:839
+msgid "Repay From Salary"
+msgstr "Цалингаас буцаан олгох"
+
+#: hrms/hr/utils.py:827
+msgid "Repay From Salary can be selected only for term loans"
+msgstr "Цалингаас эргэн төлөлтийг зөвхөн хугацаатай зээлээр сонгох боломжтой"
+
+#. Label of the repay_unclaimed_amount_from_salary (Check) field in DocType
+#. 'Employee Advance'
+#: hrms/hr/doctype/employee_advance/employee_advance.json
+msgid "Repay Unclaimed Amount from Salary"
+msgstr "Цалингаас нэхэмжлээгүй мөнгийг эргүүлэн төлөх"
+
+#. Label of the repeat_on_days (Table) field in DocType 'Shift Schedule'
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+msgid "Repeat On Days"
+msgstr "Өдөр бүр давт"
+
+#: hrms/hr/report/daily_work_summary_replies/daily_work_summary_replies.py:22
+msgid "Replies"
+msgstr "Хариултууд"
+
+#. Label of the reports_to (Link) field in DocType 'Employee Grievance'
+#. Label of the reports_to (Link) field in DocType 'Exit Interview'
+#: hrms/hr/doctype/employee_grievance/employee_grievance.json
+#: hrms/hr/doctype/exit_interview/exit_interview.json
+#: hrms/hr/report/employee_exits/employee_exits.js:45
+#: hrms/hr/report/employee_exits/employee_exits.py:79
+msgid "Reports To"
+msgstr "Мэдээлдэг"
+
+#: frontend/src/views/Home.vue:32
+#: frontend/src/views/attendance/Dashboard.vue:9
+msgid "Request Attendance"
+msgstr "Оролцох хүсэлт гаргах"
+
+#: frontend/src/views/Home.vue:42
+msgid "Request Leave"
+msgstr "Амрах хүсэлт гаргах"
+
+#: frontend/src/views/leave/Dashboard.vue:17
+msgid "Request a Leave"
+msgstr "Амралт хүсэх"
+
+#: frontend/src/views/Home.vue:37
+#: frontend/src/views/attendance/Dashboard.vue:35
+msgid "Request a Shift"
+msgstr "Шилжилт хүсэх"
+
+#: frontend/src/components/EmployeeAdvanceBalance.vue:21
+#: frontend/src/views/Home.vue:52
+msgid "Request an Advance"
+msgstr "Урьдчилгаа хүсэх"
+
+#. Label of the requested_by (Link) field in DocType 'Job Requisition'
+#. Label of the section_break_7 (Section Break) field in DocType 'Job
+#. Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Requested By"
+msgstr "Хүссэн"
+
+#. Label of the requested_by_name (Data) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Requested By (Name)"
+msgstr "Хүссэн (Нэр)"
+
+#. Option for the 'Travel Funding' (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Require Full Funding"
+msgstr "Бүрэн санхүүжилт шаардах"
+
+#: hrms/setup.py:170
+msgid "Required Skills"
+msgstr "Шаардлагатай ур чадвар"
+
+#. Label of the required_for_employee_creation (Check) field in DocType
+#. 'Employee Boarding Activity'
+#: hrms/hr/doctype/employee_boarding_activity/employee_boarding_activity.json
+msgid "Required for Employee Creation"
+msgstr "Ажилтан бий болгоход шаардлагатай"
+
+#: hrms/hr/doctype/interview/interview.js:31
+msgid "Reschedule Interview"
+msgstr "Ярилцлагын хуваарийг өөрчлөх"
+
+#: hrms/setup.py:411
+msgid "Responsibilities"
+msgstr "Хариуцлага"
+
+#. Label of the restrict_backdated_leave_application (Check) field in DocType
+#. 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Restrict Backdated Leave Application"
+msgstr "Хоцрогдсон чөлөө олгох өргөдлийг хязгаарлах"
+
+#. Label of the resume_attachment (Attach) field in DocType 'Job Applicant'
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+msgid "Resume Attachment"
+msgstr "Хавсралтыг үргэлжлүүлэх"
+
+#. Label of the resume_link (Data) field in DocType 'Employee Referral'
+#. Label of the resume_link (Data) field in DocType 'Job Applicant'
+#. Label of a field in the job-application Web Form
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Resume Link"
+msgstr "Холбоосыг үргэлжлүүлэх"
+
+#. Label of the resume_link (Data) field in DocType 'Interview'
+#: hrms/hr/doctype/interview/interview.json
+msgid "Resume link"
+msgstr "Холбоосыг үргэлжлүүлэх"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:193
+msgid "Retained"
+msgstr "Хадгалагдсан"
+
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Retention Bonus"
+msgstr "Хадгалах урамшуулал"
+
+#. Label of the retirement_age (Data) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Retirement Age (In Years)"
+msgstr "Тэтгэврийн нас (жилээр)"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:441
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:449
+#| msgid "Creation Failed"
+msgid "Retry Failed"
+msgstr "Бүтээж чадсангүй"
+
+#. Label of the retry_failed_allocations (Button) field in DocType 'Leave
+#. Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+#| msgid "Leave Allocations"
+msgid "Retry Failed Allocations"
+msgstr "Хуваарилалтаа орхи"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:191
+#| msgid "Import Successful"
+msgid "Retry Successful"
+msgstr "Импорт амжилттай боллоо"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:188
+#| msgid "Over Allocation"
+msgid "Retrying allocations"
+msgstr "Хэт хуваарилалт"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:205
+msgid "Return amount cannot be greater than unclaimed amount"
+msgstr "Буцаах хэмжээ нь нэхэмжлээгүй дүнгээс их байж болохгүй"
+
+#: hrms/hr/doctype/hr_settings/hr_settings.js:41
+msgid ""
+"Review various other settings related to Employee Leaves and Expense Claim"
+msgstr ""
+"Ажилтны чөлөө, зардлын нэхэмжлэлтэй холбоотой бусад янз бүрийн тохиргоог "
+"шалгана уу"
+
+#. Label of the reviewer (Link) field in DocType 'Employee Performance
+#. Feedback'
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Reviewer"
+msgstr "Шүүмжлэгч"
+
+#. Label of the reviewer_name (Data) field in DocType 'Employee Performance
+#. Feedback'
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Reviewer Name"
+msgstr "Шүүгчийн нэр"
+
+#. Label of the revised_ctc (Currency) field in DocType 'Employee Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Revised CTC"
+msgstr "Шинэчилсэн CTC"
+
+#. Label of the role_allowed_to_create_backdated_leave_application (Link)
+#. field
+#. in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/doctype/leave_application/leave_application.py:185
+msgid "Role Allowed to Create Backdated Leave Application"
+msgstr "Хугацаа хоцрогдсон чөлөөний програм үүсгэхийг зөвшөөрсөн үүрэг"
+
+#: hrms/public/js/utils/index.js:252 hrms/public/js/utils/index.js:273
+msgid "Roster"
+msgstr "Жагсаалт"
+
+#. Label of the color (Select) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Roster Color"
+msgstr "Жагсаалтын өнгө"
+
+#. Label of the round_name (Data) field in DocType 'Interview Round'
+#: hrms/hr/doctype/interview_round/interview_round.json
+msgid "Round Name"
+msgstr "Дугуй нэр"
+
+#. Option for the 'Work Experience Calculation Method' (Select) field in
+#. DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Round off Work Experience"
+msgstr "Ажлын туршлагыг нэгтгэх"
+
+#. Label of the round_to_the_nearest_integer (Check) field in DocType 'Salary
+#. Component'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+msgid "Round to the Nearest Integer"
+msgstr "Хамгийн ойрын бүхэл тоо руу дугуйлна"
+
+#. Label of the rounding (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "Rounding"
+msgstr "Дугуйлах"
+
+#. Description of the 'Job Application Route' (Data) field in DocType 'Job
+#. Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Route to the custom Job Application Webform"
+msgstr "Захиалгат ажлын өргөдлийн вэб маягт руу чиглүүлэх"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:86
+msgid ""
+"Row #{0}: Cannot set amount or formula for Salary Component {1} with "
+"Variable Based On Taxable Salary"
+msgstr ""
+"Мөр #{0}: Татвар ногдох цалинд суурилсан хувьсагчтай цалингийн {1} "
+"бүрэлдэхүүн хэсгийн хэмжээ эсвэл томъёог тохируулах боломжгүй"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:105
+msgid "Row #{0}: The {1} Component has the options {2} and {3} enabled."
+msgstr ""
+"Мөр #{0}: {1} Бүрэлдэхүүн хэсэг нь {2} болон {3} сонголтуудыг идэвхжүүлсэн."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:129
+msgid ""
+"Row #{0}: Timesheet amount will overwrite the Earning component amount for "
+"the Salary Component {1}"
+msgstr ""
+"Мөр #{0}: Цагийн хуудасны дүн нь Цалингийн бүрэлдэхүүн хэсгийн {1} Орлогын "
+"бүрэлдэхүүн хэсгийн дүнг дарж бичнэ."
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:901
+msgid ""
+"Row No {0}: Amount cannot be greater than the Outstanding Amount against "
+"Expense Claim {1}. Outstanding Amount is {2}"
+msgstr ""
+"Мөр No {0}: Дүн нь зардлын нэхэмжлэлийн {1}-ийн үлдэгдэл дүнгээс их байж "
+"болохгүй. Үлдэгдэл дүн {2}"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:503
+msgid ""
+"Row {0}# Allocated amount {1} cannot be greater than unclaimed amount {2}"
+msgstr ""
+"Мөр {0}# Хуваарилагдсан дүн {1} нэхэмжлээгүй дүнгээс {2} их байж болохгүй"
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:288
+#| msgid "Row {0}# Paid Amount cannot be greater than Total amount"
+msgid "Row {0}# Paid Amount cannot be greater than Encashment amount"
+msgstr "{0}# мөр Төлбөрийн дүн Нийт дүнгээс их байж болохгүй"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:133
+msgid "Row {0}# Paid Amount cannot be greater than Total amount"
+msgstr "{0}# мөр Төлбөрийн дүн Нийт дүнгээс их байж болохгүй"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:197
+msgid "Row {0}# Paid Amount cannot be greater than requested advance amount"
+msgstr "Мөр {0}# Төлсөн дүн нь хүссэн урьдчилгаа дүнгээс их байж болохгүй"
+
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.py:15
+msgid "Row {0}: From (Year) can not be greater than To (Year)"
+msgstr "{0}-р мөр: Эхлэл (Жи)-ээс (Жил)-ээс их байж болохгүй"
+
+#: hrms/hr/doctype/appraisal/appraisal.py:137
+#| msgid "Row {0}: Goal Score cannot be greater than 5"
+msgid "Row {0}: Goal Score cannot be greater than {1}"
+msgstr "{0} мөр: Зорилгын оноо нь {1}-с их байж болохгүй"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py:59
+msgid ""
+"Row {0}: Paid amount {1} is greater than pending accrued amount {2} against "
+"loan {3}"
+msgstr ""
+"{0} мөр: Төлсөн дүн {1} нь {3} зээлийн эсрэг хүлээгдэж буй хуримтлагдсан {2}"
+" дүнгээс их байна"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:65
+msgid "Row {0}: {1}"
+msgstr "Мөр {0}: {1}"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:432
+msgid ""
+"Row {0}: {1} is required in the expenses table to book an expense claim."
+msgstr ""
+"{0}-р мөр: Зардлын нэхэмжлэлийг захиалахын тулд зардлын хүснэгтэд {1} байх "
+"шаардлагатай."
+
+#. Label of the salary_component (Link) field in DocType 'Overtime Salary
+#. Component'
+#. Label of the salary_component (Link) field in DocType 'Additional Salary'
+#. Label of the salary_component (Link) field in DocType 'Employee Benefit
+#. Ledger'
+#. Label of the salary_component (Link) field in DocType 'Employee Incentive'
+#. Label of the salary_component (Link) field in DocType 'Gratuity'
+#. Label of the salary_component (Link) field in DocType 'Payroll Correction
+#. Child'
+#. Label of the salary_component (Link) field in DocType 'Retention Bonus'
+#. Name of a DocType
+#. Label of the salary_component (Link) field in DocType 'Salary Structure'
+#. Label of a Link in the Payroll Workspace
+#: hrms/hr/doctype/overtime_salary_component/overtime_salary_component.json
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.json
+#: hrms/payroll/doctype/gratuity/gratuity.json
+#: hrms/payroll/doctype/payroll_correction_child/payroll_correction_child.json
+#: hrms/payroll/doctype/retention_bonus/retention_bonus.json
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.js:77
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:33
+#: hrms/payroll/workspace/payroll/payroll.json
+#: hrms/public/js/utils/payroll_utils.js:23
+msgid "Salary Component"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг"
+
+#. Label of the salary_component (Link) field in DocType 'Gratuity Applicable
+#. Component'
+#: hrms/payroll/doctype/gratuity_applicable_component/gratuity_applicable_component.json
+msgid "Salary Component "
+msgstr "Цалингийн бүрэлдэхүүн хэсэг "
+
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_component_account/salary_component_account.json
+msgid "Salary Component Account"
+msgstr "Цалингийн бүрэлдэхүүн хэсгийн данс"
+
+#. Option for the 'Overtime Amount Calculation' (Select) field in DocType
+#. 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+#| msgid "Salary Component "
+msgid "Salary Component Based"
+msgstr "Цалингийн бүрэлдэхүүн хэсэг "
+
+#. Label of the type (Data) field in DocType 'Additional Salary'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+msgid "Salary Component Type"
+msgstr "Цалингийн бүрэлдэхүүн хэсгийн төрөл"
+
+#. Description of the 'Salary Component' (Link) field in DocType 'Salary
+#. Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Salary Component for timesheet based payroll."
+msgstr "Цагийн хүснэгтэд суурилсан цалингийн бүрэлдэхүүн хэсэг."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:440
+msgid ""
+"Salary Component {0} cannot be selected more than once in Employee Benefits"
+msgstr ""
+"{0} цалингийн бүрэлдэхүүнийг Ажилтны тэтгэмжид нэгээс олон удаа сонгох "
+"боломжгүй"
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:113
+msgid "Salary Component {0} is currently not used in any Salary Structure."
+msgstr ""
+"Цалингийн бүрэлдэхүүн хэсэг {0} одоогоор ямар ч Цалингийн бүтцэд "
+"ашиглагдаагүй байна."
+
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.py:15
+msgid ""
+"Salary Component {0} must be of type 'Earning' to be used in Employee "
+"Benefit Ledger"
+msgstr ""
+"Ажилтны тэтгэмжийн дэвтэрт ашиглахын тулд {0} цалингийн бүрэлдэхүүн нь "
+"'Орлого' төрлийн байх ёстой"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Salary Detail"
+msgstr "Цалингийн дэлгэрэнгүй"
+
+#. Label of the salary_details_section (Section Break) field in DocType
+#. 'Employee Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid "Salary Details"
+msgstr "Цалингийн дэлгэрэнгүй мэдээлэл"
+
+#. Label of the section_break_16 (Section Break) field in DocType 'Job
+#. Applicant'
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+msgid "Salary Expectation"
+msgstr "Цалингийн хүлээлт"
+
+#: frontend/src/views/Profile.vue:200
+msgid "Salary Information"
+msgstr "Цалингийн мэдээлэл"
+
+#. Label of the salary_per (Select) field in DocType 'Job Opening'
+#: hrms/hr/doctype/job_opening/job_opening.json
+msgid "Salary Paid Per"
+msgstr "Цалин тус бүрээр төлсөн"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Payments Based On Payment Mode"
+msgstr "Төлбөрийн горимд суурилсан цалингийн төлбөр"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/salary_payments_via_ecs/salary_payments_via_ecs.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Payments via ECS"
+msgstr "Цалингийн төлбөрийг ECS-ээр хийдэг"
+
+#: hrms/templates/generators/job_opening.html:108
+msgid "Salary Range"
+msgstr "Цалингийн хүрээ"
+
+#. Name of a report
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/report/salary_register/salary_register.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Register"
+msgstr "Цалингийн бүртгэл"
+
+#. Label of the salary_slip (Link) field in DocType 'Leave Application'
+#. Label of the salary_slip (Link) field in DocType 'Overtime Slip'
+#. Label of the salary_slip (Link) field in DocType 'Employee Benefit Ledger'
+#. Label of the column_break_rnoq (Section Break) field in DocType 'Payroll
+#. Settings'
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/hr/doctype/leave_application/leave_application.json
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/workspace/payroll/payroll.json hrms/setup.py:309
+msgid "Salary Slip"
+msgstr "Цалингийн хуудас"
+
+#. Label of the salary_slip_based_on_timesheet (Check) field in DocType
+#. 'Payroll Entry'
+#. Label of the salary_slip_based_on_timesheet (Check) field in DocType
+#. 'Salary
+#. Slip'
+#. Label of the salary_slip_based_on_timesheet (Check) field in DocType
+#. 'Salary
+#. Structure'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Salary Slip Based on Timesheet"
+msgstr "Цагийн хуудас дээр үндэслэн цалингийн хуудас"
+
+#: hrms/payroll/report/salary_register/salary_register.py:113
+msgid "Salary Slip ID"
+msgstr "Цалингийн хуудасны үнэмлэх"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Salary Slip Leave"
+msgstr "Цалингийн хуудасны чөлөө"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Salary Slip Loan"
+msgstr "Цалингийн хуудасны зээл"
+
+#. Label of the salary_slip_reference (Link) field in DocType 'Payroll
+#. Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#| msgid "Salary Slip Leave"
+msgid "Salary Slip Reference"
+msgstr "Цалингийн хуудасны чөлөө"
+
+#. Label of the timesheets (Table) field in DocType 'Salary Slip'
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_slip_timesheet/salary_slip_timesheet.json
+msgid "Salary Slip Timesheet"
+msgstr "Цалингийн хуудас"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:97
+msgid "Salary Slip already exists for {0} for the given dates"
+msgstr "Өгөгдсөн өдрүүдэд {0}-н цалингийн хуудас аль хэдийн байна"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:290
+msgid "Salary Slip creation is queued. It may take a few minutes"
+msgstr ""
+"Цалингийн хуудас үүсгэх дараалалд байна. Үүнд хэдэн минут зарцуулагдаж "
+"магадгүй"
+
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:121
+#| msgid "Salary Slip Loan"
+msgid "Salary Slip not found."
+msgstr "Цалингийн хуудасны зээл"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:336
+msgid "Salary Slip of employee {0} already created for this period"
+msgstr "Энэ хугацаанд аль хэдийн үүсгэсэн {0} ажилтны цалингийн хуудас"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:342
+msgid "Salary Slip of employee {0} already created for time sheet {1}"
+msgstr ""
+"Ажилтны {0} цалингийн хуудас {1} цагийн хуваарьт зориулж аль хэдийн үүсгэсэн"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:335
+msgid "Salary Slip submission is queued. It may take a few minutes"
+msgstr ""
+"Цалингийн хуудас өгөх дараалалд байна. Үүнд хэдэн минут зарцуулагдаж "
+"магадгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1525
+msgid "Salary Slip {0} failed for Payroll Entry {1}"
+msgstr "Цалингийн хуудас {0} Цалингийн бүртгэлд {1} амжилтгүй боллоо"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:117
+msgid "Salary Slip {0} failed. You can resolve the {1} and retry {0}."
+msgstr ""
+"Цалингийн хуудас {0} амжилтгүй боллоо. Та {1}-г шийдэж, {0}-г дахин оролдож "
+"болно."
+
+#: frontend/src/views/salary_slip/Dashboard.vue:2
+msgid "Salary Slips"
+msgstr "Цалингийн хуудас"
+
+#. Label of the salary_slips_created (Check) field in DocType 'Payroll Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Salary Slips Created"
+msgstr "Цалингийн хуудас үүсгэсэн"
+
+#. Label of the salary_slips_submitted (Check) field in DocType 'Payroll
+#. Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Salary Slips Submitted"
+msgstr "Цалингийн хуудас ирүүлсэн"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1567
+msgid ""
+"Salary Slips already exist for employees {}, and will not be processed by "
+"this payroll."
+msgstr ""
+"Ажилчдын {} цалингийн хуудас аль хэдийн байгаа бөгөөд энэ цалингийн "
+"жагсаалтаар боловсруулагдахгүй."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1592
+msgid "Salary Slips submitted for period from {0} to {1}"
+msgstr "{0}-с {1} хүртэлх хугацааны цалингийн хуудсыг ирүүлсэн"
+
+#. Label of the salary_structure (Link) field in DocType 'Arrear'
+#. Label of the salary_structure (Link) field in DocType 'Bulk Salary
+#. Structure
+#. Assignment'
+#. Label of the salary_structure (Link) field in DocType 'Salary Slip'
+#. Name of a DocType
+#. Label of the salary_structure (Link) field in DocType 'Salary Structure
+#. Assignment'
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/arrear/arrear.json
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+#: hrms/payroll/doctype/salary_component/salary_component.js:31
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Structure"
+msgstr "Цалингийн бүтэц"
+
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.js:8
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Structure Assignment"
+msgstr "Цалингийн бүтцийн даалгавар"
+
+#: hrms/public/js/utils/payroll_utils.js:31
+msgid "Salary Structure Assignment field"
+msgstr "Цалингийн бүтэц томилох талбар"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:46
+msgid "Salary Structure Assignment for Employee already exists"
+msgstr "Ажилтны цалингийн бүтцийн хуваарилалт аль хэдийн байна"
+
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.py:223
+#| msgid "Salary Structure not found for employee {0} and date {1}"
+msgid "Salary Structure Assignment not found for employee {0} on date {1}"
+msgstr "{0} ажилтны цалингийн бүтэц, огноо {1} олдсонгүй"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:442
+msgid "Salary Structure Missing"
+msgstr "Цалингийн бүтэц дутуу байна"
+
+#: hrms/regional/india/utils.py:29
+msgid "Salary Structure must be submitted before submission of {0}"
+msgstr "Цалингийн бүтцийг {0} илгээхээс өмнө ирүүлсэн байх ёстой."
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:92
+#| msgid "Salary Structure not found for employee {0} and date {1}"
+msgid "Salary Structure not assigned for employee {0} for date {1}"
+msgstr "{0} ажилтны цалингийн бүтэц, огноо {1} олдсонгүй"
+
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:70
+msgid "Salary Structure {0} does not belong to company {1}"
+msgstr "Цалингийн бүтэц {0} нь {1} компанид хамаарахгүй"
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:150
+msgid "Salary Structures updated successfully"
+msgstr "Цалингийн бүтцийг амжилттай шинэчилсэн"
+
+#. Label of the salary_withholding (Link) field in DocType 'Salary Slip'
+#. Name of a DocType
+#. Label of a Link in the Payroll Workspace
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+#: hrms/payroll/workspace/payroll/payroll.json
+msgid "Salary Withholding"
+msgstr "Цалин суутгал"
+
+#. Label of the salary_withholding_cycle (Data) field in DocType 'Salary Slip'
+#. Name of a DocType
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_withholding_cycle/salary_withholding_cycle.json
+msgid "Salary Withholding Cycle"
+msgstr "Цалин суутгалын мөчлөг"
+
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.py:39
+msgid ""
+"Salary Withholding {0} already exists for employee {1} for the selected "
+"period"
+msgstr "Сонгосон хугацаанд {1} ажилтны цалин суутгал {0} байгаа"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:378
+msgid ""
+"Salary already processed for period between {0} and {1}, Leave application "
+"period cannot be between this date range."
+msgstr ""
+"{0}-с {1} хүртэлх хугацааны цалинг аль хэдийн боловсруулсан, чөлөө авах "
+"өргөдөл гаргах хугацаа энэ хугацааны хооронд байж болохгүй."
+
+#. Description of the 'Earnings & Deductions' (Tab Break) field in DocType
+#. 'Salary Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Salary breakup based on Earning and Deduction."
+msgstr "Орлого, суутгал дээр үндэслэн цалингийн хуваарилалт."
+
+#: hrms/payroll/report/provident_fund_deductions/provident_fund_deductions.py:15
+msgid ""
+"Salary components of type Provident Fund, Additional Provident Fund or "
+"Provident Fund Loan are not set up."
+msgstr ""
+"Нийгмийн даатгалын сан, Нэмэлт нийгмийн даатгалын сан эсвэл Нийгмийн "
+"даатгалын сангийн зээлийн төрлийн цалингийн бүрэлдэхүүнүүд тохируулагдаагүй "
+"байна."
+
+#. Description of the 'Applicable Earnings Component' (Table MultiSelect)
+#. field
+#. in DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Salary components should be part of the Salary Structure."
+msgstr ""
+"Цалингийн бүрэлдэхүүн хэсэг нь Цалингийн бүтцийн нэг хэсэг байх ёстой."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2715
+msgid ""
+"Salary slip emails have been enqueued for sending. Check {0} for status."
+msgstr "Цалингийн хуудас илгээхээр дараалалд орсон. Төлөвийг {0} шалгана уу."
+
+#. Label of the sanctioned_amount (Currency) field in DocType 'Expense Claim
+#. Detail'
+#: hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+#: hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py:22
+msgid "Sanctioned Amount"
+msgstr "Шийдвэрлэсэн хэмжээ"
+
+#. Label of the base_sanctioned_amount (Currency) field in DocType 'Expense
+#. Claim Detail'
+#: hrms/hr/doctype/expense_claim_detail/expense_claim_detail.json
+#| msgid "Rounded Total (Company Currency)"
+msgid "Sanctioned Amount (Company Currency)"
+msgstr "Дугуйлсан нийт (Компанийн валют)"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:527
+msgid "Sanctioned Amount cannot be greater than Claim Amount in Row {0}."
+msgstr "Шийдвэрлэсэн дүн нь {0} мөрийн нэхэмжлэлийн дүнгээс их байж болохгүй."
+
+#. Label of the scheduled_on (Date) field in DocType 'Interview'
+#: hrms/hr/doctype/interview/interview.json
+msgid "Scheduled On"
+msgstr "Хуваарьтай"
+
+#. Label of the score_earned (Float) field in DocType 'Appraisal Goal'
+#: hrms/hr/doctype/appraisal_goal/appraisal_goal.json
+msgid "Score Earned"
+msgstr "Авсан оноо"
+
+#: hrms/hr/doctype/appraisal/appraisal.js:131
+msgid "Score must be less than or equal to 5"
+msgstr "Оноо 5-аас бага буюу тэнцүү байх ёстой"
+
+#: hrms/hr/doctype/appraisal/appraisal.js:104
+msgid "Scores"
+msgstr "Оноо"
+
+#: hrms/www/jobs/index.html:64
+msgid "Search for Jobs"
+msgstr "Ажлын байр хайх"
+
+#: hrms/hr/doctype/overtime_type/overtime_type.py:16
+msgid "Select Applicable Components for Overtime Type"
+msgstr "Илүү цагийн төрөлд хамаарах бүрэлдэхүүнүүдийг сонгоно уу"
+
+#: hrms/hr/doctype/interview/interview.js:209
+msgid "Select Interview Round First"
+msgstr "Эхлээд ярилцлагын шатыг сонгоно уу"
+
+#: hrms/hr/doctype/interview_feedback/interview_feedback.js:49
+msgid "Select Interview first"
+msgstr "Эхлээд ярилцлага сонгоно уу"
+
+#. Label of the month_for_lwp_reversal (Select) field in DocType 'Payroll
+#. Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+msgid "Select Month for LWP Reversal"
+msgstr "ЦЧ буцаалтын сарыг сонгоно уу"
+
+#. Description of the 'Payment Account' (Link) field in DocType 'Payroll
+#. Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Select Payment Account to make Bank Entry"
+msgstr "Төлбөрийн дансыг сонгон Банкны бичилт хийх"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1730
+msgid "Select Payroll Frequency."
+msgstr "Цалингийн давтамжийг сонгоно уу."
+
+#: frontend/src/views/salary_slip/Dashboard.vue:23
+msgid "Select Payroll Period"
+msgstr "Цалингийн хугацааг сонгоно уу"
+
+#: hrms/hr/employee_property_update.js:109
+msgid "Select Property"
+msgstr "Property сонгоно уу"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:134
+msgid "Select Shift Requests"
+msgstr "Shift хүсэлтийг сонгоно уу"
+
+#. Label of the select_terms (Link) field in DocType 'Job Offer'
+#: hrms/hr/doctype/job_offer/job_offer.json
+msgid "Select Terms and Conditions"
+msgstr "Нөхцөлүүдийг сонгоно уу"
+
+#. Label of the select_users (Section Break) field in DocType 'Daily Work
+#. Summary Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "Select Users"
+msgstr "Хэрэглэгчийг сонгоно уу"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.js:567
+msgid "Select an employee to get the employee advance."
+msgstr "Ажилтны урьдчилгааг авахын тулд ажилтнаа сонго."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:237
+msgid "Select the Employee for which you want to allocate leaves."
+msgstr "Амралт өгөхийг хүсч буй ажилтнаа сонгоно уу."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:304
+msgid "Select the Employee."
+msgstr "Ажилтнаа сонгоно уу."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:242
+msgid ""
+"Select the Leave Type like Sick leave, Privilege Leave, Casual Leave, etc."
+msgstr ""
+"Өвчний чөлөө, давуу эрх олгох, энгийн чөлөө гэх мэт чөлөөний төрлийг сонгоно"
+" уу."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:254
+msgid "Select the date after which this Leave Allocation will expire."
+msgstr "Энэ чөлөө олгох хугацаа дуусах огноог сонгоно уу."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.js:249
+msgid "Select the date from which this Leave Allocation will be valid."
+msgstr "Энэ чөлөөний хуваарилалт хүчинтэй байх огноог сонгоно уу."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:321
+msgid "Select the end date for your Leave Application."
+msgstr "Амрах өргөдлөө дуусгах огноог сонгоно уу."
+
+#. Description of the 'Applicable Salary Components' (Table MultiSelect) field
+#. in DocType 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid ""
+"Select the salary components whose total will be used from the salary slip "
+"to calculate the hourly overtime rate."
+msgstr ""
+"Цагийн илүү цагийн хөлсийг тооцоолоход ашиглагдах цалингийн хуудаснаас нийт "
+"дүн авах цалингийн бүрэлдэхүүнүүдийг сонгоно уу."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:316
+msgid "Select the start date for your Leave Application."
+msgstr "Амрах өргөдлөө эхлүүлэх огноогоо сонгоно уу."
+
+#. Description of the 'Enabled' (Check) field in DocType 'Shift Schedule
+#. Assignment'
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+msgid ""
+"Select this if you want shift assignments to be automatically created "
+"indefinitely."
+msgstr ""
+"Хэрэв та ээлжийн даалгаврыг автоматаар тодорхойгүй хугацаагаар үүсгэхийг "
+"хүсвэл үүнийг сонгоно уу."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:309
+msgid ""
+"Select type of leave the employee wants to apply for, like Sick Leave, "
+"Privilege Leave, Casual Leave, etc."
+msgstr ""
+"Ажилтны өргөдөл гаргахыг хүссэн амралтын төрлийг сонгоно уу, тухайлбал "
+"өвчний чөлөө, давуу эрх чөлөө, энгийн чөлөө гэх мэт."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:331
+msgid ""
+"Select your Leave Approver i.e. the person who approves or rejects your "
+"leaves."
+msgstr "Таныг зөвшөөрөх эсвэл татгалзсан хүнийг сонгох."
+
+#. Label of the self_appraisal_tab (Tab Break) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.py:33
+msgid "Self Appraisal"
+msgstr "Өөрийгөө үнэлэх"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:163
+msgid "Self Appraisal Pending: {0}"
+msgstr "Өөрийгөө үнэлэх хүлээгдэж буй: {0}"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:89
+msgid "Self Appraisal Score"
+msgstr "Өөрийгөө үнэлэх оноо"
+
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:56
+#: hrms/hr/report/appraisal_overview/appraisal_overview.py:123
+msgid "Self Score"
+msgstr "Өөрөө оноо"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Self-Study"
+msgstr "Бие даан суралцах"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:121
+msgid "Self-approval for Expense Claims is not allowed"
+msgstr "Зардлын нэхэмжлэлд өөрөө батлах зөвшөөрөгдөхгүй"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:877
+msgid "Self-approval for leaves is not allowed"
+msgstr "Чөлөөнд өөрөө батлах зөвшөөрөгдөхгүй"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Seminar"
+msgstr "Семинар"
+
+#. Label of the send_emails_at (Select) field in DocType 'Daily Work Summary
+#. Group'
+#: hrms/hr/doctype/daily_work_summary_group/daily_work_summary_group.json
+msgid "Send Emails At"
+msgstr "Имэйл илгээх"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.js:11
+msgid "Send Exit Questionnaire"
+msgstr "Гарах санал асуулга илгээх"
+
+#: hrms/hr/doctype/exit_interview/exit_interview_list.js:15
+msgid "Send Exit Questionnaires"
+msgstr "Гарах санал асуулга илгээх"
+
+#. Label of the send_interview_feedback_reminder (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Send Interview Feedback Reminder"
+msgstr "Ярилцлагын санал хүсэлтийн сануулагч илгээх"
+
+#. Label of the send_interview_reminder (Check) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Send Interview Reminder"
+msgstr "Ярилцлагын сануулагч илгээх"
+
+#. Label of the send_leave_notification (Check) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Send Leave Notification"
+msgstr "Амрах тухай мэдэгдэл илгээх"
+
+#. Label of the sender_copy (Link) field in DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+#| msgid "Sender"
+msgid "Sender Copy"
+msgstr "Илгээгч"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:139
+msgid "Sending Failed due to missing email information for employee(s): {1}"
+msgstr "Ажилтнуудын имэйлийн мэдээлэл дутуу байсан тул илгээж чадсангүй: {1}"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:135
+msgid "Sent Successfully: {0}"
+msgstr "Амжилттай илгээсэн: {0}"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:44
+#: hrms/public/js/salary_slip_deductions_report_filters.js:27
+msgid "Sep"
+msgstr "9-р сар"
+
+#. Label of the table_for_activity (Section Break) field in DocType 'Employee
+#. Separation'
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+msgid "Separation Activities"
+msgstr "Тусгаарлах үйл ажиллагаа"
+
+#. Label of the boarding_begins_on (Date) field in DocType 'Employee
+#. Separation'
+#: hrms/hr/doctype/employee_separation/employee_separation.json
+msgid "Separation Begins On"
+msgstr "Салалт эхэлнэ"
+
+#. Label of the service_details (Section Break) field in DocType 'Vehicle Log'
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+msgid "Service Details"
+msgstr "Үйлчилгээний дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:49
+msgid "Service Expense"
+msgstr "Үйлчилгээний зардал"
+
+#. Description of the 'Current Work Experience' (Table) field in DocType
+#. 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Set \"From(Year)\" and \"To(Year)\" to 0 for no upper and lower limit."
+msgstr ""
+"Дээд доод хязгааргүй байхын тулд \"From(Year)\" and \"To(Year)\"-г 0 болгож "
+"тохируулна уу."
+
+#. Label of the set_assignment_details_section (Section Break) field in
+#. DocType
+#. 'Bulk Salary Structure Assignment'
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.json
+msgid "Set Assignment Details"
+msgstr "Даалгаврын дэлгэрэнгүйг тохируулах"
+
+#. Label of the allocate_leaves_section (Section Break) field in DocType
+#. 'Leave
+#. Control Panel'
+#: hrms/hr/doctype/leave_control_panel/leave_control_panel.json
+msgid "Set Leave Details"
+msgstr "Амрах дэлгэрэнгүй мэдээллийг тохируулах"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:79
+msgid "Set Relieving Date for Employee: {0}"
+msgstr "Ажилтныг чөлөөлөх огноог тохируулах: {0}"
+
+#. Description of the 'Get Employees' (Section Break) field in DocType
+#. 'Employee Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Set filters to fetch employees"
+msgstr "Ажилчдыг татах шүүлтүүрийг тохируулна уу"
+
+#. Description of the 'Opening Balances' (Section Break) field in DocType
+#. 'Salary Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Set opening balances for earnings and taxes from the previous employer"
+msgstr "Өмнөх ажил олгогчоос авсан орлого, татварын эхний үлдэгдлийг тогтоох"
+
+#. Description of the 'Filters' (Section Break) field in DocType 'Appraisal
+#. Cycle'
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.json
+msgid "Set optional filters to fetch employees in the appraisee list"
+msgstr "Үнэлгээний жагсаалтад ажилчдыг татах нэмэлт шүүлтүүрийг тохируулна уу"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:684
+msgid "Set the default account for the {0} {1}"
+msgstr "{0} {1}-н өгөгдмөл бүртгэлийг тохируулах"
+
+#. Label of the frequency (Select) field in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Set the frequency for holiday reminders"
+msgstr "Амралтын сануулагчдын давтамжийг тохируулна уу"
+
+#. Description of the 'Employee Promotion Details' (Section Break) field in
+#. DocType 'Employee Promotion'
+#: hrms/hr/doctype/employee_promotion/employee_promotion.json
+msgid ""
+"Set the properties that should be updated in the Employee master on "
+"promotion submission"
+msgstr ""
+"Ажилтны мастерт тушаал дэвшихэд шинэчлэгдэх ёстой шинж чанаруудыг тохируулна"
+" уу"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:205
+msgid "Set the status to {0} if required."
+msgstr "Шаардлагатай бол статусыг {0} болгож тохируулна уу."
+
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:200
+msgid "Set {0} for selected employees"
+msgstr "Сонгосон ажилчдын хувьд {0}-г тохируулна уу"
+
+#: hrms/hr/doctype/exit_interview/exit_interview.py:128
+msgid "Settings Missing"
+msgstr "Тохиргоо дутуу байна"
+
+#: frontend/src/components/ExpenseAdvancesTable.vue:4
+msgid "Settle against Advances"
+msgstr "Урьдчилгаатай тэмцэх"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:55
+msgid "Settle all Payables and Receivables before submission"
+msgstr "Өргөдөл гаргахаас өмнө бүх өглөг, авлагыг барагдуулна уу"
+
+#: hrms/hr/utils.py:775
+#| msgid "Shared with the user {0} with 'submit' permisions"
+msgid "Shared document with the user {0} with 'Submit' permission"
+msgstr "\"Батлах\" зөвшөөрөлтэй {0} хэрэглэгчтэй хуваалцсан"
+
+#. Name of a Workspace
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift & Attendance"
+msgstr "Ээлж ба ирц"
+
+#. Label of the shift_actual_end (Datetime) field in DocType 'Employee
+#. Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Shift Actual End"
+msgstr "Бодит төгсгөлийг шилжүүлэх"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:117
+msgid "Shift Actual End Time"
+msgstr "Бодит дуусах хугацааг шилжүүлэх"
+
+#. Label of the shift_actual_start (Datetime) field in DocType 'Employee
+#. Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Shift Actual Start"
+msgstr "Бодит эхлэлийг шилжүүлэх"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:111
+msgid "Shift Actual Start Time"
+msgstr "Бодит эхлэх цагийг шилжүүлэх"
+
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Assignment"
+msgstr "Шилжилтийн даалгавар"
+
+#. Label of the shift_assignment_details_section (Section Break) field in
+#. DocType 'Shift Assignment Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Shift Assignment Details"
+msgstr "Шилжилтийн даалгаврын дэлгэрэнгүй мэдээлэл"
+
+#: frontend/src/views/attendance/ShiftAssignmentList.vue:5
+msgid "Shift Assignment History"
+msgstr "Шилжилтийн даалгаврын түүх"
+
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+#: hrms/public/js/utils/index.js:240 hrms/public/js/utils/index.js:262
+msgid "Shift Assignment Tool"
+msgstr "Shift томилох хэрэгсэл"
+
+#: hrms/hr/doctype/shift_request/shift_request.py:61
+msgid "Shift Assignment: {0} created for Employee: {1}"
+msgstr "Ээлжийн даалгавар: {0} ажилтанд зориулан үүсгэсэн: {1}"
+
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py:135
+msgid ""
+"Shift Assignments created for the schedule between {0} and {1} via "
+"background job"
+msgstr ""
+"{0}-с {1} хоорондох хуваарийн ээлжийн хуваарилалтуудыг арын даалгавраар "
+"үүсгэсэн"
+
+#. Name of a report
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/report/shift_attendance/shift_attendance.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Attendance"
+msgstr "Ээлжийн ирц"
+
+#. Label of the shift_details_section (Section Break) field in DocType 'Shift
+#. Assignment'
+#. Label of the schedule_settings_section (Section Break) field in DocType
+#. 'Shift Schedule Assignment'
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+msgid "Shift Details"
+msgstr "Шилжилтийн дэлгэрэнгүй мэдээлэл"
+
+#. Label of the shift_end (Datetime) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Shift End"
+msgstr "Шилжилтийн төгсгөл"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:61
+msgid "Shift End Time"
+msgstr "Дуусах цагийг шилжүүлэх"
+
+#. Label of the shift_location (Link) field in DocType 'Shift Assignment'
+#. Label of the shift_location (Link) field in DocType 'Shift Assignment Tool'
+#. Name of a DocType
+#. Label of the shift_location (Link) field in DocType 'Shift Schedule
+#. Assignment'
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/doctype/shift_location/shift_location.json
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Location"
+msgstr "Байршил шилжүүлэх"
+
+#. Label of the shift_request (Link) field in DocType 'Shift Assignment'
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:220
+#: hrms/hr/doctype/shift_request/shift_request.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Request"
+msgstr "Шилжүүлэх хүсэлт"
+
+#: hrms/setup.py:139 hrms/setup.py:260
+msgid "Shift Request Approver"
+msgstr "Шифтийн хүсэлтийг баталгаажуулагч"
+
+#. Label of the shift_request_filters_section (Section Break) field in DocType
+#. 'Shift Assignment Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Shift Request Filters"
+msgstr "Шилжүүлэх хүсэлтийн шүүлтүүрүүд"
+
+#. Description of the 'From Date' (Date) field in DocType 'Shift Assignment
+#. Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Shift Requests ending before this date will be excluded."
+msgstr "Энэ өдрөөс өмнө дууссан ээлжийн хүсэлтийг оруулахгүй."
+
+#. Description of the 'To Date' (Date) field in DocType 'Shift Assignment
+#. Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid "Shift Requests starting after this date will be excluded."
+msgstr "Энэ өдрөөс хойш эхлэх ээлжийн хүсэлтийг оруулахгүй."
+
+#. Label of the shift_schedule (Link) field in DocType 'Shift Assignment Tool'
+#. Name of a DocType
+#. Label of the shift_schedule (Link) field in DocType 'Shift Schedule
+#. Assignment'
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Schedule"
+msgstr "Ээлжийн хуваарь"
+
+#. Label of the shift_schedule_assignment (Link) field in DocType 'Shift
+#. Assignment'
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Schedule Assignment"
+msgstr "Ээлжийн хуваарийн даалгавар"
+
+#. Label of the shift_settings_section (Section Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Shift Settings"
+msgstr "Тохиргоог шилжүүлэх"
+
+#. Label of the shift_start (Datetime) field in DocType 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Shift Start"
+msgstr "Shift Start"
+
+#: hrms/hr/report/shift_attendance/shift_attendance.py:55
+msgid "Shift Start Time"
+msgstr "Шилжилт эхлэх цаг"
+
+#. Label of the shift_status (Select) field in DocType 'Shift Schedule
+#. Assignment'
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.json
+msgid "Shift Status"
+msgstr "Шилжилтийн төлөв"
+
+#. Label of the shift_timings_section (Section Break) field in DocType
+#. 'Employee Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Shift Timings"
+msgstr "Шилжилтийн цаг"
+
+#: hrms/public/js/utils/index.js:248 hrms/public/js/utils/index.js:256
+#: hrms/public/js/utils/index.js:270 hrms/public/js/utils/index.js:277
+msgid "Shift Tools"
+msgstr "Shift хэрэгслүүд"
+
+#. Label of the shift_type (Link) field in DocType 'Shift Assignment'
+#. Label of the shift_type (Link) field in DocType 'Shift Assignment Tool'
+#. Label of the shift_type_filter (Link) field in DocType 'Shift Assignment
+#. Tool'
+#. Label of the shift_type (Link) field in DocType 'Shift Request'
+#. Label of the shift_type (Link) field in DocType 'Shift Schedule'
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: frontend/src/views/attendance/ShiftAssignmentList.vue:24
+#: frontend/src/views/attendance/ShiftRequestList.vue:42
+#: hrms/hr/doctype/shift_assignment/shift_assignment.json
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:230
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+#: hrms/hr/doctype/shift_request/shift_request.json
+#: hrms/hr/doctype/shift_schedule/shift_schedule.json
+#: hrms/hr/doctype/shift_type/shift_type.json
+#: hrms/hr/report/shift_attendance/shift_attendance.js:28
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shift Type"
+msgstr "Шилжилтийн төрөл"
+
+#. Label of the shift_and_attendance_tab (Tab Break) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#| msgid "Shift & Attendance"
+msgid "Shift and Attendance"
+msgstr "Ээлж ба ирц"
+
+#: hrms/hr/doctype/shift_schedule_assignment/shift_schedule_assignment.py:21
+msgid ""
+"Shift assignments for {0} after {1} are already created. Please change {2} "
+"date to a date later than {3} {4}"
+msgstr ""
+"{0}-ийн {1}-с хойших ээлжийн хуваарилалтууд аль хэдийн үүсгэгдсэн. {2} "
+"огноог {3} {4}-с хойших огноо болгон өөрчилнө үү"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.js:42
+msgid "Shift has been successfully updated to {0}."
+msgstr "Shift-г {0} болгож амжилттай шинэчилсэн."
+
+#. Label of a Card Break in the Shift & Attendance Workspace
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Shifts"
+msgstr "Шилжилт"
+
+#: hrms/hr/doctype/job_offer/job_offer.js:51
+msgid "Show Employee"
+msgstr "Ажилчдыг харуулах"
+
+#. Label of the show_leave_balances_in_salary_slip (Check) field in DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Show Leave Balances in Salary Slip"
+msgstr "Цалингийн хуудаст чөлөөний үлдэгдлийг харуул"
+
+#. Label of the show_leaves_of_all_department_members_in_calendar (Check)
+#. field
+#. in DocType 'HR Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Show Leaves Of All Department Members In Calendar"
+msgstr "Календарт хэлтсийн бүх гишүүдийн навчийг харуулах"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:204
+msgid "Show Salary Slip"
+msgstr "Цалингийн хуудас харуулах"
+
+#: hrms/www/jobs/index.html:121
+msgid "Showing"
+msgstr "Харуулж байна"
+
+#: hrms/setup.py:365 hrms/setup.py:366
+msgid "Sick Leave"
+msgstr "Өвчний чөлөө"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:120
+msgid "Single Assignment"
+msgstr "Ганц даалгавар"
+
+#. Label of the skill (Link) field in DocType 'Designation Skill'
+#. Label of the skill (Link) field in DocType 'Employee Skill'
+#. Label of the skill (Link) field in DocType 'Expected Skill Set'
+#. Name of a DocType
+#. Label of the skill (Link) field in DocType 'Skill Assessment'
+#: hrms/hr/doctype/designation_skill/designation_skill.json
+#: hrms/hr/doctype/employee_skill/employee_skill.json
+#: hrms/hr/doctype/expected_skill_set/expected_skill_set.json
+#: hrms/hr/doctype/skill/skill.json
+#: hrms/hr/doctype/skill_assessment/skill_assessment.json
+msgid "Skill"
+msgstr "Ур чадвар"
+
+#. Label of the section_break_4 (Section Break) field in DocType 'Interview
+#. Feedback'
+#. Name of a DocType
+#: hrms/hr/doctype/interview/interview.js:138
+#: hrms/hr/doctype/interview_feedback/interview_feedback.json
+#: hrms/hr/doctype/skill_assessment/skill_assessment.json
+msgid "Skill Assessment"
+msgstr "Ур чадварын үнэлгээ"
+
+#. Label of the skill_name (Data) field in DocType 'Skill'
+#: hrms/hr/doctype/skill/skill.json
+msgid "Skill Name"
+msgstr "Ур чадварын нэр"
+
+#. Label of the skills_section (Section Break) field in DocType 'Employee
+#. Skill
+#. Map'
+#: hrms/hr/doctype/employee_skill_map/employee_skill_map.json
+#: hrms/setup.py:176
+msgid "Skills"
+msgstr "Ур чадвар"
+
+#. Label of the skip_auto_attendance (Check) field in DocType 'Employee
+#. Checkin'
+#: hrms/hr/doctype/employee_checkin/employee_checkin.json
+msgid "Skip Auto Attendance"
+msgstr "Автомат ирцийг алгасах"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:326
+msgid ""
+"Skipping Salary Structure Assignment for the following employees, as Salary "
+"Structure Assignment records already exists against them. {0}"
+msgstr ""
+"Дараах ажилтнуудын цалингийн бүтцийн хуваарилалт тэдний эсрэг аль хэдийн "
+"байгаа тул цалингийн бүтцийн хуваарилалтыг алгасаж байна. {0}"
+
+#. Label of the source_and_rating_section (Section Break) field in DocType
+#. 'Job
+#. Applicant'
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+msgid "Source and Rating"
+msgstr "Эх сурвалж ба үнэлгээ"
+
+#: hrms/api/roster.py:100
+msgid "Source and target shifts cannot be the same"
+msgstr "Эх сурвалж болон зорилтот шилжилтүүд ижил байж болохгүй"
+
+#. Label of the sponsored_amount (Currency) field in DocType 'Travel Request
+#. Costing'
+#: hrms/hr/doctype/travel_request_costing/travel_request_costing.json
+msgid "Sponsored Amount"
+msgstr "Ивээн тэтгэсэн дүн"
+
+#. Label of the staffing_details (Table) field in DocType 'Staffing Plan'
+#: hrms/hr/doctype/staffing_plan/staffing_plan.json
+msgid "Staffing Details"
+msgstr "Боловсон хүчний дэлгэрэнгүй мэдээлэл"
+
+#. Label of the staffing_plan (Link) field in DocType 'Job Opening'
+#. Name of a DocType
+#. Label of a Link in the Recruitment Workspace
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/staffing_plan/staffing_plan.json
+#: hrms/hr/report/recruitment_analytics/recruitment_analytics.py:24
+#: hrms/hr/workspace/recruitment/recruitment.json
+msgid "Staffing Plan"
+msgstr "Боловсон хүчний төлөвлөгөө"
+
+#. Name of a DocType
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Staffing Plan Detail"
+msgstr "Боловсон хүчний төлөвлөгөөний дэлгэрэнгүй"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.py:71
+msgid "Staffing Plan {0} already exist for designation {1}"
+msgstr "Ажилтны төлөвлөгөө {0} нь {1}-д зориулагдсан"
+
+#. Label of the standard_multiplier (Float) field in DocType 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Standard Multiplier"
+msgstr "Стандарт үржүүлэгч"
+
+#. Label of the standard_tax_exemption_amount (Currency) field in DocType
+#. 'Income Tax Slab'
+#. Label of the standard_tax_exemption_amount (Currency) field in DocType
+#. 'Salary Slip'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Standard Tax Exemption Amount"
+msgstr "Татвараас чөлөөлөх стандарт хэмжээ"
+
+#. Label of the standard_working_hours (Float) field in DocType 'Attendance'
+#. Label of the standard_working_hours (Float) field in DocType 'HR Settings'
+#. Label of the standard_working_hours (Float) field in DocType 'Overtime
+#. Details'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/doctype/overtime_details/overtime_details.json
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:36
+#: hrms/hr/report/project_profitability/project_profitability.py:102
+msgid "Standard Working Hours"
+msgstr "Стандарт ажлын цаг"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1801
+msgid ""
+"Start and end dates not in a valid Payroll Period, cannot calculate {0}."
+msgstr ""
+"Эхлэх болон дуусах огноо нь хүчинтэй цалингийн хугацаанд биш, {0}-г тооцох "
+"боломжгүй."
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:27
+#| msgid "From Date cannot be greater than To Date"
+msgid "Start date cannot be greater than end date"
+msgstr "\"Одооноос\" нь \"Одооноос\" их байж болохгүй"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:50
+#| msgid "From Date cannot be greater than To Date"
+msgid "Start date cannot be greater than end date."
+msgstr "\"Одооноос\" нь \"Одооноос\" их байж болохгүй"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:239
+msgid "Start date: {0}"
+msgstr "Эхлэх огноо: {0}"
+
+#: hrms/hr/doctype/shift_type/shift_type.py:50
+#| msgid "Source and target shifts cannot be the same"
+msgid "Start time and end time cannot be same."
+msgstr "Эх сурвалж болон зорилтот шилжилтүүд ижил байж болохгүй"
+
+#. Label of the statistical_component (Check) field in DocType 'Salary
+#. Component'
+#. Label of the statistical_component (Check) field in DocType 'Salary Detail'
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Statistical Component"
+msgstr "Статистикийн бүрэлдэхүүн хэсэг"
+
+#. Label of the half_day_status (Select) field in DocType 'Attendance'
+#. Label of the half_day_status (Select) field in DocType 'Employee Attendance
+#. Tool'
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Status for Other Half"
+msgstr "Нөгөө хагасын төлөв"
+
+#: hrms/setup.py:408
+msgid "Stock Options"
+msgstr "Нөөцийн сонголтууд"
+
+#. Description of the 'Block Days' (Section Break) field in DocType 'Leave
+#. Block List'
+#: hrms/hr/doctype/leave_block_list/leave_block_list.json
+msgid "Stop users from making Leave Applications on following days."
+msgstr "Дараагийн өдрүүдэд хэрэглэгчдийг Өргөдөл гаргахыг зогсооно уу."
+
+#. Option for the 'Determine Check-in and Check-out' (Select) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Strictly based on Log Type in Employee Checkin"
+msgstr "Ажилтны бүртгэл дэх бүртгэлийн төрөлд хатуу үндэслэсэн"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:267
+msgid "Structures have been assigned successfully"
+msgstr "Бүтцүүдийг амжилттай томилсон"
+
+#. Label of the submission_date (Date) field in DocType 'Employee Tax
+#. Exemption
+#. Proof Submission'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Submission Date"
+msgstr "Оруулсан огноо"
+
+#: hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py:475
+msgid "Submission Failed"
+msgstr "Илгээж чадсангүй"
+
+#: hrms/hr/doctype/interview_feedback/interview_feedback.py:39
+msgid "Submission of {0} before {1} is not allowed"
+msgstr "{1}-ээс өмнө {0} илгээхийг зөвшөөрөхгүй"
+
+#: hrms/hr/doctype/interview/interview.js:57
+#: hrms/hr/doctype/interview/interview.js:61
+#: hrms/hr/doctype/interview/interview.js:133
+msgid "Submit Feedback"
+msgstr "Санал хүсэлт илгээх"
+
+#: hrms/hr/doctype/exit_interview/exit_questionnaire_notification_template.html:14
+msgid "Submit Now"
+msgstr "Одоо илгээнэ үү"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:90
+#| msgid "Submit Salary Slip"
+msgid "Submit Overtime Slips"
+msgstr "Цалингийн хуудас өгөх"
+
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.js:43
+msgid "Submit Proof"
+msgstr "Нотлох баримт илгээх"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:171
+msgid "Submit Salary Slip"
+msgstr "Цалингийн хуудас өгөх"
+
+#: hrms/hr/doctype/leave_application/leave_application.js:108
+msgid "Submit this Leave Application to confirm."
+msgstr "Баталгаажуулахын тулд энэ чөлөөний өргөдлийг илгээнэ үү."
+
+#: hrms/hr/doctype/employee_onboarding/employee_onboarding.py:39
+msgid "Submit this to create the Employee record"
+msgstr "Ажилтны бүртгэлийг үүсгэхийн тулд үүнийг илгээнэ үү"
+
+#. Label of the submitted_via_payroll_entry (Check) field in DocType 'Overtime
+#. Slip'
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json
+#| msgid "Payroll Entry"
+msgid "Submitted via Payroll Entry"
+msgstr "Цалингийн бүртгэл"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:430
+msgid "Submitting Salary Slips and creating Journal Entry..."
+msgstr "Цалингийн хуудас илгээж, журналын бичилт үүсгэж байна..."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.py:1647
+msgid "Submitting Salary Slips..."
+msgstr "Цалингийн хуудас илгээж байна..."
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.py:161
+msgid ""
+"Subsidiary companies have already planned for {1} vacancies at a budget of "
+"{2}. Staffing Plan for {0} should allocate more vacancies and budget for {3}"
+" than planned for its subsidiary companies"
+msgstr ""
+"Охин компаниуд аль хэдийн {2} төсөвтэй {1} сул орон тоогоор төлөвлөжээ. "
+"{0}-н боловсон хүчний төлөвлөгөөнд {3}-д охин компанидаа төлөвлөснөөс илүү "
+"сул орон тоо, төсөв хуваарилах ёстой."
+
+#: hrms/hr/utils.py:951
+msgid "Successfully created {0} for employees:"
+msgstr "Ажилчдад зориулсан {0}-г амжилттай үүсгэсэн:"
+
+#: hrms/public/js/utils/index.js:160
+msgid "Successfully {0} {1} for the following employees:"
+msgstr "Дараах ажилчдад амжилттай {0} {1}:"
+
+#. Option for the 'Calculate Gratuity Amount Based On' (Select) field in
+#. DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Sum of all previous slabs"
+msgstr "Өмнөх бүх хавтангийн нийлбэр"
+
+#: hrms/payroll/doctype/employee_benefit_application/employee_benefit_application.py:44
+#| msgid "Maximum benefit amount of employee {0} exceeds {1}"
+msgid "Sum of benefit amounts {0} exceeds maximum limit of {1}"
+msgstr "Ажилтны тэтгэмжийн дээд хэмжээ {0} {1}-ээс хэтэрсэн байна"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js:108
+msgid "Summarized View"
+msgstr "Дүгнэж харах"
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:99
+msgid "Sync {0}"
+msgstr "{0}-г синк хийх"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1317
+msgid "Syntax error"
+msgstr "Синтакс алдаа"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2538
+msgid "Syntax error in condition: {0} in Income Tax Slab"
+msgstr "Нөхцөл дэх үг хэллэгийн алдаа: Орлогын татварын самбар дахь {0}"
+
+#. Option for the 'Work Experience Calculation Method' (Select) field in
+#. DocType 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Take Exact Completed Years"
+msgstr "Яг дууссан жилүүдийг авна уу"
+
+#. Name of a Workspace
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Tax & Benefits"
+msgstr "Татвар ба тэтгэмж"
+
+#. Label of the tax_deducted_till_date (Currency) field in DocType 'Salary
+#. Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:162
+msgid "Tax Deducted Till Date"
+msgstr "Татварыг өдөр хүртэл хассан"
+
+#. Label of the exemption_category (Link) field in DocType 'Employee Tax
+#. Exemption Sub Category'
+#: hrms/payroll/doctype/employee_tax_exemption_sub_category/employee_tax_exemption_sub_category.json
+msgid "Tax Exemption Category"
+msgstr "Татвараас чөлөөлөх ангилал"
+
+#. Label of the section_break_8 (Tab Break) field in DocType 'Employee Tax
+#. Exemption Declaration'
+#. Label of the tax_exemption_declaration (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Tax Exemption Declaration"
+msgstr "Татвараас чөлөөлөх тухай мэдэгдэл"
+
+#. Label of the tax_exemption_proofs (Table) field in DocType 'Employee Tax
+#. Exemption Proof Submission'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Tax Exemption Proofs"
+msgstr "Татвараас чөлөөлөх тухай баримтууд"
+
+#. Label of a Card Break in the Tax & Benefits Workspace
+#: hrms/payroll/workspace/tax_&_benefits/tax_&_benefits.json
+msgid "Tax Setup"
+msgstr "Татварын тохиргоо"
+
+#. Label of the tax_on_additional_salary (Currency) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Tax on additional salary"
+msgstr "Нэмэлт цалингийн татвар"
+
+#. Label of the tax_on_flexible_benefit (Currency) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Tax on flexible benefit"
+msgstr "Уян хатан тэтгэмжийн татвар"
+
+#. Label of the taxable_earnings_till_date (Currency) field in DocType 'Salary
+#. Structure Assignment'
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:161
+msgid "Taxable Earnings Till Date"
+msgstr "Өнөөдрийг хүртэлх татвар ногдох орлого"
+
+#. Label of the tax_relief_limit (Currency) field in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Taxable Income Relief Threshold Limit"
+msgstr "Татвар ногдуулах орлогын хөнгөлөлтийн босго хязгаар"
+
+#. Name of a DocType
+#: hrms/payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid "Taxable Salary Slab"
+msgstr "Татвар ногдох цалингийн хавтан"
+
+#. Label of the taxable_salary_slabs_section (Section Break) field in DocType
+#. 'Income Tax Slab'
+#. Label of the slabs (Table) field in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Taxable Salary Slabs"
+msgstr "Татвар ногдох цалингийн хавтан"
+
+#. Label of the taxes_and_charges_sb (Section Break) field in DocType 'Expense
+#. Claim'
+#: frontend/src/components/ExpenseTaxesTable.vue:4
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Taxes & Charges"
+msgstr "Татвар, хураамж"
+
+#. Label of the taxes_and_charges_on_income_tax_section (Section Break) field
+#. in DocType 'Income Tax Slab'
+#: hrms/payroll/doctype/income_tax_slab/income_tax_slab.json
+msgid "Taxes and Charges on Income Tax"
+msgstr "Орлогын албан татвар, хураамж"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Taxi"
+msgstr "Такси"
+
+#: frontend/src/views/employee_advance/List.vue:19
+msgid "Team Advances"
+msgstr "Багийн дэвшил"
+
+#: frontend/src/views/expense_claim/List.vue:19
+msgid "Team Claims"
+msgstr "Багийн нэхэмжлэл"
+
+#: frontend/src/views/leave/List.vue:19
+msgid "Team Leaves"
+msgstr "Баг орхино"
+
+#: frontend/src/components/RequestPanel.vue:36
+msgid "Team Requests"
+msgstr "Багийн хүсэлт"
+
+#: hrms/hr/page/team_updates/team_updates.js:4
+msgid "Team Updates"
+msgstr "Багийн шинэчлэлтүүд"
+
+#. Label of the tenure_tab (Tab Break) field in DocType 'HR Settings'
+#. Name of a Workspace
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Tenure"
+msgstr "Ажилласан хугацаа"
+
+#. Success message of the job-application Web Form
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Thank you for applying."
+msgstr "Өргөдөл гаргасанд баярлалаа."
+
+#: hrms/overrides/company.py:131
+msgid ""
+"The currency of {0} should be same as the company's default currency. Please"
+" select another account."
+msgstr ""
+"{0}-н валют нь компанийн үндсэн валюттай ижил байх ёстой. Өөр бүртгэл "
+"сонгоно уу."
+
+#. Description of the 'Payroll Date' (Date) field in DocType 'Additional
+#. Salary'
+#: hrms/payroll/doctype/additional_salary/additional_salary.json
+msgid ""
+"The date on which Salary Component with Amount will contribute for "
+"Earnings/Deduction in Salary Slip. "
+msgstr "Цалингийн хэсэг нь цалингийн хуудасны орлого/суутгалд оруулах огноо. "
+
+#. Description of the 'Allocate on Day' (Select) field in DocType 'Leave Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid "The day of the month when leaves should be allocated"
+msgstr "Навчийг хуваарилах ёстой сарын өдөр"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:421
+msgid ""
+"The day(s) on which you are applying for leave are holidays. You need not "
+"apply for leave."
+msgstr ""
+"Таны чөлөө авах хүсэлт гаргаж буй өдөр(үүд) нь амралтын өдрүүд юм. Та чөлөө "
+"авах хүсэлт гаргах шаардлагагүй."
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:64
+msgid "The days between {0} to {1} are not valid holidays."
+msgstr "{0}-с {1} хүртэлх өдрүүд нь амралтын өдрүүд биш юм."
+
+#: hrms/setup.py:130
+msgid "The first Approver in the list will be set as the default Approver."
+msgstr "Жагсаалтын эхний Зөвшөөрөгчийг өгөгдмөл Батлагчаар тохируулах болно."
+
+#: hrms/hr/doctype/leave_type/leave_type.py:51
+msgid "The fraction of Daily Salary per Leave should be between 0 and 1"
+msgstr "Амралтанд ногдох өдрийн цалингийн хэсэг нь 0-1 хооронд байх ёстой"
+
+#. Description of the 'Fraction of Daily Salary for Half Day' (Float) field in
+#. DocType 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "The fraction of daily wages to be paid for half-day attendance"
+msgstr "Хагас өдрийн ирцэнд төлөх өдрийн цалингийн хэсэг"
+
+#: hrms/hr/report/project_profitability/project_profitability.py:101
+msgid ""
+"The metrics for this report are calculated based on the {0}. Please set {0} "
+"in {1}."
+msgstr ""
+"Энэ тайлангийн хэмжүүрийг {0} дээр үндэслэн тооцсон. {1} дотор {0}-г "
+"тохируулна уу."
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:35
+msgid ""
+"The metrics for this report are calculated based on {0}. Please set {0} in "
+"{1}."
+msgstr ""
+"Энэ тайлангийн хэмжүүрийг {0}-д үндэслэн тооцсон. {1} дотор {0}-г тохируулна"
+" уу."
+
+#. Description of the 'Encrypt Salary Slips in Emails' (Check) field in
+#. DocType
+#. 'Payroll Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid ""
+"The salary slip emailed to the employee will be password protected, the "
+"password will be generated based on the password policy."
+msgstr ""
+"Ажилтан руу илгээсэн цалингийн хуудас нь нууц үгээр хамгаалагдсан байх "
+"бөгөөд нууц үгийн бодлогод үндэслэн нууц үг үүсгэгдэнэ."
+
+#. Description of the 'Late Entry Grace Period' (Int) field in DocType 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"The time after the shift start time when check-in is considered as late (in "
+"minutes)."
+msgstr "Бүртгэлийг хоцрогдсонд тооцдог ээлж эхлэхээс хойшхи цаг (минутаар)."
+
+#. Description of the 'Early Exit Grace Period' (Int) field in DocType 'Shift
+#. Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"The time before the shift end time when check-out is considered as early (in"
+" minutes)."
+msgstr "Шалгалт дуусахаас өмнөх цагийг (минутаар) эрт тооцно."
+
+#. Description of the 'Begin check-in before shift start time (in minutes)'
+#. (Int) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"The time before the shift start time during which Employee Check-in is "
+"considered for attendance."
+msgstr "Ажилчдын бүртгэлийг ирцэнд тооцсон ээлж эхлэхээс өмнөх цаг."
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Theory"
+msgstr "Онол"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:494
+msgid "There are more holidays than working days this month."
+msgstr "Энэ сард ажлын өдрүүдээс олон амралтын өдрүүд тохиож байна."
+
+#: hrms/payroll/doctype/arrear/arrear.py:384
+msgid ""
+"There are no arrear differences between existing and new salary structure "
+"components."
+msgstr ""
+"Одоо байгаа болон шинэ цалингийн бүтцийн бүрэлдэхүүнүүдийн хооронд өр "
+"төлбөрийн зөрүү байхгүй."
+
+#: hrms/hr/doctype/job_offer/job_offer.py:39
+msgid "There are no vacancies under staffing plan {0}"
+msgstr "Ажилтны төлөвлөгөөний дагуу сул орон тоо байхгүй байна {0}"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:53
+#: hrms/payroll/doctype/employee_incentive/employee_incentive.py:20
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py:207
+#| msgid ""
+#| "There is no Salary Structure assigned to {0}. First assign a Salary "
+#| "Stucture."
+msgid ""
+"There is no Salary Structure assigned to {0}. First assign a Salary "
+"Structure."
+msgstr ""
+"{0}-д олгосон Цалингийн бүтэц байхгүй. Эхлээд Цалингийн бүтцийг томил."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:392
+msgid ""
+"There's no Employee with Salary Structure: {0}. Assign {1} to an Employee to"
+" preview Salary Slip"
+msgstr ""
+"Цалингийн бүтэцтэй ажилтан алга: {0}. Цалингийн хуудсыг урьдчилан харахын "
+"тулд ажилтанд {1}-г даалга"
+
+#. Description of the 'Is Optional Leave' (Check) field in DocType 'Leave
+#. Type'
+#: hrms/hr/doctype/leave_type/leave_type.json
+msgid ""
+"These leaves are holidays permitted by the company however, availing it is "
+"optional for an Employee."
+msgstr ""
+"Эдгээр амралтын өдрүүд нь компаниас зөвшөөрөгдсөн амралтын өдрүүд боловч "
+"үүнийг ашиглах нь Ажилтны хувьд сонголттой байдаг."
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:130
+msgid ""
+"This action will prevent making changes to the linked appraisal "
+"feedback/goals."
+msgstr ""
+"Энэ үйлдэл нь холбосон үнэлгээний санал хүсэлт/зорилгодоо өөрчлөлт "
+"оруулахаас сэргийлнэ."
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.js:9
+msgid ""
+"This check-in is outside assigned shift hours and will not be considered for"
+" attendance. If a shift is assigned, adjust its time window and Fetch Shift "
+"again."
+msgstr ""
+"Энэ бүртгэл нь хуваарилагдсан ээлжийн цагаас гадуур байгаа тул ирцэд "
+"тооцогдохгүй. Хэрэв ээлж хуваарилагдсан бол цагийн хүрээг тохируулж, Ээлж "
+"татах дахин хийнэ үү."
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:97
+msgid "This compensatory leave will be applicable from {0}."
+msgstr "Энэхүү нөхөн олговрын амралт нь {0}-с эхлэн хэрэгжинэ."
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:49
+msgid "This employee already has a log with the same timestamp.{0}"
+msgstr "Энэ ажилтан аль хэдийн ижил цагийн тэмдэгтэй бүртгэлтэй байна.{0}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1325
+msgid "This error can be due to invalid formula or condition."
+msgstr "Энэ алдаа нь буруу томьёо эсвэл нөхцөлтэй холбоотой байж болно."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1318
+msgid "This error can be due to invalid syntax."
+msgstr "Энэ алдаа нь буруу синтакстай холбоотой байж болно."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:1311
+msgid "This error can be due to missing or deleted field."
+msgstr ""
+"Энэ алдаа нь алга болсон эсвэл устгасан талбартай холбоотой байж болно."
+
+#: hrms/hr/doctype/leave_type/leave_type.js:28
+msgid ""
+"This field allows you to set the maximum number of consecutive leaves an "
+"Employee can apply for."
+msgstr ""
+"Энэ талбар нь ажилтны өргөдөл гаргаж болох дараалсан амралтын дээд хэмжээг "
+"тогтоох боломжийг танд олгоно."
+
+#: hrms/hr/doctype/leave_type/leave_type.js:21
+msgid ""
+"This field allows you to set the maximum number of leaves that can be "
+"allocated annually for this Leave Type while creating the Leave Policy"
+msgstr ""
+"Энэ талбар нь Амралтын бодлогыг үүсгэх явцад энэ Амралтын төрөлд жил бүр "
+"хуваарилж болох навчны дээд хэмжээг тогтоох боломжийг танд олгоно."
+
+#: hrms/overrides/dashboard_overrides.py:60
+msgid "This is based on the attendance of this Employee"
+msgstr "Энэ нь тухайн ажилтны ирц дээр үндэслэсэн болно"
+
+#: hrms/www/hrms.py:19
+msgid "This method is only meant for developer mode"
+msgstr "Энэ арга нь зөвхөн хөгжүүлэгчийн горимд зориулагдсан"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:202
+msgid ""
+"This will overwrite the tax component {0} in the salary slip and tax won't "
+"be calculated based on the Income Tax Slabs"
+msgstr ""
+"Энэ нь цалингийн хуудасны {0} татварын бүрэлдэхүүн хэсгийг дарж бичих бөгөөд"
+" орлогын албан татварын хүснэгтэд үндэслэн татварыг тооцохгүй."
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:421
+msgid ""
+"This will submit Salary Slips and create accrual Journal Entry. Do you want "
+"to proceed?"
+msgstr ""
+"Энэ нь Цалингийн хуудсаа илгээж, аккруэл журналын бичилт үүсгэх болно. Та "
+"үргэлжлүүлэхийг хүсэж байна уу?"
+
+#. Description of the 'Allow check-out after shift end time (in minutes)'
+#. (Int)
+#. field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid ""
+"Time after the end of shift during which check-out is considered for "
+"attendance."
+msgstr "Ээлж дууссанаас хойшхи цаг, энэ хугацаанд гарахыг ирцэнд тооцно."
+
+#. Description of the 'Time to Fill' (Duration) field in DocType 'Job
+#. Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Time taken to fill the open positions"
+msgstr "Нээлттэй орон тоог нөхөхөд зарцуулсан хугацаа"
+
+#. Label of the time_to_fill (Duration) field in DocType 'Job Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Time to Fill"
+msgstr "Бөглөх цаг"
+
+#. Label of the timelines_tab (Section Break) field in DocType 'Job
+#. Requisition'
+#: hrms/hr/doctype/job_requisition/job_requisition.json
+msgid "Timelines"
+msgstr "Он цагийн хэлхээс"
+
+#. Label of the timesheets_section (Section Break) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Timesheet Details"
+msgstr "Цагийн хуудасны дэлгэрэнгүй мэдээлэл"
+
+#: hrms/hr/notification/training_scheduled/training_scheduled.html:29
+msgid "Timing"
+msgstr "Хугацаа"
+
+#. Label of the to_amount (Currency) field in DocType 'Taxable Salary Slab'
+#: hrms/payroll/doctype/taxable_salary_slab/taxable_salary_slab.json
+msgid "To Amount"
+msgstr "Хэмжээнд"
+
+#: hrms/hr/doctype/upload_attendance/upload_attendance.py:30
+msgid "To Date should be greater than From Date"
+msgstr "To Date нь From Date-аас их байх ёстой"
+
+#. Label of the to_user (Link) field in DocType 'PWA Notification'
+#: hrms/hr/doctype/pwa_notification/pwa_notification.json
+msgid "To User"
+msgstr "Хэрэглэгч рүү"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:104
+msgid "To allow this, enable {0} under {1}."
+msgstr "Үүнийг зөвшөөрөхийн тулд {1} доор {0}-г идэвхжүүлнэ үү."
+
+#: hrms/hr/doctype/leave_application/leave_application.js:326
+msgid "To apply for a Half Day check 'Half Day' and select the Half Day Date"
+msgstr ""
+"Хагас өдрийн өргөдөл гаргахдаа \"Хагас өдөр\"-ийг шалгаад хагас өдрийн "
+"огноог сонгоно уу"
+
+#: hrms/hr/doctype/leave_period/leave_period.py:20
+msgid "To date can not be equal or less than from date"
+msgstr "Өнөөдрийг хүртэл огноотой тэнцүү эсвэл бага байж болохгүй"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:127
+msgid "To date can not be greater than employee's relieving date."
+msgstr "Өнөөдрийг хүртэл ажилтны чөлөөлөгдсөн өдрөөс илүү байж болохгүй."
+
+#: hrms/hr/utils.py:195
+msgid "To date can not be less than from date"
+msgstr "Өнөөдрийг хүртэл огнооноос бага байж болохгүй"
+
+#: hrms/hr/utils.py:201
+msgid "To date can not greater than employee's relieving date"
+msgstr "Өнөөдрийг хүртэл ажилтны чөлөөлөгдсөн өдрөөс хэтрэхгүй байх ёстой"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:180
+#: hrms/hr/doctype/leave_application/leave_application.py:198
+msgid "To date cannot be before from date"
+msgstr "Өнөөг хүртэл огнооноос өмнө байж болохгүй"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:213
+msgid ""
+"To overwrite the salary component amount for a tax component, please enable "
+"{0}"
+msgstr ""
+"Татварын бүрэлдэхүүн хэсгийн цалингийн хэмжээг дарж бичихийн тулд {0}-г "
+"идэвхжүүлнэ үү."
+
+#. Label of the to_year (Int) field in DocType 'Gratuity Rule Slab'
+#: hrms/payroll/doctype/gratuity_rule_slab/gratuity_rule_slab.json
+msgid "To(Year)"
+msgstr "(жил)"
+
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.js:35
+msgid "To(Year) year can not be less than From(year)"
+msgstr "Он (жил) жилээс (жил) бага байж болохгүй"
+
+#: hrms/controllers/employee_reminders.py:122
+msgid "Today is {0}'s birthday 🎉"
+msgstr "Өнөөдөр {0}-н төрсөн өдөр 🎉"
+
+#: hrms/controllers/employee_reminders.py:261
+msgid "Today {0} at our Company! 🎉"
+msgstr "Өнөөдөр {0} манай компанид! 🎉"
+
+#: hrms/controllers/employee_reminders.py:241
+#| msgid "Today {0} completed {1} year(s) at our Company! 🎉"
+msgid "Today {0} completed {1} {2} at our Company! 🎉"
+msgstr "Өнөөдөр {0} манай компанид {1} {2} ажилласан! 🎉"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:149
+msgid "Total Absent"
+msgstr "Нийт байхгүй"
+
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:46
+#| msgid "Total Score"
+msgid "Total Accrued"
+msgstr "Нийт оноо"
+
+#. Label of the total_actual_amount (Currency) field in DocType 'Employee Tax
+#. Exemption Proof Submission'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Total Actual Amount"
+msgstr "Нийт бодит дүн"
+
+#. Label of the total_advance_amount (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Total Advance Amount"
+msgstr "Урьдчилгаа нийт дүн"
+
+#. Label of the base_total_advance_amount (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#| msgid "Total Deduction (Company Currency)"
+msgid "Total Advance Amount (Company Currency)"
+msgstr "Нийт суутгал (Компанийн мөнгөн тэмдэгт)"
+
+#. Label of the total_allocated_leaves (Float) field in DocType 'Salary Slip
+#. Leave'
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Total Allocated Leave(s)"
+msgstr "Нийт хуваарилагдсан чөлөө(үүд)"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:7
+msgid "Total Allocated Leaves"
+msgstr "Нийт хуваарилагдсан навч"
+
+#. Label of the total_amount_reimbursed (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Total Amount Reimbursed"
+msgstr "Нөхөн олгосон нийт дүн"
+
+#: hrms/payroll/doctype/gratuity/gratuity.py:102
+msgid "Total Amount cannot be zero"
+msgstr "Нийт дүн тэг байж болохгүй"
+
+#. Label of the total_asset_recovery_cost (Currency) field in DocType 'Full
+#. and
+#. Final Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Total Asset Recovery Cost"
+msgstr "Хөрөнгийг нөхөн сэргээх нийт зардал"
+
+#. Label of the total_claimed_amount (Currency) field in DocType 'Expense
+#. Claim'
+#: frontend/src/components/ExpenseClaimSummary.vue:9
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Total Claimed Amount"
+msgstr "Нэхэмжлэгдсэн нийт дүн"
+
+#. Label of the base_total_claimed_amount (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#| msgid "Total Deduction (Company Currency)"
+msgid "Total Claimed Amount (Company Currency)"
+msgstr "Нийт суутгал (Компанийн мөнгөн тэмдэгт)"
+
+#. Label of the lwp_days (Float) field in DocType 'Payroll Correction'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#| msgid "Is Leave Without Pay"
+msgid "Total Days Without Pay"
+msgstr "Цалингүй чөлөө"
+
+#. Label of the total_declared_amount (Currency) field in DocType 'Employee
+#. Tax
+#. Exemption Declaration'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+msgid "Total Declared Amount"
+msgstr "Нийт зарласан дүн"
+
+#. Label of the total_deduction (Currency) field in DocType 'Salary Slip'
+#. Label of the total_deduction (Currency) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+#: hrms/payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:148
+#: hrms/payroll/report/salary_register/salary_register.py:244
+msgid "Total Deduction"
+msgstr "Нийт хасалт"
+
+#. Label of the base_total_deduction (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Total Deduction (Company Currency)"
+msgstr "Нийт суутгал (Компанийн мөнгөн тэмдэгт)"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:174
+msgid "Total Early Exits"
+msgstr "Нийт эрт гарах"
+
+#. Label of the total_earning (Currency) field in DocType 'Salary Structure'
+#: hrms/payroll/doctype/salary_structure/salary_structure.json
+msgid "Total Earning"
+msgstr "Нийт орлого"
+
+#. Label of the total_earnings (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Total Earnings"
+msgstr "Нийт орлого"
+
+#. Label of the total_estimated_budget (Currency) field in DocType 'Staffing
+#. Plan'
+#: hrms/hr/doctype/staffing_plan/staffing_plan.json
+msgid "Total Estimated Budget"
+msgstr "Нийт тооцоолсон төсөв"
+
+#. Label of the total_estimated_cost (Currency) field in DocType 'Staffing
+#. Plan
+#. Detail'
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Total Estimated Cost"
+msgstr "Нийт тооцоолсон зардал"
+
+#. Label of the total_exchange_gain_loss (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#| msgid "Total Earnings"
+msgid "Total Exchange Gain/Loss"
+msgstr "Нийт орлого"
+
+#. Label of the total_exemption_amount (Currency) field in DocType 'Employee
+#. Tax Exemption Declaration'
+#. Label of the exemption_amount (Currency) field in DocType 'Employee Tax
+#. Exemption Proof Submission'
+#: hrms/payroll/doctype/employee_tax_exemption_declaration/employee_tax_exemption_declaration.json
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission/employee_tax_exemption_proof_submission.json
+msgid "Total Exemption Amount"
+msgstr "Чөлөөлөлтийн нийт дүн"
+
+#: hrms/setup.py:299
+msgid "Total Expense Claim (via Expense Claim)"
+msgstr "Нийт зардлын нэхэмжлэл (зардлын нэхэмжлэлээр)"
+
+#: hrms/setup.py:290
+msgid "Total Expense Claim (via Expense Claims)"
+msgstr "Нийт зардлын нэхэмжлэл (зардлын нэхэмжлэлээр)"
+
+#. Label of the total_score (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:79
+msgid "Total Goal Score"
+msgstr "Нийт гоолын оноо"
+
+#: hrms/payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:141
+msgid "Total Gross Pay"
+msgstr "Нийт цалин"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:66
+msgid "Total Hours (T)"
+msgstr "Нийт цаг (T)"
+
+#. Label of the total_income_tax (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Total Income Tax"
+msgstr "Нийт орлогын албан татвар"
+
+#: hrms/setup.py:803
+msgid "Total Interest Amount"
+msgstr "Хүүгийн нийт дүн"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:168
+msgid "Total Late Entries"
+msgstr "Нийт хоцорсон оруулгууд"
+
+#. Label of the total_leave_days (Float) field in DocType 'Leave Application'
+#: hrms/hr/doctype/leave_application/leave_application.json
+msgid "Total Leave Days"
+msgstr "Нийт амралтын өдрүүд"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:148
+msgid "Total Leaves"
+msgstr "Нийт навч"
+
+#: hrms/hr/report/leave_ledger/leave_ledger.py:192
+msgid "Total Leaves ({0})"
+msgstr "Нийт навч ({0})"
+
+#. Label of the total_leaves_allocated (Float) field in DocType 'Leave
+#. Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+msgid "Total Leaves Allocated"
+msgstr "Нийт хуваарилагдсан навч"
+
+#. Label of the total_leaves_encashed (Float) field in DocType 'Leave
+#. Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+msgid "Total Leaves Encashed"
+msgstr "Бэлэн болсон нийт навч"
+
+#: hrms/setup.py:817
+msgid "Total Loan Repayment"
+msgstr "Зээлийн нийт эргэн төлөлт"
+
+#: hrms/payroll/report/salary_payments_based_on_payment_mode/salary_payments_based_on_payment_mode.py:155
+msgid "Total Net Pay"
+msgstr "Нийт цэвэр цалин"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:228
+msgid "Total Non-Billed Hours"
+msgstr "Нийт төлбөр тооцоогүй цаг"
+
+#. Label of the total_overtime_duration (Float) field in DocType 'Overtime
+#. Slip'
+#: hrms/hr/doctype/overtime_slip/overtime_slip.json
+#| msgid "Total Resignations"
+msgid "Total Overtime Duration"
+msgstr "Нийт огцрох"
+
+#. Label of the total_payable_amount (Currency) field in DocType 'Full and
+#. Final Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Total Payable Amount"
+msgstr "Нийт өглөгийн дүн"
+
+#. Label of the total_payment (Currency) field in DocType 'Salary Slip Loan'
+#: hrms/payroll/doctype/salary_slip_loan/salary_slip_loan.json
+msgid "Total Payment"
+msgstr "Нийт төлбөр"
+
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:52
+#| msgid "Total Payment"
+msgid "Total Payout"
+msgstr "Нийт төлбөр"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:143
+msgid "Total Present"
+msgstr "Нийт одоогийн"
+
+#: hrms/setup.py:794
+msgid "Total Principal Amount"
+msgstr "Үндсэн зээлийн нийт дүн"
+
+#. Label of the total_receivable_amount (Currency) field in DocType 'Full and
+#. Final Statement'
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.json
+msgid "Total Receivable Amount"
+msgstr "Нийт авлагын дүн"
+
+#: hrms/hr/report/employee_exits/employee_exits.py:215
+msgid "Total Resignations"
+msgstr "Нийт огцрох"
+
+#. Label of the total_sanctioned_amount (Currency) field in DocType 'Expense
+#. Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+msgid "Total Sanctioned Amount"
+msgstr "Шийтгэлийн нийт дүн"
+
+#. Label of the base_total_sanctioned_amount (Currency) field in DocType
+#. 'Expense Claim'
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#| msgid "Total Deduction (Company Currency)"
+msgid "Total Sanctioned Amount (Company Currency)"
+msgstr "Нийт суутгал (Компанийн мөнгөн тэмдэгт)"
+
+#. Label of the total_score (Float) field in DocType 'Employee Performance
+#. Feedback'
+#: hrms/hr/doctype/employee_performance_feedback/employee_performance_feedback.json
+msgid "Total Score"
+msgstr "Нийт оноо"
+
+#. Label of the self_score (Float) field in DocType 'Appraisal'
+#: hrms/hr/doctype/appraisal/appraisal.json
+msgid "Total Self Score"
+msgstr "Өөрийнхөө нийт оноо"
+
+#: hrms/hr/doctype/expense_claim/expense_claim.py:521
+msgid "Total advance amount cannot be greater than total sanctioned amount"
+msgstr "Урьдчилгаа нийт хэмжээ зөвшөөрөгдсөн нийт дүнгээс их байж болохгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:73
+msgid ""
+"Total allocated leaves are more than maximum allocation allowed for {0} "
+"leave type for employee {1} in the period"
+msgstr ""
+"Хуваарилагдсан нийт чөлөө нь тухайн хугацаанд {0} ажилтны {1} амралтын "
+"төрөлд зөвшөөрөгдсөн дээд хэмжээнээс их байна"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:162
+msgid ""
+"Total allocated leaves {0} cannot be less than already approved leaves {1} "
+"for the period"
+msgstr ""
+"Хуваарилагдсан нийт навч {0} нь тухайн хугацааны аль хэдийн батлагдсан "
+"навчнаас {1} бага байж болохгүй"
+
+#. Label of the total_in_words (Data) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Total in words"
+msgstr "Нийт үгээр"
+
+#. Label of the base_total_in_words (Data) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Total in words (Company Currency)"
+msgstr "Үгээр илэрхийлсэн нийт дүн (Компанийн мөнгөн тэмдэгт)"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:367
+msgid "Total leaves allocated cannot exceed annual allocation of {0}."
+msgstr "Хуваарилсан нийт амралтын хэмжээ нь жилийн {0}-с хэтэрч болохгүй."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:253
+msgid "Total leaves allocated is mandatory for Leave Type {0}"
+msgstr "Амралтын төрөл {0}-д хуваарилагдсан нийт навч заавал байх ёстой."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:464
+#| msgid ""
+#| "Total advance amount cannot be greater than total sanctioned amount"
+msgid ""
+"Total of all employee benefits cannot be greater that Max Benefits Amount "
+"{0}"
+msgstr ""
+"Ажилтны нийт тэтгэмжийн дүн хамгийн их тэтгэмжийн хэмжээ {0}-с их байж "
+"болохгүй"
+
+#. Description of the 'Year To Date' (Currency) field in DocType 'Salary
+#. Detail'
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid ""
+"Total salary booked against this component for this employee from the "
+"beginning of the year (payroll period or fiscal year) up to the current "
+"salary slip's end date."
+msgstr ""
+"Энэ ажилтны жилийн эхнээс (цалингийн хугацаа эсвэл санхүүгийн жил) одоогийн "
+"цалингийн хуудас дуусах хүртэл энэ бүрэлдэхүүн хэсэгт тооцсон нийт цалин."
+
+#. Description of the 'Month To Date' (Currency) field in DocType 'Salary
+#. Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid ""
+"Total salary booked for this employee from the beginning of the month up to "
+"the current salary slip's end date."
+msgstr ""
+"Энэ ажилтны сарын эхнээс одоогийн цалингийн хуудас дуусах хүртэлх хугацаанд "
+"захиалсан нийт цалин."
+
+#. Description of the 'Year To Date' (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid ""
+"Total salary booked for this employee from the beginning of the year "
+"(payroll period or fiscal year) up to the current salary slip's end date."
+msgstr ""
+"Энэ ажилтны жилийн эхнээс (цалингийн хугацаа эсвэл санхүүгийн жил) одоогийн "
+"цалингийн хуудас дуусах хүртэлх хугацааны нийт цалин."
+
+#: hrms/hr/doctype/appraisal/appraisal.py:156 hrms/mixins/appraisal.py:17
+msgid "Total weightage for all {0} must add up to 100. Currently, it is {1}%"
+msgstr ""
+"Бүх {0} жингийн нийт жин 100 хүртэл нэмэгдэх ёстой. Одоогоор {1}% байна."
+
+#. Label of the total_working_days_per_year (Float) field in DocType 'Gratuity
+#. Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Total working Days Per Year"
+msgstr "Жилийн нийт ажлын өдрүүд"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:179
+msgid "Total working hours should not be greater than max working hours {0}"
+msgstr "Ажлын нийт цаг хамгийн их ажлын цагаас хэтрэхгүй байх ёстой {0}"
+
+#. Option for the 'Mode of Travel' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Train"
+msgstr "Галт тэрэг"
+
+#. Label of the trainer_email (Data) field in DocType 'Training Event'
+#. Label of the trainer_email (Data) field in DocType 'Training Program'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_program/training_program.json
+msgid "Trainer Email"
+msgstr "Сургагч багшийн имэйл"
+
+#. Label of the trainer_name (Data) field in DocType 'Training Event'
+#. Label of the trainer_name (Data) field in DocType 'Training Feedback'
+#. Label of the trainer_name (Data) field in DocType 'Training Program'
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_feedback/training_feedback.json
+#: hrms/hr/doctype/training_program/training_program.json
+msgid "Trainer Name"
+msgstr "Дасгалжуулагчийн нэр"
+
+#. Label of the training (Link) field in DocType 'Employee Training'
+#. Label of a Card Break in the Tenure Workspace
+#: hrms/hr/doctype/employee_training/employee_training.json
+#: hrms/hr/workspace/tenure/tenure.json
+#: hrms/overrides/dashboard_overrides.py:49
+msgid "Training"
+msgstr "Сургалт"
+
+#. Label of the training_date (Date) field in DocType 'Employee Training'
+#: hrms/hr/doctype/employee_training/employee_training.json
+msgid "Training Date"
+msgstr "Сургалтын огноо"
+
+#. Name of a DocType
+#. Label of the training_event (Link) field in DocType 'Training Feedback'
+#. Label of the training_event (Link) field in DocType 'Training Result'
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_feedback/training_feedback.json
+#: hrms/hr/doctype/training_feedback/training_feedback.py:14
+#: hrms/hr/doctype/training_result/training_result.json
+#: hrms/hr/doctype/training_result/training_result.py:16
+#: hrms/hr/workspace/tenure/tenure.json
+#: hrms/templates/emails/training_event.html:1
+msgid "Training Event"
+msgstr "Сургалтын арга хэмжээ"
+
+#. Name of a DocType
+#: hrms/hr/doctype/training_event_employee/training_event_employee.json
+msgid "Training Event Employee"
+msgstr "Сургалтын арга хэмжээний ажилтан"
+
+#: hrms/hr/notification/training_scheduled/training_scheduled.html:7
+msgid "Training Event:"
+msgstr "Сургалтын арга хэмжээ:"
+
+#: hrms/hr/doctype/training_program/training_program_dashboard.py:8
+msgid "Training Events"
+msgstr "Сургалтын арга хэмжээ"
+
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/training_event/training_event.js:16
+#: hrms/hr/doctype/training_feedback/training_feedback.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Training Feedback"
+msgstr "Сургалтын санал хүсэлт"
+
+#. Label of the training_program (Link) field in DocType 'Training Event'
+#. Name of a DocType
+#. Label of the training_program (Data) field in DocType 'Training Program'
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/training_event/training_event.json
+#: hrms/hr/doctype/training_program/training_program.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Training Program"
+msgstr "Сургалтын хөтөлбөр"
+
+#. Name of a DocType
+#. Label of a Link in the Tenure Workspace
+#: hrms/hr/doctype/training_event/training_event.js:10
+#: hrms/hr/doctype/training_result/training_result.json
+#: hrms/hr/workspace/tenure/tenure.json
+msgid "Training Result"
+msgstr "Сургалтын үр дүн"
+
+#. Name of a DocType
+#: hrms/hr/doctype/training_result_employee/training_result_employee.json
+msgid "Training Result Employee"
+msgstr "Сургалтын үр дүнгийн ажилтан"
+
+#. Label of the trainings_section (Section Break) field in DocType 'Employee
+#. Skill Map'
+#. Label of the trainings (Table) field in DocType 'Employee Skill Map'
+#: hrms/hr/doctype/employee_skill_map/employee_skill_map.json
+msgid "Trainings"
+msgstr "Сургалтууд"
+
+#. Label of a quick_list in the Tenure Workspace
+#: hrms/hr/workspace/tenure/tenure.json
+#| msgid "Training Feedback"
+msgid "Trainings (This Week)"
+msgstr "Сургалтын санал хүсэлт"
+
+#: hrms/hr/utils.py:798
+msgid "Transactions cannot be created for an Inactive Employee {0}."
+msgstr "Идэвхгүй ажилтан {0}-д гүйлгээ хийх боломжгүй."
+
+#. Label of the transfer_date (Date) field in DocType 'Employee Transfer'
+#: hrms/hr/doctype/employee_transfer/employee_transfer.json
+msgid "Transfer Date"
+msgstr "Шилжүүлгийн огноо"
+
+#. Label of a Card Break in the Expenses Workspace
+#: hrms/hr/workspace/expenses/expenses.json hrms/setup.py:336
+msgid "Travel"
+msgstr "Аялал"
+
+#. Label of the travel_advance_required (Check) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Travel Advance Required"
+msgstr "Аялал жуулчлалын урьдчилгаа шаардлагатай"
+
+#. Label of the travel_from (Data) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Travel From"
+msgstr "Аялал"
+
+#. Label of the travel_funding (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Travel Funding"
+msgstr "Аялал жуулчлалын санхүүжилт"
+
+#. Name of a DocType
+#. Label of the travel_itinerary (Section Break) field in DocType 'Travel
+#. Request'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Travel Itinerary"
+msgstr "Аялал жуулчлалын маршрут"
+
+#. Name of a DocType
+#. Label of a Link in the Expenses Workspace
+#. Label of a Link in the People Workspace
+#: hrms/hr/doctype/travel_request/travel_request.json
+#: hrms/hr/workspace/expenses/expenses.json
+#: hrms/hr/workspace/people/people.json
+msgid "Travel Request"
+msgstr "Аялал жуулчлалын хүсэлт"
+
+#. Name of a DocType
+#: hrms/hr/doctype/travel_request_costing/travel_request_costing.json
+msgid "Travel Request Costing"
+msgstr "Аялал жуулчлалын хүсэлтийн зардал"
+
+#. Label of the travel_to (Data) field in DocType 'Travel Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Travel To"
+msgstr "Аялах"
+
+#. Label of the travel_type (Select) field in DocType 'Travel Request'
+#: hrms/hr/doctype/travel_request/travel_request.json
+msgid "Travel Type"
+msgstr "Аялал жуулчлалын төрөл"
+
+#. Label of the type_of_proof (Data) field in DocType 'Employee Tax Exemption
+#. Proof Submission Detail'
+#: hrms/payroll/doctype/employee_tax_exemption_proof_submission_detail/employee_tax_exemption_proof_submission_detail.json
+msgid "Type of Proof"
+msgstr "Нотлох баримтын төрөл"
+
+#: hrms/public/js/utils/index.js:208
+msgid "Unable to retrieve your location"
+msgstr "Таны байршлыг сэргээх боломжгүй байна"
+
+#: hrms/hr/doctype/goal/goal.js:55
+msgid "Unarchive"
+msgstr "Архиваас гаргах"
+
+#. Label of the unclaimed_amount (Currency) field in DocType 'Expense Claim
+#. Advance'
+#: frontend/src/components/ExpenseAdvancesTable.vue:36
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+msgid "Unclaimed Amount"
+msgstr "Нэхэмжлэлгүй дүн"
+
+#. Label of the base_unclaimed_amount (Currency) field in DocType 'Expense
+#. Claim Advance'
+#: hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+#| msgid "Rounded Total (Company Currency)"
+msgid "Unclaimed Amount (Company Currency)"
+msgstr "Дугуйлсан нийт (Компанийн валют)"
+
+#. Option for the 'Status' (Select) field in DocType 'Interview'
+#: hrms/hr/doctype/interview/interview.json
+msgid "Under Review"
+msgstr "Хянаж байна"
+
+#: hrms/hr/doctype/attendance/attendance.py:231
+msgid "Unlinked Attendance record from Employee Checkins: {}"
+msgstr "Ажилчдын бүртгэлээс салгасан ирцийн бүртгэл: {}"
+
+#: hrms/hr/doctype/attendance/attendance.py:234
+msgid "Unlinked logs"
+msgstr "Холбогдоогүй бүртгэлүүд"
+
+#: hrms/hr/doctype/attendance/attendance_list.js:91
+msgid "Unmarked Attendance for days"
+msgstr "Өдрийн тэмдэглэлгүй ирц"
+
+#: hrms/hr/doctype/shift_type/shift_type.py:97
+msgid "Unmarked Check-in Logs Found"
+msgstr "Тэмдэглэгдээгүй бүртгэлийн бичлэгүүд олдлоо"
+
+#: hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py:157
+#: hrms/public/js/templates/employees_with_unmarked_attendance.html:19
+msgid "Unmarked Days"
+msgstr "Тэмдэглэгдээгүй өдрүүд"
+
+#. Label of the unmarked_employee_header (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#| msgid "Employee Grade"
+msgid "Unmarked Employee Header"
+msgstr "Ажилтны зэрэг"
+
+#. Label of the unmarked_employees_html (HTML) field in DocType 'Employee
+#. Attendance Tool'
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+#| msgid "Employees HTML"
+msgid "Unmarked Employees HTML"
+msgstr "Ажилчдын HTML"
+
+#. Label of the unmarked_days (Float) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Unmarked days"
+msgstr "Тэмдэглэгдээгүй өдрүүд"
+
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:58
+#| msgid "Unpaid"
+msgid "Unpaid Accrual"
+msgstr "Төлбөргүй"
+
+#. Name of a report
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.json
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Unpaid Expense Claim"
+msgstr "Төлөгдөөгүй зардлын нэхэмжлэл"
+
+#. Option for the 'Status' (Select) field in DocType 'Full and Final
+#. Outstanding Statement'
+#: hrms/hr/doctype/full_and_final_outstanding_statement/full_and_final_outstanding_statement.json
+msgid "Unsettled"
+msgstr "Тогтворгүй байна"
+
+#: hrms/hr/doctype/full_and_final_statement/full_and_final_statement.py:56
+msgid "Unsettled Transactions"
+msgstr "Тогтоогдоогүй гүйлгээ"
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:158
+msgid "Unsubmitted Appraisals"
+msgstr "Илгээгдээгүй үнэлгээ"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:251
+msgid "Untracked Hours"
+msgstr "Хяналтгүй цаг"
+
+#: hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py:80
+msgid "Untracked Hours (U)"
+msgstr "Хяналтгүй цаг (U)"
+
+#. Label of the unused_leaves (Float) field in DocType 'Leave Allocation'
+#: hrms/hr/doctype/leave_allocation/leave_allocation.json
+msgid "Unused leaves"
+msgstr "Ашиглагдаагүй навч"
+
+#: frontend/src/components/Holidays.vue:4
+msgid "Upcoming Holidays"
+msgstr "Удахгүй болох баярын өдрүүд"
+
+#: hrms/controllers/employee_reminders.py:69
+msgid "Upcoming Holidays Reminder"
+msgstr "Удахгүй болох баярын сануулга"
+
+#: frontend/src/views/attendance/Dashboard.vue:23
+msgid "Upcoming Shifts"
+msgstr "Удахгүй болох ээлжүүд"
+
+#: frontend/src/components/ExpensesTable.vue:123
+msgid "Update Expense"
+msgstr "Зардал шинэчлэх"
+
+#: hrms/hr/doctype/interview/interview.py:71
+msgid "Update Job Applicant"
+msgstr "Ажил горилогчийг шинэчлэх"
+
+#: hrms/hr/doctype/goal/goal_tree.js:232 hrms/hr/doctype/goal/goal_tree.js:238
+msgid "Update Progress"
+msgstr "Явцыг шинэчлэх"
+
+#: hrms/templates/emails/training_event.html:11
+msgid "Update Response"
+msgstr "Хариуг шинэчлэх"
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:120
+msgid "Update Salary Structures"
+msgstr "Цалингийн бүтцийг шинэчлэх"
+
+#: hrms/hr/doctype/goal/goal_list.js:35
+msgid "Update Status"
+msgstr "Статусыг шинэчлэх"
+
+#: frontend/src/components/ExpenseTaxesTable.vue:118
+msgid "Update Tax"
+msgstr "Татварыг шинэчлэх"
+
+#: hrms/hr/doctype/attendance_request/attendance_request.py:115
+msgid ""
+"Updated status from {0} to {1} for date {2} in the attendance record {3}"
+msgstr "Ирцийн бүртгэлд {3} {2} огнооны төлөвийг {0}-с {1} болгон шинэчилсэн"
+
+#: hrms/hr/doctype/interview/interview.py:201
+msgid "Updated the Job Applicant status to {0}"
+msgstr "Ажил горилогчийн статусыг {0} болгож шинэчилсэн"
+
+#: hrms/overrides/employee_master.py:77
+msgid ""
+"Updated the status of Job Offer {0} for the linked Job Applicant {1} to {2}"
+msgstr ""
+"Холбогдсон ажил горилогчийн {1}-д зориулсан {0} ажлын саналын статусыг {2} "
+"болгон шинэчилсэн."
+
+#: hrms/overrides/employee_master.py:63
+msgid "Updated the status of linked Job Applicant {0} to {1}"
+msgstr "Холбогдсон ажил горилогчийн статусыг {0} {1} рүү шинэчилсэн"
+
+#. Name of a DocType
+#. Label of a Link in the Shift & Attendance Workspace
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+#: hrms/hr/workspace/shift_&_attendance/shift_&_attendance.json
+msgid "Upload Attendance"
+msgstr "Ирцийг байршуулах"
+
+#. Label of the upload_html (HTML) field in DocType 'Upload Attendance'
+#: hrms/hr/doctype/upload_attendance/upload_attendance.json
+msgid "Upload HTML"
+msgstr "HTML байршуулах"
+
+#: frontend/src/components/FileUploaderView.vue:11
+msgid "Upload images or documents"
+msgstr "Зураг эсвэл баримт бичгийг байршуулах"
+
+#: frontend/src/components/FormView.vue:124
+#: frontend/src/components/FormView.vue:163
+msgid "Uploading..."
+msgstr "Байршуулж байна..."
+
+#. Label of the upper_range (Currency) field in DocType 'Job Applicant'
+#. Label of the upper_range (Currency) field in DocType 'Job Opening'
+#. Label of a field in the job-application Web Form
+#: hrms/hr/doctype/job_applicant/job_applicant.json
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/web_form/job_application/job_application.json
+msgid "Upper Range"
+msgstr "Дээд хүрээ"
+
+#. Label of the used_leaves (Float) field in DocType 'Salary Slip Leave'
+#: hrms/payroll/doctype/salary_slip_leave/salary_slip_leave.json
+msgid "Used Leave(s)"
+msgstr "Ашигласан чөлөө(үүд)"
+
+#: hrms/hr/doctype/leave_application/leave_application_dashboard.html:9
+msgid "Used Leaves"
+msgstr "Ашигласан навч"
+
+#. Label of the vacancies (Int) field in DocType 'Job Opening'
+#. Label of the vacancies (Int) field in DocType 'Staffing Plan Detail'
+#: hrms/hr/doctype/job_opening/job_opening.json
+#: hrms/hr/doctype/staffing_plan_detail/staffing_plan_detail.json
+msgid "Vacancies"
+msgstr "Сул орон тоо"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.js:81
+msgid "Vacancies cannot be lower than the current openings"
+msgstr "Сул орон тоо нь одоо нээгдэж буй орон тооноос доогуур байж болохгүй"
+
+#: hrms/hr/doctype/job_opening/job_opening.py:88
+msgid "Vacancies fulfilled"
+msgstr "Сул орон тоо хангагдсан"
+
+#. Label of the validate_attendance (Check) field in DocType 'Payroll Entry'
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.json
+msgid "Validate Attendance"
+msgstr "Ирцийг баталгаажуулах"
+
+#: hrms/payroll/doctype/payroll_entry/payroll_entry.js:404
+msgid "Validating Employee Attendance..."
+msgstr "Ажилчдын ирцийг баталгаажуулж байна..."
+
+#. Label of the value (Small Text) field in DocType 'Job Offer Term'
+#: hrms/hr/doctype/job_offer_term/job_offer_term.json
+msgid "Value / Description"
+msgstr "Үнэ цэнэ / Тайлбар"
+
+#: hrms/hr/employee_property_update.js:196
+msgid "Value missing"
+msgstr "Утга дутуу байна"
+
+#. Label of the variable (Currency) field in DocType 'Salary Structure
+#. Assignment'
+#: hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.js:185
+#: hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+msgid "Variable"
+msgstr "Хувьсагч"
+
+#. Label of the variable_based_on_taxable_salary (Check) field in DocType
+#. 'Salary Component'
+#. Label of the variable_based_on_taxable_salary (Check) field in DocType
+#. 'Salary Detail'
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:211
+#: hrms/payroll/doctype/salary_component/salary_component.json
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+msgid "Variable Based On Taxable Salary"
+msgstr "Татвар ногдох цалин дээр суурилсан хувьсагч"
+
+#. Option for the 'Meal Preference' (Select) field in DocType 'Travel
+#. Itinerary'
+#: hrms/hr/doctype/travel_itinerary/travel_itinerary.json
+msgid "Vegetarian"
+msgstr "Цагаан хоолтон"
+
+#. Name of a report
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/doctype/vehicle_log/vehicle_log.py:51
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.json
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Vehicle Expenses"
+msgstr "Тээврийн хэрэгслийн зардал"
+
+#. Label of the vehicle_log (Link) field in DocType 'Expense Claim'
+#. Name of a DocType
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/doctype/expense_claim/expense_claim.json
+#: hrms/hr/doctype/vehicle_log/vehicle_log.json
+#: hrms/hr/report/vehicle_expenses/vehicle_expenses.py:37
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Vehicle Log"
+msgstr "Тээврийн хэрэгслийн бүртгэл"
+
+#. Name of a DocType
+#: hrms/hr/doctype/vehicle_service/vehicle_service.json
+msgid "Vehicle Service"
+msgstr "Тээврийн хэрэгслийн үйлчилгээ"
+
+#. Name of a DocType
+#. Label of a Link in the Expenses Workspace
+#: hrms/hr/doctype/vehicle_service_item/vehicle_service_item.json
+#: hrms/hr/workspace/expenses/expenses.json
+msgid "Vehicle Service Item"
+msgstr "Тээврийн хэрэгслийн үйлчилгээний зүйл"
+
+#: hrms/hr/doctype/appraisal/appraisal.js:56
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.js:22
+msgid "View Goals"
+msgstr "Зорилго харах"
+
+#: frontend/src/components/LeaveBalance.vue:14
+msgid "View Leave History"
+msgstr "Орхих түүхийг харах"
+
+#: frontend/src/views/Home.vue:57
+msgid "View Salary Slips"
+msgstr "Цалингийн хуудас үзэх"
+
+#. Option for the 'Roster Color' (Select) field in DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Violet"
+msgstr "Нил ягаан"
+
+#: hrms/patches/v15_0/notify_about_loan_app_separation.py:16
+msgid "WARNING: Loan Management module has been separated from ERPNext."
+msgstr "АНХААРУУЛГА: Зээлийн удирдлагын модулийг ERPNext-ээс тусгаарласан."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:448
+msgid ""
+"Warning: Insufficient leave balance for Leave Type {0} in this allocation."
+msgstr ""
+"Анхааруулга: Энэ хуваарилалтын {0} төрлийн амралтын үлдэгдэл хангалтгүй "
+"байна."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:456
+msgid "Warning: Insufficient leave balance for Leave Type {0}."
+msgstr "Анхааруулга: Амралтын төрөл {0}-д үлдээх үлдэгдэл хангалтгүй байна."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:394
+msgid "Warning: Leave application contains following block dates"
+msgstr "Анхааруулга: Өргөдөл гаргах нь дараах блок огноог агуулна"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:91
+msgid ""
+"Warning: {0} already has an active Shift Assignment {1} for some/all of "
+"these dates."
+msgstr ""
+"Анхааруулга: {0}-д эдгээр огнооны зарим/бүх огнооны хувьд {1} шилжих "
+"даалгаврыг аль хэдийн идэвхжүүлсэн байна."
+
+#: hrms/setup.py:398
+msgid "Website Listing"
+msgstr "Вэб сайтын жагсаалт"
+
+#. Label of the weekend_multiplier (Float) field in DocType 'Overtime Type'
+#: hrms/hr/doctype/overtime_type/overtime_type.json
+msgid "Weekend Multiplier"
+msgstr "Амралтын өдрийн үржүүлэгч"
+
+#. Label of the per_weightage (Float) field in DocType 'Appraisal Goal'
+#. Label of the per_weightage (Percent) field in DocType 'Appraisal KRA'
+#. Label of the per_weightage (Percent) field in DocType 'Appraisal Template
+#. Goal'
+#. Label of the per_weightage (Percent) field in DocType 'Employee Feedback
+#. Rating'
+#: hrms/hr/doctype/appraisal_goal/appraisal_goal.json
+#: hrms/hr/doctype/appraisal_kra/appraisal_kra.json
+#: hrms/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+#: hrms/hr/doctype/employee_feedback_rating/employee_feedback_rating.json
+msgid "Weightage (%)"
+msgstr "Жин (%)"
+
+#. Description of the 'Status' (Select) field in DocType 'Shift Assignment
+#. Tool'
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.json
+msgid ""
+"When set to 'Inactive', employees with conflicting active shifts will not be"
+" excluded."
+msgstr ""
+"\"Идэвхгүй\" гэж тохируулсан тохиолдолд идэвхтэй ээлжийн зөрчилтэй ажилчдыг "
+"оруулахгүй."
+
+#: hrms/hr/doctype/leave_type/leave_type.py:36
+msgid ""
+"Whereas allocation for Compensatory Leaves is automatically created or "
+"updated on submission of Compensatory Leave Request."
+msgstr ""
+"Нөхөн олговрын чөлөө олгох хүсэлтийг ирүүлснээр нөхөн олговрын амралтын "
+"хуваарилалтыг автоматаар үүсгэж эсвэл шинэчилдэг."
+
+#. Label of the qualification_reason (Text Editor) field in DocType 'Employee
+#. Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Why is this Candidate Qualified for this Position?"
+msgstr "Энэ нэр дэвшигч яагаад энэ албан тушаалд тэнцсэн бэ?"
+
+#. Option for the 'Status' (Select) field in DocType 'Salary Slip'
+#. Option for the 'Status' (Select) field in DocType 'Salary Withholding'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+#: hrms/payroll/doctype/salary_withholding/salary_withholding.json
+msgid "Withheld"
+msgstr "Суутгасан"
+
+#. Label of the send_work_anniversary_reminders (Check) field in DocType 'HR
+#. Settings'
+#: hrms/hr/doctype/hr_settings/hr_settings.json
+msgid "Work Anniversaries "
+msgstr "Ажлын тэмдэглэлт ой "
+
+#: hrms/controllers/employee_reminders.py:278
+#: hrms/controllers/employee_reminders.py:285
+msgid "Work Anniversary Reminder"
+msgstr "Ажлын жилийн ойн сануулга"
+
+#. Label of the work_end_date (Date) field in DocType 'Compensatory Leave
+#. Request'
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgid "Work End Date"
+msgstr "Ажил дуусах огноо"
+
+#. Label of the work_experience_calculation_function (Select) field in DocType
+#. 'Gratuity Rule'
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.json
+msgid "Work Experience Calculation Method"
+msgstr "Ажлын туршлага тооцох арга"
+
+#. Label of the work_from_date (Date) field in DocType 'Compensatory Leave
+#. Request'
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgid "Work From Date"
+msgstr "Огнооноос эхлэн ажиллах"
+
+#. Option for the 'Status' (Select) field in DocType 'Attendance'
+#. Option for the 'Reason' (Select) field in DocType 'Attendance Request'
+#. Option for the 'Status' (Select) field in DocType 'Employee Attendance
+#. Tool'
+#: frontend/src/components/AttendanceCalendar.vue:80
+#: hrms/hr/doctype/attendance/attendance.json
+#: hrms/hr/doctype/attendance_request/attendance_request.json
+#: hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+msgid "Work From Home"
+msgstr "Гэрээсээ ажиллах"
+
+#. Label of the work_references (Text Editor) field in DocType 'Employee
+#. Referral'
+#: hrms/hr/doctype/employee_referral/employee_referral.json
+msgid "Work References"
+msgstr "Ажлын лавлагаа"
+
+#: hrms/hr/doctype/daily_work_summary/daily_work_summary.py:100
+msgid "Work Summary for {0}"
+msgstr "{0}-н ажлын хураангуй"
+
+#. Label of the worked_on (Section Break) field in DocType 'Compensatory Leave
+#. Request'
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.json
+msgid "Worked On Holiday"
+msgstr "Амралтын өдрөөр ажилласан"
+
+#. Label of the working_days (Float) field in DocType 'Payroll Correction'
+#. Label of the total_working_days (Float) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Working Days"
+msgstr "Ажлын өдрүүд"
+
+#. Label of the working_days_section (Section Break) field in DocType 'Payroll
+#. Settings'
+#: hrms/payroll/doctype/payroll_settings/payroll_settings.json
+msgid "Working Days and Hours"
+msgstr "Ажлын өдөр, цаг"
+
+#. Label of the working_hours_calculation_based_on (Select) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Working Hours Calculation Based On"
+msgstr "Үндэслэн ажлын цагийн тооцоо"
+
+#. Label of the working_hours_threshold_for_absent (Float) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Working Hours Threshold for Absent"
+msgstr "Эзгүй хүмүүсийн ажлын цагийн босго"
+
+#. Label of the working_hours_threshold_for_half_day (Float) field in DocType
+#. 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Working Hours Threshold for Half Day"
+msgstr "Хагас өдрийн ажлын цагийн босго"
+
+#. Description of the 'Working Hours Threshold for Absent' (Float) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Working hours below which Absent is marked. (Zero to disable)"
+msgstr "Эзгүй гэж тэмдэглэсэн ажлын цаг. (Идэвхгүй болгохын тулд тэг)"
+
+#. Description of the 'Working Hours Threshold for Half Day' (Float) field in
+#. DocType 'Shift Type'
+#: hrms/hr/doctype/shift_type/shift_type.json
+msgid "Working hours below which Half Day is marked. (Zero to disable)"
+msgstr "Хагас өдрийг тэмдэглэсэн ажлын цаг. (Идэвхгүй болгохын тулд тэг)"
+
+#. Option for the 'Type' (Select) field in DocType 'Training Event'
+#: hrms/hr/doctype/training_event/training_event.json
+msgid "Workshop"
+msgstr "Семинар"
+
+#. Label of the year_to_date (Currency) field in DocType 'Salary Detail'
+#. Label of the year_to_date (Currency) field in DocType 'Salary Slip'
+#: frontend/src/views/salary_slip/Dashboard.vue:8
+#: hrms/payroll/doctype/salary_detail/salary_detail.json
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Year To Date"
+msgstr "Он өнөөг хүртэл"
+
+#. Label of the base_year_to_date (Currency) field in DocType 'Salary Slip'
+#: hrms/payroll/doctype/salary_slip/salary_slip.json
+msgid "Year To Date(Company Currency)"
+msgstr "Өнөөдрийг хүртэлх он (Компанийн валют)"
+
+#. Label of the yearly_benefit (Currency) field in DocType 'Employee Benefit
+#. Claim'
+#: hrms/payroll/doctype/employee_benefit_claim/employee_benefit_claim.json
+#| msgid "Default Amount"
+msgid "Yearly Amount"
+msgstr "Өгөгдмөл дүн"
+
+#. Label of the yearly_benefit (Currency) field in DocType 'Employee Benefit
+#. Ledger'
+#: hrms/payroll/doctype/employee_benefit_ledger/employee_benefit_ledger.json
+#: hrms/payroll/report/accrued_earnings_report/accrued_earnings_report.py:40
+#| msgid "Benefit"
+msgid "Yearly Benefit"
+msgstr "Ашиг тус"
+
+#: hrms/hr/doctype/hr_settings/hr_settings.py:86
+msgid "Yes, Proceed"
+msgstr "Тиймээ, үргэлжлүүлээрэй"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:404
+msgid "You are not authorized to approve leaves on Block Dates"
+msgstr "Та Блокны огнооны навчийг зөвшөөрөх эрхгүй"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:58
+msgid "You are not present all day(s) between compensatory leave request days"
+msgstr ""
+"Та нөхөн олговор олгох хүсэлт гаргасан өдрүүдийн хооронд өдөржингөө байхгүй "
+"байна"
+
+#: hrms/payroll/doctype/gratuity_rule/gratuity_rule.py:24
+msgid ""
+"You can not define multiple slabs if you have a slab with no lower and upper"
+" limits."
+msgstr ""
+"Доод болон дээд хязгааргүй хавтантай бол та олон хавтанг тодорхойлж "
+"чадахгүй."
+
+#: hrms/hr/doctype/shift_request/shift_request.py:82
+msgid "You can not request for your Default Shift: {0}"
+msgstr "Та өгөгдмөл ээлжийн хүсэлт гаргах боломжгүй: {0}"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.py:94
+msgid ""
+"You can only plan for upto {0} vacancies and budget {1} for {2} as per "
+"staffing plan {3} for parent company {4}."
+msgstr ""
+"Та зөвхөн {4} толгой компанийн {3} боловсон хүчний төлөвлөгөөний дагуу {0} "
+"хүртэлх сул орон тоо, {2}-д {1} төсөв төлөвлөх боломжтой."
+
+#: hrms/hr/doctype/leave_encashment/leave_encashment.py:43
+msgid "You can only submit Leave Encashment for a valid encashment amount"
+msgstr "Та зөвхөн хүчинтэй мөнгөн дүнгээр чөлөөний мөнгө өгөх боломжтой"
+
+#: hrms/api/__init__.py:726
+msgid "You can only upload JPG, PNG, PDF, TXT or Microsoft documents."
+msgstr ""
+"Та зөвхөн JPG, PNG, PDF, TXT эсвэл Microsoft баримтуудыг байршуулах "
+"боломжтой."
+
+#: hrms/payroll/doctype/payroll_correction/payroll_correction.py:48
+msgid ""
+"You cannot reverse more than the total LWP days {0}. You have already "
+"reversed {1} days for this employee."
+msgstr ""
+"Та нийт ЦЧ өдрүүд {0}-с илүү буцаах боломжгүй. Та энэ ажилтанд аль хэдийн "
+"{1} өдөр буцаасан."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:417
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:580
+msgid "You do not have permission to complete this action"
+msgstr "Танд энэ үйлдлийг гүйцэтгэх зөвшөөрөл байхгүй"
+
+#: frontend/src/components/EmployeeAdvanceBalance.vue:26
+msgid "You have no advances"
+msgstr "Танд урьдчилгаа байхгүй"
+
+#: frontend/src/components/LeaveBalance.vue:42
+#| msgid "Total Leaves Allocated"
+msgid "You have no leaves allocated"
+msgstr "Нийт хуваарилагдсан навч"
+
+#: frontend/src/views/Notifications.vue:91
+#| msgid "Send Leave Notification"
+msgid "You have no notifications"
+msgstr "Амрах тухай мэдэгдэл илгээх"
+
+#: frontend/src/components/RequestList.vue:31
+#| msgid "You have no upcoming shifts"
+msgid "You have no requests"
+msgstr "Танд удахгүй болох ээлж алга"
+
+#: frontend/src/components/Holidays.vue:32
+#| msgid "You have no upcoming shifts"
+msgid "You have no upcoming holidays"
+msgstr "Танд удахгүй болох ээлж алга"
+
+#: frontend/src/views/attendance/Dashboard.vue:29
+msgid "You have no upcoming shifts"
+msgstr "Танд удахгүй болох ээлж алга"
+
+#: hrms/overrides/employee_master.py:83
+msgid "You may add additional details, if any, and submit the offer."
+msgstr "Хэрэв байгаа бол нэмэлт мэдээлэл нэмж, саналаа илгээж болно."
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:128
+msgid "You must be within {0} meters of your shift location to check in."
+msgstr ""
+"Та бүртгүүлэхийн тулд ээлжийнхээ байршлаас {0} метрийн зайд байх ёстой."
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:52
+msgid ""
+"You were only present for Half Day on {}. Cannot apply for a full day "
+"compensatory leave"
+msgstr ""
+"Та {}-д зөвхөн хагас өдөр ирсэн. Бүтэн өдрийн нөхөн олговор авах хүсэлт "
+"гаргах боломжгүй"
+
+#: hrms/hr/doctype/interview/interview.py:104
+msgid ""
+"Your Interview session is rescheduled from {0} {1} - {2} to {3} {4} - {5}"
+msgstr ""
+"Таны ярилцлагын хуралдааныг {0} {1} - {2}-с {3} {4} - {5} хүртэл товлолоо."
+
+#: frontend/src/views/Login.vue:63
+msgid "Your password has expired. Please reset your password to continue"
+msgstr ""
+"Таны нууц үгийн хугацаа дууссан. Үргэлжлүүлэхийн тулд нууц үгээ шинэчилнэ үү"
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:100
+msgid "active"
+msgstr "идэвхтэй"
+
+#: hrms/public/js/templates/feedback_summary.html:16
+msgid "based on"
+msgstr "дээр суурилсан"
+
+#: frontend/src/components/RequestActionSheet.vue:292
+msgid "cancellation"
+msgstr "цуцлах"
+
+#: frontend/src/components/RequestActionSheet.vue:283
+msgid "cancelled"
+msgstr "цуцалсан"
+
+#: hrms/public/js/utils/index.js:131
+msgid "create/submit"
+msgstr "үүсгэх/илгээх"
+
+#: hrms/public/js/utils/index.js:132
+msgid "created"
+msgstr "үүсгэсэн"
+
+#: hrms/hr/doctype/employee_advance/employee_advance.py:49
+msgid "here"
+msgstr "энд"
+
+#: frontend/src/views/Login.vue:16
+msgid "johndoe@mail.com"
+msgstr "johndoe@mail.com"
+
+#. Label of the modify_half_day_status (Check) field in DocType 'Attendance'
+#: hrms/hr/doctype/attendance/attendance.json
+msgid "modify_half_day_status"
+msgstr "modify_half_day_status"
+
+#: hrms/hr/doctype/department_approver/department_approver.py:89
+msgid "or for the Employee's Department: {0}"
+msgstr "эсвэл Ажилтны хэлтэст: {0}"
+
+#: hrms/public/js/utils/index.js:134
+msgid "process"
+msgstr "үйл явц"
+
+#: hrms/public/js/utils/index.js:135
+msgid "processed"
+msgstr "боловсруулсан"
+
+#: hrms/www/jobs/index.html:122
+msgid "result"
+msgstr "үр дүн"
+
+#: hrms/www/jobs/index.html:122
+msgid "results"
+msgstr "үр дүн"
+
+#: hrms/public/js/templates/feedback_summary.html:16
+msgid "review"
+msgstr "хянан үзэх"
+
+#: hrms/public/js/templates/feedback_summary.html:16
+msgid "reviews"
+msgstr "тойм"
+
+#: frontend/src/components/RequestActionSheet.vue:283
+msgid "submitted"
+msgstr "оруулсан"
+
+#: hrms/payroll/doctype/salary_component/salary_component.py:139
+msgid "via Salary Component sync"
+msgstr "Цалингийн бүрэлдэхүүн хэсгийн синхрончлолоор дамжуулан"
+
+#: hrms/controllers/employee_reminders.py:265
+msgid "year"
+msgstr "жил"
+
+#: hrms/controllers/employee_reminders.py:265
+msgid "years"
+msgstr "жил"
+
+#: hrms/controllers/employee_reminders.py:120
+#: hrms/controllers/employee_reminders.py:254
+#: hrms/controllers/employee_reminders.py:260
+msgid "{0} & {1}"
+msgstr "{0} ба {1}"
+
+#: frontend/src/components/ExpenseClaimItem.vue:84
+msgid "{0} & {1} more"
+msgstr "{0} болон өөр {1}"
+
+#: hrms/hr/doctype/overtime_slip/overtime_slip.py:489
+#| msgid "{0}: {1}"
+msgid "{0} : {1}"
+msgstr "{0}: {1}"
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2534
+msgid "{0} <br> This error can be due to missing or deleted field."
+msgstr ""
+"{0} <br> Энэ алдаа нь дутуу эсвэл устгасан талбартай холбоотой байж болно."
+
+#: hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py:155
+msgid "{0} Appraisal(s) are not submitted yet"
+msgstr "{0} Үнэлгээг хараахан ирүүлээгүй байна"
+
+#: hrms/public/js/utils/index.js:231
+msgid "{0} Field"
+msgstr "{0} талбар"
+
+#: hrms/hr/doctype/department_approver/department_approver.py:92
+msgid "{0} Missing"
+msgstr "{0} алга"
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.py:44
+msgid ""
+"{0} Row #{1}: Formula is set but {2} is disabled for the Salary Component "
+"{3}."
+msgstr ""
+"{0} Мөр #{1}: Томьёог тохируулсан боловч Цалингийн бүрэлдэхүүн хэсэг {3}-д "
+"{2}-г идэвхгүй болгосон."
+
+#: hrms/payroll/doctype/salary_structure/salary_structure.js:319
+msgid ""
+"{0} Row #{1}: {2} needs to be enabled for the formula to be considered."
+msgstr ""
+"{0} Мөр #{1}: Томьёог авч үзэхийн тулд {2}-г идэвхжүүлэх шаардлагатай."
+
+#: frontend/src/views/Notifications.vue:27
+#| msgid "{} Unclaimed"
+msgid "{0} Unread"
+msgstr "{0} уншаагүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:203
+msgid "{0} already allocated for Employee {1} for period {2} to {3}"
+msgstr ""
+"{2}-с {3} хүртэлх хугацаанд {1} ажилтанд {0} аль хэдийн хуваарилагдсан байна"
+
+#: hrms/hr/utils.py:271
+msgid "{0} already exists for employee {1} and period {2}"
+msgstr "{1} ажилтан болон {2} хугацаанд {0} аль хэдийн байна"
+
+#: hrms/hr/doctype/shift_assignment/shift_assignment.py:99
+msgid ""
+"{0} already has an active Shift Assignment {1} for some/all of these dates."
+msgstr ""
+"{0}-д аль хэдийн эдгээр огнооны зарим/бүх огнооны {1}-н ээлжийн даалгавар "
+"идэвхтэй байна."
+
+#: hrms/hr/doctype/leave_application/leave_application.py:169
+msgid "{0} applicable after {1} working days"
+msgstr "{0} ажлын {1} өдрийн дараа хэрэгжинэ"
+
+#: frontend/src/components/LeaveBalance.vue:37
+msgctxt "Leave Type"
+msgid "{0} balance"
+msgstr "{0} үлдэгдэл"
+
+#: hrms/controllers/employee_reminders.py:253
+#| msgid "{0} completed {1} year(s)"
+msgid "{0} completed {1} {2}"
+msgstr "{0} нь {1} {2} ажилласан"
+
+#: frontend/src/components/FormView.vue:528
+msgid "{0} created successfully!"
+msgstr "{0} амжилттай үүсгэгдсэн!"
+
+#: frontend/src/components/FormView.vue:583
+msgid "{0} deleted successfully!"
+msgstr "{0} амжилттай устгагдсан!"
+
+#: frontend/src/components/CheckInPanel.vue:186
+#: frontend/src/components/RequestActionSheet.vue:290
+msgid "{0} failed!"
+msgstr "{0} амжилтгүй боллоо!"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:209
+msgid "{0} has {1} enabled"
+msgstr "{0} {1}-г идэвхжүүлсэн"
+
+#: hrms/payroll/doctype/additional_salary/additional_salary.py:221
+msgid ""
+"{0} is an Accrual Component and this will be recorded as a payout in "
+"Employee Benefits Ledger"
+msgstr ""
+"{0} нь Хуримтлалын бүрэлдэхүүн бөгөөд Ажилтны тэтгэмжийн дэвтэрт олголт "
+"хэлбэрээр бүртгэгдэнэ"
+
+#: hrms/hr/doctype/employee_checkin/employee_checkin.py:228
+#| msgid "{} is an invalid Attendance Status."
+msgid "{0} is an invalid Attendance Status."
+msgstr "{0} нь хүчингүй Ирцийн төлөв юм."
+
+#: hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py:69
+msgid "{0} is not a holiday."
+msgstr "{0} бол амралт биш."
+
+#: hrms/hr/doctype/interview_feedback/interview_feedback.py:29
+msgid "{0} is not allowed to submit Interview Feedback for the Interview: {1}"
+msgstr "{0}-г ярилцлаганд оруулах санал хүсэлтийг илгээх эрхгүй: {1}"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:648
+msgid "{0} is not in Optional Holiday List"
+msgstr "{0} нэмэлт амралтын жагсаалтад байхгүй"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:361
+msgid "{0} leaves allocated successfully"
+msgstr "{0} навч амжилттай хуваарилагдсан"
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:563
+msgid ""
+"{0} leaves from allocation for {1} leave type have expired and will be "
+"processed during the next scheduled job. It is recommended to expire them "
+"now before creating new leave policy assignments."
+msgstr ""
+"{1} чөлөөний төрлийн хуваарилалтаас {0} чөлөөний хугацаа дууссан бөгөөд "
+"дараагийн товлогдсон даалгаврын үед боловсруулагдана. Шинэ чөлөөний бодлогын"
+" хуваарилалт үүсгэхийн өмнө тэдгээрийг одоо дуусгавар болгохыг зөвлөж байна."
+
+#: hrms/hr/doctype/leave_allocation/leave_allocation.py:356
+msgid "{0} leaves were manually allocated by {1} on {2}"
+msgstr "{0} навчийг {2}-д {1} гараар хуваарилсан"
+
+#: hrms/hr/doctype/training_feedback/training_feedback.py:14
+#: hrms/hr/doctype/training_result/training_result.py:16
+msgid "{0} must be submitted"
+msgstr "{0} оруулах ёстой"
+
+#: hrms/hr/doctype/goal/goal.py:194
+msgid "{0} of {1} Completed"
+msgstr "{1}-н {0}-г дуусгасан"
+
+#: frontend/src/components/CheckInPanel.vue:174
+msgid "{0} successful!"
+msgstr "{0} амжилттай!"
+
+#: frontend/src/components/RequestActionSheet.vue:280
+msgid "{0} successfully!"
+msgstr "{0} амжилттай!"
+
+#: hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.js:261
+msgid "{0} to {1} employee(s)?"
+msgstr "{0}-ээс {1} ажилтанд?"
+
+#: frontend/src/components/FormView.vue:561
+msgid "{0} updated successfully!"
+msgstr "{0} амжилттай шинэчлэгдсэн!"
+
+#: hrms/hr/doctype/staffing_plan/staffing_plan.py:128
+msgid ""
+"{0} vacancies and {1} budget for {2} already planned for subsidiary "
+"companies of {3}. You can only plan for upto {4} vacancies and and budget "
+"{5} as per staffing plan {6} for parent company {3}."
+msgstr ""
+"{3}-н охин компаниудад аль хэдийн төлөвлөсөн {2}-д зориулсан {0} сул орон "
+"тоо, {1} төсөв. Та зөвхөн {3} толгой компанийн {6} боловсон хүчний "
+"төлөвлөгөөний дагуу {4} хүртэлх сул орон тоо, төсөв {5} хүртэл төлөвлөх "
+"боломжтой."
+
+#: hrms/payroll/doctype/salary_component/salary_component.js:130
+msgid "{0} will be updated for the following Salary Structures: {1}."
+msgstr "{0} нь дараах цалингийн бүтцэд шинэчлэгдэнэ: {1}."
+
+#: hrms/hr/doctype/goal/goal_list.js:70
+msgid "{0} {1} {2}?"
+msgstr "{0} {1} {2}?"
+
+#: hrms/hr/utils.py:456
+#| msgid "Check Error Log {0} for more details."
+msgid "{0}. Check error log for more details."
+msgstr "Дэлгэрэнгүй мэдээллийг {0} алдааны бүртгэлээс шалгана уу."
+
+#: hrms/payroll/doctype/salary_slip/salary_slip.py:2195
+msgid "{0}: Employee email not found, hence email not sent"
+msgstr "{0}: Ажилтны имэйл олдсонгүй, тиймээс имэйл илгээгээгүй"
+
+#: hrms/hr/doctype/leave_application/leave_application.py:71
+msgid "{0}: From {0} of type {1}"
+msgstr "{0}: {1} төрлийн {0}-с"
+
+#: frontend/src/components/AttendanceRequestItem.vue:17
+#: frontend/src/components/LeaveRequestItem.vue:16
+#: frontend/src/components/ShiftAssignmentItem.vue:12
+#: frontend/src/components/ShiftRequestItem.vue:17
+msgid "{0}d"
+msgstr "{0}г"
+
+#: hrms/hr/doctype/job_requisition/job_requisition.js:22
+msgid "{} {} open for this position."
+msgstr "{} {} энэ албан тушаалд нээлттэй."
+
+#~ msgid "<span class=\"h4\"><b>Masters &amp; Reports</b></span>"
+#~ msgstr "<span class=\"h4\"><b>Магистр ба тайлан</b></span>"
+
+#~ msgid "<span class=\"h4\"><b>Masters &amp; Transactions</b></span>"
+#~ msgstr "<span class=\"h4\"><b>Магистр ба гүйлгээ</b></span>"
+
+#~ msgid "<span class=\"h4\"><b>Reports &amp; Masters</b></span>"
+#~ msgstr "<span class=\"h4\"><b>Тайлан ба мастерууд</b></span>"
+
+#~ msgid "<span class=\"h4\"><b>Your Shortcuts</b></span>"
+#~ msgstr "<span class=\"h4\"><b>Таны товчлолууд</b></span>"
+
+#~ msgid "Abbr"
+#~ msgstr "Хураангуй"
+
+#~ msgid "Academics User"
+#~ msgstr "Академик хэрэглэгч"
+
+#~ msgid "Account"
+#~ msgstr "Данс"
+
+#~ msgid "Account Head"
+#~ msgstr "Дансны дарга"
+
+#~ msgid "Account {0} does not belong to company: {1}"
+#~ msgstr "{0} бүртгэл нь компанид харьяалагддаггүй: {1}"
+
+#~ msgid "Accounting"
+#~ msgstr "Нягтлан бодох бүртгэл"
+
+#~ msgid "Accounting Details"
+#~ msgstr "Нягтлан бодох бүртгэлийн дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Accounting Dimension"
+#~ msgstr "Нягтлан бодох бүртгэлийн хэмжээ"
+
+#~ msgid "Accounting Dimensions"
+#~ msgstr "Нягтлан бодох бүртгэлийн хэмжээсүүд"
+
+#~ msgid "Accounting Ledger"
+#~ msgstr "Нягтлан бодох бүртгэлийн дэвтэр"
+
+#~ msgid "Accounts"
+#~ msgstr "Дансууд"
+
+#~ msgid "Accounts Payable"
+#~ msgstr "Дансны өглөг"
+
+#~ msgid "Accounts Receivable"
+#~ msgstr "Дансны авлага"
+
+#~ msgid "Accounts Settings"
+#~ msgstr "Бүртгэлийн тохиргоо"
+
+#~ msgid "Action"
+#~ msgstr "Үйлдэл"
+
+#~ msgid "Actions"
+#~ msgstr "Үйлдлүүд"
+
+#~ msgid "Active"
+#~ msgstr "Идэвхтэй"
+
+#~ msgid "Activities"
+#~ msgstr "Үйл ажиллагаа"
+
+#~ msgid "Activity Type"
+#~ msgstr "Үйл ажиллагааны төрөл"
+
+#~ msgid "Actual Cost"
+#~ msgstr "Бодит зардал"
+
+#~ msgid "Added On"
+#~ msgstr "Нэмэгдсэн"
+
+#~ msgid "Advance Amount"
+#~ msgstr "Урьдчилгаа дүн"
+
+#~ msgid "Advance Paid"
+#~ msgstr "Урьдчилгаа төлсөн"
+
+#~ msgid "Advance Payments"
+#~ msgstr "Урьдчилгаа төлбөр"
+
+#~ msgid "Advances"
+#~ msgstr "Урьдчилгаа"
+
+#~ msgid "All"
+#~ msgstr "Бүгд"
+
+#~ msgid "Allocate Leaves"
+#~ msgstr "Навч хуваарилах"
+
+#~ msgid "Allocated Amount"
+#~ msgstr "Хуваарилагдсан дүн"
+
+#~ msgid ""
+#~ "Allocated {0} leave(s) via scheduler on {1} based on the 'Allocate on Day' "
+#~ "option set to {2}"
+#~ msgstr ""
+#~ "'Өдөрт хуваарилах' сонголтыг {2} болгон тохируулсны үндсэн дээр {1}-д "
+#~ "хуваарь гаргагчаар {0} чөлөө хуваарилсан."
+
+#~ msgid "Amended From"
+#~ msgstr "-аас нэмэлт өөрчлөлт оруулсан"
+
+#~ msgid "Amount"
+#~ msgstr "Дүн"
+
+#~ msgid ""
+#~ "An amount of {0} already claimed for the component {1}, set the amount equal"
+#~ " or greater than {2}"
+#~ msgstr ""
+#~ "{1} бүрэлдэхүүн хэсэг дээр аль хэдийн нэхэмжилсэн {0}-н дүн, {2}-тай тэнцүү "
+#~ "буюу түүнээс их хэмжээг тохируулна уу"
+
+#~ msgid "Applicable For"
+#~ msgstr "Хэрэглэх боломжтой"
+
+#~ msgid "Apply"
+#~ msgstr "Өргөдөл гаргах"
+
+#~ msgid "Apply Filters"
+#~ msgstr "Шүүлтүүр хэрэглэх"
+
+#~ msgid "Appointment"
+#~ msgstr "Уулзалт"
+
+#~ msgid "Archive"
+#~ msgstr "Архив"
+
+#~ msgid "Archived"
+#~ msgstr "Архивлагдсан"
+
+#~ msgid "Are you sure you want to proceed?"
+#~ msgstr "Та үргэлжлүүлэхдээ итгэлтэй байна уу?"
+
+#~ msgid "Asset Name"
+#~ msgstr "Хөрөнгийн нэр"
+
+#~ msgid "Assigning..."
+#~ msgstr "Даалгаж байна..."
+
+#~ msgid "Attachments"
+#~ msgstr "Хавсралтууд"
+
+#~ msgid "Attendance for employee {0} is already marked for this day"
+#~ msgstr "{0} ажилтны ирцийг энэ өдөр аль хэдийн тэмдэглэсэн байна"
+
+#~ msgid "Attendance has been marked as per employee check-ins"
+#~ msgstr "Ажилчдын бүртгэлд хамрагдсанаар ирцийг тэмдэглэсэн"
+
+#~ msgid "Bank"
+#~ msgstr "Банк"
+
+#~ msgid "Bank Account No"
+#~ msgstr "Банкны дансны дугаар"
+
+#~ msgid "Bank Details"
+#~ msgstr "Банкны дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Bank Name"
+#~ msgstr "Банкны нэр"
+
+#~ msgid "Base & Variable"
+#~ msgstr "Үндсэн ба хувьсагч"
+
+#~ msgid "Begin On (Days)"
+#~ msgstr "Эхлэх (өдрүүд)"
+
+#~ msgid "Beginner"
+#~ msgstr "Эхлэгч"
+
+#~ msgid "Blue"
+#~ msgstr "Цэнхэр"
+
+#~ msgid "Body"
+#~ msgstr "Бие"
+
+#~ msgid "Branch"
+#~ msgstr "Салбар"
+
+#~ msgid "Campaign"
+#~ msgstr "Кампанит ажил"
+
+#~ msgid "Cancel"
+#~ msgstr "Цуцлах"
+
+#~ msgid "Cancelled"
+#~ msgstr "Цуцлагдсан"
+
+#~ msgid "Change"
+#~ msgstr "Өөрчлөх"
+
+#~ msgid "Chart of Accounts"
+#~ msgstr "Дансны график"
+
+#~ msgid "Chart of Cost Centers"
+#~ msgstr "Зардлын төвүүдийн график"
+
+#~ msgid "Claim Date"
+#~ msgstr "Нэхэмжлэлийн огноо"
+
+#~ msgid "Clear All"
+#~ msgstr "Бүгдийг арилгах"
+
+#~ msgid "Clearance Date"
+#~ msgstr "Бүртгэлийн огноо"
+
+#~ msgid "Close"
+#~ msgstr "Хаах"
+
+#~ msgid "Closed"
+#~ msgstr "Хаалттай"
+
+#~ msgid "Closing Balance"
+#~ msgstr "Хаалтын үлдэгдэл"
+
+#~ msgid "Collapse All"
+#~ msgstr "Бүгдийг нураа"
+
+#~ msgid "Color"
+#~ msgstr "Өнгө"
+
+#~ msgid "Comments"
+#~ msgstr "Сэтгэгдэл"
+
+#~ msgid "Commission"
+#~ msgstr "Комисс"
+
+#~ msgid "Company"
+#~ msgstr "Компани"
+
+#~ msgid "Company Details"
+#~ msgstr "Компанийн дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Completed"
+#~ msgstr "Дууссан"
+
+#~ msgid "Completed On"
+#~ msgstr "Дууссан"
+
+#~ msgid "Component"
+#~ msgstr "Бүрэлдэхүүн хэсэг"
+
+#~ msgid "Condition"
+#~ msgstr "Нөхцөл байдал"
+
+#~ msgid "Conditions"
+#~ msgstr "Нөхцөл байдал"
+
+#~ msgid "Confirm"
+#~ msgstr "Баталгаажуулах"
+
+#~ msgid "Connections"
+#~ msgstr "Холболтууд"
+
+#~ msgid "Contact Email"
+#~ msgstr "Холбоо барих имэйл"
+
+#~ msgid "Contact Information"
+#~ msgstr "Холбоо барих мэдээлэл"
+
+#~ msgid "Contact No."
+#~ msgstr "Холбоо барих дугаар"
+
+#~ msgid "Continue"
+#~ msgstr "Үргэлжлүүлэх"
+
+#~ msgid "Contract"
+#~ msgstr "Гэрээ"
+
+#~ msgid "Cost"
+#~ msgstr "Зардал"
+
+#~ msgid "Cost Center"
+#~ msgstr "Зардлын төв"
+
+#~ msgid "Cost Centers"
+#~ msgstr "Зардлын төвүүд"
+
+#~ msgid "Costing"
+#~ msgstr "Өртөг тооцох"
+
+#~ msgid "Costing Details"
+#~ msgstr "Зардлын дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Country"
+#~ msgstr "Улс"
+
+#~ msgid "Create"
+#~ msgstr "Үүсгэх"
+
+#~ msgid "Create Employee"
+#~ msgstr "Ажилтан бий болгох"
+
+#~ msgid "Create Journal Entry"
+#~ msgstr "Тэмдэглэлийн бүртгэл үүсгэх"
+
+#~ msgid "Create Payment Entry"
+#~ msgstr "Төлбөрийн бүртгэл үүсгэх"
+
+#~ msgid "Create Separate Payment Entry Against Benefit Claim"
+#~ msgstr "Тэтгэмжийн нэхэмжлэлийн эсрэг тусдаа төлбөрийн бичилт үүсгэх"
+
+#~ msgid "Criteria"
+#~ msgstr "Шалгуур"
+
+#~ msgid "Currency"
+#~ msgstr "Валют"
+
+#~ msgid "Current"
+#~ msgstr "Одоогийн"
+
+#~ msgid "Customer"
+#~ msgstr "Харилцагч"
+
+#~ msgid "Cyan"
+#~ msgstr "Цэнхэр"
+
+#~ msgid "Daily"
+#~ msgstr "Өдөр бүр"
+
+#~ msgid "Dashboard"
+#~ msgstr "Хяналтын самбар"
+
+#~ msgid "Date"
+#~ msgstr "Огноо"
+
+#~ msgid "Date "
+#~ msgstr "Огноо "
+
+#~ msgid "Date of Birth"
+#~ msgstr "Төрсөн огноо"
+
+#~ msgid "Date of Joining"
+#~ msgstr "Нэгдсэн огноо"
+
+#~ msgid "Deduct Tax For Unclaimed Employee Benefits"
+#~ msgstr "Нэхэмжлэлгүй ажилчдын тэтгэмжийн татварыг хас"
+
+#~ msgid "Default Account"
+#~ msgstr "Өгөгдмөл данс"
+
+#~ msgid "Deferred Expense Account"
+#~ msgstr "Хойшлогдсон зардлын данс"
+
+#~ msgid "Delete"
+#~ msgstr "Устгах"
+
+#~ msgid "Delivery Trip"
+#~ msgstr "Хүргэлтийн аялал"
+
+#~ msgid "Department"
+#~ msgstr "хэлтэс"
+
+#~ msgid "Description"
+#~ msgstr "Тодорхойлолт"
+
+#~ msgid "Designation"
+#~ msgstr "Тэмдэглэл"
+
+#~ msgid "Details"
+#~ msgstr "Дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Disable"
+#~ msgstr "Идэвхгүй болгох"
+
+#~ msgid "Disable Rounded Total"
+#~ msgstr "Дугуйлсан нийтийг идэвхгүй болгох"
+
+#~ msgid "Disabled"
+#~ msgstr "Идэвхгүй"
+
+#~ msgid "Dismiss"
+#~ msgstr "Өгүүлэх"
+
+#~ msgid "Dispensed Amount (Pro-rated)"
+#~ msgstr "Олгосон дүн (тооцоотой)"
+
+#~ msgid "Do you still want to proceed?"
+#~ msgstr "Та үргэлжлүүлэхийг хүсэж байна уу?"
+
+#~ msgid "Document Status"
+#~ msgstr "Баримт бичгийн төлөв"
+
+#~ msgid "Download Template"
+#~ msgstr "Загвар татаж авах"
+
+#~ msgid "Draft"
+#~ msgstr "Ноорог"
+
+#~ msgid "Driver"
+#~ msgstr "Жолооч"
+
+#~ msgid "Duplicate Entry"
+#~ msgstr "Давхардсан оруулга"
+
+#~ msgid "Duration (Days)"
+#~ msgstr "Үргэлжлэх хугацаа (өдөр)"
+
+#~ msgid "Edit"
+#~ msgstr "Засварлах"
+
+#~ msgid "Email"
+#~ msgstr "Имэйл"
+
+#~ msgid "Email Address"
+#~ msgstr "Имэйл хаяг"
+
+#~ msgid "Email ID"
+#~ msgstr "Имэйл ID"
+
+#~ msgid "Email Template"
+#~ msgstr "Имэйлийн загвар"
+
+#~ msgid "Email sent to {0}"
+#~ msgstr "{0} руу имэйл илгээсэн"
+
+#~ msgid "Employee"
+#~ msgstr "Ажилтан"
+
+#~ msgid "Employee Advance"
+#~ msgstr "Ажилчдын урьдчилгаа"
+
+#~ msgid "Employee Advances"
+#~ msgstr "Ажилчдын урьдчилгаа"
+
+#~ msgid "Employee Group"
+#~ msgstr "Ажилчдын бүлэг"
+
+#~ msgid "Employee Lifecycle"
+#~ msgstr "Ажилтны амьдралын мөчлөг"
+
+#~ msgid "Employee Name"
+#~ msgstr "Ажилтны нэр"
+
+#~ msgid "Employee Number"
+#~ msgstr "Ажилтны дугаар"
+
+#~ msgid "Employee {0} has no maximum benefit amount"
+#~ msgstr "{0} ажилтанд тэтгэмжийн дээд хэмжээ байхгүй"
+
+#~ msgid "Employees"
+#~ msgstr "Ажилчид"
+
+#~ msgid "Enabled"
+#~ msgstr "Идэвхжүүлсэн"
+
+#~ msgid "Encashment Date"
+#~ msgstr "Бэлэн мөнгө авах огноо"
+
+#~ msgid "End"
+#~ msgstr "Төгсгөл"
+
+#~ msgid "End Date"
+#~ msgstr "Дуусах огноо"
+
+#~ msgid "End Time"
+#~ msgstr "Дуусах цаг"
+
+#~ msgid "Energy Point Log"
+#~ msgstr "Эрчим хүчний цэгийн бүртгэл"
+
+#~ msgid "Energy Point Rule"
+#~ msgstr "Эрчим хүчний цэгийн дүрэм"
+
+#~ msgid "Energy Point Settings"
+#~ msgstr "Эрчим хүчний цэгийн тохиргоо"
+
+#~ msgid "Energy Points"
+#~ msgstr "Эрчим хүчний цэгүүд"
+
+#~ msgid "Error"
+#~ msgstr "Алдаа"
+
+#~ msgid "Error Log"
+#~ msgstr "Алдааны бүртгэл"
+
+#~ msgid "Error Message"
+#~ msgstr "Алдааны мессеж"
+
+#~ msgid "Exchange Rate"
+#~ msgstr "Валютын ханш"
+
+#~ msgid "Exchange Rate cannot be zero."
+#~ msgstr "Валютын ханш тэг байж болохгүй."
+
+#~ msgid "Exit"
+#~ msgstr "Гарах"
+
+#~ msgid "Expand All"
+#~ msgstr "Бүгдийг өргөжүүлэх"
+
+#~ msgid "Expense"
+#~ msgstr "Зардал"
+
+#~ msgid "Expense Account"
+#~ msgstr "Зардлын данс"
+
+#~ msgid "Expense Claim"
+#~ msgstr "Зардлын нэхэмжлэл"
+
+#~ msgid "Expenses"
+#~ msgstr "Зардал"
+
+#~ msgid "Expired"
+#~ msgstr "Хугацаа дууссан"
+
+#~ msgid "Export"
+#~ msgstr "Экспорт"
+
+#~ msgid "Failed"
+#~ msgstr "Амжилтгүй"
+
+#~ msgid "Failure"
+#~ msgstr "Бүтэлгүйтэл"
+
+#~ msgid "Feedback"
+#~ msgstr "Санал хүсэлт"
+
+#~ msgid "Field Name"
+#~ msgstr "Талбайн нэр"
+
+#~ msgid "Filter Based On"
+#~ msgstr "Үндэслэн шүүлтүүр"
+
+#~ msgid "Filters"
+#~ msgstr "Шүүлтүүр"
+
+#~ msgid "Fiscal Year"
+#~ msgstr "Санхүүгийн жил"
+
+#~ msgid "Fleet Manager"
+#~ msgstr "Флотын менежер"
+
+#~ msgid "Fortnightly"
+#~ msgstr "Хоёр долоо хоног тутам"
+
+#~ msgid "Frequency"
+#~ msgstr "Давтамж"
+
+#~ msgid "Friday"
+#~ msgstr "Баасан гараг"
+
+#~ msgid "From"
+#~ msgstr "-аас"
+
+#~ msgid "From Date"
+#~ msgstr "Огнооноос"
+
+#~ msgid "From Employee"
+#~ msgstr "Ажилтнаас"
+
+#~ msgid "From Time"
+#~ msgstr "Цаг хугацаанаас"
+
+#~ msgid "From User"
+#~ msgstr "Хэрэглэгчээс"
+
+#~ msgid "Full Name"
+#~ msgstr "Бүтэн нэр"
+
+#~ msgid "Full and Final Settlement"
+#~ msgstr "Бүрэн болон эцсийн төлбөр тооцоо"
+
+#~ msgid "Full and Final Statement"
+#~ msgstr "Бүрэн ба эцсийн мэдэгдэл"
+
+#~ msgid "Gender"
+#~ msgstr "Хүйс"
+
+#~ msgid "General Ledger"
+#~ msgstr "Ерөнхий дэвтэр"
+
+#~ msgid "Geolocation"
+#~ msgstr "Газарзүйн байршил"
+
+#~ msgid "Goal"
+#~ msgstr "Зорилго"
+
+#~ msgid "Goals"
+#~ msgstr "Зорилго"
+
+#~ msgid "Grand Total"
+#~ msgstr "Их нийт"
+
+#~ msgid "Green"
+#~ msgstr "Ногоон"
+
+#~ msgid "Group"
+#~ msgstr "Бүлэг"
+
+#~ msgid "Group By"
+#~ msgstr "Группээр"
+
+#~ msgid "HR Dashboard"
+#~ msgstr "Хүний нөөцийн хяналтын самбар"
+
+#~ msgid "HR Manager"
+#~ msgstr "Хүний нөөцийн менежер"
+
+#~ msgid "HR User"
+#~ msgstr "Хүний нөөцийн хэрэглэгч"
+
+#~ msgid "Half Yearly"
+#~ msgstr "Хагас жил бүр"
+
+#~ msgid "Half-Yearly"
+#~ msgstr "Хагас жил"
+
+#~ msgid "Hello"
+#~ msgstr "Сайн уу"
+
+#~ msgid "Help"
+#~ msgstr "Туслаач"
+
+#~ msgid "Hold"
+#~ msgstr "Барь"
+
+#~ msgid "Holiday"
+#~ msgstr "Амралт"
+
+#~ msgid "Holidays"
+#~ msgstr "Амралтын өдрүүд"
+
+#~ msgid "Home"
+#~ msgstr "Гэр"
+
+#~ msgid "Hours"
+#~ msgstr "Цаг"
+
+#~ msgid "Import Log"
+#~ msgstr "Импортын бүртгэл"
+
+#~ msgid "In Process"
+#~ msgstr "Боловсруулж байна"
+
+#~ msgid "In Progress"
+#~ msgstr "Ажиллаж байна"
+
+#~ msgid "Inactive"
+#~ msgstr "Идэвхгүй"
+
+#~ msgid "Incentives"
+#~ msgstr "Урамшуулал"
+
+#~ msgid "Interest"
+#~ msgstr "Сонирхол"
+
+#~ msgid "Intermediate"
+#~ msgstr "Дунд зэрэг"
+
+#~ msgid "Introduction"
+#~ msgstr "Танилцуулга"
+
+#~ msgid "Invalid"
+#~ msgstr "Хүчингүй"
+
+#~ msgid "Invalid Action"
+#~ msgstr "Хүчингүй үйлдэл"
+
+#~ msgid "Invalid Cost Center"
+#~ msgstr "Буруу зардлын төв"
+
+#~ msgid "Is Active"
+#~ msgstr "Идэвхтэй байна"
+
+#~ msgid "Is Default"
+#~ msgstr "Өгөгдмөл"
+
+#~ msgid "Is Group"
+#~ msgstr "Групп юм"
+
+#~ msgid "Is Mandatory"
+#~ msgstr "Заавал байна"
+
+#~ msgid "Is Paid"
+#~ msgstr "Төлбөртэй"
+
+#~ msgid "Job Title"
+#~ msgstr "Ажлын байрны нэр"
+
+#~ msgid "Journal Entry"
+#~ msgstr "Өдрийн тэмдэглэл"
+
+#~ msgid "Journey"
+#~ msgstr "Аялал"
+
+#~ msgid "Key Reports"
+#~ msgstr "Гол тайлангууд"
+
+#~ msgid "Last Name"
+#~ msgstr "Овог"
+
+#~ msgid "Latitude"
+#~ msgstr "Өргөрөг"
+
+#~ msgid "Leave and Expense Claim Settings"
+#~ msgstr "Амралт, зардлын нэхэмжлэлийн тохиргоо"
+
+#~ msgid "Left"
+#~ msgstr "Зүүн"
+
+#~ msgid "Letter Head"
+#~ msgstr "Захидлын толгой"
+
+#~ msgid "Level"
+#~ msgstr "Түвшин"
+
+#~ msgid "License Plate"
+#~ msgstr "Лицензийн дугаар"
+
+#~ msgid "Loan"
+#~ msgstr "Зээл"
+
+#~ msgid "Location"
+#~ msgstr "Байршил"
+
+#~ msgid "Location Name"
+#~ msgstr "Байршлын нэр"
+
+#~ msgid "Login"
+#~ msgstr "Нэвтрэх"
+
+#~ msgid "Longitude"
+#~ msgstr "Уртраг"
+
+#~ msgid "Make"
+#~ msgstr "Хийх"
+
+#~ msgid "Mandatory"
+#~ msgstr "Заавал"
+
+#~ msgid "Mandatory fields required in {0}"
+#~ msgstr "{0}-д заавал оруулах шаардлагатай талбарууд"
+
+#~ msgid "Mark all as read"
+#~ msgstr "Бүгдийг уншсан гэж тэмдэглэ"
+
+#~ msgid "Masters"
+#~ msgstr "Магиструуд"
+
+#~ msgid "Max benefits should be greater than zero to dispense benefits"
+#~ msgstr "Тэтгэмж олгохын тулд тэтгэмжийн дээд хэмжээ тэгээс их байх ёстой"
+
+#~ msgid "Maximum amount eligible for the component {0} exceeds {1}"
+#~ msgstr "{0} бүрэлдэхүүнд тохирох дээд хэмжээ {1}-ээс хэтэрсэн байна"
+
+#~ msgid ""
+#~ "Maximum benefit of employee {0} exceeds {1} by the sum {2} of benefit "
+#~ "application pro-rata component amount and previous claimed amount"
+#~ msgstr ""
+#~ "Ажилтны {0} тэтгэмжийн дээд хэмжээ нь тэтгэмжийн өргөдлийн пропорциональ "
+#~ "бүрэлдэхүүн хэсэг болон өмнөх нэхэмжилсэн дүнгийн {2}-н нийлбэрээс {1}-ээс "
+#~ "хэтэрсэн байна."
+
+#~ msgid ""
+#~ "Maximum benefit of employee {0} exceeds {1} by the sum {2} of previous "
+#~ "claimed amount"
+#~ msgstr ""
+#~ "Ажилтны {0} тэтгэмжийн дээд хэмжээ нь өмнөх нэхэмжилсэн дүнгийн {2} "
+#~ "нийлбэрээс {1}-ээс хэтэрсэн байна"
+
+#~ msgid "Menu"
+#~ msgstr "Цэс"
+
+#~ msgid "Message"
+#~ msgstr "Мессеж"
+
+#~ msgid "Missing Field"
+#~ msgstr "Алга болсон талбар"
+
+#~ msgid "Missing Fields"
+#~ msgstr "Алга болсон талбарууд"
+
+#~ msgid "Mode Of Payment"
+#~ msgstr "Төлбөрийн хэлбэр"
+
+#~ msgid "Mode of Payment"
+#~ msgstr "Төлбөрийн хэлбэр"
+
+#~ msgid "Model"
+#~ msgstr "Загвар"
+
+#~ msgid "Monday"
+#~ msgstr "Даваа гараг"
+
+#~ msgid "Month"
+#~ msgstr "Сар"
+
+#~ msgid "Monthly"
+#~ msgstr "Сар бүр"
+
+#~ msgid "More"
+#~ msgstr "Илүү"
+
+#~ msgid "More Info"
+#~ msgstr "Дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "My Account"
+#~ msgstr "Миний данс"
+
+#~ msgid "Name"
+#~ msgstr "Нэр"
+
+#~ msgid "Naming Series"
+#~ msgstr "Нэрийн цуврал"
+
+#~ msgid "New"
+#~ msgstr "Шинэ"
+
+#~ msgid "New Company"
+#~ msgstr "Шинэ компани"
+
+#~ msgid "New {0}"
+#~ msgstr "Шинэ {0}"
+
+#~ msgid "No"
+#~ msgstr "Үгүй"
+
+#~ msgid "No Data"
+#~ msgstr "Өгөгдөл байхгүй"
+
+#~ msgid "Not Allowed"
+#~ msgstr "Зөвшөөрөгдөөгүй"
+
+#~ msgid "Not Permitted"
+#~ msgstr "Зөвшөөрөгдөөгүй"
+
+#~ msgid "Not Started"
+#~ msgstr "Эхлээгүй байна"
+
+#~ msgid "Note"
+#~ msgstr "Анхаарна уу"
+
+#~ msgid "Notes"
+#~ msgstr "Тэмдэглэл"
+
+#~ msgid "Notifications"
+#~ msgstr "Мэдэгдэл"
+
+#~ msgid "Offer Date"
+#~ msgstr "Санал болгох огноо"
+
+#~ msgid "Old Parent"
+#~ msgstr "Хуучин эцэг эх"
+
+#~ msgid "On Hold"
+#~ msgstr "Хүлээлтэнд"
+
+#~ msgid "Only Tax Impact (Cannot Claim But Part of Taxable Income)"
+#~ msgstr ""
+#~ "Зөвхөн татварын нөлөөлөл (Нэхэмжлэх боломжгүй, харин татвар ногдох орлогын "
+#~ "нэг хэсэг)"
+
+#~ msgid "Open"
+#~ msgstr "Нээлттэй"
+
+#~ msgid "Opening Balance"
+#~ msgstr "Нээлтийн үлдэгдэл"
+
+#~ msgid "Opening Balances"
+#~ msgstr "Нээлтийн үлдэгдэл"
+
+#~ msgid "Orange"
+#~ msgstr "Улбар шар"
+
+#~ msgid "Other Reports"
+#~ msgstr "Бусад тайлангууд"
+
+#~ msgid "Other Settings"
+#~ msgstr "Бусад тохиргоо"
+
+#~ msgid "Others"
+#~ msgstr "Бусад"
+
+#~ msgid "Out of 5"
+#~ msgstr "5-аас"
+
+#~ msgid "Outstanding Amount"
+#~ msgstr "Үлдэгдэл дүн"
+
+#~ msgid "Owned"
+#~ msgstr "эзэмшдэг"
+
+#~ msgid "Paid"
+#~ msgstr "Төлбөртэй"
+
+#~ msgid "Paid Amount"
+#~ msgstr "Төлбөрийн дүн"
+
+#~ msgid "Parameter"
+#~ msgstr "Параметр"
+
+#~ msgid "Partial Success"
+#~ msgstr "Хэсэгчилсэн амжилт"
+
+#~ msgid "Passport Number"
+#~ msgstr "Паспортын дугаар"
+
+#~ msgid "Password"
+#~ msgstr "Нууц үг"
+
+#~ msgid "Pay Against Benefit Claim"
+#~ msgstr "Тэтгэмжийн нэхэмжлэлийн эсрэг төлөх"
+
+#~ msgid "Payable Account"
+#~ msgstr "Төлбөрийн данс"
+
+#~ msgid "Payables"
+#~ msgstr "Өр төлбөр"
+
+#~ msgid "Payment"
+#~ msgstr "Төлбөр"
+
+#~ msgid "Payment Account"
+#~ msgstr "Төлбөрийн данс"
+
+#~ msgid "Payment Entry"
+#~ msgstr "Төлбөрийн бүртгэл"
+
+#, fuzzy
+#~ msgid "Payroll Dashboard"
+#~ msgstr "Хяналтын самбар"
+
+#~ msgid "Payroll Payable"
+#~ msgstr "Цалингийн төлбөр"
+
+#~ msgid "Pending"
+#~ msgstr "Хүлээгдэж байна"
+
+#~ msgid "Pending Amount"
+#~ msgstr "Хүлээгдэж буй дүн"
+
+#~ msgid "Percent"
+#~ msgstr "Хувь"
+
+#~ msgid "Percentage (%)"
+#~ msgstr "Хувь (%)"
+
+#~ msgid "Phone Number"
+#~ msgstr "Утасны дугаар"
+
+#~ msgid "Pink"
+#~ msgstr "Ягаан"
+
+#~ msgid "Please add the remaining benefits {0} to any of the existing component"
+#~ msgstr ""
+#~ "Үлдсэн үр өгөөжийг {0} одоо байгаа бүрэлдэхүүн хэсгүүдийн аль нэгэнд нэмнэ "
+#~ "үү"
+
+#~ msgid ""
+#~ "Please add the remaining benefits {0} to the application as pro-rata "
+#~ "component"
+#~ msgstr ""
+#~ "Үлдсэн үр өгөөжийг {0} программд пропорциональ бүрэлдэхүүн хэсэг болгон "
+#~ "нэмнэ үү"
+
+#~ msgid "Please select a Company"
+#~ msgstr "Компани сонгоно уу"
+
+#~ msgid "Please select {0}"
+#~ msgstr "{0}-г сонгоно уу"
+
+#~ msgid "Please set a Default Cash Account in Company defaults"
+#~ msgstr "Компанийн өгөгдмөл хэсэгт үндсэн бэлэн мөнгөний дансыг тохируулна уу"
+
+#~ msgid "Posting Date"
+#~ msgstr "Нийтэлсэн огноо"
+
+#~ msgid "Print Heading"
+#~ msgstr "Гарчиг хэвлэх"
+
+#~ msgid "Printing Details"
+#~ msgstr "Хэвлэлийн дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Profile"
+#~ msgstr "Профайл"
+
+#~ msgid "Progress"
+#~ msgstr "Ахиц дэвшил"
+
+#~ msgid "Project"
+#~ msgstr "Төсөл"
+
+#~ msgid "Promotion"
+#~ msgstr "Урамшуулал"
+
+#~ msgid "Property"
+#~ msgstr "Өмч"
+
+#~ msgid "Purpose"
+#~ msgstr "Зорилго"
+
+#~ msgid "Quarterly"
+#~ msgstr "Улирал бүр"
+
+#~ msgid "Queued"
+#~ msgstr "Дараалалд орсон"
+
+#~ msgid "Raised By"
+#~ msgstr "Хүмүүжүүлсэн"
+
+#~ msgid "Rate"
+#~ msgstr "Үнэлгээ"
+
+#~ msgid "Rating"
+#~ msgstr "Үнэлгээ"
+
+#~ msgid "Read"
+#~ msgstr "Унших"
+
+#~ msgid "Reason"
+#~ msgstr "Шалтгаан"
+
+#~ msgid "Receivables"
+#~ msgstr "Авлага"
+
+#~ msgid "Red"
+#~ msgstr "Улаан"
+
+#~ msgid "Reference"
+#~ msgstr "Лавлагаа"
+
+#~ msgid "Reference Document"
+#~ msgstr "Лавлах баримт бичиг"
+
+#~ msgid "Reference Document Name"
+#~ msgstr "Лавлах баримт бичгийн нэр"
+
+#~ msgid "Reference Document Type"
+#~ msgstr "Лавлах баримт бичгийн төрөл"
+
+#~ msgid "References"
+#~ msgstr "Лавлагаа"
+
+#~ msgid "Referrer"
+#~ msgstr "Илтгэгч"
+
+#~ msgid "Rejected"
+#~ msgstr "Татгалзсан"
+
+#~ msgid "Relieving Date"
+#~ msgstr "Тайвшруулах огноо"
+
+#~ msgid "Reload"
+#~ msgstr "Дахин ачаалах"
+
+#~ msgid "Remark"
+#~ msgstr "Тайлбар"
+
+#~ msgid "Remarks"
+#~ msgstr "Тайлбар"
+
+#~ msgid "Reminder"
+#~ msgstr "Сануулагч"
+
+#~ msgid "Reopen"
+#~ msgstr "Дахин нээх"
+
+#~ msgid "Replied"
+#~ msgstr "гэж хариулав"
+
+#~ msgid "Reports"
+#~ msgstr "Тайлангууд"
+
+#~ msgid "Reset Password"
+#~ msgstr "Нууц үгээ дахин тохируулах"
+
+#~ msgid "Resignation Letter Date"
+#~ msgstr "Огцрох өргөдлийн огноо"
+
+#~ msgid "Resolution Date"
+#~ msgstr "Шийдвэрлэсэн огноо"
+
+#~ msgid "Resolution Details"
+#~ msgstr "Шийдвэрийн дэлгэрэнгүй мэдээлэл"
+
+#~ msgid "Resolved"
+#~ msgstr "Шийдвэрлэсэн"
+
+#~ msgid "Resolved By"
+#~ msgstr "Шийдвэрлэсэн"
+
+#~ msgid "Result"
+#~ msgstr "Үр дүн"
+
+#~ msgid "Resume"
+#~ msgstr "Үргэлжлэл"
+
+#~ msgid "Return"
+#~ msgstr "Буцах"
+
+#~ msgid "Returned"
+#~ msgstr "Буцсан"
+
+#~ msgid "Returned Amount"
+#~ msgstr "Буцаасан дүн"
+
+#~ msgid "Right"
+#~ msgstr "Зөв"
+
+#~ msgid "Role"
+#~ msgstr "Үүрэг"
+
+#~ msgid "Rounded Total"
+#~ msgstr "Дугуйлсан нийт"
+
+#~ msgid "Route"
+#~ msgstr "Маршрут"
+
+#~ msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
+#~ msgstr "Мөр {0}: Зардлын төв {1} нь {2} компанид харьяалагддаггүй"
+
+#~ msgid "Rules"
+#~ msgstr "Дүрэм"
+
+#~ msgid "Salary"
+#~ msgstr "Цалин"
+
+#~ msgid "Salary Currency"
+#~ msgstr "Цалингийн валют"
+
+#~ msgid ""
+#~ "Salary Structure should have flexible benefit component(s) to dispense "
+#~ "benefit amount"
+#~ msgstr ""
+#~ "Цалингийн бүтэц нь тэтгэмжийн хэмжээг олгох уян хатан тэтгэмжийн бүрэлдэхүүн"
+#~ " хэсгүүдтэй байх ёстой"
+
+#~ msgid "Sales Invoice"
+#~ msgstr "Борлуулалтын нэхэмжлэх"
+
+#~ msgid "Same Company is entered more than once"
+#~ msgstr "Нэг компанийг нэгээс олон удаа оруулсан"
+
+#~ msgid "Sanctioned"
+#~ msgstr "Шийдвэрлэсэн"
+
+#~ msgid "Saturday"
+#~ msgstr "Бямба гариг"
+
+#~ msgid "Scheduled"
+#~ msgstr "Төлөвлөсөн"
+
+#~ msgid "Score (0-5)"
+#~ msgstr "Оноо (0-5)"
+
+#~ msgid "Select Company"
+#~ msgstr "Компани сонгох"
+
+#~ msgid "Select Employees"
+#~ msgstr "Ажилчдыг сонгоно уу"
+
+#~ msgid "Select {0}"
+#~ msgstr "{0}-г сонгох"
+
+#~ msgid "Sender Email"
+#~ msgstr "Илгээгчийн имэйл"
+
+#~ msgid "Sent"
+#~ msgstr "Илгээсэн"
+
+#~ msgid "Series"
+#~ msgstr "Цуврал"
+
+#~ msgid "Service"
+#~ msgstr "Үйлчилгээ"
+
+#~ msgid "Service Expenses"
+#~ msgstr "Үйлчилгээний зардал"
+
+#~ msgid "Service Item"
+#~ msgstr "Үйлчилгээний зүйл"
+
+#~ msgid "Set Attendance Details"
+#~ msgstr "Ирцийн мэдээллийг тохируулах"
+
+#~ msgid "Set attendance details for the employees select above"
+#~ msgstr "Дээрээс сонгосон ажилчдын ирцийн мэдээллийг тохируулна уу"
+
+#~ msgid "Settings"
+#~ msgstr "Тохиргоо"
+
+#~ msgid "Settled"
+#~ msgstr "Суурин"
+
+#~ msgid "Setup"
+#~ msgstr "Тохиргоо"
+
+#~ msgid "Shift"
+#~ msgstr "Шилжилт"
+
+#~ msgid "Source"
+#~ msgstr "Эх сурвалж"
+
+#~ msgid "Source Name"
+#~ msgstr "Эх сурвалжийн нэр"
+
+#~ msgid "Start"
+#~ msgstr "Эхлэх"
+
+#~ msgid "Start Time"
+#~ msgstr "Эхлэх цаг"
+
+#~ msgid ""
+#~ "Start and end dates not in a valid Payroll Period, cannot calculate {0}"
+#~ msgstr ""
+#~ "Эхлэх болон дуусах огноо нь хүчинтэй цалингийн хугацаанд биш, {0}-г "
+#~ "тооцоолох боломжгүй"
+
+#~ msgid "Status"
+#~ msgstr "Статус"
+
+#~ msgid "Subject"
+#~ msgstr "Сэдэв"
+
+#~ msgid "Submit"
+#~ msgstr "Батлах"
+
+#~ msgid "Submitted"
+#~ msgstr "Илгээсэн"
+
+#~ msgid "Success"
+#~ msgstr "Амжилт"
+
+#~ msgid "Sunday"
+#~ msgstr "Ням гараг"
+
+#~ msgid "Supplier"
+#~ msgstr "Нийлүүлэгч"
+
+#~ msgid "Suspended"
+#~ msgstr "Түр түдгэлзүүлсэн"
+
+#~ msgid "System Manager"
+#~ msgstr "Системийн менежер"
+
+#~ msgid "Task"
+#~ msgstr "Даалгавар"
+
+#~ msgid "Task Weight"
+#~ msgstr "Ажлын жин"
+
+#~ msgid "Template Name"
+#~ msgstr "Загварын нэр"
+
+#~ msgid "Terms"
+#~ msgstr "Нөхцөл"
+
+#~ msgid "Terms and Conditions"
+#~ msgstr "Үйлчилгээний нөхцөл"
+
+#~ msgid "Thank you"
+#~ msgstr "Баярлалаа"
+
+#~ msgid "Thursday"
+#~ msgstr "Пүрэв гараг"
+
+#~ msgid "Time"
+#~ msgstr "Цаг хугацаа"
+
+#~ msgid "Time Interval"
+#~ msgstr "Цагийн интервал"
+
+#~ msgid "Time Sheet"
+#~ msgstr "Цагийн хуудас"
+
+#~ msgid "Timesheet"
+#~ msgstr "Цагийн хуудас"
+
+#~ msgid "Title"
+#~ msgstr "Гарчиг"
+
+#~ msgid "To"
+#~ msgstr "руу"
+
+#~ msgid "To Date"
+#~ msgstr "Өнөөг хүртэл"
+
+#~ msgid "To Date cannot be before From Date"
+#~ msgstr "To Date нь From Date-аас өмнө байж болохгүй"
+
+#~ msgid "To Time"
+#~ msgstr "Цаг руу"
+
+#~ msgid "Total"
+#~ msgstr "Нийт"
+
+#~ msgid "Total Amount"
+#~ msgstr "Нийт дүн"
+
+#~ msgid "Total Billed Hours"
+#~ msgstr "Нийт тооцооны цаг"
+
+#~ msgid "Total Expense Amount"
+#~ msgstr "Зардлын нийт дүн"
+
+#~ msgid "Total Holidays"
+#~ msgstr "Нийт амралтын өдрүүд"
+
+#~ msgid "Total Taxes and Charges"
+#~ msgstr "Нийт татвар, хураамж"
+
+#~ msgid "Total Working Hours"
+#~ msgstr "Нийт ажлын цаг"
+
+#~ msgid ""
+#~ "Total flexible benefit component amount {0} should not be less than max "
+#~ "benefits {1}"
+#~ msgstr ""
+#~ "Уян хатан тэтгэмжийн бүрэлдэхүүн хэсгийн нийт дүн {0} нь хамгийн их ашиг "
+#~ "{1}-ээс бага байж болохгүй."
+
+#~ msgid "Total percentage against cost centers should be 100"
+#~ msgstr "Зардлын төвүүдийн эсрэг нийт хувь нь 100 байх ёстой"
+
+#~ msgid "Totals"
+#~ msgstr "Нийт дүн"
+
+#~ msgid "Transaction Date"
+#~ msgstr "Гүйлгээний огноо"
+
+#~ msgid "Transaction Name"
+#~ msgstr "Гүйлгээний нэр"
+
+#~ msgid "Transaction Type"
+#~ msgstr "Гүйлгээний төрөл"
+
+#~ msgid "Transactions"
+#~ msgstr "Гүйлгээ"
+
+#~ msgid "Tuesday"
+#~ msgstr "Мягмар гараг"
+
+#~ msgid "Type"
+#~ msgstr "Төрөл"
+
+#~ msgid "Unable to find Salary Component {0}"
+#~ msgstr "Цалингийн бүрэлдэхүүн хэсэг {0} олдохгүй байна"
+
+#~ msgid "Unlink Payment"
+#~ msgstr "Төлбөрийг салга"
+
+#~ msgid "Unmarked Attendance"
+#~ msgstr "Тэмдэглэгдээгүй ирц"
+
+#~ msgid "Update"
+#~ msgstr "Шинэчлэх"
+
+#~ msgid "User"
+#~ msgstr "Хэрэглэгч"
+
+#~ msgid "Users"
+#~ msgstr "Хэрэглэгчид"
+
+#~ msgid "Utilization"
+#~ msgstr "Ашиглалт"
+
+#~ msgid "Vehicle"
+#~ msgstr "Тээврийн хэрэгсэл"
+
+#~ msgid "View"
+#~ msgstr "Харах"
+
+#~ msgid "View All"
+#~ msgstr "Бүгдийг харах"
+
+#~ msgid "View Ledger"
+#~ msgstr "Ledger үзэх"
+
+#~ msgid "View List"
+#~ msgstr "Жагсаалтыг харах"
+
+#~ msgid "Walk In"
+#~ msgstr "Орох"
+
+#~ msgid "Warning"
+#~ msgstr "Анхааруулга"
+
+#~ msgid "Wednesday"
+#~ msgstr "Лхагва гараг"
+
+#~ msgid "Weekly"
+#~ msgstr "Долоо хоног бүр"
+
+#~ msgid "Working Hours"
+#~ msgstr "Ажлын цаг"
+
+#~ msgid "Year"
+#~ msgstr "Жил"
+
+#~ msgid "Yearly"
+#~ msgstr "Жил бүр"
+
+#~ msgid "Yellow"
+#~ msgstr "Шар"
+
+#~ msgid "Yes"
+#~ msgstr "Тиймээ"
+
+#~ msgid ""
+#~ "You can claim only an amount of {0}, the rest amount {1} should be in the "
+#~ "application as pro-rata component"
+#~ msgstr ""
+#~ "Та зөвхөн {0}-н дүнг нэхэмжлэх боломжтой, үлдсэн дүн {1} нь пропорциональ "
+#~ "бүрэлдэхүүн хэсэг болгон өргөдөлд байх ёстой."
+
+#~ msgid "email"
+#~ msgstr "имэйл"
+
+#~ msgid "to"
+#~ msgstr "руу"
+
+#~ msgid "{0} is mandatory"
+#~ msgstr "{0} заавал байх ёстой"
+
+#~ msgid "{0} is not in a valid Payroll Period"
+#~ msgstr "{0} хүчинтэй цалингийн хугацаанд биш байна"
+
+#~ msgid "{0} is required"
+#~ msgstr "{0} шаардлагатай"
+
+#~ msgid "{} "
+#~ msgstr "{} "
+
+#~ msgid "{} Accepted"
+#~ msgstr "{} Зөвшөөрөгдсөн"
+
+#~ msgid "{} Active"
+#~ msgstr "{} Идэвхтэй"
+
+#~ msgid "{} Draft"
+#~ msgstr "{} Ноорог"
+
+#~ msgid "{} Open"
+#~ msgstr "{} Нээлттэй"
+
+#~ msgid "{} Pending"
+#~ msgstr "{} Хүлээгдэж байна"
+
+#~ msgid "Amount returned by the employee after the advance is paid"
+#~ msgstr "Урьдчилгаа төлбөрийг төлсний дараа ажилтны буцааж өгсөн дүн"
+
+#~ msgid "Attendance Dashboard"
+#~ msgstr "Ирцийн хяналтын самбар"
+
+#~ msgid "Could not find any salary slip(s) for the employee {0}"
+#~ msgstr "Ажилтны цалингийн хуудас олдсонгүй {0}"
+
+#~ msgid "Employee Lifecycle Dashboard"
+#~ msgstr "Ажилтны амьдралын мөчлөгийн хяналтын самбар"
+
+#~ msgid "Expense Claims Dashboard"
+#~ msgstr "Зардлын нэхэмжлэлийн хяналтын самбар"
+
+#~ msgid "Guest"
+#~ msgstr "Зочин"
+
+#~ msgid "Hiring vs Attrition Count"
+#~ msgstr "Ажилд авах ба Элэгдлийн тоо"
+
+#~ msgid "Recruitment Dashboard"
+#~ msgstr "Ажилд авах хяналтын самбар"
+
+#~ msgid "To date needs to be before from date"
+#~ msgstr "Өнөөг хүртэл огнооноос өмнө байх шаардлагатай"


### PR DESCRIPTION
## Description

Add complete Mongolian (Cyrillic) translation for Frappe HRMS (`hrms/locale/mn.po`).

### Translation Details

| Metric | Value |
|--------|-------|
| Translated entries | 2,183 |
| Untranslated | 0 |
| Fuzzy | 0 |
| Placeholder mismatches | 0 |

### Quality Assurance

- **Machine-translated** using Poedit 3.8, then **manually reviewed and corrected**
- **8 quality fixes** applied after audit:
  - 2 entries: Submit terminology fixed (Илгээх→Батлах)
  - 4 entries: Double spaces removed
  - 1 entry: Customer terminology fixed (Хэрэглэгч→Харилцагч)
  - 1 entry: Stock terminology fixed (Хувьцаа→Нөөц)
- **Placeholder integrity** verified
- **No traditional Mongolian script** contamination (pure Cyrillic)

### Key Terminology

| English | Mongolian |
|---------|-----------|
| Submit | Батлах |
| Employee | Ажилтан |
| Customer | Харилцагч |
| Company | Компани |
| Save | Хадгалах |

### Related PRs

- Frappe: mn-frappe/frappe#add-mongolian-translation
- ERPNext: mn-frappe/erpnext#add-mongolian-translation