### PR TITLE
ci: run split tests into 3 parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2]
+        container: [1, 2, 3]
 
     name: Python Unit Tests
 


### PR DESCRIPTION
Tried with 4 too, the extra job causes others to be queued, and the time improvement is only marginal 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI parallel test runs from 2 to 3 to broaden execution coverage and speed up matrix-based testing.
  * Expanded coverage artifact outputs to include a third set for non-pull-request runs, ensuring capture of results from the additional parallel job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->