### PR TITLE
fix(expense-claim): revalidate reimbursement amount against grand total and advance

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -80,7 +80,10 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 						flt(self.total_sanctioned_amount) > 0
 						and (
 							# grand total is reimbursed
-							(flt(self.grand_total, precision) == flt(self.total_amount_reimbursed, precision))
+							(
+								flt(self.grand_total, precision) + flt(self.total_advance_amount)
+								== flt(self.total_amount_reimbursed, precision)
+							)
 							# grand total (to be paid) is 0 since linked advances already cover the claimed amount
 							or (flt(self.grand_total, precision) == 0)
 						)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -616,7 +616,6 @@ def get_outstanding_amount_for_claim(claim):
 		flt(claim.total_sanctioned_amount)
 		+ flt(claim.total_taxes_and_charges)
 		- flt(claim.total_amount_reimbursed)
-		- flt(claim.total_advance_amount)
 	)
 
 	return flt(outstanding_amt, precision)


### PR DESCRIPTION
**Issue:** Expense Claim reimbursement and outstanding amount were miscalculated when advance amounts were involved, and the status was not updated correctly when the payment was fully paid.

**Fix:** Updated the reimbursement logic to properly consider advance amounts and corrected the outstanding amount calculation, and ensured the status updates correctly when the claim is fully paid.

**Closes:** [4117](https://github.com/frappe/hrms/issues/4117)

**Before:**

[Screencast from 2026-02-19 12-36-21.webm](https://github.com/user-attachments/assets/75223e12-d04b-4145-8f33-0ae9cf8983f6)

**After:**

[Screencast from 2026-02-19 12-37-20.webm](https://github.com/user-attachments/assets/05ec00e1-e3ce-43a5-bd75-46e1bf7e5500)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Modified how expense claims are marked as paid when advances are linked to reimbursements
* Adjusted outstanding amount calculations related to advance deductions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->