### PR TITLE
fix: Overlapping attendance request for different shift types

### DIFF
--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -71,7 +71,7 @@ class AttendanceRequest(Document):
 			self.name = "New Attendance Request"
 
 		Request = frappe.qb.DocType("Attendance Request")
-		overlapping_request = (
+		query = (
 			frappe.qb.from_(Request)
 			.select(Request.name)
 			.where(
@@ -81,7 +81,12 @@ class AttendanceRequest(Document):
 				& (self.to_date >= Request.from_date)
 				& (self.from_date <= Request.to_date)
 			)
-		).run(as_dict=True)
+		)
+
+		if self.shift_type:
+			query = query.where(Request.shift_type == self.shift_type)
+
+		overlapping_request = query.run()
 
 		if overlapping_request:
 			self.throw_overlap_error(overlapping_request[0].name)

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -44,6 +44,7 @@ class AttendanceRequest(Document):
 	def validate(self):
 		validate_active_employee(self.employee)
 		validate_dates(self, self.from_date, self.to_date, False)
+		self.validate_shifts()
 		self.validate_half_day()
 		self.validate_request_overlap()
 		self.validate_no_attendance_to_create()
@@ -66,6 +67,33 @@ class AttendanceRequest(Document):
 				),
 			)
 
+	def validate_shifts(self):
+		# Shift should be mentioned if employee has a shift assignment
+		shifts = self.get_active_shifts()
+		if shifts and not self.shift:
+			if len(shifts) == 1:
+				self.shift = shifts[0]
+			else:
+				frappe.throw(
+					_(
+						"There are multiple shifts assigned to the employee for the same period. Please mention the shift"
+					)
+				)
+
+	def get_active_shifts(self):
+		shifts = frappe.get_all(
+			"Shift Assignment",
+			filters={
+				"docstatus": 1,
+				"employee": self.employee,
+				"start_date": ("<=", self.from_date),
+				"end_date": (">=", self.to_date),
+			},
+			pluck="shift_type",
+		)
+
+		return list(set(shifts))
+
 	def validate_request_overlap(self):
 		if not self.name:
 			self.name = "New Attendance Request"
@@ -83,10 +111,10 @@ class AttendanceRequest(Document):
 			)
 		)
 
-		if self.shift_type:
-			query = query.where(Request.shift_type == self.shift_type)
+		if self.shift:
+			query = query.where(Request.shift == self.shift)
 
-		overlapping_request = query.run()
+		overlapping_request = query.run(as_dict=True)
 
 		if overlapping_request:
 			self.throw_overlap_error(overlapping_request[0].name)
@@ -201,6 +229,7 @@ class AttendanceRequest(Document):
 				"employee": self.employee,
 				"attendance_date": attendance_date,
 				"docstatus": ("!=", 2),
+				"shift": self.shift,
 			},
 		)
 		return frappe.get_doc("Attendance", attendance) if attendance else None

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -85,6 +85,7 @@ class AttendanceRequest(Document):
 			"Shift Assignment",
 			filters={
 				"docstatus": 1,
+				"status": "Active",
 				"employee": self.employee,
 				"start_date": ("<=", self.from_date),
 				"end_date": (">=", self.to_date),

--- a/hrms/hr/doctype/attendance_request/test_attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/test_attendance_request.py
@@ -8,7 +8,6 @@ from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.attendance_request.attendance_request import OverlappingAttendanceRequestError
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
-	make_holiday_list,
 	make_leave_application,
 )
 from hrms.tests.test_utils import add_date_to_holiday_list, get_first_sunday
@@ -244,6 +243,71 @@ class TestAttendanceRequest(HRMSTestSuite):
 		)
 		self.assertEqual(half_day_status, "Absent")
 
+	@HRMSTestSuite.change_settings("HR Settings", {"allow_multiple_shift_assignments": True})
+	def test_overlap_with_different_shifts(self):
+		shift_1 = create_shift("Morning Shift", "08:00:00", "12:00:00")
+		shift_2 = create_shift("Evening Shift", "14:00:00", "18:00:00")
+
+		create_shift_assignment(
+			self.employee.name, shift_1.name, add_days(getdate(), -1), add_days(getdate(), 1)
+		)
+		create_shift_assignment(
+			self.employee.name, shift_2.name, add_days(getdate(), -1), add_days(getdate(), 1)
+		)
+
+		today = getdate()
+
+		frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": self.employee.name,
+				"attendance_date": today,
+				"status": "Absent",
+				"shift": shift_1.name,
+				"company": "_Test Company",
+			}
+		).insert()
+
+		frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": self.employee.name,
+				"attendance_date": today,
+				"status": "Absent",
+				"shift": shift_2.name,
+				"company": "_Test Company",
+			}
+		).insert()
+
+		create_attendance_request(
+			employee=self.employee.name,
+			reason="On Duty",
+			company="_Test Company",
+			from_date=today,
+			to_date=today,
+			shift=shift_1.name,
+		)
+
+		# same dates with a different shift should NOT overlap
+		self.assertTrue(
+			create_attendance_request(
+				employee=self.employee.name,
+				reason="On Duty",
+				company="_Test Company",
+				from_date=today,
+				to_date=today,
+				shift=shift_2.name,
+			)
+		)
+
+		attendances = frappe.db.get_all(
+			"Attendance",
+			{"employee": self.employee.name, "attendance_date": today, "status": "Present"},
+			pluck="name",
+		)
+
+		self.assertEqual(len(attendances), 2)
+
 
 def get_employee():
 	return frappe.get_doc("Employee", "_T-Employee-00001")
@@ -261,6 +325,7 @@ def create_attendance_request(**args: dict) -> dict:
 			"to_date": today,
 			"reason": "On Duty",
 			"company": "_Test Company",
+			"shift": args.shift or None,
 		}
 	)
 
@@ -268,3 +333,24 @@ def create_attendance_request(**args: dict) -> dict:
 		attendance_request.update(args)
 
 	return attendance_request.submit()
+
+
+def create_shift(name, start_time, end_time):
+	if frappe.db.exists("Shift Type", name):
+		return frappe.get_doc("Shift Type", name)
+	return frappe.get_doc(
+		{"doctype": "Shift Type", "__newname": name, "start_time": start_time, "end_time": end_time}
+	).insert()
+
+
+def create_shift_assignment(employee, shift_type, start_date, end_date):
+	return frappe.get_doc(
+		{
+			"doctype": "Shift Assignment",
+			"employee": employee,
+			"shift_type": shift_type,
+			"start_date": start_date,
+			"end_date": end_date,
+			"company": "_Test Company",
+		}
+	).submit()


### PR DESCRIPTION
The attendance request workflow did not consider the multiple shift scenarios on the same date
When an employee tried to regularize his attendance for both shifts using the attendance request, they used to get an overlap validation.

To avoid this, the overlap validation now checks for shift as well to check for overlap requests. Additionally, it also validates if the user has added a shift in case multiple shifts are assigned to the employee, and also auto-assigns a shift in case of a single shift assignment.    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attendance requests now support shift-specific validation and overlap detection for employees with multiple shift assignments.
  * System automatically assigns shifts to attendance requests when only one shift applies during the request period.

* **Tests**
  * Added test coverage for attendance request handling across different shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->