### PR TITLE
fix: remove ess user type limit from site_config

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -35,8 +35,10 @@ hrms.patches.v15_0.update_advance_payment_ledger_amount #2025-09-23
 hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim
 hrms.patches.v15_0.add_leave_type_permission_for_ess
+hrms.patches.v15_0.remove_ess_user_type_limit
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
 hrms.patches.v16_0.delete_old_workspaces #2026-01-09
 hrms.patches.v16_0.create_holiday_list_assignments
 hrms.patches.v16_0.set_base_paid_amount_in_employee_advance
 hrms.patches.v16_0.set_currency_and_base_fields_in_expense_claim
+hrms.patches.v16_0.remove_ess_user_type_limit

--- a/hrms/patches/v15_0/add_loan_docperms_to_ess.py
+++ b/hrms/patches/v15_0/add_loan_docperms_to_ess.py
@@ -1,9 +1,8 @@
 import frappe
 
-from hrms.setup import add_lending_docperms_to_ess, update_user_type_doctype_limit
+from hrms.setup import add_lending_docperms_to_ess
 
 
 def execute():
 	if "lending" in frappe.get_installed_apps():
-		update_user_type_doctype_limit()
 		add_lending_docperms_to_ess()

--- a/hrms/patches/v15_0/remove_ess_user_type_limit.py
+++ b/hrms/patches/v15_0/remove_ess_user_type_limit.py
@@ -3,7 +3,8 @@ from frappe.installer import update_site_config
 
 
 def execute():
-	old_user_type_limits = get_site_config().get("user_type_doctype_limit")
-	new_user_type_limits = dict(old_user_type_limits)
-	new_user_type_limits.pop("employee_self_service", None)
-	update_site_config("user_type_doctype_limit", new_user_type_limits)
+	old_user_type_limits = get_site_config().get("user_type_doctype_limit", None)
+	if old_user_type_limits:
+		new_user_type_limits = dict(old_user_type_limits)
+		new_user_type_limits.pop("employee_self_service", None)
+		update_site_config("user_type_doctype_limit", new_user_type_limits)

--- a/hrms/patches/v15_0/remove_ess_user_type_limit.py
+++ b/hrms/patches/v15_0/remove_ess_user_type_limit.py
@@ -1,0 +1,9 @@
+from frappe import get_site_config
+from frappe.installer import update_site_config
+
+
+def execute():
+	old_user_type_limits = get_site_config().get("user_type_doctype_limit")
+	new_user_type_limits = dict(old_user_type_limits)
+	new_user_type_limits.pop("employee_self_service", None)
+	update_site_config("user_type_doctype_limit", new_user_type_limits)

--- a/hrms/patches/v16_0/remove_ess_user_type_limit.py
+++ b/hrms/patches/v16_0/remove_ess_user_type_limit.py
@@ -3,7 +3,8 @@ from frappe.installer import update_site_config
 
 
 def execute():
-	old_user_type_limits = get_site_config().get("user_type_doctype_limit")
-	new_user_type_limits = dict(old_user_type_limits)
-	new_user_type_limits.pop("employee_self_service", None)
-	update_site_config("user_type_doctype_limit", new_user_type_limits)
+	old_user_type_limits = get_site_config().get("user_type_doctype_limit", None)
+	if old_user_type_limits:
+		new_user_type_limits = dict(old_user_type_limits)
+		new_user_type_limits.pop("employee_self_service", None)
+		update_site_config("user_type_doctype_limit", new_user_type_limits)

--- a/hrms/patches/v16_0/remove_ess_user_type_limit.py
+++ b/hrms/patches/v16_0/remove_ess_user_type_limit.py
@@ -1,0 +1,9 @@
+from frappe import get_site_config
+from frappe.installer import update_site_config
+
+
+def execute():
+	old_user_type_limits = get_site_config().get("user_type_doctype_limit")
+	new_user_type_limits = dict(old_user_type_limits)
+	new_user_type_limits.pop("employee_self_service", None)
+	update_site_config("user_type_doctype_limit", new_user_type_limits)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -6,7 +6,6 @@ from frappe.desk.page.setup_wizard.install_fixtures import (
 	_,  # NOTE: this is not the real translation function
 )
 from frappe.desk.page.setup_wizard.setup_wizard import make_records
-from frappe.installer import update_site_config
 
 from hrms.overrides.company import delete_company_fixtures
 
@@ -609,22 +608,10 @@ def remove_lending_docperms_from_ess():
 # ESS USER TYPE SETUP & CLEANUP
 def add_non_standard_user_types():
 	user_types = get_user_types_data()
-	update_user_type_doctype_limit(user_types)
 
 	for user_type, data in user_types.items():
 		create_custom_role(data)
 		create_user_type(user_type, data)
-
-
-def update_user_type_doctype_limit(user_types=None):
-	if not user_types:
-		user_types = get_user_types_data()
-
-	user_type_limit = {}
-	for user_type, __ in user_types.items():
-		user_type_limit.setdefault(frappe.scrub(user_type), 40)
-
-	update_site_config("user_type_doctype_limit", user_type_limit)
 
 
 def get_user_types_data():


### PR DESCRIPTION
Remnant of a long-deprecated restriction, not required anymore. Also, the patch is written to preserve custom user-type limits, if any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added upgrade patches to remove Employee Self Service user-type limits during upgrades for v15.0 and v16.0; patch list updated and file end-of-file newline fixed.

* **Chores**
  * Simplified setup by removing legacy user-type limit persistence.
  * Made lending-related patch conditional so it only runs when the lending feature is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->