### PR TITLE
chore: correct datetime in fnf test setup

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
+++ b/hrms/hr/doctype/full_and_final_statement/test_full_and_final_statement.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils import add_days, today
+from frappe.utils import add_days, now_datetime, today
 
 from erpnext.assets.doctype.asset.test_asset import create_asset_data
 from erpnext.setup.doctype.employee.test_employee import make_employee
@@ -90,7 +90,7 @@ def create_asset_movement(employee):
 	movement = frappe.new_doc("Asset Movement")
 	movement.company = "_Test Company"
 	movement.purpose = "Issue"
-	movement.transaction_date = today()
+	movement.transaction_date = now_datetime()
 
 	movement.append("assets", {"asset": asset_name, "to_employee": employee})
 


### PR DESCRIPTION
After frappe/erpnext#52340, transaction date in asset movement is validated to be after previous movement date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset movement transaction timestamps now record precise date and time (not just the date), improving accuracy of financial settlement records, reporting, reconciliation, and audit trails while leaving user workflows and interfaces unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->