### PR TITLE
fix: use supported wkhtmltox packages for Linux setup

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -33,6 +33,23 @@ mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON 
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
 
 install_whktml() {
+    local arch os_like wkhtml_package
+
+    arch="$(dpkg --print-architecture)"
+    os_like="$(. /etc/os-release && printf '%s %s' "$ID" "$ID_LIKE")"
+
+    if echo "$os_like" | grep -Eq '(^| )ubuntu( |$)'; then
+        wkhtml_package="wkhtmltox_0.12.6.1-3.jammy_${arch}.deb"
+    elif echo "$os_like" | grep -Eq '(^| )debian( |$)'; then
+        wkhtml_package="wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb"
+    fi
+
+    if [ -n "$wkhtml_package" ]; then
+        wget -O "/tmp/${wkhtml_package}" "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/${wkhtml_package}"
+        sudo apt install -y xvfb xfonts-75dpi xfonts-base "/tmp/${wkhtml_package}"
+        return
+    fi
+
     wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
     tar -xf /tmp/wkhtmltox.tar.xz -C /tmp
     sudo mv /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -44,9 +44,9 @@ install_whktml() {
         wkhtml_package="wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb"
     fi
 
-    if [ -n "$wkhtml_package" ]; then
-        wget -O "/tmp/${wkhtml_package}" "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/${wkhtml_package}"
-        sudo apt install -y xvfb xfonts-75dpi xfonts-base "/tmp/${wkhtml_package}"
+    if [ -n "$wkhtml_package" ] \
+       && wget -O "/tmp/${wkhtml_package}" "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/${wkhtml_package}" \
+       && sudo apt install -y xvfb xfonts-75dpi xfonts-base "/tmp/${wkhtml_package}"; then
         return
     fi
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ Use the following credentials to log in:
 
 ### Local
 
-1. Set up bench by following the [Installation Steps](https://frappeframework.com/docs/user/en/installation) and start the server and keep it running
+1. Set up bench by following the [Installation Steps](https://docs.frappe.io/framework/user/en/installation) and start the server and keep it running
 	```sh
 	$ bench start
 	```
+	For Debian and Ubuntu derivatives, install the distro-specific `wkhtmltox` package from the official [wkhtmltopdf packaging releases](https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3) (`bookworm` for Debian/Parrot, `jammy` for Ubuntu) instead of using the placeholder `wkhtmltox_file.deb` command from the generic downloads page.
 2. In a separate terminal window, run the following commands
 	```sh
 	$ bench new-site hrms.localhost

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Use the following credentials to log in:
 
 1. Set up bench by following the [Installation Steps](https://docs.frappe.io/framework/user/en/installation) and start the server and keep it running
 	```sh
-	$ bench start
+	bench start
 	```
 	For Debian and Ubuntu derivatives, install the distro-specific `wkhtmltox` package from the official [wkhtmltopdf packaging releases](https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3) (`bookworm` for Debian/Parrot, `jammy` for Ubuntu) instead of using the placeholder `wkhtmltox_file.deb` command from the generic downloads page.
 2. In a separate terminal window, run the following commands


### PR DESCRIPTION
closes #4197

## Summary
- switch the Linux helper to the official wkhtmltopdf packaging releases for Debian and Ubuntu derivatives
- use the maintained `bookworm` and `jammy` packages that depend on `libssl3`
- update the local setup note in the README to point contributors to the current installation doc and the distro-specific wkhtmltox packages

## Why
The current installation path around `wkhtmltox_file.deb` is misleading for modern Debian and Ubuntu derivatives. The maintained packaging release assets provide the correct filename pattern and avoid the legacy `libssl1.1` dependency that blocks manual installs on newer systems.

## Validation
- checked the referenced `jammy` and `bookworm` assets exist in `wkhtmltopdf/packaging` release `0.12.6.1-3`
- inspected both `.deb` control files to confirm they depend on `libssl3` and not `libssl1.1`
- ran `bash -n .github/helper/install.sh` with Git Bash
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified installation for Debian and Ubuntu systems with automatic selection of compatible wkhtmltox packages.

* **Documentation**
  * Updated framework documentation links.
  * Added platform-specific installation guidance for Debian and Ubuntu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->