### PR TITLE
fix(UX): Leave Type Master

### DIFF
--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -9,22 +9,20 @@
  "engine": "InnoDB",
  "field_order": [
   "leave_type_name",
-  "max_leaves_allowed",
-  "applicable_after",
-  "max_continuous_days_allowed",
-  "column_break_3",
-  "is_carry_forward",
+  "is_compensatory",
   "is_lwp",
   "is_ppl",
   "fraction_of_daily_salary_per_leave",
-  "is_optional_leave",
+  "column_break_3",
   "allow_negative",
   "allow_over_allocation",
   "include_holiday",
-  "is_compensatory",
+  "is_optional_leave",
   "carry_forward_section",
+  "is_carry_forward",
   "maximum_carry_forwarded_leaves",
   "expire_carry_forwarded_leaves_after_days",
+  "column_break_lfjz",
   "encashment",
   "allow_encashment",
   "max_encashable_leaves",
@@ -36,7 +34,13 @@
   "earned_leave_frequency",
   "column_break_22",
   "allocate_on_day",
-  "rounding"
+  "rounding",
+  "limits_tab",
+  "max_leaves_allowed",
+  "max_continuous_days_allowed",
+  "column_break_bsas",
+  "applicable_after",
+  "connections_tab"
  ],
  "fields": [
   {
@@ -77,7 +81,7 @@
    "fieldname": "is_carry_forward",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Is Carry Forward",
+   "label": "Carry Forward",
    "oldfieldname": "is_carry_forward",
    "oldfieldtype": "Check"
   },
@@ -93,7 +97,7 @@
    "description": "These leaves are holidays permitted by the company however, availing it is optional for an Employee.",
    "fieldname": "is_optional_leave",
    "fieldtype": "Check",
-   "label": "Is Optional Leave"
+   "label": "Leave for optional holiday"
   },
   {
    "default": "0",
@@ -114,13 +118,7 @@
    "label": "Is Compensatory"
   },
   {
-   "collapsible": 1,
-   "depends_on": "eval: doc.is_carry_forward == 1",
-   "fieldname": "carry_forward_section",
-   "fieldtype": "Section Break",
-   "label": "Carry Forward"
-  },
-  {
+   "depends_on": "is_carry_forward",
    "description": "Calculated in days",
    "fieldname": "expire_carry_forwarded_leaves_after_days",
    "fieldtype": "Int",
@@ -230,12 +228,38 @@
    "fieldtype": "Int",
    "label": "Non-Encashable Leaves",
    "non_negative": 1
+  },
+  {
+   "fieldname": "limits_tab",
+   "fieldtype": "Tab Break",
+   "label": "Limits"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "is_carry_forward",
+   "fieldname": "carry_forward_section",
+   "fieldtype": "Section Break",
+   "label": "Carry Forward"
+  },
+  {
+   "fieldname": "column_break_lfjz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
+  },
+  {
+   "fieldname": "column_break_bsas",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2024-12-18 19:51:44.162375",
+ "modified": "2026-02-06 18:26:27.583525",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",
@@ -269,6 +293,7 @@
    "role": "Employee"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
### Before
<img width="1305" height="987" alt="image" src="https://github.com/user-attachments/assets/b9544a1a-4273-4285-a3c2-3e6c5e0acdce" />

### After
<img width="2470" height="1580" alt="Screenshot From 2026-03-30 12-59-35" src="https://github.com/user-attachments/assets/c4a621fe-e912-4220-b050-84a19681d04a" />
<img width="2470" height="1580" alt="Screenshot From 2026-03-30 12-59-09" src="https://github.com/user-attachments/assets/2ce3a631-d1ea-4581-a22d-c3ba9f04db83" />

- Moved limit type fields into a separate limits tab
- Moved connections dashboard to a separate tab
- Fieldname remains same for fields with a lable change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized leave type management interface with improved field grouping and layout structure
  * Updated field labels for enhanced clarity ("Carry Forward" and "Leave for optional holiday")
  * Simplified carry-forward settings display and dependency logic
  * Enhanced form organization with better section grouping and UI breaks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->