### PR TITLE
fix: use background job to bulk mark attendance for more than 10 records

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -424,8 +424,8 @@ def process_bulk_attendance_in_batches(data, chunk_size=20):
 				if not frappe.flags.in_test:
 					frappe.db.rollback(save_point=savepoint)
 				continue
-	if not frappe.flags.in_test:
-		frappe.db.commit()  # nosemgrep
+		if not frappe.flags.in_test:
+			frappe.db.commit()  # nosemgrep
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -11,6 +11,7 @@ from frappe.query_builder.terms import ValueWrapper
 from frappe.utils import (
 	add_days,
 	cint,
+	create_batch,
 	cstr,
 	format_date,
 	get_datetime,
@@ -18,6 +19,7 @@ from frappe.utils import (
 	getdate,
 	nowdate,
 )
+from frappe.utils.background_jobs import get_job
 
 import hrms
 from hrms.hr.doctype.shift_assignment.shift_assignment import has_overlapping_timings
@@ -383,18 +385,47 @@ def mark_bulk_attendance(data: str | dict):
 	if not data.unmarked_days:
 		frappe.throw(_("Please select a date."))
 		return
+	if len(data.unmarked_days) > 10 or frappe.flags.test_bg_job:
+		job_id = f"process_bulk_attendance_for_employee_{data.employee}"
+		job = frappe.enqueue(
+			process_bulk_attendance_in_batches, data=data, job_id=job_id, timeout=600, deduplicate=True
+		)
+		if job:
+			message = _(
+				"Bulk attendance marking is queued with a background job. It may take a while. You can monitor the job status {0}"
+			).format(get_link_to_form("RQ Job", job.id, label="here"))
+		else:
+			message = _(
+				"Bulk attendance marking is already in progress for employee {0}. You can monitor the job status {1}"
+			).format(frappe.bold(data.employee), get_link_to_form("RQ Job", get_job(job_id).id, label="here"))
+		frappe.msgprint(message, allow_dangerous_html=True)
+	else:
+		process_bulk_attendance_in_batches(data)
+		frappe.msgprint(_("Attendance marked successfully."), alert=True)
 
-	for attendance_date in data.unmarked_days:
-		doc_dict = {
-			"doctype": "Attendance",
-			"employee": data.employee,
-			"attendance_date": get_datetime(attendance_date),
-			"status": data.status,
-			"half_day_status": "Absent" if data.status == "Half Day" else None,
-			"shift": data.shift,
-		}
-		attendance = frappe.get_doc(doc_dict).insert()
-		attendance.submit()
+
+def process_bulk_attendance_in_batches(data, chunk_size=20):
+	savepoint = "mark_bulk_attendance"
+	for days in create_batch(data.unmarked_days, chunk_size):
+		for attendance_date in days:
+			try:
+				frappe.db.savepoint(savepoint)
+				doc_dict = {
+					"doctype": "Attendance",
+					"employee": data.employee,
+					"attendance_date": getdate(attendance_date),
+					"status": data.status,
+					"half_day_status": "Absent" if data.status == "Half Day" else None,
+					"shift": data.shift,
+				}
+				attendance = frappe.get_doc(doc_dict).insert()
+				attendance.submit()
+			except (DuplicateAttendanceError, OverlappingShiftAttendanceError, Exception):
+				if not frappe.flags.in_test:
+					frappe.db.rollback(save_point=savepoint)
+				continue
+	if not frappe.flags.in_test:
+		frappe.db.commit()  # nosemgrep
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -10,7 +10,6 @@ frappe.listview_settings["Attendance"] = {
 			return [__(doc.status), "orange", "status,=," + doc.status];
 		}
 	},
-
 	onload: function (list_view) {
 		let me = this;
 		if (frappe.perm.has_perm("Attendance", 0, "create")) {
@@ -115,15 +114,6 @@ frappe.listview_settings["Attendance"] = {
 										method: "hrms.hr.doctype.attendance.attendance.mark_bulk_attendance",
 										args: {
 											data: data,
-										},
-										callback: function (r) {
-											if (r.message === 1) {
-												frappe.show_alert({
-													message: __("Attendance Marked"),
-													indicator: "blue",
-												});
-												cur_dialog.hide();
-											}
 										},
 									});
 								},

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -15,6 +15,7 @@ from frappe.utils import (
 	getdate,
 	nowdate,
 )
+from frappe.utils.user import add_role
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
@@ -24,6 +25,7 @@ from hrms.hr.doctype.attendance.attendance import (
 	get_events,
 	get_unmarked_days,
 	mark_attendance,
+	mark_bulk_attendance,
 )
 from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
 	assign_holiday_list,
@@ -293,3 +295,36 @@ class TestAttendance(HRMSTestSuite):
 			frappe.db.get_value("Employee", employee.name, "employee_name"),
 		)
 		self.assertEqual(attendance_events[0].get("attendance_date"), getdate())
+
+	def test_bulk_attendance_marking_through_bg(self):
+		user1 = "test_bg1@example.com"
+		user2 = "test_bg2@example.com"
+		employee1 = make_employee("test_bg1@example.com", company="_Test Company")
+		employee2 = make_employee("test_bg2@example.com", company="_Test Company")
+		add_role(user1, "HR Manager")
+		add_role(user2, "HR Manager")
+		frappe.flags.test_bg_job = True
+		frappe.set_user(user1)
+		data1 = frappe._dict(unmarked_days=[getdate()], employee=employee1, status="Present", shift="")
+		data2 = frappe._dict(unmarked_days=[getdate()], employee=employee2, status="Present", shift="")
+		mark_bulk_attendance(data1)
+		self.assertStartsWith(
+			frappe.message_log[-1].message, "Bulk attendance marking is queued with a background job."
+		)
+		frappe.set_user(user2)
+		mark_bulk_attendance(data1)
+		self.assertStartsWith(
+			frappe.message_log[-1].message, "Bulk attendance marking is already in progress for employee"
+		)
+		mark_bulk_attendance(data2)
+		self.assertStartsWith(
+			frappe.message_log[-1].message, "Bulk attendance marking is queued with a background job."
+		)
+		frappe.flags.test_bg_job = False
+		mark_bulk_attendance(data2)
+		frappe.set_user("Administrator")
+		attendance_records = frappe.get_all("Attendance", {"employee": employee2})
+		self.assertEqual(len(attendance_records), 1)
+
+	def tearDown(self):
+		frappe.db.rollback()


### PR DESCRIPTION
Bulk mark attendance tool doesn't impose any limit on the number of dates a user can select to mark attendance. But it also tries to save all those records in a single request.

https://github.com/user-attachments/assets/32b2d3e2-00a0-48e1-bd2e-850a953b1478

While this use is extreme, what is more common is user customisation causing saving of records to slow down and multiple users trying to mark attendance simultaneously which makes them run into deadlocks and timeouts.

Now less than 10 records are processed inside the http request, any more than, that are handed over to a background job that keeps committing in batches. 

https://github.com/user-attachments/assets/899f648c-bdc0-440a-a96d-85514d1864f6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Bulk attendance marking now processes asynchronously in the background when marking 10 or more days, providing faster user response.
  * Improved error resilience: bulk operations continue processing even when encountering duplicate or overlapping shift attendance records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->