### PR TITLE
fix: correct overtime hourly rate calculation using total working days

### DIFF
--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -19,31 +19,6 @@ from hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignmen
 
 
 class OvertimeSlip(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		from hrms.hr.doctype.overtime_details.overtime_details import OvertimeDetails
-
-		amended_from: DF.Link | None
-		company: DF.Link
-		department: DF.Link | None
-		employee: DF.Link
-		employee_name: DF.Data | None
-		end_date: DF.Date
-		overtime_details: DF.Table[OvertimeDetails]
-		payroll_entry: DF.Link | None
-		posting_date: DF.Date
-		salary_slip: DF.Link | None
-		start_date: DF.Date
-		submitted_via_payroll_entry: DF.Check
-		total_overtime_duration: DF.Float
-	# end: auto-generated types
-
 	def validate(self):
 		if not (self.start_date or self.end_date):
 			self.get_frequency_and_dates()
@@ -331,8 +306,18 @@ class OvertimeSlip(Document):
 			for data in self._cached_salary_slip.earnings
 			if data.salary_component in components and not data.get("additional_salary", None)
 		)
-		payment_days = max(self._cached_salary_slip.payment_days, 1)
-		applicable_daily_amount = component_amount / payment_days
+		# payment_days = max(self._cached_salary_slip.payment_days, 1)
+		# applicable_daily_amount = component_amount / payment_days
+
+
+		# Modified OT hourly rate calculation
+		# Earlier calculation was based on payment_days which may default to 30 in payroll.
+		# Updated logic uses total_working_days to ensure overtime is calculated based on actual working days.
+		# Fallback kept as 30 if working days are not available.
+		# Change implemented by Krishna Kachhad – Anansi Techsol LLP
+		
+		total_working_days = self._cached_salary_slip.total_working_days or 30
+		applicable_daily_amount = component_amount / total_working_days
 
 		return applicable_daily_amount / standard_working_hours
 
@@ -417,6 +402,7 @@ class OvertimeSlip(Document):
 		return details
 
 
+@frappe.whitelist()
 def filter_employees_for_overtime_slip_creation(start_date, end_date, employees, limit=None):
 	if not employees:
 		return []


### PR DESCRIPTION
Title: Overtime calculation using `payment_days` inflates hourly rate when employee has absences

## Description

Overtime calculation using the **"Salary Component Based"** method currently derives the hourly rate using **`payment_days`** from a generated salary slip.

This causes incorrect overtime payments when an employee has absences.

Specifically, when `payment_days` decrease due to absences or leave without pay, the calculated **hourly overtime rate increases**, resulting in inflated overtime pay.

---

## Current Implementation

In `Overtime Slip`:

File:

```
hrms/payroll/doctype/overtime_slip/overtime_slip.py
```

Function:

```
_calculate_component_based_hourly_rate()
```

Current logic:

```python
payment_days = max(self._cached_salary_slip.payment_days, 1)
applicable_daily_amount = component_amount / payment_days

return applicable_daily_amount / standard_working_hours
```

Which results in the formula:

```
Hourly Rate =
(Salary Component Total / Payment Days) / Standard Working Hours
```

---

## Why This Is Incorrect

If an employee has absences, `payment_days` decreases, which artificially **increases the hourly overtime rate**.

Example:

Salary Component: **Basic = 30,000**

Month = 30 days
Standard working hours = 8

### Case 1 — No Absence

```
payment_days = 30

Daily = 30000 / 30 = 1000
Hourly = 1000 / 8 = 125
```

Correct overtime rate = **125/hr**

---

### Case 2 — 10 Absence Days

```
payment_days = 20

Daily = 30000 / 20 = 1500
Hourly = 1500 / 8 = 187.5
```

Now overtime rate becomes **187.5/hr**, which is **incorrect**.

Overtime should not increase due to absence.

---

## Expected Behavior

Overtime hourly rate should be based on the **contractual salary structure**, not on reduced `payment_days`.

Industry-standard formula:

```
Hourly Rate =
Salary Component Amount
/
(Total Working Days × Standard Working Hours)
```

Example:

```
30000 / 30 = 1000
1000 / 8 = 125
```

This rate remains stable regardless of absences.

---

## Suggested Fix

Replace the current calculation:

```python
payment_days = max(self._cached_salary_slip.payment_days, 1)
applicable_daily_amount = component_amount / payment_days
```

With something like:

```python
total_working_days = self._cached_salary_slip.total_working_days or 30
applicable_daily_amount = component_amount / total_working_days
```

or ideally:

```
Hourly Rate =
component_amount / (total_working_days × standard_working_hours)
```

---

## Impact

This issue affects payroll accuracy when:

* Employees have **Leave Without Pay**
* Employees are **absent**
* Payroll uses **salary component based overtime calculation**

Result: **Overtime payment becomes higher when employee works fewer days**, which is logically incorrect.

---

## Environment

HRMS Version: (FrappeHR 16)
ERPNext Version: (FrappeHR 16)

---

## Additional Note

This change would align overtime calculations with typical payroll practices where overtime is calculated based on **contractual salary**, not adjusted salary after absences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to filter employees eligible for overtime slip creation based on date range and attendance criteria.

* **Bug Fixes**
  * Updated overtime slip daily amount calculation to use total working days instead of payment days for more accurate hourly rate computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->