### PR TITLE
fix: Ignore user permissions for approver field in employee doctype

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -36,6 +36,7 @@ hrms.patches.v15_0.call_set_total_advance_paid_on_advance_documents #2025-09-23
 hrms.patches.v15_0.rename_claim_date_to_payroll_date_in_employee_benefit_claim
 hrms.patches.v15_0.add_leave_type_permission_for_ess
 hrms.patches.v15_0.remove_ess_user_type_limit
+hrms.patches.v15_0.update_approver_custom_fields
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
 hrms.patches.v16_0.delete_old_workspaces #2026-01-09
 hrms.patches.v16_0.create_holiday_list_assignments

--- a/hrms/patches/v15_0/update_approver_custom_fields.py
+++ b/hrms/patches/v15_0/update_approver_custom_fields.py
@@ -1,0 +1,35 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe import _
+
+def execute():
+	approver_fields = {
+		"Employee": [
+				{
+					"fieldname": "expense_approver",
+					"fieldtype": "Link",
+					"label": _("Expense Approver"),
+					"options": "User",
+					"insert_after": "approvers_section",
+					"ignore_user_permissions": 1,
+				},
+				{
+					"fieldname": "leave_approver",
+					"fieldtype": "Link",
+					"label": _("Leave Approver"),
+					"options": "User",
+					"insert_after": "expense_approver",
+					"ignore_user_permissions": 1,
+				},
+				{
+					"fieldname": "shift_request_approver",
+					"fieldtype": "Link",
+					"label": _("Shift Request Approver"),
+					"options": "User",
+					"insert_after": "column_break_45",
+					"ignore_user_permissions": 1,
+				}
+		]
+	}
+
+	create_custom_fields(approver_fields, ignore_validate=True)
+

--- a/hrms/patches/v15_0/update_approver_custom_fields.py
+++ b/hrms/patches/v15_0/update_approver_custom_fields.py
@@ -1,35 +1,35 @@
-from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe import _
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
 
 def execute():
 	approver_fields = {
 		"Employee": [
-				{
-					"fieldname": "expense_approver",
-					"fieldtype": "Link",
-					"label": _("Expense Approver"),
-					"options": "User",
-					"insert_after": "approvers_section",
-					"ignore_user_permissions": 1,
-				},
-				{
-					"fieldname": "leave_approver",
-					"fieldtype": "Link",
-					"label": _("Leave Approver"),
-					"options": "User",
-					"insert_after": "expense_approver",
-					"ignore_user_permissions": 1,
-				},
-				{
-					"fieldname": "shift_request_approver",
-					"fieldtype": "Link",
-					"label": _("Shift Request Approver"),
-					"options": "User",
-					"insert_after": "column_break_45",
-					"ignore_user_permissions": 1,
-				}
+			{
+				"fieldname": "expense_approver",
+				"fieldtype": "Link",
+				"label": _("Expense Approver"),
+				"options": "User",
+				"insert_after": "approvers_section",
+				"ignore_user_permissions": 1,
+			},
+			{
+				"fieldname": "leave_approver",
+				"fieldtype": "Link",
+				"label": _("Leave Approver"),
+				"options": "User",
+				"insert_after": "expense_approver",
+				"ignore_user_permissions": 1,
+			},
+			{
+				"fieldname": "shift_request_approver",
+				"fieldtype": "Link",
+				"label": _("Shift Request Approver"),
+				"options": "User",
+				"insert_after": "column_break_45",
+				"ignore_user_permissions": 1,
+			},
 		]
 	}
 
 	create_custom_fields(approver_fields, ignore_validate=True)
-

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -241,6 +241,7 @@ def get_custom_fields():
 				"label": _("Expense Approver"),
 				"options": "User",
 				"insert_after": "approvers_section",
+				"ignore_user_permissions": 1,
 			},
 			{
 				"fieldname": "leave_approver",
@@ -248,6 +249,7 @@ def get_custom_fields():
 				"label": _("Leave Approver"),
 				"options": "User",
 				"insert_after": "expense_approver",
+				"ignore_user_permissions": 1,
 			},
 			{
 				"fieldname": "column_break_45",
@@ -260,6 +262,7 @@ def get_custom_fields():
 				"label": _("Shift Request Approver"),
 				"options": "User",
 				"insert_after": "column_break_45",
+				"ignore_user_permissions": 1,
 			},
 			{
 				"fieldname": "employee_advance_account",


### PR DESCRIPTION
User is unable to see their own employee record and details if user permission is applied on the User Doctype, as the Employee Doctype has different users as approvers.

Ignoring user permission on these fields solves the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three approver fields on Employee records: expense approver, leave approver, and shift request approver to streamline approvals.
* **Chores**
  * Ensured the new patch is registered to run during post-model synchronization.
  * Updated pre-commit configuration to run hooks at the pre-commit stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->