### PR TITLE
fix(patch): check user type existence

### DIFF
--- a/hrms/patches/v15_0/add_leave_type_permission_for_ess.py
+++ b/hrms/patches/v15_0/add_leave_type_permission_for_ess.py
@@ -2,6 +2,10 @@ import frappe
 
 
 def execute():
+	usertype = frappe.get_all("User Type", filters={"name": "Employee Self Service"})
+	if not usertype:
+		return
+
 	doc = frappe.get_doc("User Type", "Employee Self Service")
 
 	existing = {d.document_type for d in doc.user_doctypes}


### PR DESCRIPTION
**Ref:** [60723](https://support.frappe.io/helpdesk/tickets/60723?view=VIEW-HD+Ticket-781)

**Issue:** If the user type Employee Self Service is deleted, the error will be thrown while on migration

Error Message:
Executing hrms.patches.v15_0.add_leave_type_permission_for_ess

```

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 525, in _raise_exception
    raise exc
frappe.exceptions.DoesNotExistError: User Type Employee Self Service not found
```


Backport needed for v-15, v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability by adding validation to prevent potential errors during leave type permission configuration for Employee Self Service users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->