### PR TITLE
fix(expense_claim): reimbursed amount calculation for payment entry

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -643,7 +643,11 @@ def get_total_reimbursed_amount(doc):
 
 		amount_via_payment_entry = frappe.db.get_value(
 			"Payment Entry Reference",
-			{"reference_name": doc.name, "docstatus": 1},
+			{
+				"reference_name": doc.name,
+				"advance_voucher_type": None,
+				"docstatus": 1,
+			},
 			[{"SUM": "allocated_amount"}],
 		)
 


### PR DESCRIPTION
## Problem
- While doing payment entry for amount exceeding already paid advance, the calculated paid amount doesn't match with the remaining amount
- As advance payment entry is also linked to expense claim (from v16 onwards), the payment entry of advance was considered in calculating reimbursed amount.

### Fix
- Added a filter in fetching allocated amount for total reimbursed amount

closes: https://github.com/frappe/hrms/issues/4117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reimbursed totals for expense claims now exclude payment amounts tied to advance vouchers. Displayed reimbursed amounts on claim summaries and reports are more accurate for affected claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->