### PR TITLE
fix: Self-approval of leave applications

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -120,6 +120,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if frappe.db.get_value("Leave Type", self.leave_type, "is_optional_leave"):
 			self.validate_optional_leave()
 		self.validate_applicable_after()
+		self.validate_for_self_approval()
 
 	def on_update(self):
 		if self.status == "Open" and self.docstatus < 1:
@@ -137,7 +138,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 
 		self.validate_back_dated_application()
 		self.update_attendance()
-		self.validate_for_self_approval()
 
 		# notify leave applier about approval
 		if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
@@ -905,6 +905,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self_leave_approval_not_allowed
 			and employee_user == frappe.session.user
 			and not get_workflow_name("Leave Application")
+			and self.status == "Approved"
 		):
 			frappe.throw(_("Self-approval for leaves is not allowed"))
 

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -961,7 +961,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		add_role(leave_approver, "Leave Approver")
 
 		make_allocation_record(employee.name)
-		application = application = frappe.get_doc(
+		application = frappe.get_doc(
 			doctype="Leave Application",
 			employee=employee.name,
 			leave_type="_Test Leave Type",
@@ -974,12 +974,13 @@ class TestLeaveApplication(HRMSTestSuite):
 		)
 		application.insert()
 		application.status = "Approved"
-
 		frappe.set_user(employee.user_id)
-		self.assertRaises(frappe.ValidationError, application.submit)
+		self.assertRaises(frappe.ValidationError, application.save)
 
 		frappe.set_user(leave_approver)
 		application.reload()
+		application.status = "Approved"
+		application.save()
 		application.submit()
 		self.assertEqual(1, application.docstatus)
 


### PR DESCRIPTION
If a user has disabled self approvals and is approving leave applications using PWA then they get an illusion of self approving during the status update (as they are able to update the status as "Approved") before submitting.

To prevent this confusion, self approver validation should be on save instead of submit action.