### PR TITLE
feat: add unreimbursed expense claim support

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.json
+++ b/hrms/hr/doctype/expense_claim/expense_claim.json
@@ -501,7 +501,14 @@
    "label": "Total Exchange Gain/Loss",
    "options": "Company:company:default_currency",
    "read_only": 1
-  }
+  },
+  {
+    "fieldname": "custom_unreimbursed_amount",
+    "label": "Unreimbursed Amount",
+    "fieldtype": "Currency",
+    "read_only": 1,
+    "insert_after": "total_amount_reimbursed"
+}   
  ],
  "icon": "fa fa-money",
  "idx": 1,

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -61,10 +61,19 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		self.set_expense_account(validate=True)
 		self.set_default_accounting_dimension()
 		self.calculate_taxes()
+		# important
+		self.calculate_unreimbursed_amount()
 		self.set_status()
 		self.validate_company_and_department()
 		if self.task and not self.project:
 			self.project = frappe.db.get_value("Task", self.task, "project")
+
+	def calculate_unreimbursed_amount(self):
+	# """Calculate remaining amount that is not reimbursed yet"""
+		claimed = flt(self.grand_total or 0)
+		reimbursed = flt(self.total_amount_reimbursed or 0)
+
+		self.custom_unreimbursed_amount = claimed - reimbursed
 
 	def set_status(self, update=False):
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]
@@ -454,6 +463,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 		self.set_base_fields_amount(self, ["total_sanctioned_amount", "total_claimed_amount"])
 
+
 	def set_base_fields_amount(self, doc, fields, exchange_rate=None):
 		"""set values in base currency"""
 		for f in fields:
@@ -586,7 +596,19 @@ def update_reimbursed_amount(doc):
 	total_amount_reimbursed = get_total_reimbursed_amount(doc)
 
 	doc.total_amount_reimbursed = total_amount_reimbursed
-	frappe.db.set_value("Expense Claim", doc.name, "total_amount_reimbursed", total_amount_reimbursed)
+	# frappe.db.set_value("Expense Claim", doc.name, "total_amount_reimbursed", total_amount_reimbursed)
+	# doc.unreimbursed_amount = flt(doc.grand_total) - flt(total_amount_reimbursed)
+	unreimbursed = flt(doc.grand_total or 0) - flt(total_amount_reimbursed or 0)
+
+	frappe.db.set_value(
+		"Expense Claim",
+		doc.name,
+		{
+			"total_amount_reimbursed": total_amount_reimbursed,
+			# "unreimbursed_amount": doc.custom_unreimbursed_amount,
+			"custom_unreimbursed_amount": unreimbursed,
+		},
+	)
 
 	doc.set_status(update=True)
 


### PR DESCRIPTION
### **Introduction:**

This PR adds a calculation for the Unreimbursed Amount in the Expense Claim doctype of HRMS to clearly show the remaining amount yet to be reimbursed.

### **Description:**

- Added Unreimbursed Amount field to Expense Claim.

- Calculated as: Grand Total − Total Amount Reimbursed.

- Updated logic to auto-update the value when reimbursements are made.

- This helps users easily track the pending reimbursement amount.

**### Screenshots:**

Before:

![WhatsApp Image 2026-03-09 at 4 19 12 PM](https://github.com/user-attachments/assets/42182c87-4e36-40b6-88e5-15f2b6e02281)

After:

![WhatsApp Image 2026-03-09 at 4 20 44 PM](https://github.com/user-attachments/assets/72b6acfd-7f59-4a16-bec4-862ad1cd06c1)

