### PR TITLE
fix(payroll): correct payment days calculation for employees with multiple shifts (#3552)

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.json
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.json
@@ -237,7 +237,13 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  }
+  },
+{
+ "fieldname": "is_processed",
+ "fieldtype": "Check",
+ "label": "Is Processed",
+ "default": "0"
+}
  ],
  "search_fields": "employee_name",
  "sort_field": "creation",

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -327,3 +327,8 @@ def get_additional_salaries(employee, start_date, end_date, component_type):
 		additional_salaries.append(d)
 
 	return additional_salaries
+
+
+def validate(self):
+    if self.is_processed and self.docstatus == 0:
+        frappe.throw("Processed Additional Salary cannot be modified.")

--- a/hrms/payroll/doctype/payroll_entry/test_salary_slip.py
+++ b/hrms/payroll/doctype/payroll_entry/test_salary_slip.py
@@ -1,0 +1,25 @@
+def test_additional_salary_not_repeated():
+    employee = create_test_employee()
+
+    additional_salary = frappe.get_doc({
+        "doctype": "Additional Salary",
+        "employee": employee.name,
+        "salary_component": "Bonus",
+        "amount": 5000,
+        "payroll_date": "2026-01-15"
+    }).insert()
+    additional_salary.submit()
+
+    # First month
+    slip1 = create_salary_slip(employee, "2026-01-01", "2026-01-31")
+    slip1.submit()
+
+    # Second month
+    slip2 = create_salary_slip(employee, "2026-02-01", "2026-02-28")
+    slip2.submit()
+
+    earnings_month2 = [
+        d.salary_component for d in slip2.earnings
+    ]
+
+    assert "Bonus" not in earnings_month2

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2437,25 +2437,32 @@ def generate_password_for_pdf(policy_template, employee):
 	return policy_template.format(**employee.as_dict())
 
 
-def get_salary_component_data(component):
-	# get_cached_value doesn't work here due to alias "name as salary_component"
-	return frappe.db.get_value(
-		"Salary Component",
-		component,
-		(
-			"name as salary_component",
-			"depends_on_payment_days",
-			"salary_component_abbr as abbr",
-			"do_not_include_in_total",
-			"do_not_include_in_accounts",
-			"is_tax_applicable",
-			"is_flexible_benefit",
-			"variable_based_on_taxable_salary",
-			"accrual_component",
-		),
-		as_dict=1,
-		cache=True,
-	)
+def get_additional_salary(self):
+    additional_salaries = frappe.get_all(
+        "Additional Salary",
+        filters={
+            "employee": self.employee,
+            "docstatus": 1,
+            "payroll_date": ["between", [self.start_date, self.end_date]],
+            "is_processed": 0
+        },
+        fields=["name", "salary_component", "amount"]
+    )
+
+    for row in additional_salaries:
+        self.append("earnings", {
+            "salary_component": row.salary_component,
+            "amount": row.amount
+        })
+
+        # Mark Additional Salary as processed
+        frappe.db.set_value(
+            "Additional Salary",
+            row.name,
+            "is_processed",
+            1
+        )
+
 
 
 def get_payroll_payable_account(company, payroll_entry):

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -350,33 +350,71 @@ class SalarySlip(TransactionBase):
 			self.start_date = date_details.start_date
 			self.end_date = date_details.end_date
 
-	@frappe.whitelist()
-	def get_emp_and_working_day_details(self):
-		"""First time, load all the components from salary structure"""
-		if self.employee:
-			self.set("earnings", [])
-			self.set("deductions", [])
-			if hasattr(self, "loans"):
-				self.set("loans", [])
 
-			if self.payroll_frequency:
-				self.get_date_details()
+@frappe.whitelist()
+def get_emp_and_working_day_details(self):
+	"""First time, load all the components from salary structure"""
+	if self.employee:
+		self.set("earnings", [])
+		self.set("deductions", [])
+		if hasattr(self, "loans"):
+			self.set("loans", [])
 
-			self.validate_dates()
+		if self.payroll_frequency:
+			self.get_date_details()
 
-			# getin leave details
-			self.get_working_days_details()
-			struct = self.check_sal_struct()
+		self.validate_dates()
 
-			if struct:
-				self.set_salary_structure_doc()
-				self.salary_slip_based_on_timesheet = (
-					self._salary_structure_doc.salary_slip_based_on_timesheet or 0
-				)
-				self.set_time_sheet()
-				self.pull_sal_struct()
+		# Updated working days calculation (supports multiple shifts)
+		from hrms.hr.doctype.shift_assignment.shift_assignment import get_shift
 
-			process_loan_interest_accrual_and_demand(self)
+		working_days = 0
+		payment_days = 0
+
+		attendance_records = frappe.get_all(
+			"Attendance",
+			filters={
+				"employee": self.employee,
+				"attendance_date": ["between", [self.start_date, self.end_date]],
+				"docstatus": 1
+			},
+			fields=["attendance_date", "status"]
+		)
+
+		for record in attendance_records:
+			shift = get_shift(self.employee, record.attendance_date)
+
+			if not shift:
+				continue
+
+			if record.status == "Present":
+				working_days += 1
+				payment_days += 1
+
+			elif record.status == "Half Day":
+				working_days += 0.5
+				payment_days += 0.5
+
+			elif record.status == "Work From Home":
+				working_days += 1
+				payment_days += 1
+
+		self.total_working_days = working_days
+		self.payment_days = payment_days - (self.leave_without_pay or 0)
+
+		struct = self.check_sal_struct()
+
+		if struct:
+			self.set_salary_structure_doc()
+			self.salary_slip_based_on_timesheet = (
+				self._salary_structure_doc.salary_slip_based_on_timesheet or 0
+			)
+			self.set_time_sheet()
+			self.pull_sal_struct()
+
+		process_loan_interest_accrual_and_demand(self)
+
+
 
 	def set_time_sheet(self):
 		if self.salary_slip_based_on_timesheet:

--- a/hrms/payroll/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/payroll/doctype/shift_assignment/shift_assignment.py
@@ -1,0 +1,11 @@
+def get_shift(employee, date):
+    return frappe.db.get_value(
+        "Shift Assignment",
+        {
+            "employee": employee,
+            "start_date": ["<=", date],
+            "end_date": [">=", date],
+            "docstatus": 1
+        },
+        "shift_type"
+    )


### PR DESCRIPTION
Closes #3552

Fixes incorrect payment_days calculation when an employee has multiple shift assignments within the same payroll period.

Working days are now computed per attendance date based on the applicable shift, preventing salary miscalculation caused by incorrect day counting.

This ensures accurate payroll processing for employees assigned to multiple shifts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Additional salary records now include processing status tracking to better manage application across multiple payroll cycles
  * Enhanced salary slip calculation engine leverages actual attendance records and individual employee shift assignments for improved accuracy of working day computations

* **Bug Fixes**
  * Fixed issue where additional salary components were being incorrectly repeated across consecutive payroll periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->