### PR TITLE
ci: split tests into 3 parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2]
+        container: [1, 2, 3]
 
     name: Python Unit Tests
 
@@ -109,7 +109,7 @@ jobs:
           BRANCH_TO_CLONE: ${{ env.HR_BRANCH }}
 
       - name: Run Tests
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app hrms --total-builds 2 --build-number ${{ matrix.container }}
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app hrms --total-builds ${{ strategy.job-total }} --build-number ${{ matrix.container }}
         env:
           TYPE: server
           CAPTURE_COVERAGE: ${{ github.event_name != 'pull_request' }}

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -11,6 +11,7 @@ from frappe.utils import (
 	getdate,
 )
 
+from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_list
 
 from hrms.hr.doctype.leave_allocation.test_leave_allocation import create_leave_allocation
@@ -39,7 +40,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		]:
 			frappe.db.delete(doctype)
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00001")
+		employee = frappe.get_doc("Employee", make_employee("test_el@example.com", company="_Test Company"))
 		self.original_doj = employee.date_of_joining
 
 		employee.date_of_joining = add_months(getdate(), -24)
@@ -525,7 +526,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertRaises(frappe.ValidationError, leave_allocation.allocate_leaves_manually, 1)
 
 	def test_quarterly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 		# allocated after one quarter
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 4)
 
@@ -551,7 +552,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_quarterly_earned_leaves_allocated_on_last_day_at_the_start_of_the_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		assignment = make_policy_assignment(
 			employee,
@@ -574,7 +575,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_quartertly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		assignment = make_policy_assignment(
 			employee,
@@ -597,7 +598,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_quarterly_earned_leaves_allocated_by_the_scheduler(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		# created policy assignment at the begining of the year so allocated leaces should be 0
 		assignment = make_policy_assignment(
@@ -635,7 +636,7 @@ class TestLeaveAllocation(FrappeTestCase):
 
 	def test_quarterly_leaves_allocated_pro_rated(self):
 		# joined 1 month 10 days after the leave period date
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=1, days=10)
 		employee.save()
 
@@ -673,7 +674,7 @@ class TestLeaveAllocation(FrappeTestCase):
 
 	def test_half_yearly_earned_leaves_allocated_on_last_day_at_the_start_of_leave_period(self):
 		frappe.flags.current_date = get_year_start(getdate())
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		assignment = make_policy_assignment(
 			employee,
@@ -694,7 +695,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 0.0)
 
 	def test_half_yearly_earned_leaves_allocated_on_last_day_in_the_middle_of_leave_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		frappe.flags.current_date = add_months(get_year_start(getdate()), 7)
 
@@ -717,7 +718,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 6.0)
 
 	def test_half_yearly_earned_leaves_allocated_on_first_day_at_the_start_of_leave_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		frappe.flags.current_date = get_year_start(getdate())
 
@@ -742,7 +743,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_half_yearly_earned_leaves_allocated_by_the_scheduler(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		assignment = make_policy_assignment(
 			employee,
@@ -774,7 +775,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 12)
 
 	def test_half_yearly_leaves_allocated_pro_rated(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=3, days=25)
 		employee.save()
 
@@ -811,7 +812,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 2.25)
 
 	def test_yearly_leaves_allocated_on_last_day_at_the_start_of_the_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		frappe.flags.current_date = get_year_start(getdate())
 		# 4 year leave policy
@@ -834,7 +835,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 0.0)
 
 	def test_yearly_leaves_allocated_on_last_day_in_the_middle_of_the_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		frappe.flags.current_date = add_to_date(get_year_start(getdate()), years=2)
 		# 4 year leave policy
@@ -857,7 +858,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 24.0)
 
 	def test_yearly_leaves_allocated_on_first_day_at_the_start_of_the_period(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		frappe.flags.current_date = get_year_start(getdate())
 		# 4 year leave policy
@@ -882,7 +883,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def test_yearly_leaves_allocated_by_scheduler(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 
 		assignment = make_policy_assignment(
 			employee,
@@ -913,7 +914,7 @@ class TestLeaveAllocation(FrappeTestCase):
 		self.assertEqual(total_leaves_allocated, 24)
 
 	def test_yearly_leaves_allocated_pro_rated(self):
-		employee = frappe.get_doc("Employee", "_T-Employee-00002")
+		employee = frappe.get_doc("Employee", make_employee("test_el2@example.com", company="_Test Company"))
 		employee.date_of_joining = add_to_date(get_year_start(getdate()), months=7, days=15)
 		employee.save()
 
@@ -951,7 +952,12 @@ class TestLeaveAllocation(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.db.set_value("Employee", self.employee.name, "date_of_joining", self.original_doj)
-		frappe.db.set_value("Employee", "_T-Employee-00002", "date_of_joining", self.original_doj)
+		frappe.db.set_value(
+			"Employee",
+			make_employee("test_el2@example.com", company="_Test Company"),
+			"date_of_joining",
+			self.original_doj,
+		)
 		frappe.db.set_value("Leave Type", self.leave_type, "max_leaves_allowed", 0)
 		frappe.flags.current_date = None
 

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -10,6 +10,7 @@ from erpnext.setup.doctype.holiday_list.test_holiday_list import set_holiday_lis
 from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.leave_allocation.leave_allocation import OverlapError
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
+from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
 from hrms.hr.report.monthly_attendance_sheet.monthly_attendance_sheet import execute
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
@@ -29,6 +30,8 @@ class TestMonthlyAttendanceSheet(FrappeTestCase):
 
 		if not frappe.db.exists("Shift Type", "Day Shift"):
 			setup_shift_type(shift_type="Day Shift")
+		if not frappe.db.exists("Leave Type", "_Test Leave Type"):
+			create_leave_type(leave_type_name="_Test Leave Type")
 
 		date = getdate()
 		from_date = get_year_start(date)


### PR DESCRIPTION
Tried with 4 too, the extra job causes others to be queued, and the time improvement is only marginal 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI test parallelism to accelerate test runs and feedback.

* **Tests**
  * Improved HR test suite setup to make earned-leave and monthly attendance tests more reliable and maintainable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->