### PR TITLE
fix: show date for which the holiday list is missing

### DIFF
--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -1,6 +1,8 @@
+from datetime import date
+
 import frappe
 from frappe import _
-from frappe.utils import add_days, get_link_to_form, getdate
+from frappe.utils import add_days, formatdate, get_link_to_form, getdate
 
 
 def get_holiday_dates_between(
@@ -92,19 +94,22 @@ def get_holiday_dates_between_range(
 
 
 def get_holiday_list_for_employee(
-	employee: str, raise_exception: bool = True, as_on=None, as_dict=False
+	employee: str, raise_exception: bool = True, as_on: date | str | None = None, as_dict: bool = False
 ) -> str:
+	as_on = frappe.utils.getdate(as_on)
 	holiday_list = get_assigned_holiday_list(employee, as_on, as_dict)
-
 	if not holiday_list:
 		company = frappe.db.get_value("Employee", employee, "company")
 		holiday_list = get_assigned_holiday_list(company, as_on, as_dict)
 
 	if not holiday_list and raise_exception:
 		frappe.throw(
-			_("Please assign Holiday List for Employee {0} or their company {1} through {2}").format(
-				employee,
-				company,
+			_(
+				"No Holiday List was found for Employee {0} or their company {1} for date {2}. Please assign through {3}"
+			).format(
+				frappe.bold(employee),
+				frappe.bold(company),
+				frappe.bold(formatdate(as_on)),
 				get_link_to_form("Holiday List Assignment", label="Holiday List Assignment"),
 			)
 		)


### PR DESCRIPTION
Reported in #4086 

### Case
When `applicable_after_days` is set for a leave type, the leave application validates for the number of working days since the date of joining of the employee. This calculation requires holiday list to be set for the date of joining, which may or may not exist.

### Fix
The message now indicates the date for which the list is missing, making it easier to assign one for that date.
This should have been painfully obvious, live and learn :melting_face: 

https://github.com/user-attachments/assets/b2853044-8e57-407b-b6fd-cb89b2740f16



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holiday list retrieval now accepts dates in multiple formats and offers optional dictionary output format.

* **Bug Fixes**
  * Enhanced error messages when holiday list is unavailable with date details and direct link to Holiday List Assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->