### PR TITLE
chore: add docs to project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ section-order = [
 [project.urls]
 Homepage = "https://frappe.io/hr"
 Repository = "https://github.com/frappe/hrms.git"
+Documentation = "https://docs.frappe.io/hr"
 "Bug Reports" = "https://github.com/frappe/hrms/issues"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Documentation URL to the project metadata, linking the project to the online documentation (https://docs.frappe.io/hr) to make docs more discoverable and accessible from package information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->