### PR TITLE
fix(roster): Use frappe client api to get employee values in Roster

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -8,31 +8,10 @@ from hrms.hr.doctype.shift_assignment.shift_assignment import ShiftAssignment
 from hrms.hr.doctype.shift_assignment_tool.shift_assignment_tool import create_shift_assignment
 from hrms.hr.doctype.shift_schedule.shift_schedule import get_or_insert_shift_schedule
 
-ALLOWED_EMPLOYEE_FIELDS = {
-	"employee_name",
-	"company",
-	"department",
-}
-
 
 @frappe.whitelist()
 def get_default_company() -> str:
 	return frappe.defaults.get_user_default("Company")
-
-
-@frappe.whitelist()
-def get_employee_values(employee: str, fields: list):
-	if not employee:
-		frappe.throw(_("Employee is required"))
-
-	doc = frappe.get_doc("Employee", employee)
-	doc.check_permission("read")
-
-	# Validate requested fields
-	for field in fields:
-		if field not in ALLOWED_EMPLOYEE_FIELDS:
-			frappe.throw(_("Field not allowed: {}").format(field), frappe.PermissionError)
-	return {field: doc.get(field) for field in fields}
 
 
 @frappe.whitelist()

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -8,6 +8,12 @@ from hrms.hr.doctype.shift_assignment.shift_assignment import ShiftAssignment
 from hrms.hr.doctype.shift_assignment_tool.shift_assignment_tool import create_shift_assignment
 from hrms.hr.doctype.shift_schedule.shift_schedule import get_or_insert_shift_schedule
 
+ALLOWED_EMPLOYEE_FIELDS = {
+	"employee_name",
+	"company",
+	"department",
+}
+
 
 @frappe.whitelist()
 def get_default_company() -> str:
@@ -15,8 +21,18 @@ def get_default_company() -> str:
 
 
 @frappe.whitelist()
-def get_values(doctype: str, name: str, fields: list) -> dict[str, str]:
-	return frappe.db.get_value(doctype, name, fields, as_dict=True)
+def get_employee_values(employee: str, fields: list):
+	if not employee:
+		frappe.throw("Employee is required")
+
+	doc = frappe.get_doc("Employee", employee)
+	doc.check_permission("read")
+
+	# Validate requested fields
+	for field in fields:
+		if field not in ALLOWED_EMPLOYEE_FIELDS:
+			frappe.throw(f"Field not allowed: {field}", frappe.PermissionError)
+	return {field: doc.get(field) for field in fields}
 
 
 @frappe.whitelist()

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -31,7 +31,7 @@ def get_employee_values(employee: str, fields: list):
 	# Validate requested fields
 	for field in fields:
 		if field not in ALLOWED_EMPLOYEE_FIELDS:
-			frappe.throw(_(f"Field not allowed: {field}"), frappe.PermissionError)
+			frappe.throw(_("Field not allowed: {}").format(field), frappe.PermissionError)
 	return {field: doc.get(field) for field in fields}
 
 

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -23,7 +23,7 @@ def get_default_company() -> str:
 @frappe.whitelist()
 def get_employee_values(employee: str, fields: list):
 	if not employee:
-		frappe.throw("Employee is required")
+		frappe.throw(_("Employee is required"))
 
 	doc = frappe.get_doc("Employee", employee)
 	doc.check_permission("read")
@@ -31,7 +31,7 @@ def get_employee_values(employee: str, fields: list):
 	# Validate requested fields
 	for field in fields:
 		if field not in ALLOWED_EMPLOYEE_FIELDS:
-			frappe.throw(f"Field not allowed: {field}", frappe.PermissionError)
+			frappe.throw(_(f"Field not allowed: {field}"), frappe.PermissionError)
 	return {field: doc.get(field) for field in fields}
 
 

--- a/roster/src/components/ShiftAssignmentDialog.vue
+++ b/roster/src/components/ShiftAssignmentDialog.vue
@@ -391,12 +391,11 @@ const getShiftAssignment = (name: string) =>
 	});
 
 const employee = createResource({
-	url: "hrms.api.roster.get_values",
+	url: "hrms.api.roster.get_employee_values",
 	makeParams() {
 		const employee = (form.employee as { value: string }).value;
 		return {
-			doctype: "Employee",
-			name: employee,
+			employee: employee,
 			fields: ["employee_name", "company", "department"],
 		};
 	},

--- a/roster/src/components/ShiftAssignmentDialog.vue
+++ b/roster/src/components/ShiftAssignmentDialog.vue
@@ -2,12 +2,11 @@
 	<Dialog :options="{ title: dialog.title, size: '4xl' }">
 		<template #body-content>
 			<div class="grid grid-cols-2 gap-6">
-				<FormControl
-					type="autocomplete"
+				<Link
+					doctype="Employee"
 					label="Employee"
 					v-model="form.employee"
 					:disabled="!!props.shiftAssignmentName"
-					:options="employees"
 				/>
 				<FormControl type="text" label="Company" v-model="form.company" :disabled="true" />
 				<FormControl
@@ -141,7 +140,6 @@
 <script setup lang="ts">
 import { reactive, ref, computed, watch } from "vue";
 import {
-	DatePicker,
 	Dialog,
 	FormControl,
 	Dropdown,
@@ -319,7 +317,7 @@ watch(
 			Object.assign(form, formObject);
 			if (!props.selectedCell) return;
 
-			form.employee = { value: props.selectedCell.employee };
+			form.employee = props.selectedCell.employee;
 			form.start_date = props.selectedCell.date;
 			form.end_date = props.selectedCell.date;
 		}
@@ -391,12 +389,12 @@ const getShiftAssignment = (name: string) =>
 	});
 
 const employee = createResource({
-	url: "hrms.api.roster.get_employee_values",
+	url: "frappe.client.get_value",
 	makeParams() {
-		const employee = (form.employee as { value: string }).value;
 		return {
-			employee: employee,
-			fields: ["employee_name", "company", "department"],
+			doctype: "Employee",
+			fieldname: ["employee_name", "company", "department"],
+			filters: { name: form.employee },
 		};
 	},
 	onSuccess: (data: { [K in "employee_name" | "company" | "department"]: string }) => {
@@ -451,7 +449,7 @@ const insertShift = createResource({
 	url: "hrms.api.roster.insert_shift",
 	makeParams() {
 		return {
-			employee: (form.employee as { value: string }).value,
+			employee: form.employee,
 			shift_type: form.shift_type,
 			shift_location: form.shift_location,
 			company: form.company,
@@ -490,7 +488,7 @@ const createShiftAssignmentSchedule = createResource({
 	url: "hrms.api.roster.create_shift_schedule_assignment",
 	makeParams() {
 		return {
-			employee: (form.employee as { value: string }).value,
+			employee: form.employee,
 			shift_type: form.shift_type,
 			company: form.company,
 			status: form.status,


### PR DESCRIPTION
## Reason
- Improve API end point
## Changes done
- Replace roster api with frappe client api to get values

Closes: [#59914](https://support.frappe.io/helpdesk/tickets/59914?view=VIEW-HD+Ticket-1232)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Employee data retrieval now only returns permitted fields (name, company, department) and will error if no employee identifier is provided.

* **Refactor**
  * Shift assignment UI updated to request employee-specific data (employee id + allowed fields) using the revised retrieval behavior, with stricter field-level validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->