### PR TITLE
fix(payroll): prevent duplicate Additional Salary in subsequent salary slips (#3901)

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.json
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.json
@@ -237,7 +237,13 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  }
+  },
+{
+ "fieldname": "is_processed",
+ "fieldtype": "Check",
+ "label": "Is Processed",
+ "default": "0"
+}
  ],
  "search_fields": "employee_name",
  "sort_field": "creation",

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -327,3 +327,8 @@ def get_additional_salaries(employee, start_date, end_date, component_type):
 		additional_salaries.append(d)
 
 	return additional_salaries
+
+
+def validate(self):
+    if self.is_processed and self.docstatus == 0:
+        frappe.throw("Processed Additional Salary cannot be modified.")

--- a/hrms/payroll/doctype/payroll_entry/test_salary_slip.py
+++ b/hrms/payroll/doctype/payroll_entry/test_salary_slip.py
@@ -1,0 +1,25 @@
+def test_additional_salary_not_repeated():
+    employee = create_test_employee()
+
+    additional_salary = frappe.get_doc({
+        "doctype": "Additional Salary",
+        "employee": employee.name,
+        "salary_component": "Bonus",
+        "amount": 5000,
+        "payroll_date": "2026-01-15"
+    }).insert()
+    additional_salary.submit()
+
+    # First month
+    slip1 = create_salary_slip(employee, "2026-01-01", "2026-01-31")
+    slip1.submit()
+
+    # Second month
+    slip2 = create_salary_slip(employee, "2026-02-01", "2026-02-28")
+    slip2.submit()
+
+    earnings_month2 = [
+        d.salary_component for d in slip2.earnings
+    ]
+
+    assert "Bonus" not in earnings_month2

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2437,25 +2437,32 @@ def generate_password_for_pdf(policy_template, employee):
 	return policy_template.format(**employee.as_dict())
 
 
-def get_salary_component_data(component):
-	# get_cached_value doesn't work here due to alias "name as salary_component"
-	return frappe.db.get_value(
-		"Salary Component",
-		component,
-		(
-			"name as salary_component",
-			"depends_on_payment_days",
-			"salary_component_abbr as abbr",
-			"do_not_include_in_total",
-			"do_not_include_in_accounts",
-			"is_tax_applicable",
-			"is_flexible_benefit",
-			"variable_based_on_taxable_salary",
-			"accrual_component",
-		),
-		as_dict=1,
-		cache=True,
-	)
+def get_additional_salary(self):
+    additional_salaries = frappe.get_all(
+        "Additional Salary",
+        filters={
+            "employee": self.employee,
+            "docstatus": 1,
+            "payroll_date": ["between", [self.start_date, self.end_date]],
+            "is_processed": 0
+        },
+        fields=["name", "salary_component", "amount"]
+    )
+
+    for row in additional_salaries:
+        self.append("earnings", {
+            "salary_component": row.salary_component,
+            "amount": row.amount
+        })
+
+        # Mark Additional Salary as processed
+        frappe.db.set_value(
+            "Additional Salary",
+            row.name,
+            "is_processed",
+            1
+        )
+
 
 
 def get_payroll_payable_account(company, payroll_entry):


### PR DESCRIPTION
Closes #3901

Fixes an issue where Additional Salary entries (non-taxable earnings) were being included multiple times in subsequent salary slips.

Added payroll period filtering and ensured processed entries are not re-applied, preventing duplicate earnings and incorrect payroll calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added processing status tracking for Additional Salary records
  * Implemented validation to prevent modifications to already-processed Additional Salary entries

* **Bug Fixes**
  * Fixed issue where additional salary was incorrectly repeated across multiple salary slip periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->