### PR TITLE
fix: Organization chart rendering issues

### DIFF
--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -426,6 +426,13 @@ hrms.HierarchyChart = class {
 		node.$children.show();
 		$(`path[data-parent="${node.id}"]`).show();
 		node.expanded = true;
+
+		// Push this parent away from the next sibling parent so their
+		// connector lines occupy distinct vertical bands.
+		if (child_nodes && child_nodes.length > 1) {
+			const extra = (child_nodes.length - 1) * 88;
+			node.$link.closest(".child-node").css("margin-bottom", extra + "px");
+		}
 	}
 
 	add_node(node, data) {

--- a/hrms/public/scss/hierarchy_chart.scss
+++ b/hrms/public/scss/hierarchy_chart.scss
@@ -2,7 +2,7 @@
 	background: white;
 	border-radius: 0.5rem;
 	padding: 0.75rem;
-	margin-left: 3rem;
+	margin-left: 5rem;
 	width: 18rem;
 	overflow: hidden;
 
@@ -192,6 +192,11 @@
 
 .hierarchy {
 	display: flex;
+
+	&::after {
+		content: "";
+		min-width: 80px;
+	}
 }
 
 .hierarchy li {
@@ -201,6 +206,7 @@
 .child-node {
 	margin: 0px 0px 16px 0px;
 }
+
 
 .hierarchy,
 .hierarchy-mobile {

--- a/hrms/public/scss/hierarchy_chart.scss
+++ b/hrms/public/scss/hierarchy_chart.scss
@@ -207,7 +207,6 @@
 	margin: 0px 0px 16px 0px;
 }
 
-
 .hierarchy,
 .hierarchy-mobile {
 	.level {


### PR DESCRIPTION
<details>

<summary>No gap/padding on the right side of the chart </summary>
Before:
<img width="2228" height="1498" alt="image" src="https://github.com/user-attachments/assets/43ef5c8c-aad1-4c8a-9a60-4dd7019f3910" />

After:
<img width="1718" height="1532" alt="image" src="https://github.com/user-attachments/assets/9daa4647-1cd1-4ed7-9f5d-8ddff7e05b9c" />

</details>

<details>

<summary> Child Node arrows getting mixed up </summary>

Updated placement of parent nodes to fix this

Before:
<img width="1434" height="974" alt="image" src="https://github.com/user-attachments/assets/75a75a02-9ad8-4604-9d60-d329005f3e12" />

After:
<img width="2194" height="1438" alt="image" src="https://github.com/user-attachments/assets/abd4f5f0-e422-4232-8199-3c929e446506" />

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined hierarchy chart layout with optimized spacing and alignment when expanding nodes with multiple children.
  * Enhanced horizontal positioning of node cards for improved visual clarity throughout the chart.
  * Improved vertical spacing in the hierarchy display, with dynamic adjustments based on the number of child items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->