### PR TITLE
fix(salary_slip): update round() for remaining sub period

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1018,7 +1018,7 @@ class SalarySlip(TransactionBase):
 		# get taxable_earnings for current period (all days)
 		self.current_taxable_earnings = self.get_taxable_earnings(self.tax_slab.allow_tax_exemption)
 		self.future_structured_taxable_earnings = self.current_taxable_earnings.taxable_earnings * (
-			ceil(self.remaining_sub_periods) - 1
+			round(self.remaining_sub_periods) - 1
 		)
 
 		current_taxable_earnings_before_exemption = (
@@ -1026,7 +1026,7 @@ class SalarySlip(TransactionBase):
 			+ self.current_taxable_earnings.amount_exempted_from_income_tax
 		)
 		self.future_structured_taxable_earnings_before_exemption = (
-			current_taxable_earnings_before_exemption * (ceil(self.remaining_sub_periods) - 1)
+			current_taxable_earnings_before_exemption * (round(self.remaining_sub_periods) - 1)
 		)
 
 		# get taxable_earnings, addition_earnings for current actual payment days


### PR DESCRIPTION
**Ref:** [62117](https://support.frappe.io/helpdesk/tickets/62117?view=VIEW-HD+Ticket-781)

**Issue:** When running payroll with fortnightly frequency for payroll period 2025-26, the future_structured_taxable_earnings and future_structured_taxable_earnings_before_exemption are incorrectly calculated.
The system calculates remaining_sub_periods as 365 / 14 = 26.07. Using ceil(26.07) converts this to 27, resulting in 27 - 1 = 26 future periods being projected instead of the correct 25. This inflates the CTC and annual taxable amount, causing incorrect income tax deduction.

**Before:**

[Screencast from 2026-03-19 11-11-41.webm](https://github.com/user-attachments/assets/f63994bb-c326-4507-9b85-ade58a52c498)


**After:**

[Screencast from 2026-03-19 11-10-30.webm](https://github.com/user-attachments/assets/42182fc4-760c-43d7-8841-8429729fc485)


Backport needed for v-15, v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in salary slip calculations by refining how fractional sub-periods are handled when projecting future taxable earnings. This yields more consistent, precise payroll projections and tax-related values on generated salary slips. No other user-visible behaviors or error handling were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->