### PR TITLE
Add date range (to_date) support in Employee Attendance Tool

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -1,297 +1,246 @@
 frappe.ui.form.on("Employee Attendance Tool", {
-	refresh(frm) {
-		frm.trigger("reset_attendance_fields");
-		frm.trigger("reset_tool_actions");
-		hide_field("select_employees_section");
-		hide_field("marked_attendance_section");
-	},
+    refresh(frm) {
+        frm.trigger("reset_attendance_fields");
+        frm.trigger("reset_tool_actions");
+        hide_field("select_employees_section");
+        hide_field("marked_attendance_section");
+    },
 
-	onload(frm) {
-		frm.set_value("from_date", frappe.datetime.get_today());
-	},
+    onload(frm) {
+        frm.set_value("from_date", frappe.datetime.get_today());
+    },
 
-	from_date: function (frm) {
-		hide_field("select_employees_section");
-		hide_field("marked_attendance_section");
-		frm.trigger("reset_tool_actions");
-	},
+    from_date(frm) {
+        hide_field("select_employees_section");
+        hide_field("marked_attendance_section");
+        frm.trigger("reset_tool_actions");
+    },
 
-	reset_tool_actions(frm) {
-		frm.disable_save();
-		get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
-		get_employees_button.removeClass("btn-default").addClass("btn-primary");
-	},
+    reset_tool_actions(frm) {
+        frm.disable_save();
+        const get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
+        get_employees_button.removeClass("btn-default").addClass("btn-primary");
+    },
 
-	get_employees: function (frm) {
-		frm.trigger("load_employees");
-	},
+    get_employees(frm) {
+        frm.trigger("load_employees");
+    },
 
-	reset_attendance_fields(frm) {
-		frm.set_value("status", "");
-		frm.set_value("shift", "");
-		frm.set_value("late_entry", 0);
-		frm.set_value("early_exit", 0);
-		frm.set_value("half_day_status", "");
-	},
+    reset_attendance_fields(frm) {
+        frm.set_value("status", "");
+        frm.set_value("shift", "");
+        frm.set_value("late_entry", 0);
+        frm.set_value("early_exit", 0);
+        frm.set_value("half_day_status", "");
+    },
 
-	load_employees(frm) {
-		if (!frm.doc.from_date) return;
-		frappe
-			.call({
-				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
-				args: {
-					from_date: frm.doc.from_date,
-					department: frm.doc.department,
-					branch: frm.doc.branch,
-					company: frm.doc.company,
-					employment_type: frm.doc.employment_type,
-					designation: frm.doc.designation,
-					employee_grade: frm.doc.employee_grade,
-				},
-				freeze: true,
-				freeze_message: __("...Fetching Employees"),
-			})
-			.then((r) => {
-				unmarked_employees = r.message["unmarked"].length;
-				half_day_marked_employees = r.message["half_day_marked"].length;
-				if (r.message["marked"].length > 0) {
-					unhide_field("marked_attendance_section");
-					frm.events.show_marked_employees(frm, r.message["marked"]);
-				} else {
-					hide_field("marked_attendance_section");
-				}
-				if (unmarked_employees > 0 || half_day_marked_employees > 0) {
-					if (unmarked_employees) {
-						unhide_field("status");
-						unhide_field("unmarked_employee_header");
-					} else {
-						hide_field("status");
-						hide_field("unmarked_employee_header");
-					}
-					frm.events.show_employees_to_mark(
-						frm,
-						"unmarked_employees_html",
-						"unmarked_employees_multicheck",
-						r.message["unmarked"],
-					);
-					if (half_day_marked_employees) {
-						unhide_field("half_day_status");
-						unhide_field("half_day_marked_employee_header");
-					} else {
-						hide_field("half_day_status");
-						hide_field("half_day_marked_employee_header");
-					}
-					frm.events.show_employees_to_mark(
-						frm,
-						"half_marked_employees_html",
-						"half_marked_employees_multicheck",
-						r.message["half_day_marked"],
-					);
-					unmarked_employees && half_day_marked_employees
-						? unhide_field("horizontal_break")
-						: hide_field("horizontal_break");
-					unhide_field("select_employees_section");
-					frm.trigger("set_primary_action");
-				} else {
-					frappe.msgprint({
-						message: __(
-							"Attendance for all the employees under this criteria has been marked already.",
-						),
-						title: __("Attendance Marked"),
-						indicator: "green",
-					});
-				}
-			});
-	},
-	show_employees_to_mark(frm, html_fieldname, multicheck_fieldname, employee_list) {
-		if (!employee_list.length) return;
-		const $wrapper = frm.get_field(html_fieldname).$wrapper;
-		$wrapper.empty();
-		const employee_wrapper = $(`<div class="employee_wrapper">`).appendTo($wrapper);
-		frm.fields_dict[multicheck_fieldname] = frappe.ui.form.make_control({
-			parent: employee_wrapper,
-			df: {
-				fieldname: multicheck_fieldname,
-				fieldtype: "MultiCheck",
-				select_all: true,
-				columns: 3,
-				get_data: () => {
-					return employee_list.map((employee) => {
-						return {
-							label: `${employee.employee} : ${employee.employee_name}`,
-							value: employee.employee,
-							checked: 0,
-						};
-					});
-				},
-			},
-			render_input: true,
-		});
+    load_employees(frm) {
+        if (!frm.doc.from_date) return;
 
-		frm.get_field(multicheck_fieldname).refresh_input();
-	},
+        frappe.call({
+            method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
+            args: {
+                from_date: frm.doc.from_date,
+                to_date: frm.doc.to_date,  // Pass to_date
+                department: frm.doc.department,
+                branch: frm.doc.branch,
+                company: frm.doc.company,
+                employment_type: frm.doc.employment_type,
+                designation: frm.doc.designation,
+                employee_grade: frm.doc.employee_grade,
+            },
+            freeze: true,
+            freeze_message: __("...Fetching Employees"),
+        }).then(r => {
+            const unmarked_employees = r.message["unmarked"].length;
+            const half_day_marked_employees = r.message["half_day_marked"].length;
 
-	show_marked_employees(frm, marked_employees) {
-		const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
-		const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
-		const columns = frm.events.get_columns_for_marked_attendance_table(frm);
-		const data = marked_employees.map((entry) => {
-			return [`${entry.employee} : ${entry.employee_name}`, entry.status];
-		});
-		frm.events.render_marked_employee_datatable(frm, data, summary_wrapper, columns);
-	},
+            if (r.message["marked"].length > 0) {
+                unhide_field("marked_attendance_section");
+                frm.events.show_marked_employees(frm, r.message["marked"]);
+            } else {
+                hide_field("marked_attendance_section");
+            }
 
-	get_columns_for_marked_attendance_table() {
-		return [
-			{
-				name: "employee",
-				id: "employee",
-				content: __("Employee"),
-				width: 300,
-			},
-			{
-				name: "status",
-				id: "status",
-				content: __("Status"),
-				width: 100,
-				format: (value) => {
-					if (value == "Present" || value == "Work From Home")
-						return `<span style="color:green">${__(value)}</span>`;
-					else if (value == "Absent")
-						return `<span style="color:red">${__(value)}</span>`;
-					else if (value == "Half Day")
-						return `<span style="color:orange">${__(value)}</span>`;
-					else if (value == "On Leave")
-						return `<span style="color:#318AD8">${__(value)}</span>`;
-				},
-			},
-			{
-				name: "shift",
-				id: "shift",
-				content: __("Shift"),
-				width: 200,
-			},
-			{
-				name: "leave_type",
-				id: "leave_type",
-				content: __("Leave Type"),
-				width: 200,
-			},
-		].map((x) => ({
-			...x,
-			editable: false,
-			sortable: false,
-			focusable: false,
-			dropdown: false,
-			align: "left",
-		}));
-	},
-	show_marked_employees(frm, marked_employees) {
-		const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
-		const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
+            if (unmarked_employees > 0 || half_day_marked_employees > 0) {
+                if (unmarked_employees) {
+                    unhide_field("status");
+                    unhide_field("unmarked_employee_header");
+                } else {
+                    hide_field("status");
+                    hide_field("unmarked_employee_header");
+                }
 
-		const data = marked_employees.map((entry) => {
-			return [
-				`${entry.employee} : ${entry.employee_name}`,
-				entry.status,
-				entry.shift,
-				entry.leave_type,
-			];
-		});
+                frm.events.show_employees_to_mark(
+                    frm,
+                    "unmarked_employees_html",
+                    "unmarked_employees_multicheck",
+                    r.message["unmarked"]
+                );
 
-		frm.events.render_datatable(frm, data, summary_wrapper);
-	},
+                if (half_day_marked_employees) {
+                    unhide_field("half_day_status");
+                    unhide_field("half_day_marked_employee_header");
+                } else {
+                    hide_field("half_day_status");
+                    hide_field("half_day_marked_employee_header");
+                }
 
-	render_datatable(frm, data, summary_wrapper) {
-		const columns = frm.events.get_columns_for_marked_attendance_table(frm);
+                frm.events.show_employees_to_mark(
+                    frm,
+                    "half_marked_employees_html",
+                    "half_marked_employees_multicheck",
+                    r.message["half_day_marked"]
+                );
 
-		if (!frm.marked_emp_datatable) {
-			const datatable_options = {
-				columns: columns,
-				data: data,
-				dynamicRowHeight: true,
-				inlineFilters: true,
-				layout: "fixed",
-				cellHeight: 35,
-				noDataMessage: __("No Data"),
-				disableReorderColumn: true,
-			};
-			frm.marked_emp_datatable = new frappe.DataTable(
-				summary_wrapper.get(0),
-				datatable_options,
-			);
-		} else {
-			frm.marked_emp_datatable.refresh(data, columns);
-		}
-	},
-	set_primary_action(frm) {
-		get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
-		get_employees_button.removeClass("btn-primary").addClass("btn-default");
-		frm.page.set_primary_action(__("Mark Attendance"), () => {
-			const employees_to_mark_full_day =
-				frm.get_field("unmarked_employees_multicheck")?.get_checked_options() || [];
-			const employees_to_mark_half_day =
-				frm.get_field("half_marked_employees_multicheck")?.get_checked_options() || [];
+                unmarked_employees && half_day_marked_employees
+                    ? unhide_field("horizontal_break")
+                    : hide_field("horizontal_break");
 
-			if (
-				employees_to_mark_full_day.length === 0 &&
-				employees_to_mark_half_day.length === 0
-			) {
-				frappe.throw({
-					message: __("Please select the employees you want to mark attendance for."),
-					title: __("Mandatory"),
-				});
-			}
+                unhide_field("select_employees_section");
+                frm.trigger("set_primary_action");
+            } else {
+                frappe.msgprint({
+                    message: __("Attendance for all the employees under this criteria has been marked already."),
+                    title: __("Attendance Marked"),
+                    indicator: "green"
+                });
+            }
+        });
+    },
 
-			if (employees_to_mark_full_day.length > 0 && !frm.doc.status) {
-				frappe.throw({
-					message: __("Please select the attendance status."),
-					title: __("Mandatory"),
-				});
-			}
-			if (employees_to_mark_half_day.length > 0 && !frm.doc.half_day_status) {
-				frappe.throw({
-					message: __("Please select half day attendance status."),
-					title: __("Mandatory"),
-				});
-			}
-			if (employees_to_mark_full_day.length > 0 || employees_to_mark_half_day.length > 0) {
-				frm.events.mark_full_day_attendance(
-					frm,
-					employees_to_mark_full_day,
-					employees_to_mark_half_day,
-				);
-			}
-		});
-	},
+    show_employees_to_mark(frm, html_fieldname, multicheck_fieldname, employee_list) {
+        if (!employee_list.length) return;
 
-	mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day) {
-		frappe
-			.call({
-				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.mark_employee_attendance",
-				args: {
-					employee_list: employees_to_mark_full_day,
-					status: frm.doc.status,
-					from_date: frm.doc.from_date,
-					to_date: frm.doc.to_date,
-					late_entry: frm.doc.late_entry,
-					early_exit: frm.doc.early_exit,
-					shift: frm.doc.shift,
-					mark_half_day: employees_to_mark_half_day.length ? true : false,
-					half_day_status: frm.doc.half_day_status,
-					half_day_employee_list: employees_to_mark_half_day,
-				},
-				freeze: true,
-				freeze_message: __("Marking Attendance"),
-			})
-			.then((r) => {
-				if (!r.exc) {
-					frappe.show_alert({
-						message: __("Attendance marked successfully"),
-						indicator: "green",
-					});
-					frm.refresh();
-				}
-			});
-	},
+        const $wrapper = frm.get_field(html_fieldname).$wrapper;
+        $wrapper.empty();
+        const employee_wrapper = $(`<div class="employee_wrapper">`).appendTo($wrapper);
+
+        frm.fields_dict[multicheck_fieldname] = frappe.ui.form.make_control({
+            parent: employee_wrapper,
+            df: {
+                fieldname: multicheck_fieldname,
+                fieldtype: "MultiCheck",
+                select_all: true,
+                columns: 3,
+                get_data: () => {
+                    return employee_list.map(emp => ({
+                        label: `${emp.employee} : ${emp.employee_name}`,
+                        value: emp.employee,
+                        checked: 0
+                    }));
+                }
+            },
+            render_input: true
+        });
+
+        frm.get_field(multicheck_fieldname).refresh_input();
+    },
+
+    show_marked_employees(frm, marked_employees) {
+        const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
+        const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
+
+        const data = marked_employees.map(entry => [
+            `${entry.employee} : ${entry.employee_name}`,
+            entry.status,
+            entry.shift,
+            entry.leave_type
+        ]);
+
+        frm.events.render_datatable(frm, data, summary_wrapper);
+    },
+
+    get_columns_for_marked_attendance_table() {
+        return [
+            { name: "employee", id: "employee", content: __("Employee"), width: 300 },
+            { name: "status", id: "status", content: __("Status"), width: 100, 
+                format: value => {
+                    if (value == "Present" || value == "Work From Home") return `<span style="color:green">${__(value)}</span>`;
+                    else if (value == "Absent") return `<span style="color:red">${__(value)}</span>`;
+                    else if (value == "Half Day") return `<span style="color:orange">${__(value)}</span>`;
+                    else if (value == "On Leave") return `<span style="color:#318AD8">${__(value)}</span>`;
+                }
+            },
+            { name: "shift", id: "shift", content: __("Shift"), width: 200 },
+            { name: "leave_type", id: "leave_type", content: __("Leave Type"), width: 200 }
+        ].map(x => ({ ...x, editable: false, sortable: false, focusable: false, dropdown: false, align: "left" }));
+    },
+
+    render_datatable(frm, data, summary_wrapper) {
+        const columns = frm.events.get_columns_for_marked_attendance_table();
+        if (!frm.marked_emp_datatable) {
+            const datatable_options = {
+                columns,
+                data,
+                dynamicRowHeight: true,
+                inlineFilters: true,
+                layout: "fixed",
+                cellHeight: 35,
+                noDataMessage: __("No Data"),
+                disableReorderColumn: true
+            };
+            frm.marked_emp_datatable = new frappe.DataTable(summary_wrapper.get(0), datatable_options);
+        } else {
+            frm.marked_emp_datatable.refresh(data, columns);
+        }
+    },
+
+    set_primary_action(frm) {
+        const get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
+        get_employees_button.removeClass("btn-primary").addClass("btn-default");
+
+        frm.page.set_primary_action(__("Mark Attendance"), () => {
+            const employees_to_mark_full_day = frm.get_field("unmarked_employees_multicheck")?.get_checked_options() || [];
+            const employees_to_mark_half_day = frm.get_field("half_marked_employees_multicheck")?.get_checked_options() || [];
+
+            if (employees_to_mark_full_day.length === 0 && employees_to_mark_half_day.length === 0) {
+                frappe.throw({
+                    message: __("Please select the employees you want to mark attendance for."),
+                    title: __("Mandatory")
+                });
+            }
+
+            if (employees_to_mark_full_day.length > 0 && !frm.doc.status) {
+                frappe.throw({
+                    message: __("Please select the attendance status."),
+                    title: __("Mandatory")
+                });
+            }
+
+            if (employees_to_mark_half_day.length > 0 && !frm.doc.half_day_status) {
+                frappe.throw({
+                    message: __("Please select half day attendance status."),
+                    title: __("Mandatory")
+                });
+            }
+
+            frm.events.mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day);
+        });
+    },
+
+    mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day) {
+        frappe.call({
+            method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.mark_employee_attendance",
+            args: {
+                employee_list: employees_to_mark_full_day,
+                status: frm.doc.status,
+                from_date: frm.doc.from_date,
+                to_date: frm.doc.to_date,
+                late_entry: frm.doc.late_entry,
+                early_exit: frm.doc.early_exit,
+                shift: frm.doc.shift,
+                mark_half_day: employees_to_mark_half_day.length ? true : false,
+                half_day_status: frm.doc.half_day_status,
+                half_day_employee_list: employees_to_mark_half_day
+            },
+            freeze: true,
+            freeze_message: __("Marking Attendance")
+        }).then(r => {
+            if (!r.exc) {
+                frappe.show_alert({ message: __("Attendance marked successfully"), indicator: "green" });
+                frm.refresh();
+            }
+        });
+    }
 });

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -17,7 +17,6 @@ frappe.ui.form.on("Employee Attendance Tool", {
     },
 
     to_date(frm) {
-        // Refresh UI when end date changes
         hide_field("select_employees_section");
         hide_field("marked_attendance_section");
         frm.trigger("reset_tool_actions");
@@ -43,6 +42,10 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
     load_employees(frm) {
         if (!frm.doc.from_date) return;
+
+        if (frm.doc.to_date && frm.doc.to_date < frm.doc.from_date) {
+            frappe.throw(__("To Date cannot be before From Date."));
+        }
 
         frappe.call({
             method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
@@ -70,6 +73,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
             }
 
             if (unmarked_employees > 0 || half_day_marked_employees > 0) {
+                // Unmarked employees
                 if (unmarked_employees) {
                     unhide_field("status");
                     unhide_field("unmarked_employee_header");
@@ -85,6 +89,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
                     r.message["unmarked"]
                 );
 
+                // Half-day employees
                 if (half_day_marked_employees) {
                     unhide_field("half_day_status");
                     unhide_field("half_day_marked_employee_header");
@@ -121,6 +126,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
         const $wrapper = frm.get_field(html_fieldname).$wrapper;
         $wrapper.empty();
+
         const employee_wrapper = $(`<div class="employee_wrapper">`).appendTo($wrapper);
 
         frm.fields_dict[multicheck_fieldname] = frappe.ui.form.make_control({
@@ -144,6 +150,9 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
     show_marked_employees(frm, marked_employees) {
         const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
+        $wrapper.empty();  // Clear old table
+        frm.marked_emp_datatable = null;  // Reset cached datatable
+
         const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
 
         const data = marked_employees.map(entry => [
@@ -235,7 +244,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 late_entry: frm.doc.late_entry,
                 early_exit: frm.doc.early_exit,
                 shift: frm.doc.shift,
-                mark_half_day: employees_to_mark_half_day.length ? true : false,
+                mark_half_day: employees_to_mark_half_day.length > 0,
                 half_day_status: frm.doc.half_day_status,
                 half_day_employee_list: employees_to_mark_half_day
             },

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -7,10 +7,10 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	},
 
 	onload(frm) {
-		frm.set_value("date", frappe.datetime.get_today());
+		frm.set_value("from_date", frappe.datetime.get_today());
 	},
 
-	date: function (frm) {
+	from_date: function (frm) {
 		hide_field("select_employees_section");
 		hide_field("marked_attendance_section");
 		frm.trigger("reset_tool_actions");
@@ -35,12 +35,12 @@ frappe.ui.form.on("Employee Attendance Tool", {
 	},
 
 	load_employees(frm) {
-		if (!frm.doc.date) return;
+		if (!frm.doc.from_date) return;
 		frappe
 			.call({
 				method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
 				args: {
-					date: frm.doc.date,
+					from_date: frm.doc.from_date,
 					department: frm.doc.department,
 					branch: frm.doc.branch,
 					company: frm.doc.company,
@@ -272,7 +272,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 				args: {
 					employee_list: employees_to_mark_full_day,
 					status: frm.doc.status,
-					date: frm.doc.date,
+					from_date: frm.doc.from_date,
 					to_date: frm.doc.to_date,
 					late_entry: frm.doc.late_entry,
 					early_exit: frm.doc.early_exit,

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -16,9 +16,16 @@ frappe.ui.form.on("Employee Attendance Tool", {
         frm.trigger("reset_tool_actions");
     },
 
+    to_date(frm) {
+        // Refresh UI when end date changes
+        hide_field("select_employees_section");
+        hide_field("marked_attendance_section");
+        frm.trigger("reset_tool_actions");
+    },
+
     reset_tool_actions(frm) {
         frm.disable_save();
-        const get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
+        const get_employees_button = frm.fields_dict.get_employees.$input;
         get_employees_button.removeClass("btn-default").addClass("btn-primary");
     },
 
@@ -41,7 +48,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
             method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.get_employees",
             args: {
                 from_date: frm.doc.from_date,
-                to_date: frm.doc.to_date,  // Pass to_date
+                to_date: frm.doc.to_date,
                 department: frm.doc.department,
                 branch: frm.doc.branch,
                 company: frm.doc.company,
@@ -123,13 +130,11 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 fieldtype: "MultiCheck",
                 select_all: true,
                 columns: 3,
-                get_data: () => {
-                    return employee_list.map(emp => ({
-                        label: `${emp.employee} : ${emp.employee_name}`,
-                        value: emp.employee,
-                        checked: 0
-                    }));
-                }
+                get_data: () => employee_list.map(emp => ({
+                    label: `${emp.employee} : ${emp.employee_name}`,
+                    value: emp.employee,
+                    checked: 0
+                }))
             },
             render_input: true
         });
@@ -187,7 +192,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
     },
 
     set_primary_action(frm) {
-        const get_employees_button = this.cur_frm.fields_dict.get_employees.$input;
+        const get_employees_button = frm.fields_dict.get_employees.$input;
         get_employees_button.removeClass("btn-primary").addClass("btn-default");
 
         frm.page.set_primary_action(__("Mark Attendance"), () => {
@@ -215,11 +220,11 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 });
             }
 
-            frm.events.mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day);
+            frm.events.mark_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day);
         });
     },
 
-    mark_full_day_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day) {
+    mark_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day) {
         frappe.call({
             method: "hrms.hr.doctype.employee_attendance_tool.employee_attendance_tool.mark_employee_attendance",
             args: {

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -73,7 +73,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
             }
 
             if (unmarked_employees > 0 || half_day_marked_employees > 0) {
-                // Unmarked employees
+
                 if (unmarked_employees) {
                     unhide_field("status");
                     unhide_field("unmarked_employee_header");
@@ -89,7 +89,6 @@ frappe.ui.form.on("Employee Attendance Tool", {
                     r.message["unmarked"]
                 );
 
-                // Half-day employees
                 if (half_day_marked_employees) {
                     unhide_field("half_day_status");
                     unhide_field("half_day_marked_employee_header");
@@ -111,6 +110,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
                 unhide_field("select_employees_section");
                 frm.trigger("set_primary_action");
+
             } else {
                 frappe.msgprint({
                     message: __("Attendance for all the employees under this criteria has been marked already."),
@@ -150,12 +150,13 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
     show_marked_employees(frm, marked_employees) {
         const $wrapper = frm.get_field("marked_attendance_html").$wrapper;
-        $wrapper.empty();  // Clear old table
-        frm.marked_emp_datatable = null;  // Reset cached datatable
+        $wrapper.empty();
+        frm.marked_emp_datatable = null;
 
         const summary_wrapper = $(`<div class="summary_wrapper">`).appendTo($wrapper);
 
         const data = marked_employees.map(entry => [
+            entry.attendance_date,
             `${entry.employee} : ${entry.employee_name}`,
             entry.status,
             entry.shift,
@@ -167,22 +168,41 @@ frappe.ui.form.on("Employee Attendance Tool", {
 
     get_columns_for_marked_attendance_table() {
         return [
+            { name: "date", id: "date", content: __("Date"), width: 120 },
             { name: "employee", id: "employee", content: __("Employee"), width: 300 },
-            { name: "status", id: "status", content: __("Status"), width: 100, 
+            {
+                name: "status",
+                id: "status",
+                content: __("Status"),
+                width: 120,
                 format: value => {
-                    if (value == "Present" || value == "Work From Home") return `<span style="color:green">${__(value)}</span>`;
-                    else if (value == "Absent") return `<span style="color:red">${__(value)}</span>`;
-                    else if (value == "Half Day") return `<span style="color:orange">${__(value)}</span>`;
-                    else if (value == "On Leave") return `<span style="color:#318AD8">${__(value)}</span>`;
+                    if (value == "Present" || value == "Work From Home")
+                        return `<span style="color:green">${__(value)}</span>`;
+                    else if (value == "Absent")
+                        return `<span style="color:red">${__(value)}</span>`;
+                    else if (value == "Half Day")
+                        return `<span style="color:orange">${__(value)}</span>`;
+                    else if (value == "On Leave")
+                        return `<span style="color:#318AD8">${__(value)}</span>`;
+
+                    return __(value || "");
                 }
             },
             { name: "shift", id: "shift", content: __("Shift"), width: 200 },
             { name: "leave_type", id: "leave_type", content: __("Leave Type"), width: 200 }
-        ].map(x => ({ ...x, editable: false, sortable: false, focusable: false, dropdown: false, align: "left" }));
+        ].map(x => ({
+            ...x,
+            editable: false,
+            sortable: false,
+            focusable: false,
+            dropdown: false,
+            align: "left"
+        }));
     },
 
     render_datatable(frm, data, summary_wrapper) {
         const columns = frm.events.get_columns_for_marked_attendance_table();
+
         if (!frm.marked_emp_datatable) {
             const datatable_options = {
                 columns,
@@ -194,7 +214,12 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 noDataMessage: __("No Data"),
                 disableReorderColumn: true
             };
-            frm.marked_emp_datatable = new frappe.DataTable(summary_wrapper.get(0), datatable_options);
+
+            frm.marked_emp_datatable = new frappe.DataTable(
+                summary_wrapper.get(0),
+                datatable_options
+            );
+
         } else {
             frm.marked_emp_datatable.refresh(data, columns);
         }
@@ -205,31 +230,39 @@ frappe.ui.form.on("Employee Attendance Tool", {
         get_employees_button.removeClass("btn-primary").addClass("btn-default");
 
         frm.page.set_primary_action(__("Mark Attendance"), () => {
-            const employees_to_mark_full_day = frm.get_field("unmarked_employees_multicheck")?.get_checked_options() || [];
-            const employees_to_mark_half_day = frm.get_field("half_marked_employees_multicheck")?.get_checked_options() || [];
 
-            if (employees_to_mark_full_day.length === 0 && employees_to_mark_half_day.length === 0) {
+            const employees_to_mark_full_day =
+                frm.get_field("unmarked_employees_multicheck")?.get_checked_options() || [];
+
+            const employees_to_mark_half_day =
+                frm.get_field("half_marked_employees_multicheck")?.get_checked_options() || [];
+
+            if (!employees_to_mark_full_day.length && !employees_to_mark_half_day.length) {
                 frappe.throw({
                     message: __("Please select the employees you want to mark attendance for."),
                     title: __("Mandatory")
                 });
             }
 
-            if (employees_to_mark_full_day.length > 0 && !frm.doc.status) {
+            if (employees_to_mark_full_day.length && !frm.doc.status) {
                 frappe.throw({
                     message: __("Please select the attendance status."),
                     title: __("Mandatory")
                 });
             }
 
-            if (employees_to_mark_half_day.length > 0 && !frm.doc.half_day_status) {
+            if (employees_to_mark_half_day.length && !frm.doc.half_day_status) {
                 frappe.throw({
                     message: __("Please select half day attendance status."),
                     title: __("Mandatory")
                 });
             }
 
-            frm.events.mark_attendance(frm, employees_to_mark_full_day, employees_to_mark_half_day);
+            frm.events.mark_attendance(
+                frm,
+                employees_to_mark_full_day,
+                employees_to_mark_half_day
+            );
         });
     },
 
@@ -253,10 +286,12 @@ frappe.ui.form.on("Employee Attendance Tool", {
             freeze_message: __("Marking Attendance")
         }).then(r => {
             if (!r.exc) {
-                frappe.show_alert({ message: __("Attendance marked successfully"), indicator: "green" });
+                frappe.show_alert({
+                    message: __("Attendance marked successfully"),
+                    indicator: "green"
+                });
                 frm.refresh();
             }
         });
-    }
     }
 });

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -273,6 +273,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
 					employee_list: employees_to_mark_full_day,
 					status: frm.doc.status,
 					date: frm.doc.date,
+					to_date: frm.doc.to_date,
 					late_entry: frm.doc.late_entry,
 					early_exit: frm.doc.early_exit,
 					shift: frm.doc.shift,

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -241,6 +241,7 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 status: frm.doc.status,
                 from_date: frm.doc.from_date,
                 to_date: frm.doc.to_date,
+                company: frm.doc.company,
                 late_entry: frm.doc.late_entry,
                 early_exit: frm.doc.early_exit,
                 shift: frm.doc.shift,
@@ -256,5 +257,6 @@ frappe.ui.form.on("Employee Attendance Tool", {
                 frm.refresh();
             }
         });
+    }
     }
 });

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -52,7 +52,7 @@
   },
   {
    "collapsible": 1,
-   "depends_on": "date",
+   "depends_on": "from_date",
    "fieldname": "marked_attendance_section",
    "fieldtype": "Section Break",
    "label": "Marked Attendance"

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -1,208 +1,209 @@
 {
- "actions": [],
- "allow_copy": 1,
- "creation": "2016-01-27 14:59:47.849379",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "from_date",
-  "to_date",
-  "shift",
-  "column_break_gmhs",
-  "late_entry",
-  "early_exit",
-  "section_break_ackd",
-  "company",
-  "branch",
-  "department",
-  "column_break_bhny",
-  "employment_type",
-  "designation",
-  "employee_grade",
-  "get_employees",
-  "select_employees_section",
-  "unmarked_employee_header",
-  "status",
-  "unmarked_employees_html",
-  "horizontal_break",
-  "half_day_marked_employee_header",
-  "half_day_status",
-  "half_marked_employees_html",
-  "marked_attendance_section",
-  "marked_attendance_html"
- ],
- "fields": [
-  {
-   "fieldname": "department",
-   "fieldtype": "Link",
-   "label": "Department",
-   "options": "Department"
-  },
-  {
-   "fieldname": "branch",
-   "fieldtype": "Link",
-   "label": "Branch",
-   "options": "Branch"
-  },
-  {
-   "fieldname": "company",
-   "fieldtype": "Link",
-   "label": "Company",
-   "options": "Company"
-  },
-  {
-   "collapsible": 1,
-   "depends_on": "date",
-   "fieldname": "marked_attendance_section",
-   "fieldtype": "Section Break",
-   "label": "Marked Attendance"
-  },
-  {
-   "fieldname": "marked_attendance_html",
-   "fieldtype": "HTML",
-   "label": "Marked Attendance HTML"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Status",
-   "options": "\nPresent\nAbsent\nHalf Day\nWork From Home"
-  },
-  {
-   "collapsible": 1,
-   "collapsible_depends_on": "eval:true",
-   "description": "Set filters to fetch employees",
-   "fieldname": "section_break_ackd",
-   "fieldtype": "Section Break",
-   "label": "Get Employees"
-  },
-  {
-   "fieldname": "column_break_bhny",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "late_entry",
-   "fieldtype": "Check",
-   "label": "Late Entry"
-  },
-  {
-   "default": "0",
-   "fieldname": "early_exit",
-   "fieldtype": "Check",
-   "label": "Early Exit"
-  },
-  {
-   "fieldname": "shift",
-   "fieldtype": "Link",
-   "label": "Shift",
-   "options": "Shift Type"
-  },
-  {
-   "fieldname": "employment_type",
-   "fieldtype": "Link",
-   "label": "Employment Type",
-   "options": "Employment Type"
-  },
-  {
-   "fieldname": "designation",
-   "fieldtype": "Link",
-   "label": "Designation",
-   "options": "Designation"
-  },
-  {
-   "fieldname": "employee_grade",
-   "fieldtype": "Link",
-   "label": "Employee Grade",
-   "options": "Employee Grade"
-  },
-  {
-   "fieldname": "unmarked_employees_html",
-   "fieldtype": "HTML",
-   "label": "Unmarked Employees HTML",
-   "read_only": 1
-  },
-  {
-   "fieldname": "half_marked_employees_html",
-   "fieldtype": "HTML",
-   "label": "Employees on Half Day HTML"
-  },
-  {
-   "fieldname": "half_day_status",
-   "fieldtype": "Select",
-   "label": "Status for Other Half",
-   "options": "Present\nAbsent"
-  },
-  {
-   "fieldname": "column_break_gmhs",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "get_employees",
-   "fieldtype": "Button",
-   "label": "Get Employees"
-  },
-  {
-   "collapsible": 1,
-   "collapsible_depends_on": "eval:true",
-   "fieldname": "select_employees_section",
-   "fieldtype": "Section Break",
-   "label": "Select Employees"
-  },
-  {
-   "fieldname": "unmarked_employee_header",
-   "fieldtype": "HTML",
-   "label": "Unmarked Employee Header",
-   "options": "<h5>Unmarked Employees</h5>"
-  },
-  {
-   "fieldname": "half_day_marked_employee_header",
-   "fieldtype": "HTML",
-   "label": "Half Day Marked Employee Header",
-   "options": "<h5>Employees on Half Day</h5>"
-  },
-  {
-   "fieldname": "horizontal_break",
-   "fieldtype": "HTML",
-   "label": "Horizontal Break",
-   "options": "<hr>"
-  },
-  {
-   "depends_on": "eval:doc.from_date",
-   "description": "Leave blank for single-day attendance.",
-   "fieldname": "to_date",
-   "fieldtype": "Date",
-   "label": "To Date"
-  },
-  {
-   "default": "Today",
-   "description": "For single-day attendance, select only this date.",
-   "fieldname": "from_date",
-   "fieldtype": "Date",
-   "label": "From Date",
-   "reqd": 1
-  }
- ],
- "grid_page_length": 50,
- "hide_toolbar": 1,
- "issingle": 1,
- "links": [],
- "modified": "2026-02-13 13:29:02.778094",
- "modified_by": "nikita.pawar@intellore.com",
- "module": "HR",
- "name": "Employee Attendance Tool",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "read": 1,
-   "role": "HR Manager",
-   "write": 1
-  }
- ],
- "row_format": "Dynamic",
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
-}
+    "actions": [],
+    "allow_copy": 1,
+    "creation": "2016-01-27 14:59:47.849379",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "field_order": [
+     "from_date",
+     "to_date",
+     "shift",
+     "column_break_gmhs",
+     "late_entry",
+     "early_exit",
+     "section_break_ackd",
+     "company",
+     "branch",
+     "department",
+     "column_break_bhny",
+     "employment_type",
+     "designation",
+     "employee_grade",
+     "get_employees",
+     "select_employees_section",
+     "unmarked_employee_header",
+     "status",
+     "unmarked_employees_html",
+     "horizontal_break",
+     "half_day_marked_employee_header",
+     "half_day_status",
+     "half_marked_employees_html",
+     "marked_attendance_section",
+     "marked_attendance_html"
+    ],
+    "fields": [
+     {
+      "default": "Today",
+      "description": "For single-day attendance, select only this date.",
+      "fieldname": "from_date",
+      "fieldtype": "Date",
+      "label": "From Date",
+      "reqd": 1
+     },
+     {
+      "depends_on": "eval:doc.from_date",
+      "description": "Leave blank for single-day attendance.",
+      "fieldname": "to_date",
+      "fieldtype": "Date",
+      "label": "To Date"
+     },
+     {
+      "fieldname": "shift",
+      "fieldtype": "Link",
+      "label": "Shift",
+      "options": "Shift Type"
+     },
+     {
+      "fieldname": "column_break_gmhs",
+      "fieldtype": "Column Break"
+     },
+     {
+      "default": "0",
+      "fieldname": "late_entry",
+      "fieldtype": "Check",
+      "label": "Late Entry"
+     },
+     {
+      "default": "0",
+      "fieldname": "early_exit",
+      "fieldtype": "Check",
+      "label": "Early Exit"
+     },
+     {
+      "collapsible": 1,
+      "collapsible_depends_on": "eval:true",
+      "description": "Set filters to fetch employees",
+      "fieldname": "section_break_ackd",
+      "fieldtype": "Section Break",
+      "label": "Get Employees"
+     },
+     {
+      "fieldname": "company",
+      "fieldtype": "Link",
+      "label": "Company",
+      "options": "Company"
+     },
+     {
+      "fieldname": "branch",
+      "fieldtype": "Link",
+      "label": "Branch",
+      "options": "Branch"
+     },
+     {
+      "fieldname": "department",
+      "fieldtype": "Link",
+      "label": "Department",
+      "options": "Department"
+     },
+     {
+      "fieldname": "column_break_bhny",
+      "fieldtype": "Column Break"
+     },
+     {
+      "fieldname": "employment_type",
+      "fieldtype": "Link",
+      "label": "Employment Type",
+      "options": "Employment Type"
+     },
+     {
+      "fieldname": "designation",
+      "fieldtype": "Link",
+      "label": "Designation",
+      "options": "Designation"
+     },
+     {
+      "fieldname": "employee_grade",
+      "fieldtype": "Link",
+      "label": "Employee Grade",
+      "options": "Employee Grade"
+     },
+     {
+      "fieldname": "get_employees",
+      "fieldtype": "Button",
+      "label": "Get Employees"
+     },
+     {
+      "collapsible": 1,
+      "collapsible_depends_on": "eval:true",
+      "fieldname": "select_employees_section",
+      "fieldtype": "Section Break",
+      "label": "Select Employees"
+     },
+     {
+      "fieldname": "unmarked_employee_header",
+      "fieldtype": "HTML",
+      "label": "Unmarked Employee Header",
+      "options": "<h5>Unmarked Employees</h5>"
+     },
+     {
+      "fieldname": "status",
+      "fieldtype": "Select",
+      "in_list_view": 1,
+      "label": "Status",
+      "options": "\nPresent\nAbsent\nHalf Day\nWork From Home"
+     },
+     {
+      "fieldname": "unmarked_employees_html",
+      "fieldtype": "HTML",
+      "label": "Unmarked Employees HTML",
+      "read_only": 1
+     },
+     {
+      "fieldname": "horizontal_break",
+      "fieldtype": "HTML",
+      "label": "Horizontal Break",
+      "options": "<hr>"
+     },
+     {
+      "fieldname": "half_day_marked_employee_header",
+      "fieldtype": "HTML",
+      "label": "Half Day Marked Employee Header",
+      "options": "<h5>Employees on Half Day</h5>"
+     },
+     {
+      "fieldname": "half_day_status",
+      "fieldtype": "Select",
+      "label": "Status for Other Half",
+      "options": "Present\nAbsent"
+     },
+     {
+      "fieldname": "half_marked_employees_html",
+      "fieldtype": "HTML",
+      "label": "Employees on Half Day HTML"
+     },
+     {
+      "collapsible": 1,
+      "depends_on": "from_date",
+      "fieldname": "marked_attendance_section",
+      "fieldtype": "Section Break",
+      "label": "Marked Attendance"
+     },
+     {
+      "fieldname": "marked_attendance_html",
+      "fieldtype": "HTML",
+      "label": "Marked Attendance HTML"
+     }
+    ],
+    "grid_page_length": 50,
+    "hide_toolbar": 1,
+    "issingle": 1,
+    "links": [],
+    "modified": "2026-02-13 13:29:02.778094",
+    "modified_by": "nikita.pawar@intellore.com",
+    "module": "HR",
+    "name": "Employee Attendance Tool",
+    "owner": "Administrator",
+    "permissions": [
+     {
+      "create": 1,
+      "read": 1,
+      "role": "HR Manager",
+      "write": 1
+     }
+    ],
+    "row_format": "Dynamic",
+    "sort_field": "creation",
+    "sort_order": "DESC",
+    "states": []
+   }
+   

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -52,7 +52,7 @@
   },
   {
    "collapsible": 1,
-   "depends_on": "from_date",
+   "depends_on": "date",
    "fieldname": "marked_attendance_section",
    "fieldtype": "Section Break",
    "label": "Marked Attendance"
@@ -169,6 +169,8 @@
    "options": "<hr>"
   },
   {
+   "depends_on": "eval:doc.from_date",
+   "description": "Leave blank for single-day attendance.",
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date"
@@ -186,7 +188,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-13 10:28:03.188483",
+ "modified": "2026-02-13 13:29:02.778094",
  "modified_by": "nikita.pawar@intellore.com",
  "module": "HR",
  "name": "Employee Attendance Tool",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -5,7 +5,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "date",
+  "from_date",
   "to_date",
   "shift",
   "column_break_gmhs",
@@ -32,12 +32,6 @@
   "marked_attendance_html"
  ],
  "fields": [
-  {
-   "default": "Today",
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "label": "Date"
-  },
   {
    "fieldname": "department",
    "fieldtype": "Link",
@@ -178,14 +172,22 @@
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date"
+  },
+  {
+   "default": "Today",
+   "description": "For single-day attendance, select only this date.",
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "label": "From Date",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-12 18:17:54.307888",
- "modified_by": "Administrator",
+ "modified": "2026-02-13 10:28:03.188483",
+ "modified_by": "nikita.pawar@intellore.com",
  "module": "HR",
  "name": "Employee Attendance Tool",
  "owner": "Administrator",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "date",
+  "to_date",
   "shift",
   "column_break_gmhs",
   "late_entry",
@@ -172,13 +173,18 @@
    "fieldtype": "HTML",
    "label": "Horizontal Break",
    "options": "<hr>"
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "label": "To Date"
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-26 09:42:36.888216",
+ "modified": "2026-02-12 18:17:54.307888",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Attendance Tool",

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd.
 # For license information, please see license.txt
 
 import datetime
@@ -10,7 +10,6 @@ from frappe.utils import getdate, add_days
 
 
 class EmployeeAttendanceTool(Document):
-    """DocType class for Employee Attendance Tool"""
     pass
 
 
@@ -29,17 +28,18 @@ def get_employees(
     designation: str | None = None,
     employee_grade: str | None = None,
 ) -> dict[str, list]:
-    """
-    Returns marked, half-day marked, and unmarked employees for a date range.
-    """
+
     from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
 
     if to_date < from_date:
         frappe.throw(_("To Date cannot be before From Date."))
 
-    # Filters for active employees (date_of_joining <= to_date)
-    filters = {"status": "Active", "date_of_joining": ["<=", to_date]}
+    filters = {
+        "status": "Active",
+        "date_of_joining": ["<=", to_date],
+    }
+
     optional_filters = {
         "department": department,
         "branch": branch,
@@ -48,11 +48,11 @@ def get_employees(
         "designation": designation,
         "employee_grade": employee_grade,
     }
+
     for field, value in optional_filters.items():
         if value:
             filters[field] = value
 
-    # All active employees, fetch joining date for skipping pre-joining dates
     employee_list = frappe.get_list(
         "Employee",
         fields=["name as employee", "employee_name", "date_of_joining"],
@@ -60,10 +60,16 @@ def get_employees(
         order_by="employee_name",
     )
 
-    # Attendance records within the date range
     attendance_list = frappe.get_list(
         "Attendance",
-        fields=["employee", "employee_name", "status", "shift", "leave_type", "attendance_date"],
+        fields=[
+            "employee",
+            "employee_name",
+            "status",
+            "shift",
+            "leave_type",
+            "attendance_date",
+        ],
         filters={
             "attendance_date": ["between", [from_date, to_date]],
             "docstatus": 1,
@@ -72,7 +78,6 @@ def get_employees(
         order_by="employee_name",
     )
 
-    # Half-day attendances
     half_day_attendance_list = frappe.get_list(
         "Attendance",
         fields=["employee", "employee_name", "attendance_date"],
@@ -85,7 +90,6 @@ def get_employees(
         order_by="employee_name",
     )
 
-    # All attendance (for unmarked calculation)
     all_attendance = frappe.get_list(
         "Attendance",
         fields=["employee", "attendance_date"],
@@ -95,7 +99,9 @@ def get_employees(
         },
     )
 
-    unmarked_attendance = _get_unmarked_attendance(employee_list, all_attendance, from_date, to_date)
+    unmarked_attendance = _get_unmarked_attendance(
+        employee_list, all_attendance, from_date, to_date
+    )
 
     return {
         "marked": attendance_list,
@@ -104,24 +110,29 @@ def get_employees(
     }
 
 
-def _get_unmarked_attendance(employee_list: list, attendance_list: list, from_date, to_date) -> list:
-    """
-    Returns employees missing attendance on any date in the range.
-    """
-    # Normalize dates for set lookup
-    marked_set = set((att["employee"], getdate(att["attendance_date"])) for att in attendance_list)
+def _get_unmarked_attendance(employee_list, attendance_list, from_date, to_date):
+
+    marked_set = set(
+        (att["employee"], getdate(att["attendance_date"]))
+        for att in attendance_list
+    )
 
     unmarked = []
+
     for emp in employee_list:
         has_missing = False
+
         for n in range((to_date - from_date).days + 1):
             current_date = add_days(from_date, n)
-            # Skip dates before employee's joining
+
+            # Skip pre-joining dates
             if emp.get("date_of_joining") and current_date < getdate(emp["date_of_joining"]):
                 continue
+
             if (emp["employee"], current_date) not in marked_set:
                 has_missing = True
                 break
+
         if has_missing:
             unmarked.append(emp)
 
@@ -129,7 +140,7 @@ def _get_unmarked_attendance(employee_list: list, attendance_list: list, from_da
 
 
 # -------------------------------------------------------------------------
-# MARK ATTENDANCE (DATE RANGE)
+# MARK ATTENDANCE
 # -------------------------------------------------------------------------
 
 @frappe.whitelist()
@@ -146,18 +157,13 @@ def mark_employee_attendance(
     mark_half_day: bool | None = False,
     half_day_status: str | None = None,
     half_day_employee_list: list | str | None = None,
-) -> None:
-    """
-    Marks attendance for employees over a date range.
-    Handles full-day and optional half-day marking.
-    """
+):
+
     if isinstance(employee_list, str):
         employee_list = json.loads(employee_list)
+
     if isinstance(half_day_employee_list, str):
         half_day_employee_list = json.loads(half_day_employee_list)
-
-    if not employee_list and not half_day_employee_list:
-        frappe.throw(_("Please select at least one employee."))
 
     from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
@@ -165,24 +171,34 @@ def mark_employee_attendance(
     if to_date < from_date:
         frappe.throw(_("To Date cannot be before From Date."))
 
-    # Cache employee joining dates for performance
+    # Combine employees for joining date cache
+    all_employees = set(employee_list or []) | set(half_day_employee_list or [])
+
     joining_dates = {
-        e: frappe.db.get_value("Employee", e, "date_of_joining") for e in employee_list
+        emp: frappe.db.get_value("Employee", emp, "date_of_joining")
+        for emp in all_employees
     }
 
-    # -------------------------------
-    # Full-day attendance
-    # -------------------------------
+    # -------------------------
+    # Full-Day Attendance
+    # -------------------------
     for n in range((to_date - from_date).days + 1):
         current_date = add_days(from_date, n)
-        for employee in employee_list:
+
+        for employee in employee_list or []:
             joining_date = joining_dates.get(employee)
+
+            # Skip pre-joining
             if joining_date and current_date < getdate(joining_date):
                 continue
 
             if frappe.db.exists(
                 "Attendance",
-                {"employee": employee, "attendance_date": current_date, "docstatus": ["!=", 2]},
+                {
+                    "employee": employee,
+                    "attendance_date": current_date,
+                    "docstatus": ["!=", 2],
+                },
             ):
                 continue
 
@@ -199,14 +215,16 @@ def mark_employee_attendance(
                     "shift": shift,
                 }
             )
+
             attendance.insert()
             attendance.submit()
 
-    # -------------------------------
-    # Half-day update
-    # -------------------------------
+    # -------------------------
+    # Half-Day Update
+    # -------------------------
     if mark_half_day and half_day_employee_list:
         for employee in half_day_employee_list:
+
             attendance_docs = frappe.get_list(
                 "Attendance",
                 filters={
@@ -214,15 +232,18 @@ def mark_employee_attendance(
                     "attendance_date": ["between", [from_date, to_date]],
                     "docstatus": 1,
                 },
-                fields=["name"]
+                fields=["name"],
             )
+
             for att in attendance_docs:
                 doc = frappe.get_doc("Attendance", att.name)
-                # Allow modification on submitted documents
+
                 doc.flags.ignore_validate_update_after_submit = True
+
                 # Only update half-day fields
                 doc.half_day_status = half_day_status
                 doc.modify_half_day_status = 0
+
                 doc.save()
 
     frappe.msgprint(_("Attendance marked successfully."))

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd.
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
 import datetime
@@ -19,7 +19,7 @@ class EmployeeAttendanceTool(Document):
 
 @frappe.whitelist()
 def get_employees(
-    date: str | datetime.date,
+    from_date: str | datetime.date,
     department: str | None = None,
     branch: str | None = None,
     company: str | None = None,
@@ -28,11 +28,11 @@ def get_employees(
     employee_grade: str | None = None,
 ) -> dict[str, list]:
 
-    date = getdate(date)
+    from_date = getdate(from_date)
 
     filters = {
         "status": "Active",
-        "date_of_joining": ["<=", date],
+        "date_of_joining": ["<=", from_date],
     }
 
     optional_filters = {
@@ -61,7 +61,7 @@ def get_employees(
         "Attendance",
         fields=["employee", "employee_name", "status", "shift", "leave_type"],
         filters={
-            "attendance_date": date,
+            "attendance_date": from_date,
             "docstatus": 1,
             "modify_half_day_status": 0,
         },
@@ -73,7 +73,7 @@ def get_employees(
         "Attendance",
         fields=["employee", "employee_name"],
         filters={
-            "attendance_date": date,
+            "attendance_date": from_date,
             "docstatus": 1,
             "modify_half_day_status": 1,
             "leave_type": ("is", "set"),
@@ -93,7 +93,7 @@ def get_employees(
 
 
 def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
-
+    """Return employees who don’t have attendance marked yet"""
     marked_employees = [entry.get("employee") for entry in attendance_list]
 
     return [
@@ -111,7 +111,7 @@ def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[di
 def mark_employee_attendance(
     employee_list: list | str,
     status: str,
-    date: str | datetime.date,
+    from_date: str | datetime.date,
     to_date: str | datetime.date | None = None,
     leave_type: str | None = None,
     company: str | None = None,
@@ -123,7 +123,7 @@ def mark_employee_attendance(
     half_day_employee_list: list | str | None = None,
 ) -> None:
 
-    # Convert JSON string to list
+    # Convert JSON strings to lists if needed
     if isinstance(employee_list, str):
         employee_list = json.loads(employee_list)
 
@@ -133,7 +133,8 @@ def mark_employee_attendance(
     if not employee_list:
         frappe.throw("Please select at least one employee.")
 
-    from_date = getdate(date)
+    # Convert to datetime
+    from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
 
     # Validate date range

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -35,7 +35,7 @@ def get_employees(
     to_date = getdate(to_date) if to_date else from_date
 
     if to_date < from_date:
-        frappe.throw("To Date cannot be before From Date.")
+        frappe.throw(_("To Date cannot be before From Date."))
 
     # Filters for active employees
     filters = {"status": "Active", "date_of_joining": ["<=", from_date]}

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -1,134 +1,204 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd.
 # For license information, please see license.txt
-
 
 import datetime
 import json
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import getdate, add_days
 
 
 class EmployeeAttendanceTool(Document):
-	pass
+    pass
 
+
+# -------------------------------------------------------------------------
+# GET EMPLOYEES
+# -------------------------------------------------------------------------
 
 @frappe.whitelist()
 def get_employees(
-	date: str | datetime.date,
-	department: str | None = None,
-	branch: str | None = None,
-	company: str | None = None,
-	employment_type: str | None = None,
-	designation: str | None = None,
-	employee_grade: str | None = None,
+    date: str | datetime.date,
+    department: str | None = None,
+    branch: str | None = None,
+    company: str | None = None,
+    employment_type: str | None = None,
+    designation: str | None = None,
+    employee_grade: str | None = None,
 ) -> dict[str, list]:
-	filters = {"status": "Active", "date_of_joining": ["<=", date]}
 
-	for field, value in {
-		"department": department,
-		"branch": branch,
-		"company": company,
-		"employment_type": employment_type,
-		"designation": designation,
-		"employee_grade": employee_grade,
-	}.items():
-		if value:
-			filters[field] = value
-	# list of all employees
-	employee_list = frappe.get_list(
-		"Employee",
-		fields=["employee", "employee_name"],
-		filters=filters,
-		order_by="employee_name",
-	)
-	# marked attendance
-	attendance_list = frappe.get_list(
-		"Attendance",
-		fields=["employee", "employee_name", "status", "shift", "leave_type"],
-		filters={
-			"attendance_date": date,
-			"docstatus": 1,
-			"modify_half_day_status": 0,
-		},
-		order_by="employee_name",
-	)
-	half_day_attendance_list = frappe.get_list(
-		"Attendance",
-		fields=["employee", "employee_name"],
-		filters={
-			"attendance_date": date,
-			"docstatus": 1,
-			"modify_half_day_status": 1,
-			"leave_type": ("is", "set"),
-		},
-		order_by="employee_name",
-	)
-	unmarked_attendance = _get_unmarked_attendance(
-		employee_list, [*attendance_list, *half_day_attendance_list]
-	)
-	return {
-		"marked": attendance_list,
-		"half_day_marked": half_day_attendance_list,
-		"unmarked": unmarked_attendance,
-	}
+    date = getdate(date)
+
+    filters = {
+        "status": "Active",
+        "date_of_joining": ["<=", date],
+    }
+
+    optional_filters = {
+        "department": department,
+        "branch": branch,
+        "company": company,
+        "employment_type": employment_type,
+        "designation": designation,
+        "employee_grade": employee_grade,
+    }
+
+    for field, value in optional_filters.items():
+        if value:
+            filters[field] = value
+
+    # All employees
+    employee_list = frappe.get_list(
+        "Employee",
+        fields=["name as employee", "employee_name"],
+        filters=filters,
+        order_by="employee_name",
+    )
+
+    # Marked attendance
+    attendance_list = frappe.get_list(
+        "Attendance",
+        fields=["employee", "employee_name", "status", "shift", "leave_type"],
+        filters={
+            "attendance_date": date,
+            "docstatus": 1,
+            "modify_half_day_status": 0,
+        },
+        order_by="employee_name",
+    )
+
+    # Half day attendance
+    half_day_attendance_list = frappe.get_list(
+        "Attendance",
+        fields=["employee", "employee_name"],
+        filters={
+            "attendance_date": date,
+            "docstatus": 1,
+            "modify_half_day_status": 1,
+            "leave_type": ("is", "set"),
+        },
+        order_by="employee_name",
+    )
+
+    unmarked_attendance = _get_unmarked_attendance(
+        employee_list, [*attendance_list, *half_day_attendance_list]
+    )
+
+    return {
+        "marked": attendance_list,
+        "half_day_marked": half_day_attendance_list,
+        "unmarked": unmarked_attendance,
+    }
 
 
 def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
-	marked_employees = [entry.employee for entry in attendance_list]
-	unmarked_attendance = []
 
-	for entry in employee_list:
-		if entry.employee not in marked_employees:
-			unmarked_attendance.append(entry)
+    marked_employees = [entry.get("employee") for entry in attendance_list]
 
-	return unmarked_attendance
+    return [
+        employee
+        for employee in employee_list
+        if employee.get("employee") not in marked_employees
+    ]
 
+
+# -------------------------------------------------------------------------
+# MARK ATTENDANCE (SINGLE DATE OR DATE RANGE)
+# -------------------------------------------------------------------------
 
 @frappe.whitelist()
 def mark_employee_attendance(
-	employee_list: list | str,
-	status: str,
-	date: str | datetime.date,
-	leave_type: str | None = None,
-	company: str | None = None,
-	late_entry: int | None = None,
-	early_exit: int | None = None,
-	shift: str | None = None,
-	mark_half_day: bool | None = False,
-	half_day_status: str | None = None,
-	half_day_employee_list: list | str | None = None,
+    employee_list: list | str,
+    status: str,
+    date: str | datetime.date,
+    to_date: str | datetime.date | None = None,
+    leave_type: str | None = None,
+    company: str | None = None,
+    late_entry: int | None = None,
+    early_exit: int | None = None,
+    shift: str | None = None,
+    mark_half_day: bool | None = False,
+    half_day_status: str | None = None,
+    half_day_employee_list: list | str | None = None,
 ) -> None:
-	if isinstance(employee_list, str):
-		employee_list = json.loads(employee_list)
 
-	for employee in employee_list:
-		leave_type = None
-		if status == "On Leave" and leave_type:
-			leave_type = leave_type
+    # Convert JSON string to list
+    if isinstance(employee_list, str):
+        employee_list = json.loads(employee_list)
 
-		attendance = frappe.get_doc(
-			dict(
-				doctype="Attendance",
-				employee=employee,
-				attendance_date=getdate(date),
-				status=status,
-				leave_type=leave_type,
-				late_entry=late_entry,
-				early_exit=early_exit,
-				shift=shift,
-			)
-		)
-		attendance.insert()
-		attendance.submit()
-	if mark_half_day:
-		if isinstance(half_day_employee_list, str):
-			half_day_employee_list = json.loads(half_day_employee_list)
-		Attendance = frappe.qb.DocType("Attendance")
-		for employee in half_day_employee_list:
-			frappe.qb.update(Attendance).where(
-				(Attendance.employee == employee) & (Attendance.attendance_date == date)
-			).set(Attendance.half_day_status, half_day_status).set(Attendance.shift, shift).set(
-				Attendance.late_entry, late_entry
-			).set(Attendance.early_exit, early_exit).set(Attendance.modify_half_day_status, 0).run()
+    if isinstance(half_day_employee_list, str):
+        half_day_employee_list = json.loads(half_day_employee_list)
+
+    if not employee_list:
+        frappe.throw("Please select at least one employee.")
+
+    from_date = getdate(date)
+    to_date = getdate(to_date) if to_date else from_date
+
+    # Validate date range
+    if to_date < from_date:
+        frappe.throw("To Date cannot be before From Date.")
+
+    current_date = from_date
+
+    while current_date <= to_date:
+
+        for employee in employee_list:
+
+            # Skip if attendance already exists
+            if frappe.db.exists(
+                "Attendance",
+                {
+                    "employee": employee,
+                    "attendance_date": current_date,
+                    "docstatus": ["!=", 2],
+                },
+            ):
+                continue
+
+            attendance = frappe.get_doc(
+                {
+                    "doctype": "Attendance",
+                    "employee": employee,
+                    "attendance_date": current_date,
+                    "status": status,
+                    "leave_type": leave_type if status == "On Leave" else None,
+                    "company": company,
+                    "late_entry": late_entry,
+                    "early_exit": early_exit,
+                    "shift": shift,
+                }
+            )
+
+            attendance.insert()
+            attendance.submit()
+
+        current_date = add_days(current_date, 1)
+
+    # -----------------------------------------------------------------
+    # HALF DAY UPDATE (OPTIONAL)
+    # -----------------------------------------------------------------
+
+    if mark_half_day and half_day_employee_list:
+
+        Attendance = frappe.qb.DocType("Attendance")
+
+        for employee in half_day_employee_list:
+            frappe.qb.update(Attendance).where(
+                (Attendance.employee == employee)
+                & (Attendance.attendance_date >= from_date)
+                & (Attendance.attendance_date <= to_date)
+            ).set(
+                Attendance.half_day_status, half_day_status
+            ).set(
+                Attendance.shift, shift
+            ).set(
+                Attendance.late_entry, late_entry
+            ).set(
+                Attendance.early_exit, early_exit
+            ).set(
+                Attendance.modify_half_day_status, 0
+            ).run()
+
+    frappe.msgprint("Attendance marked successfully.")

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -52,7 +52,7 @@ def get_employees(
         if value:
             filters[field] = value
 
-    # All active employees
+    # All active employees, fetch joining date for skipping pre-joining dates
     employee_list = frappe.get_list(
         "Employee",
         fields=["name as employee", "employee_name", "date_of_joining"],
@@ -72,6 +72,7 @@ def get_employees(
         order_by="employee_name",
     )
 
+    # Half-day attendances
     half_day_attendance_list = frappe.get_list(
         "Attendance",
         fields=["employee", "employee_name", "attendance_date"],
@@ -84,7 +85,7 @@ def get_employees(
         order_by="employee_name",
     )
 
-    # All attendance (for unmarked calculation) including half-day modified
+    # All attendance (for unmarked calculation)
     all_attendance = frappe.get_list(
         "Attendance",
         fields=["employee", "attendance_date"],
@@ -164,17 +165,27 @@ def mark_employee_attendance(
     if to_date < from_date:
         frappe.throw(_("To Date cannot be before From Date."))
 
+    # Cache employee joining dates for performance
+    joining_dates = {
+        e: frappe.db.get_value("Employee", e, "date_of_joining") for e in employee_list
+    }
+
     # -------------------------------
     # Full-day attendance
     # -------------------------------
     for n in range((to_date - from_date).days + 1):
         current_date = add_days(from_date, n)
         for employee in employee_list:
+            joining_date = joining_dates.get(employee)
+            if joining_date and current_date < getdate(joining_date):
+                continue
+
             if frappe.db.exists(
                 "Attendance",
                 {"employee": employee, "attendance_date": current_date, "docstatus": ["!=", 2]},
             ):
                 continue
+
             attendance = frappe.get_doc(
                 {
                     "doctype": "Attendance",
@@ -209,10 +220,8 @@ def mark_employee_attendance(
                 doc = frappe.get_doc("Attendance", att.name)
                 # Allow modification on submitted documents
                 doc.flags.ignore_validate_update_after_submit = True
+                # Only update half-day fields
                 doc.half_day_status = half_day_status
-                doc.shift = shift
-                doc.late_entry = late_entry
-                doc.early_exit = early_exit
                 doc.modify_half_day_status = 0
                 doc.save()
 

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -3,13 +3,13 @@
 
 import datetime
 import json
-
 import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate, add_days
 
 
 class EmployeeAttendanceTool(Document):
+    """DocType class for Employee Attendance Tool"""
     pass
 
 
@@ -20,6 +20,7 @@ class EmployeeAttendanceTool(Document):
 @frappe.whitelist()
 def get_employees(
     from_date: str | datetime.date,
+    to_date: str | datetime.date | None = None,
     department: str | None = None,
     branch: str | None = None,
     company: str | None = None,
@@ -27,14 +28,17 @@ def get_employees(
     designation: str | None = None,
     employee_grade: str | None = None,
 ) -> dict[str, list]:
-
+    """
+    Returns marked, half-day marked, and unmarked employees for a date range.
+    """
     from_date = getdate(from_date)
+    to_date = getdate(to_date) if to_date else from_date
 
-    filters = {
-        "status": "Active",
-        "date_of_joining": ["<=", from_date],
-    }
+    if to_date < from_date:
+        frappe.throw("To Date cannot be before From Date.")
 
+    # Filters for active employees
+    filters = {"status": "Active", "date_of_joining": ["<=", from_date]}
     optional_filters = {
         "department": department,
         "branch": branch,
@@ -43,12 +47,11 @@ def get_employees(
         "designation": designation,
         "employee_grade": employee_grade,
     }
-
     for field, value in optional_filters.items():
         if value:
             filters[field] = value
 
-    # All employees
+    # All active employees
     employee_list = frappe.get_list(
         "Employee",
         fields=["name as employee", "employee_name"],
@@ -56,24 +59,23 @@ def get_employees(
         order_by="employee_name",
     )
 
-    # Marked attendance
+    # Attendance records within the date range
     attendance_list = frappe.get_list(
         "Attendance",
-        fields=["employee", "employee_name", "status", "shift", "leave_type"],
+        fields=["employee", "employee_name", "status", "shift", "leave_type", "attendance_date"],
         filters={
-            "attendance_date": from_date,
+            "attendance_date": ["between", [from_date, to_date]],
             "docstatus": 1,
             "modify_half_day_status": 0,
         },
         order_by="employee_name",
     )
 
-    # Half day attendance
     half_day_attendance_list = frappe.get_list(
         "Attendance",
-        fields=["employee", "employee_name"],
+        fields=["employee", "employee_name", "attendance_date"],
         filters={
-            "attendance_date": from_date,
+            "attendance_date": ["between", [from_date, to_date]],
             "docstatus": 1,
             "modify_half_day_status": 1,
             "leave_type": ("is", "set"),
@@ -81,9 +83,7 @@ def get_employees(
         order_by="employee_name",
     )
 
-    unmarked_attendance = _get_unmarked_attendance(
-        employee_list, [*attendance_list, *half_day_attendance_list]
-    )
+    unmarked_attendance = _get_unmarked_attendance(employee_list, attendance_list, from_date, to_date)
 
     return {
         "marked": attendance_list,
@@ -92,19 +92,29 @@ def get_employees(
     }
 
 
-def _get_unmarked_attendance(employee_list: list[dict], attendance_list: list[dict]) -> list[dict]:
-    """Return employees who don’t have attendance marked yet"""
-    marked_employees = [entry.get("employee") for entry in attendance_list]
+def _get_unmarked_attendance(employee_list: list, attendance_list: list, from_date, to_date) -> list:
+    """
+    Returns employees missing attendance on any date in the range.
+    """
+    # Build a set of (employee, date) that already have attendance
+    marked_set = set((att["employee"], att["attendance_date"]) for att in attendance_list)
 
-    return [
-        employee
-        for employee in employee_list
-        if employee.get("employee") not in marked_employees
-    ]
+    unmarked = []
+    for emp in employee_list:
+        has_missing = False
+        for n in range((to_date - from_date).days + 1):
+            current_date = add_days(from_date, n)
+            if (emp["employee"], current_date) not in marked_set:
+                has_missing = True
+                break
+        if has_missing:
+            unmarked.append(emp)
+
+    return unmarked
 
 
 # -------------------------------------------------------------------------
-# MARK ATTENDANCE (SINGLE DATE OR DATE RANGE)
+# MARK ATTENDANCE (DATE RANGE)
 # -------------------------------------------------------------------------
 
 @frappe.whitelist()
@@ -122,42 +132,35 @@ def mark_employee_attendance(
     half_day_status: str | None = None,
     half_day_employee_list: list | str | None = None,
 ) -> None:
-
-    # Convert JSON strings to lists if needed
+    """
+    Marks attendance for employees over a date range.
+    Handles full-day and optional half-day marking.
+    """
     if isinstance(employee_list, str):
         employee_list = json.loads(employee_list)
-
     if isinstance(half_day_employee_list, str):
         half_day_employee_list = json.loads(half_day_employee_list)
 
-    if not employee_list:
+    if not employee_list and not half_day_employee_list:
         frappe.throw("Please select at least one employee.")
 
-    # Convert to datetime
     from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
 
-    # Validate date range
     if to_date < from_date:
         frappe.throw("To Date cannot be before From Date.")
 
-    current_date = from_date
-
-    while current_date <= to_date:
-
+    # -------------------------------
+    # Full-day attendance
+    # -------------------------------
+    for n in range((to_date - from_date).days + 1):
+        current_date = add_days(from_date, n)
         for employee in employee_list:
-
-            # Skip if attendance already exists
             if frappe.db.exists(
                 "Attendance",
-                {
-                    "employee": employee,
-                    "attendance_date": current_date,
-                    "docstatus": ["!=", 2],
-                },
+                {"employee": employee, "attendance_date": current_date, "docstatus": ["!=", 2]},
             ):
                 continue
-
             attendance = frappe.get_doc(
                 {
                     "doctype": "Attendance",
@@ -171,35 +174,30 @@ def mark_employee_attendance(
                     "shift": shift,
                 }
             )
-
             attendance.insert()
             attendance.submit()
 
-        current_date = add_days(current_date, 1)
-
-    # -----------------------------------------------------------------
-    # HALF DAY UPDATE (OPTIONAL)
-    # -----------------------------------------------------------------
-
+    # -------------------------------
+    # Half-day update
+    # -------------------------------
     if mark_half_day and half_day_employee_list:
-
-        Attendance = frappe.qb.DocType("Attendance")
-
         for employee in half_day_employee_list:
-            frappe.qb.update(Attendance).where(
-                (Attendance.employee == employee)
-                & (Attendance.attendance_date >= from_date)
-                & (Attendance.attendance_date <= to_date)
-            ).set(
-                Attendance.half_day_status, half_day_status
-            ).set(
-                Attendance.shift, shift
-            ).set(
-                Attendance.late_entry, late_entry
-            ).set(
-                Attendance.early_exit, early_exit
-            ).set(
-                Attendance.modify_half_day_status, 0
-            ).run()
+            attendance_docs = frappe.get_list(
+                "Attendance",
+                filters={
+                    "employee": employee,
+                    "attendance_date": ["between", [from_date, to_date]],
+                    "docstatus": 1,
+                },
+                fields=["name"]
+            )
+            for att in attendance_docs:
+                doc = frappe.get_doc("Attendance", att.name)
+                doc.half_day_status = half_day_status
+                doc.shift = shift
+                doc.late_entry = late_entry
+                doc.early_exit = early_exit
+                doc.modify_half_day_status = 0
+                doc.save()
 
     frappe.msgprint("Attendance marked successfully.")

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import getdate, add_days
 
@@ -37,8 +38,8 @@ def get_employees(
     if to_date < from_date:
         frappe.throw(_("To Date cannot be before From Date."))
 
-    # Filters for active employees
-    filters = {"status": "Active", "date_of_joining": ["<=", from_date]}
+    # Filters for active employees (date_of_joining <= to_date)
+    filters = {"status": "Active", "date_of_joining": ["<=", to_date]}
     optional_filters = {
         "department": department,
         "branch": branch,
@@ -54,7 +55,7 @@ def get_employees(
     # All active employees
     employee_list = frappe.get_list(
         "Employee",
-        fields=["name as employee", "employee_name"],
+        fields=["name as employee", "employee_name", "date_of_joining"],
         filters=filters,
         order_by="employee_name",
     )
@@ -83,7 +84,17 @@ def get_employees(
         order_by="employee_name",
     )
 
-    unmarked_attendance = _get_unmarked_attendance(employee_list, attendance_list, from_date, to_date)
+    # All attendance (for unmarked calculation) including half-day modified
+    all_attendance = frappe.get_list(
+        "Attendance",
+        fields=["employee", "attendance_date"],
+        filters={
+            "attendance_date": ["between", [from_date, to_date]],
+            "docstatus": 1,
+        },
+    )
+
+    unmarked_attendance = _get_unmarked_attendance(employee_list, all_attendance, from_date, to_date)
 
     return {
         "marked": attendance_list,
@@ -96,14 +107,17 @@ def _get_unmarked_attendance(employee_list: list, attendance_list: list, from_da
     """
     Returns employees missing attendance on any date in the range.
     """
-    # Build a set of (employee, date) that already have attendance
-    marked_set = set((att["employee"], att["attendance_date"]) for att in attendance_list)
+    # Normalize dates for set lookup
+    marked_set = set((att["employee"], getdate(att["attendance_date"])) for att in attendance_list)
 
     unmarked = []
     for emp in employee_list:
         has_missing = False
         for n in range((to_date - from_date).days + 1):
             current_date = add_days(from_date, n)
+            # Skip dates before employee's joining
+            if emp.get("date_of_joining") and current_date < getdate(emp["date_of_joining"]):
+                continue
             if (emp["employee"], current_date) not in marked_set:
                 has_missing = True
                 break
@@ -142,13 +156,13 @@ def mark_employee_attendance(
         half_day_employee_list = json.loads(half_day_employee_list)
 
     if not employee_list and not half_day_employee_list:
-        frappe.throw("Please select at least one employee.")
+        frappe.throw(_("Please select at least one employee."))
 
     from_date = getdate(from_date)
     to_date = getdate(to_date) if to_date else from_date
 
     if to_date < from_date:
-        frappe.throw("To Date cannot be before From Date.")
+        frappe.throw(_("To Date cannot be before From Date."))
 
     # -------------------------------
     # Full-day attendance
@@ -193,6 +207,8 @@ def mark_employee_attendance(
             )
             for att in attendance_docs:
                 doc = frappe.get_doc("Attendance", att.name)
+                # Allow modification on submitted documents
+                doc.flags.ignore_validate_update_after_submit = True
                 doc.half_day_status = half_day_status
                 doc.shift = shift
                 doc.late_entry = late_entry
@@ -200,4 +216,4 @@ def mark_employee_attendance(
                 doc.modify_half_day_status = 0
                 doc.save()
 
-    frappe.msgprint("Attendance marked successfully.")
+    frappe.msgprint(_("Attendance marked successfully."))


### PR DESCRIPTION
### Summary
This PR adds the ability to mark attendance for employees over a date range in the Employee Attendance Tool.

### Changes
- Added `to_date` field in Employee Attendance Tool DocType.
- Updated Python (`.py`) code to handle marking attendance for a range of dates.
- Updated JS (`.js`) code to allow selecting multiple dates and marking attendance in one action.
- Updated JSON (`.json`) to include the new field and ensure UI compatibility.

### Testing
- Verified marking attendance for a single day still works.
- Verified marking attendance for multiple days updates all selected dates.
- Verified half-day marking works across date ranges.
- No regression in existing reports or workflows.

### Related Issue
Closes #3706

https://github.com/user-attachments/assets/e0ef5b45-ed25-4f79-aad7-fea1df1ec94d

### Note - Adding description to to date was done after the video was recorded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mark attendance across a date range (From Date → To Date), defaulting From Date to today; per-day processing and joining-date-aware behavior.
  * Employee loading and attendance views now operate over date ranges and support existing filters (department, branch, company, employment type, designation, grade).
  * UI flows updated for selecting/showing employees and marking full/half days with clearer success feedback.

* **Bug Fixes**
  * Client-side validation prevents To Date earlier than From Date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->