### PR TITLE
fix: restrict API for pwa to fetch current logged-in employee only

### DIFF
--- a/frontend/src/components/AttendanceCalendar.vue
+++ b/frontend/src/components/AttendanceCalendar.vue
@@ -64,7 +64,6 @@ import { computed, inject, ref, watch } from "vue"
 import { createResource } from "frappe-ui"
 
 const dayjs = inject("$dayjs")
-const employee = inject("$employee")
 const __ = inject("$translate")
 const firstOfMonth = ref(dayjs().date(1).startOf("D"))
 
@@ -125,7 +124,6 @@ const calendarEvents = createResource({
 	cache: "hrms:attendance_calendar_events",
 	makeParams() {
 		return {
-			employee: employee.data.name,
 			from_date: firstOfMonth.value.format("YYYY-MM-DD"),
 			to_date: firstOfMonth.value.endOf("M").format("YYYY-MM-DD"),
 		}

--- a/frontend/src/data/advances.js
+++ b/frontend/src/data/advances.js
@@ -1,5 +1,4 @@
 import { createResource } from "frappe-ui"
-import { employeeResource } from "./employee"
 
 const transformAdvanceData = (data) => {
 	return data.map((claim) => {
@@ -10,9 +9,6 @@ const transformAdvanceData = (data) => {
 
 export const advanceBalance = createResource({
 	url: "hrms.api.get_employee_advance_balance",
-	params: {
-		employee: employeeResource.data.name,
-	},
 	auto: true,
 	cache: "hrms:employee_advance_balance",
 	transform(data) {

--- a/frontend/src/data/claims.js
+++ b/frontend/src/data/claims.js
@@ -4,9 +4,6 @@ import { reactive } from "vue"
 
 export const expenseClaimSummary = createResource({
 	url: "hrms.api.get_expense_claim_summary",
-	params: {
-		employee: employeeResource.data.name,
-	},
 	auto: true,
 	cache: "hrms:expense_claim_summary",
 })

--- a/frontend/src/data/leaves.js
+++ b/frontend/src/data/leaves.js
@@ -53,9 +53,6 @@ export const teamLeaves = createResource({
 
 export const leaveBalance = createResource({
 	url: "hrms.api.get_leave_balance_map",
-	params: {
-		employee: employeeResource.data.name,
-	},
 	auto: true,
 	cache: "hrms:leave_balance",
 	transform: (data) => {

--- a/frontend/src/views/attendance/Dashboard.vue
+++ b/frontend/src/views/attendance/Dashboard.vue
@@ -69,18 +69,12 @@ import {
 	myShiftRequests,
 } from "@/data/attendance"
 
-const employee = inject("$employee")
 const dayjs = inject("$dayjs")
 
 const shifts = createResource({
 	url: "hrms.api.get_shifts",
 	auto: true,
 	cache: "hrms:shifts",
-	makeParams() {
-		return {
-			employee: employee.data?.name,
-		}
-	},
 	transform: (data) => {
 		return data.map((assignment) => {
 			assignment.doctype = "Shift Assignment"

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -383,6 +383,7 @@ def get_leave_balance_map() -> dict[str, dict[str, float]]:
 	}
 	"""
 	from hrms.hr.doctype.leave_application.leave_application import get_leave_details
+
 	employee = get_current_employee()
 
 	date = getdate()

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -302,7 +302,8 @@ def get_shift_request_approvers(employee: str) -> str | list[str]:
 
 
 @frappe.whitelist()
-def get_shifts(employee: str) -> list[dict[str, str]]:
+def get_shifts() -> list[dict[str, str]]:
+	employee = get_current_employee()
 	ShiftAssignment = frappe.qb.DocType("Shift Assignment")
 	ShiftType = frappe.qb.DocType("Shift Type")
 	return (
@@ -373,7 +374,7 @@ def get_leave_applications(
 
 
 @frappe.whitelist()
-def get_leave_balance_map(employee: str) -> dict[str, dict[str, float]]:
+def get_leave_balance_map() -> dict[str, dict[str, float]]:
 	"""
 	Returns a map of leave type and balance details like:
 	{
@@ -382,6 +383,7 @@ def get_leave_balance_map(employee: str) -> dict[str, dict[str, float]]:
 	}
 	"""
 	from hrms.hr.doctype.leave_application.leave_application import get_leave_details
+	employee = get_current_employee()
 
 	date = getdate()
 	leave_map = {}

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -61,7 +61,7 @@ def get_current_employee_info() -> dict:
 
 @frappe.whitelist()
 def get_all_employees() -> list[dict]:
-	return frappe.get_all(
+	return frappe.get_list(
 		"Employee",
 		fields=[
 			"name",

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -78,6 +78,13 @@ def get_all_employees() -> list[dict]:
 	)
 
 
+def get_current_employee() -> str:
+	employee = get_current_employee_info().get("name")
+	if not employee:
+		frappe.throw(_("Employee not found"), frappe.PermissionError)
+	return employee
+
+
 # HR Settings
 @frappe.whitelist()
 def get_hr_settings() -> dict:
@@ -119,7 +126,8 @@ def are_push_notifications_enabled() -> bool:
 
 # Attendance
 @frappe.whitelist()
-def get_attendance_calendar_events(employee: str, from_date: str, to_date: str) -> dict[str, str]:
+def get_attendance_calendar_events(from_date: str, to_date: str) -> dict[str, str]:
+	employee = get_current_employee()
 	holidays = get_holidays_for_calendar(employee, from_date, to_date)
 	attendance = get_attendance_for_calendar(employee, from_date, to_date)
 	events = {}
@@ -526,7 +534,9 @@ def get_expense_claims(
 
 
 @frappe.whitelist()
-def get_expense_claim_summary(employee: str) -> dict:
+def get_expense_claim_summary() -> dict:
+	employee = get_current_employee()
+
 	from frappe.query_builder.functions import Sum
 
 	Claim = frappe.qb.DocType("Expense Claim")
@@ -614,7 +624,8 @@ def get_expense_approval_details(employee: str) -> dict:
 
 # Employee Advance
 @frappe.whitelist()
-def get_employee_advance_balance(employee: str) -> list[dict]:
+def get_employee_advance_balance() -> list[dict]:
+	employee = get_current_employee()
 	Advance = frappe.qb.DocType("Employee Advance")
 
 	advances = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized employee context resolution across attendance, shifts, leave balance, expense claims, and advance features
  * API endpoints now automatically determine the current employee instead of requiring explicit parameters from frontend requests
  * Enhanced consistency and maintainability of employee-scoped data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->