### PR TITLE
fix(expense-claim): remove create payment button on rejected claims

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -103,6 +103,7 @@ frappe.ui.form.on("Expense Claim", {
 		if (
 			frm.doc.docstatus === 1 &&
 			frm.doc.status !== "Paid" &&
+			frm.doc.approval_status !== "Rejected" &&
 			frappe.model.can_create("Payment Entry")
 		) {
 			frm.add_custom_button(


### PR DESCRIPTION
**Ref:** [59827](https://support.frappe.io/helpdesk/tickets/59827?view=VIEW-HD+Ticket-781)

**Issue:** The payment button is visible even when the Expense Claim was rejected.

**Before:** 

[Screencast from 2026-02-11 11-31-41.webm](https://github.com/user-attachments/assets/dcc83950-d4c1-4022-a47a-64c73ae982fc)

**After:**

[Screencast from 2026-02-11 11-30-47.webm](https://github.com/user-attachments/assets/645f3ee0-3428-419d-87a4-21348984a9c1)

Backport needed for v-15, v-16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where payment entries could be created for rejected expense claims. The Payment button now includes validation to check approval status, preventing payments from being processed when an expense claim has been rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->