### PR TITLE
Add date range (to_date) support in Employee Attendance Tool

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -7,10 +7,10 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	},
 
 	onload(frm) {
-		frm.set_value("date", frappe.datetime.get_today());
+		frm.set_value("from_date", frappe.datetime.get_today());
 	},
 
-	date: function (frm) {
+	from_date: function (frm) {
 		hide_field("select_employees_section");
 		hide_field("marked_attendance_section");
 		frm.trigger("reset_tool_actions");
@@ -35,12 +35,12 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	},
 
 	load_employees(frm) {
-		if (!frm.doc.date) return;
+		if (!frm.doc.from_date) return;
 		frappe
 			.call({
 				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
 				args: {
-					date: frm.doc.date,
+					from_date: frm.doc.from_date,
 					department: frm.doc.department,
 					branch: frm.doc.branch,
 					company: frm.doc.company,
@@ -272,7 +272,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				args: {
 					employee_list: employees_to_mark_full_day,
 					status: frm.doc.status,
-					date: frm.doc.date,
+					from_date: frm.doc.from_date,
 					to_date: frm.doc.to_date,
 					late_entry: frm.doc.late_entry,
 					early_exit: frm.doc.early_exit,

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -273,6 +273,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					employee_list: employees_to_mark_full_day,
 					status: frm.doc.status,
 					date: frm.doc.date,
+					to_date: frm.doc.to_date,
 					late_entry: frm.doc.late_entry,
 					early_exit: frm.doc.early_exit,
 					shift: frm.doc.shift,

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -5,7 +5,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "date",
+  "from_date",
   "to_date",
   "shift",
   "column_break_gmhs",
@@ -32,12 +32,6 @@
   "marked_attendance_html"
  ],
  "fields": [
-  {
-   "default": "Today",
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "label": "Date"
-  },
   {
    "fieldname": "department",
    "fieldtype": "Link",
@@ -178,14 +172,22 @@
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date"
+  },
+  {
+   "default": "Today",
+   "description": "For single-day attendance, select only this date.",
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "label": "From Date",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-12 18:17:54.307888",
- "modified_by": "Administrator",
+ "modified": "2026-02-13 10:28:03.188483",
+ "modified_by": "nikita.pawar@intellore.com",
  "module": "HR",
  "name": "Employee Attendance Tool",
  "owner": "Administrator",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "date",
+  "to_date",
   "shift",
   "column_break_gmhs",
   "late_entry",
@@ -172,13 +173,18 @@
    "fieldtype": "HTML",
    "label": "Horizontal Break",
    "options": "<hr>"
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "label": "To Date"
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-26 09:42:36.888216",
+ "modified": "2026-02-12 18:17:54.307888",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Attendance Tool",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd.
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
 import datetime
@@ -19,7 +19,7 @@ class EmployeeAttendanceTool(Document):
 
 @frappe.whitelist()
 def get_employees(
-    date: str | datetime.date,
+    from_date: str | datetime.date,
     department: str | None = None,
     branch: str | None = None,
     company: str | None = None,
@@ -28,11 +28,11 @@ def get_employees(
     employee_grade: str | None = None,
 ) -> dict[str, list]:
 
-    date = getdate(date)
+    from_date = getdate(from_date)
 
     filters = {
         "status": "Active",
-        "date_of_joining": ["<=", date],
+        "date_of_joining": ["<=", from_date],
     }
 
     optional_filters = {
@@ -61,7 +61,7 @@ def get_employees(
         "Attendance",
         fields=["employee", "employee_name", "status", "shift", "leave_type"],
         filters={
-            "attendance_date": date,
+            "attendance_date": from_date,
             "docstatus": 1,
             "modify_half_day_status": 0,
         },
@@ -73,7 +73,7 @@ def get_employees(
         "Attendance",
         fields=["employee", "employee_name"],
         filters={
-            "attendance_date": date,
+            "attendance_date": from_date,
             "docstatus": 1,
             "modify_half_day_status": 1,
             "leave_type": ("is", "set"),
@@ -93,7 +93,7 @@ def get_employees(
 
 
 def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
-
+    """Return employees who don’t have attendance marked yet"""
     marked_employees = [entry.get("employee") for entry in attendance_list]
 
     return [
@@ -111,7 +111,7 @@ def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[di
 def mark_employee_attendance(
     employee_list: list | str,
     status: str,
-    date: str | datetime.date,
+    from_date: str | datetime.date,
     to_date: str | datetime.date | None = None,
     leave_type: str | None = None,
     company: str | None = None,
@@ -123,7 +123,7 @@ def mark_employee_attendance(
     half_day_employee_list: list | str | None = None,
 ) -> None:
 
-    # Convert JSON string to list
+    # Convert JSON strings to lists if needed
     if isinstance(employee_list, str):
         employee_list = json.loads(employee_list)
 
@@ -133,7 +133,8 @@ def mark_employee_attendance(
     if not employee_list:
         frappe.throw("Please select at least one employee.")
 
-    from_date = getdate(date)
+    # Convert to datetime
+    from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
 
     # Validate date range

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -1,134 +1,204 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd.
 # For license information, please see license.txt
-
 
 import datetime
 import json
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import getdate, add_days
 
 
 class EmployeeAttendanceTool(Document):
-	pass
+    pass
 
+
+# -------------------------------------------------------------------------
+# GET EMPLOYEES
+# -------------------------------------------------------------------------
 
 @frappe.whitelist()
 def get_employees(
-	date: str | datetime.date,
-	department: str | None = None,
-	branch: str | None = None,
-	company: str | None = None,
-	employment_type: str | None = None,
-	designation: str | None = None,
-	employee_grade: str | None = None,
+    date: str | datetime.date,
+    department: str | None = None,
+    branch: str | None = None,
+    company: str | None = None,
+    employment_type: str | None = None,
+    designation: str | None = None,
+    employee_grade: str | None = None,
 ) -> dict[str, list]:
-	filters = {"status": "Active", "date_of_joining": ["<=", date]}
 
-	for field, value in {
-		"department": department,
-		"branch": branch,
-		"company": company,
-		"employment_type": employment_type,
-		"designation": designation,
-		"employee_grade": employee_grade,
-	}.items():
-		if value:
-			filters[field] = value
-	# list of all employees
-	employee_list = frappe.get_list(
-		"Employee",
-		fields=["employee", "employee_name"],
-		filters=filters,
-		order_by="employee_name",
-	)
-	# marked attendance
-	attendance_list = frappe.get_list(
-		"Attendance",
-		fields=["employee", "employee_name", "status", "shift", "leave_type"],
-		filters={
-			"attendance_date": date,
-			"docstatus": 1,
-			"modify_half_day_status": 0,
-		},
-		order_by="employee_name",
-	)
-	half_day_attendance_list = frappe.get_list(
-		"Attendance",
-		fields=["employee", "employee_name"],
-		filters={
-			"attendance_date": date,
-			"docstatus": 1,
-			"modify_half_day_status": 1,
-			"leave_type": ("is", "set"),
-		},
-		order_by="employee_name",
-	)
-	unmarked_attendance = _get_unmarked_attendance(
-		employee_list, [*attendance_list, *half_day_attendance_list]
-	)
-	return {
-		"marked": attendance_list,
-		"half_day_marked": half_day_attendance_list,
-		"unmarked": unmarked_attendance,
-	}
+    date = getdate(date)
+
+    filters = {
+        "status": "Active",
+        "date_of_joining": ["<=", date],
+    }
+
+    optional_filters = {
+        "department": department,
+        "branch": branch,
+        "company": company,
+        "employment_type": employment_type,
+        "designation": designation,
+        "employee_grade": employee_grade,
+    }
+
+    for field, value in optional_filters.items():
+        if value:
+            filters[field] = value
+
+    # All employees
+    employee_list = frappe.get_list(
+        "Employee",
+        fields=["name as employee", "employee_name"],
+        filters=filters,
+        order_by="employee_name",
+    )
+
+    # Marked attendance
+    attendance_list = frappe.get_list(
+        "Attendance",
+        fields=["employee", "employee_name", "status", "shift", "leave_type"],
+        filters={
+            "attendance_date": date,
+            "docstatus": 1,
+            "modify_half_day_status": 0,
+        },
+        order_by="employee_name",
+    )
+
+    # Half day attendance
+    half_day_attendance_list = frappe.get_list(
+        "Attendance",
+        fields=["employee", "employee_name"],
+        filters={
+            "attendance_date": date,
+            "docstatus": 1,
+            "modify_half_day_status": 1,
+            "leave_type": ("is", "set"),
+        },
+        order_by="employee_name",
+    )
+
+    unmarked_attendance = _get_unmarked_attendance(
+        employee_list, [*attendance_list, *half_day_attendance_list]
+    )
+
+    return {
+        "marked": attendance_list,
+        "half_day_marked": half_day_attendance_list,
+        "unmarked": unmarked_attendance,
+    }
 
 
 def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
-	marked_employees = [entry.employee for entry in attendance_list]
-	unmarked_attendance = []
 
-	for entry in employee_list:
-		if entry.employee not in marked_employees:
-			unmarked_attendance.append(entry)
+    marked_employees = [entry.get("employee") for entry in attendance_list]
 
-	return unmarked_attendance
+    return [
+        employee
+        for employee in employee_list
+        if employee.get("employee") not in marked_employees
+    ]
 
+
+# -------------------------------------------------------------------------
+# MARK ATTENDANCE (SINGLE DATE OR DATE RANGE)
+# -------------------------------------------------------------------------
 
 @frappe.whitelist()
 def mark_employee_attendance(
-	employee_list: list | str,
-	status: str,
-	date: str | datetime.date,
-	leave_type: str | None = None,
-	company: str | None = None,
-	late_entry: int | None = None,
-	early_exit: int | None = None,
-	shift: str | None = None,
-	mark_half_day: bool | None = False,
-	half_day_status: str | None = None,
-	half_day_employee_list: list | str | None = None,
+    employee_list: list | str,
+    status: str,
+    date: str | datetime.date,
+    to_date: str | datetime.date | None = None,
+    leave_type: str | None = None,
+    company: str | None = None,
+    late_entry: int | None = None,
+    early_exit: int | None = None,
+    shift: str | None = None,
+    mark_half_day: bool | None = False,
+    half_day_status: str | None = None,
+    half_day_employee_list: list | str | None = None,
 ) -> None:
-	if isinstance(employee_list, str):
-		employee_list = json.loads(employee_list)
 
-	for employee in employee_list:
-		leave_type = None
-		if status == "On Leave" and leave_type:
-			leave_type = leave_type
+    # Convert JSON string to list
+    if isinstance(employee_list, str):
+        employee_list = json.loads(employee_list)
 
-		attendance = frappe.get_doc(
-			dict(
-				doctype="Attendance",
-				employee=employee,
-				attendance_date=getdate(date),
-				status=status,
-				leave_type=leave_type,
-				late_entry=late_entry,
-				early_exit=early_exit,
-				shift=shift,
-			)
-		)
-		attendance.insert()
-		attendance.submit()
-	if mark_half_day:
-		if isinstance(half_day_employee_list, str):
-			half_day_employee_list = json.loads(half_day_employee_list)
-		Attendance = frappe.qb.DocType("Attendance")
-		for employee in half_day_employee_list:
-			frappe.qb.update(Attendance).where(
-				(Attendance.employee == employee) & (Attendance.attendance_date == date)
-			).set(Attendance.half_day_status, half_day_status).set(Attendance.shift, shift).set(
-				Attendance.late_entry, late_entry
-			).set(Attendance.early_exit, early_exit).set(Attendance.modify_half_day_status, 0).run()
+    if isinstance(half_day_employee_list, str):
+        half_day_employee_list = json.loads(half_day_employee_list)
+
+    if not employee_list:
+        frappe.throw("Please select at least one employee.")
+
+    from_date = getdate(date)
+    to_date = getdate(to_date) if to_date else from_date
+
+    # Validate date range
+    if to_date < from_date:
+        frappe.throw("To Date cannot be before From Date.")
+
+    current_date = from_date
+
+    while current_date <= to_date:
+
+        for employee in employee_list:
+
+            # Skip if attendance already exists
+            if frappe.db.exists(
+                "Attendance",
+                {
+                    "employee": employee,
+                    "attendance_date": current_date,
+                    "docstatus": ["!=", 2],
+                },
+            ):
+                continue
+
+            attendance = frappe.get_doc(
+                {
+                    "doctype": "Attendance",
+                    "employee": employee,
+                    "attendance_date": current_date,
+                    "status": status,
+                    "leave_type": leave_type if status == "On Leave" else None,
+                    "company": company,
+                    "late_entry": late_entry,
+                    "early_exit": early_exit,
+                    "shift": shift,
+                }
+            )
+
+            attendance.insert()
+            attendance.submit()
+
+        current_date = add_days(current_date, 1)
+
+    # -----------------------------------------------------------------
+    # HALF DAY UPDATE (OPTIONAL)
+    # -----------------------------------------------------------------
+
+    if mark_half_day and half_day_employee_list:
+
+        Attendance = frappe.qb.DocType("Attendance")
+
+        for employee in half_day_employee_list:
+            frappe.qb.update(Attendance).where(
+                (Attendance.employee == employee)
+                & (Attendance.attendance_date >= from_date)
+                & (Attendance.attendance_date <= to_date)
+            ).set(
+                Attendance.half_day_status, half_day_status
+            ).set(
+                Attendance.shift, shift
+            ).set(
+                Attendance.late_entry, late_entry
+            ).set(
+                Attendance.early_exit, early_exit
+            ).set(
+                Attendance.modify_half_day_status, 0
+            ).run()
+
+    frappe.msgprint("Attendance marked successfully.")


### PR DESCRIPTION
### Summary
This PR adds the ability to mark attendance for employees over a date range in the Employee Attendance Tool.

### Changes
- Added `to_date` field in Employee Attendance Tool DocType.
- Updated Python (`.py`) code to handle marking attendance for a range of dates.
- Updated JS (`.js`) code to allow selecting multiple dates and marking attendance in one action.
- Updated JSON (`.json`) to include the new field and ensure UI compatibility.

### Testing
- Verified marking attendance for a single day still works.
- Verified marking attendance for multiple days updates all selected dates.
- Verified half-day marking works across date ranges.
- No regression in existing reports or workflows.

https://github.com/user-attachments/assets/05605d9c-d054-41f6-8489-e4c30e0a272a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employee Attendance Tool now supports marking attendance across a date range. Users can specify a "From Date" and "To Date" to batch mark attendance for multiple days at once, replacing the previous single-day limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->