### PR TITLE
fix: fetch holiday list of an employee based on month end date filter…

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -197,7 +197,9 @@ def get_holidays(month_start: str, month_end: str, employee_filters: dict[str, s
 	holiday_lists = {}
 
 	for employee in frappe.get_list("Employee", filters=employee_filters, pluck="name"):
-		if not (holiday_list := get_holiday_list_for_employee(employee, raise_exception=False)):
+		if not (
+			holiday_list := get_holiday_list_for_employee(employee, raise_exception=False, as_on=month_end)
+		):
 			continue
 		if holiday_list not in holiday_lists:
 			holiday_lists[holiday_list] = frappe.get_all(


### PR DESCRIPTION
**Issue Ref**: [61990](https://support.frappe.io/helpdesk/tickets/61990?view=VIEW-HD+Ticket-781)

**Issue Description**: When assigning multiple Holiday Lists with different weekend configurations to the same employee, the system incorrectly updates past roster entries based on the latest assignment.

**Before**: 
<img width="528" height="347" alt="hla-emp1" src="https://github.com/user-attachments/assets/6f06011a-0c03-4df8-9bc9-44e9ce7f8b40" />
<img width="1077" height="324" alt="before-fix-roster" src="https://github.com/user-attachments/assets/4c371907-ada1-4996-a9e8-e72ca8dc479f" />

**After**: 
<img width="1077" height="324" alt="after-fix-roster" src="https://github.com/user-attachments/assets/b1b6505c-5517-4839-934c-fad1d34b0d7b" />

backport needed in v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal adjustment to how holiday lists are resolved (uses month-end as the reference date).
  * No changes to public APIs or user-facing behavior; existing holiday collection and grouping remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->