### PR TITLE
fix:roster navbar wrong url and favicon icon

### DIFF
--- a/roster/index.html
+++ b/roster/index.html
@@ -1,19 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" href="/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Roster</title>
-	</head>
-	<body class="text-gray-800">
-		<div id="app"></div>
-		<div id="modals"></div>
-		<div id="popovers"></div>
 
-		<script>
-			window.csrf_token = "{{ csrf_token }}";
-		</script>
-		<script type="module" src="/src/main.ts"></script>
-	</body>
+<head>
+	<meta charset="UTF-8" />
+	<link rel="icon" href="/assets/erpnext/images/erpnext-favicon.svg" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Roster</title>
+</head>
+
+<body class="text-gray-800">
+	<div id="app"></div>
+	<div id="modals"></div>
+	<div id="popovers"></div>
+
+	<script>
+		window.csrf_token = "{{ csrf_token }}";
+	</script>
+	<script type="module" src="/src/main.ts"></script>
+</body>
+
 </html>

--- a/roster/index.html
+++ b/roster/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-	<meta charset="UTF-8" />
-	<link rel="icon" href="/assets/erpnext/images/erpnext-favicon.svg" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Roster</title>
-</head>
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" href="/assets/erpnext/images/erpnext-favicon.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Roster</title>
+	</head>
 
-<body class="text-gray-800">
-	<div id="app"></div>
-	<div id="modals"></div>
-	<div id="popovers"></div>
+	<body class="text-gray-800">
+		<div id="app"></div>
+		<div id="modals"></div>
+		<div id="popovers"></div>
 
-	<script>
-		window.csrf_token = "{{ csrf_token }}";
-	</script>
-	<script type="module" src="/src/main.ts"></script>
-</body>
+		<script>
+			window.csrf_token = "{{ csrf_token }}";
+		</script>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
 
 </html>

--- a/roster/index.html
+++ b/roster/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/assets/erpnext/images/erpnext-favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Roster</title>
 	</head>
-
 	<body class="text-gray-800">
 		<div id="app"></div>
 		<div id="modals"></div>
@@ -18,5 +16,4 @@
 		</script>
 		<script type="module" src="/src/main.ts"></script>
 	</body>
-
 </html>

--- a/roster/src/components/NavBar.vue
+++ b/roster/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="h-12 bg-white border-b px-12 flex items-center">
 		<div class="flex items-center space-x-1.5">
-			<a href="/app/hr" class="text-gray-600 hover:text-gray-700 flex items-center">
+			<a href="/app" class="text-gray-600 hover:text-gray-700 flex items-center">
 				<FrappeHRLogo class="h-6 w-6 mr-2.5" />
 				Frappe HR
 			</a>


### PR DESCRIPTION
Fixes #4098 

changed the reference url of Frappe HR to fix the page found error
earlier - app/hr
now - app/

changed the favicon icon of roster to use the favicon of erpnext (same as Frappe HR)

After change screenshot -
<img width="1853" height="1046" alt="image" src="https://github.com/user-attachments/assets/33ba0bf9-38f3-4e61-ac09-515a2cc436f9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the browser tab favicon.

* **Bug Fixes**
  * Corrected the home navigation link destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->