### PR TITLE
fix: multicurrency employee advance & expense claim bugs (backport #3952)

### DIFF
--- a/frontend/src/views/employee_advance/Form.vue
+++ b/frontend/src/views/employee_advance/Form.vue
@@ -69,13 +69,6 @@ const employeeCurrency = createResource({
 	},
 })
 
-const exchangeRate = createResource({
-	url: "erpnext.setup.utils.get_exchange_rate",
-	onSuccess(data) {
-		employeeAdvance.value.exchange_rate = data
-	},
-})
-
 const advanceAccount = createResource({
 	url: "hrms.api.get_advance_account",
 	params: { company: employeeAdvance.value.company },
@@ -83,12 +76,6 @@ const advanceAccount = createResource({
 		employeeAdvance.value.advance_account = data
 	},
 })
-
-// form scripts
-watch(
-	() => employeeAdvance.value.currency,
-	() => setExchangeRate()
-)
 
 // helper functions
 function getFilteredFields(fields) {
@@ -127,24 +114,6 @@ function applyFilters(fields) {
 
 		return field
 	})
-}
-
-function setExchangeRate() {
-	if (!employeeAdvance.value.currency) return
-	const exchange_rate_field = formFields.data?.find(
-		(field) => field.fieldname === "exchange_rate"
-	)
-
-	if (employeeAdvance.value.currency === companyCurrency.value) {
-		employeeAdvance.value.exchange_rate = 1
-		exchange_rate_field.hidden = 1
-	} else {
-		exchangeRate.fetch({
-			from_currency: employeeAdvance.value.currency,
-			to_currency: companyCurrency.value,
-		})
-		exchange_rate_field.hidden = 0
-	}
 }
 
 function validateForm() {}

--- a/frontend/src/views/employee_advance/Form.vue
+++ b/frontend/src/views/employee_advance/Form.vue
@@ -69,6 +69,13 @@ const employeeCurrency = createResource({
 	},
 })
 
+const exchangeRate = createResource({
+	url: "erpnext.setup.utils.get_exchange_rate",
+	onSuccess(data) {
+		employeeAdvance.value.exchange_rate = data
+	},
+})
+
 const advanceAccount = createResource({
 	url: "hrms.api.get_advance_account",
 	params: { company: employeeAdvance.value.company },
@@ -76,6 +83,12 @@ const advanceAccount = createResource({
 		employeeAdvance.value.advance_account = data
 	},
 })
+
+// form scripts
+watch(
+	() => employeeAdvance.value.currency,
+	() => setExchangeRate()
+)
 
 // helper functions
 function getFilteredFields(fields) {
@@ -114,6 +127,24 @@ function applyFilters(fields) {
 
 		return field
 	})
+}
+
+function setExchangeRate() {
+	if (!employeeAdvance.value.currency) return
+	const exchange_rate_field = formFields.data?.find(
+		(field) => field.fieldname === "exchange_rate"
+	)
+
+	if (employeeAdvance.value.currency === companyCurrency.value) {
+		employeeAdvance.value.exchange_rate = 1
+		exchange_rate_field.hidden = 1
+	} else {
+		exchangeRate.fetch({
+			from_currency: employeeAdvance.value.currency,
+			to_currency: companyCurrency.value,
+		})
+		exchange_rate_field.hidden = 0
+	}
 }
 
 function validateForm() {}

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -90,6 +90,7 @@ const tabs = [
 const expenseClaim = ref({
 	employee: currEmployee,
 	company: employeeCompany,
+	doctype: "Expense Claim"
 })
 
 const currency = computed(() => getCompanyCurrency(expenseClaim.value.company))
@@ -109,6 +110,7 @@ const formFields = createResource({
 	onSuccess(_data) {
 		expenseApproverDetails.reload()
 		companyDetails.reload()
+		employeeCurrency.reload()
 	},
 })
 formFields.reload()
@@ -116,35 +118,22 @@ formFields.reload()
 // resources
 const advances = createResource({
 	url: "hrms.hr.doctype.expense_claim.expense_claim.get_advances",
-	params: { employee: currEmployee.value },
+	params: { expense_claim: expenseClaim.value },
 	auto: true,
 	onSuccess(data) {
 		// set advances
-		if (props.id) {
-			expenseClaim.value.advances?.map((advance) => (advance.selected = true))
-		} else {
+		if (!data) {
 			expenseClaim.value.advances = []
+			return
 		}
 
-		return data.forEach((advance) => {
-			if (
-				props.id &&
-				expenseClaim.value.advances?.some(
-					(entry) => entry.employee_advance === advance.name
-				)
-			)
-				return
-
-			expenseClaim.value.advances?.push({
-				employee_advance: advance.name,
-				purpose: advance.purpose,
-				posting_date: advance.posting_date,
-				advance_account: advance.advance_account,
-				advance_paid: advance.paid_amount,
-				unclaimed_amount: advance.paid_amount - advance.claimed_amount,
-				allocated_amount: 0,
+		if (!props.id) {
+			data.forEach((advance) => {
+				advance.allocated_amount = 0
+				advance.selected = true
 			})
-		})
+			expenseClaim.value.advances = data
+		}
 	},
 })
 
@@ -163,6 +152,21 @@ const companyDetails = createResource({
 		expenseClaim.value.cost_center = data?.cost_center
 		expenseClaim.value.payable_account =
 			data?.default_expense_claim_payable_account
+	},
+})
+
+const employeeCurrency = createResource({
+	url: "hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment.get_employee_currency",
+	params: { employee: currEmployee.value },
+	onSuccess(data) {
+		expenseClaim.value.currency = data
+	},
+})
+
+const exchangeRate = createResource({
+	url: "erpnext.setup.utils.get_exchange_rate",
+	onSuccess(data) {
+		expenseClaim.value.exchange_rate = data
 	},
 })
 
@@ -186,9 +190,13 @@ watch(
 	}
 )
 watch(
-	() => props.id && expenseClaim.value.expenses,
+	() => expenseClaim.value.currency,
+	() => setExchangeRate()
+)
+watch(
+	() => expenseClaim.value.expenses,
 	(_) => {
-		if (expenseClaim.value.docstatus === 0) {
+		if (!props.id && expenseClaim.value.docstatus === 0) {
 			advances.reload()
 		}
 	}
@@ -411,6 +419,24 @@ function validateForm() {
 	expenseClaim?.value?.expenses?.forEach((expense) => {
 		expense.cost_center = expenseClaim.value.cost_center
 	})
+}
+
+function setExchangeRate() {
+	if (!expenseClaim.value.currency) return
+	const exchange_rate_field = formFields.data?.find(
+		(field) => field.fieldname === "exchange_rate"
+	)
+
+	if (expenseClaim.value.currency === currency.value) {
+		expenseClaim.value.exchange_rate = 1
+		exchange_rate_field.hidden = 1
+	} else {
+		exchangeRate.fetch({
+			from_currency: expenseClaim.value.currency,
+			to_currency: currency.value,
+		})
+		exchange_rate_field.hidden = 0
+	}
 }
 
 </script>

--- a/frontend/src/views/expense_claim/Form.vue
+++ b/frontend/src/views/expense_claim/Form.vue
@@ -90,7 +90,6 @@ const tabs = [
 const expenseClaim = ref({
 	employee: currEmployee,
 	company: employeeCompany,
-	doctype: "Expense Claim"
 })
 
 const currency = computed(() => getCompanyCurrency(expenseClaim.value.company))
@@ -110,7 +109,6 @@ const formFields = createResource({
 	onSuccess(_data) {
 		expenseApproverDetails.reload()
 		companyDetails.reload()
-		employeeCurrency.reload()
 	},
 })
 formFields.reload()
@@ -118,22 +116,35 @@ formFields.reload()
 // resources
 const advances = createResource({
 	url: "hrms.hr.doctype.expense_claim.expense_claim.get_advances",
-	params: { expense_claim: expenseClaim.value },
+	params: { employee: currEmployee.value },
 	auto: true,
 	onSuccess(data) {
 		// set advances
-		if (!data) {
+		if (props.id) {
+			expenseClaim.value.advances?.map((advance) => (advance.selected = true))
+		} else {
 			expenseClaim.value.advances = []
-			return
 		}
 
-		if (!props.id) {
-			data.forEach((advance) => {
-				advance.allocated_amount = 0
-				advance.selected = true
+		return data.forEach((advance) => {
+			if (
+				props.id &&
+				expenseClaim.value.advances?.some(
+					(entry) => entry.employee_advance === advance.name
+				)
+			)
+				return
+
+			expenseClaim.value.advances?.push({
+				employee_advance: advance.name,
+				purpose: advance.purpose,
+				posting_date: advance.posting_date,
+				advance_account: advance.advance_account,
+				advance_paid: advance.paid_amount,
+				unclaimed_amount: advance.paid_amount - advance.claimed_amount,
+				allocated_amount: 0,
 			})
-			expenseClaim.value.advances = data
-		}
+		})
 	},
 })
 
@@ -152,21 +163,6 @@ const companyDetails = createResource({
 		expenseClaim.value.cost_center = data?.cost_center
 		expenseClaim.value.payable_account =
 			data?.default_expense_claim_payable_account
-	},
-})
-
-const employeeCurrency = createResource({
-	url: "hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment.get_employee_currency",
-	params: { employee: currEmployee.value },
-	onSuccess(data) {
-		expenseClaim.value.currency = data
-	},
-})
-
-const exchangeRate = createResource({
-	url: "erpnext.setup.utils.get_exchange_rate",
-	onSuccess(data) {
-		expenseClaim.value.exchange_rate = data
 	},
 })
 
@@ -190,13 +186,9 @@ watch(
 	}
 )
 watch(
-	() => expenseClaim.value.currency,
-	() => setExchangeRate()
-)
-watch(
-	() => expenseClaim.value.expenses,
+	() => props.id && expenseClaim.value.expenses,
 	(_) => {
-		if (!props.id && expenseClaim.value.docstatus === 0) {
+		if (expenseClaim.value.docstatus === 0) {
 			advances.reload()
 		}
 	}
@@ -419,24 +411,6 @@ function validateForm() {
 	expenseClaim?.value?.expenses?.forEach((expense) => {
 		expense.cost_center = expenseClaim.value.cost_center
 	})
-}
-
-function setExchangeRate() {
-	if (!expenseClaim.value.currency) return
-	const exchange_rate_field = formFields.data?.find(
-		(field) => field.fieldname === "exchange_rate"
-	)
-
-	if (expenseClaim.value.currency === currency.value) {
-		expenseClaim.value.exchange_rate = 1
-		exchange_rate_field.hidden = 1
-	} else {
-		exchangeRate.fetch({
-			from_currency: expenseClaim.value.currency,
-			to_currency: currency.value,
-		})
-		exchange_rate_field.hidden = 0
-	}
 }
 
 </script>

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -126,18 +126,8 @@ frappe.ui.form.on("Employee Advance", {
 		return frappe.call({
 			method: "hrms.hr.doctype.expense_claim.expense_claim.get_expense_claim",
 			args: {
-				advance_details: {
-					employee_name: frm.doc.employee,
-					company: frm.doc.company,
-					currency: frm.doc.currency,
-					employee_advance_name: frm.doc.name,
-					posting_date: frm.doc.posting_date,
-					paid_amount: frm.doc.paid_amount,
-					base_paid_amount: frm.doc.base_paid_amount,
-					claimed_amount: frm.doc.claimed_amount,
-					return_amount: frm.doc.return_amount,
-					payment_via_journal_entry: frm.doc.__onload.make_payment_via_journal_entry,
-				},
+				employee_advance: frm.doc.name,
+				payment_via_journal_entry: frm.doc.__onload.make_payment_via_journal_entry,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);
@@ -173,8 +163,10 @@ frappe.ui.form.on("Employee Advance", {
 
 	update_fields_label: function (frm) {
 		var company_currency = erpnext.get_currency(frm.doc.company);
-		frm.set_currency_labels(["paid_amount"], frm.doc.currency);
-		frm.set_currency_labels(["base_paid_amount"], company_currency);
+		if (frm.doc.currency != company_currency) {
+			frm.set_currency_labels(["paid_amount"], frm.doc.currency);
+			frm.set_currency_labels(["base_paid_amount"], company_currency);
+		}
 		frm.toggle_display("base_paid_amount", frm.doc.currency != company_currency);
 		frm.refresh_fields();
 	},

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -172,8 +172,10 @@ frappe.ui.form.on("Employee Advance", {
 	},
 
 	update_fields_label: function (frm) {
+		var company_currency = erpnext.get_currency(frm.doc.company);
 		frm.set_currency_labels(["paid_amount"], frm.doc.currency);
-		frm.set_currency_labels(["base_paid_amount"], erpnext.get_currency(frm.doc.company));
+		frm.set_currency_labels(["base_paid_amount"], company_currency);
+		frm.toggle_display("base_paid_amount", frm.doc.currency != company_currency);
 		frm.refresh_fields();
 	},
 });

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -46,7 +46,7 @@ class EmployeeAdvance(Document):
 			if not same_currency:
 				frappe.throw(
 					_("Please set the Advance Account {0} or in {1}").format(
-						get_link_to_form("Employee Advance", self.name + "#advance_account", "here"),
+						get_link_to_form("Employee Advance", self.name + "#advance_account", _("here")),
 						get_link_to_form("Employee", self.employee + "#salary_information", self.employee),
 					),
 					title=_("Advance Account Required"),

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -37,15 +37,25 @@ class EmployeeAdvance(Document):
 			default_advance_account = frappe.db.get_value(
 				"Company", self.company, "default_employee_advance_account"
 			)
-			if default_advance_account:
+			same_currency = self.currency == erpnext.get_company_currency(self.company)
+
+			if default_advance_account and same_currency:
 				self.advance_account = default_advance_account
-			else:
+				return
+
+			if not same_currency:
 				frappe.throw(
-					_(
-						'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0} and submit this document.'
-					).format(self.company),
-					title=_("Missing Advance Account"),
+					_("Please set the Advance Account manually or in {0}").format(
+						get_link_to_form("Employee", self.employee + "#salary_information", self.employee)
+					)
 				)
+
+			frappe.throw(
+				_(
+					'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0} and submit this document.'
+				).format(self.company),
+				title=_("Missing Advance Account"),
+			)
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Payment Ledger Entry", "Advance Payment Ledger Entry")

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -45,15 +45,22 @@ class EmployeeAdvance(Document):
 
 			if not same_currency:
 				frappe.throw(
-					_("Please set the Advance Account manually or in {0}").format(
-						get_link_to_form("Employee", self.employee + "#salary_information", self.employee)
-					)
+					_("Please set the Advance Account {0} or in {1}").format(
+						get_link_to_form("Employee Advance", self.name + "#advance_account", "here"),
+						get_link_to_form("Employee", self.employee + "#salary_information", self.employee),
+					),
+					title=_("Advance Account Required"),
 				)
 
 			frappe.throw(
 				_(
-					'Advance Account is mandatory. Please set the <a href="/app/company/{0}#default_employee_advance_account" target="_blank">Default Employee Advance Account</a> in the Company record {0} and submit this document.'
-				).format(self.company),
+					"Advance Account is mandatory. Please set the {0} in the Company {1} and submit this document."
+				).format(
+					get_link_to_form(
+						"Company", self.company + "#hr_and_payroll_tab", "Default Employee Advance Account"
+					),
+					frappe.bold(self.company),
+				),
 				title=_("Missing Advance Account"),
 			)
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -457,13 +457,12 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 	def set_base_fields_amount(self, doc, fields, exchange_rate=None):
 		"""set values in base currency"""
 		for f in fields:
-			if doc.get(f):
-				val = flt(
-					flt(doc.get(f), doc.precision(f))
-					* flt(exchange_rate if exchange_rate else self.exchange_rate),
-					doc.precision("base_" + f),
-				)
-				doc.set("base_" + f, val)
+			val = flt(
+				flt(doc.get(f), doc.precision(f))
+				* flt(exchange_rate if exchange_rate else self.exchange_rate),
+				doc.precision("base_" + f),
+			)
+			doc.set("base_" + f, val)
 
 	@frappe.whitelist()
 	def calculate_taxes(self):
@@ -497,23 +496,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 		for d in self.get("advances"):
 			self.round_floats_in(d)
-
-			adv_doc = frappe.db.get_value(
-				"Employee Advance",
-				d.employee_advance,
-				["posting_date", "advance_account", "paid_amount"],
-				as_dict=1,
-			)
-			aple_amount = frappe.db.get_value(
-				"Advance Payment Ledger Entry",
-				{"voucher_no": d.payment_entry, "event": "Submit", "delinked": 0},
-				"amount",
-			)
-			d.posting_date = adv_doc.posting_date
-			d.advance_account = adv_doc.advance_account
-			d.advance_paid = aple_amount if aple_amount else adv_doc.paid_amount
-			# d.unclaimed_amount = flt(ref_doc.paid_amount) - flt(ref_doc.claimed_amount)
-
 			if d.allocated_amount and flt(d.allocated_amount) > flt(
 				flt(d.unclaimed_amount) - flt(d.return_amount), precision
 			):
@@ -768,7 +750,7 @@ def get_expense_claim(employee_advance, payment_via_journal_entry):
 	expense_claim = frappe.new_doc("Expense Claim")
 	expense_claim.company = company
 	expense_claim.currency = employee_advance.currency
-	expense_claim.employee = employee_advance.employee_name
+	expense_claim.employee = employee_advance.employee
 	expense_claim.payable_account = (
 		default_payable_account
 		if employee_advance.currency == erpnext.get_company_currency(company)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.workflow import get_workflow_name
 from frappe.query_builder.functions import Sum
@@ -695,7 +696,7 @@ def get_expense_claim_account(expense_claim_type, company):
 
 
 @frappe.whitelist()
-def get_advances(expense_claim, advance_id=None):
+def get_advances(expense_claim: str | dict | Document, advance_id: str | None = None):
 	import json
 
 	if isinstance(expense_claim, str):
@@ -737,7 +738,7 @@ def get_advances(expense_claim, advance_id=None):
 
 
 @frappe.whitelist()
-def get_expense_claim(employee_advance, payment_via_journal_entry):
+def get_expense_claim(employee_advance: str | dict, payment_via_journal_entry: str | int | bool) -> Document:
 	if isinstance(employee_advance, str):
 		employee_advance = frappe.get_doc("Employee Advance", employee_advance)
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -792,6 +792,7 @@ def get_expense_claim_advances(expense_claim, employee_advance):
 		expense_claim.append(
 			"advances",
 			{
+				"advance_account": employee_advance.advance_account,
 				"employee_advance": employee_advance.name,
 				"posting_date": employee_advance.posting_date,
 				"advance_paid": paid_amount,

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -504,14 +504,14 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				["posting_date", "advance_account", "paid_amount"],
 				as_dict=1,
 			)
-			aple_doc = frappe.db.get_value(
+			aple_amount = frappe.db.get_value(
 				"Advance Payment Ledger Entry",
 				{"voucher_no": d.payment_entry, "event": "Submit", "delinked": 0},
 				"amount",
 			)
 			d.posting_date = adv_doc.posting_date
 			d.advance_account = adv_doc.advance_account
-			d.advance_paid = aple_doc if aple_doc else adv_doc.paid_amount
+			d.advance_paid = aple_amount if aple_amount else adv_doc.paid_amount
 			# d.unclaimed_amount = flt(ref_doc.paid_amount) - flt(ref_doc.claimed_amount)
 
 			if d.allocated_amount and flt(d.allocated_amount) > flt(
@@ -724,7 +724,7 @@ def get_advances(expense_claim, advance_id=None):
 	advance = frappe.qb.DocType("Employee Advance")
 
 	query = frappe.qb.from_(advance).select(
-		advance.name.as_("employee_advance_name"),
+		advance.name,
 		advance.purpose,
 		advance.posting_date,
 		advance.paid_amount,
@@ -736,7 +736,7 @@ def get_advances(expense_claim, advance_id=None):
 	if not advance_id:
 		query = query.where(
 			(advance.docstatus == 1)
-			& (advance.employee == expense_claim.employee)
+			& (advance.employee == expense_claim_doc.employee)
 			& (advance.paid_amount > 0)
 			& (advance.status.notin(["Claimed", "Returned", "Partly Claimed and Returned"]))
 		)
@@ -755,13 +755,11 @@ def get_advances(expense_claim, advance_id=None):
 
 
 @frappe.whitelist()
-def get_expense_claim(advance_details):
-	import json
+def get_expense_claim(employee_advance, payment_via_journal_entry):
+	if isinstance(employee_advance, str):
+		employee_advance = frappe.get_doc("Employee Advance", employee_advance)
 
-	if isinstance(advance_details, str):
-		advance_details = frappe._dict(json.loads(advance_details))
-
-	company = advance_details.company
+	company = employee_advance.company
 	default_payable_account = frappe.get_cached_value(
 		"Company", company, "default_expense_claim_payable_account"
 	)
@@ -769,29 +767,37 @@ def get_expense_claim(advance_details):
 
 	expense_claim = frappe.new_doc("Expense Claim")
 	expense_claim.company = company
-	expense_claim.currency = advance_details.currency
-	expense_claim.employee = advance_details.employee_name
+	expense_claim.currency = employee_advance.currency
+	expense_claim.employee = employee_advance.employee_name
 	expense_claim.payable_account = (
-		default_payable_account if advance_details.currency == erpnext.get_company_currency(company) else None
+		default_payable_account
+		if employee_advance.currency == erpnext.get_company_currency(company)
+		else None
 	)
 	expense_claim.cost_center = default_cost_center
-	expense_claim.is_paid = 1 if flt(advance_details.paid_amount) else 0
+	expense_claim.is_paid = 1 if flt(employee_advance.paid_amount) else 0
 
-	get_expense_claim_advances(expense_claim, advance_details)
+	employee_advance.update(
+		{
+			"payment_via_journal_entry": payment_via_journal_entry,
+		}
+	)
+
+	get_expense_claim_advances(expense_claim, employee_advance)
 	return expense_claim
 
 
-def get_expense_claim_advances(expense_claim, advance_details):
-	return_amount = flt(advance_details.return_amount)
-	if int(advance_details.payment_via_journal_entry):
-		paid_amount = flt(advance_details.paid_amount)
-		claimed_amount = flt(advance_details.claimed_amount)
+def get_expense_claim_advances(expense_claim, employee_advance):
+	return_amount = flt(employee_advance.return_amount)
+	if int(employee_advance.payment_via_journal_entry):
+		paid_amount = flt(employee_advance.paid_amount)
+		claimed_amount = flt(employee_advance.claimed_amount)
 		exchange_rate = frappe.db.get_value(
 			"Advance Payment Ledger Entry",
 			{
 				"voucher_type": "Journal Entry",
 				"against_voucher_type": "Employee Advance",
-				"against_voucher_no": advance_details.employee_advance_name,
+				"against_voucher_no": employee_advance.name,
 				"delinked": False,
 				"amount": paid_amount,
 			},
@@ -804,10 +810,10 @@ def get_expense_claim_advances(expense_claim, advance_details):
 		expense_claim.append(
 			"advances",
 			{
-				"employee_advance": advance_details.employee_advance_name,
-				"posting_date": advance_details.posting_date,
+				"employee_advance": employee_advance.name,
+				"posting_date": employee_advance.posting_date,
 				"advance_paid": paid_amount,
-				"base_advance_paid": flt(advance_details.base_paid_amount),
+				"base_advance_paid": flt(employee_advance.base_paid_amount),
 				"unclaimed_amount": unclaimed_amount,
 				"allocated_amount": allocated_amount,
 				"return_amount": return_amount,
@@ -834,7 +840,7 @@ def get_expense_claim_advances(expense_claim, advance_details):
 			.where(
 				(pe.docstatus == 1)
 				& (pe_ref.reference_doctype == "Employee Advance")
-				& (pe_ref.reference_name == advance_details.employee_advance_name)
+				& (pe_ref.reference_name == employee_advance.name)
 				& (pe_ref.allocated_amount > 0)
 			)
 		).run(as_dict=True)
@@ -853,8 +859,9 @@ def get_expense_claim_advances(expense_claim, advance_details):
 			expense_claim.append(
 				"advances",
 				{
-					"employee_advance": advance_details.employee_advance_name,
-					"posting_date": advance_details.posting_date,
+					"advance_account": employee_advance.advance_account,
+					"employee_advance": employee_advance.name,
+					"posting_date": employee_advance.posting_date,
 					"advance_paid": advance_paid,
 					"base_advance_paid": advance_paid * pe.exchange_rate,
 					"unclaimed_amount": unclaimed_amount,
@@ -865,6 +872,7 @@ def get_expense_claim_advances(expense_claim, advance_details):
 					"payment_entry_reference": pe.pe_ref_name
 					if flt(pe.advance_paid) >= advance_paid
 					else None,
+					"purpose": employee_advance.purpose,
 				},
 			)
 
@@ -903,16 +911,18 @@ def update_outstanding_amount_in_payment_entry(expense_claim: dict, pe_reference
 
 def validate_expense_claim_in_jv(doc, method=None):
 	"""Validates Expense Claim amount in Journal Entry"""
-	if doc.voucher_type != "Exchange Gain Or Loss":
-		for d in doc.accounts:
-			if d.reference_type == "Expense Claim":
-				outstanding_amt = get_outstanding_amount_for_claim(d.reference_name)
-				if d.debit and (d.debit > outstanding_amt):
-					frappe.throw(
-						_(
-							"Row No {0}: Amount cannot be greater than the Outstanding Amount against Expense Claim {1}. Outstanding Amount is {2}"
-						).format(d.idx, d.reference_name, outstanding_amt)
-					)
+	if doc.voucher_type == "Exchange Gain Or Loss":
+		return
+
+	for d in doc.accounts:
+		if d.reference_type == "Expense Claim":
+			outstanding_amt = get_outstanding_amount_for_claim(d.reference_name)
+			if d.debit and (d.debit > outstanding_amt):
+				frappe.throw(
+					_(
+						"Row No {0}: Amount cannot be greater than the Outstanding Amount against Expense Claim {1}. Outstanding Amount is {2}"
+					).format(d.idx, d.reference_name, outstanding_amt)
+				)
 
 
 @frappe.whitelist()

--- a/hrms/patches/v16_0/set_base_paid_amount_in_employee_advance.py
+++ b/hrms/patches/v16_0/set_base_paid_amount_in_employee_advance.py
@@ -1,0 +1,21 @@
+import frappe
+from frappe.query_builder.functions import IfNull
+
+
+def execute():
+	frappe.reload_doc("HR", "doctype", "Employee Advance")
+
+	EmployeeAdvance = frappe.qb.DocType("Employee Advance")
+	Company = frappe.qb.DocType("Company")
+
+	(
+		frappe.qb.update(EmployeeAdvance)
+		.join(Company)
+		.on(EmployeeAdvance.company == Company.name)
+		.set(EmployeeAdvance.base_paid_amount, EmployeeAdvance.paid_amount)
+		.where(
+			(EmployeeAdvance.currency == Company.default_currency)
+			& (IfNull(EmployeeAdvance.paid_amount, 0) != 0)
+			& (IfNull(EmployeeAdvance.base_paid_amount, 0) == 0)
+		)
+	).run()

--- a/hrms/patches/v16_0/set_base_paid_amount_in_employee_advance.py
+++ b/hrms/patches/v16_0/set_base_paid_amount_in_employee_advance.py
@@ -3,8 +3,6 @@ from frappe.query_builder.functions import IfNull
 
 
 def execute():
-	frappe.reload_doc("HR", "doctype", "Employee Advance")
-
 	EmployeeAdvance = frappe.qb.DocType("Employee Advance")
 	Company = frappe.qb.DocType("Company")
 

--- a/hrms/patches/v16_0/set_currency_and_base_fields_in_expense_claim.py
+++ b/hrms/patches/v16_0/set_currency_and_base_fields_in_expense_claim.py
@@ -2,8 +2,6 @@ import frappe
 
 
 def execute():
-	frappe.reload_doc("HR", "doctype", "Expense Claim")
-
 	ExpenseClaim = frappe.qb.DocType("Expense Claim")
 	Company = frappe.qb.DocType("Company")
 

--- a/hrms/patches/v16_0/set_currency_and_base_fields_in_expense_claim.py
+++ b/hrms/patches/v16_0/set_currency_and_base_fields_in_expense_claim.py
@@ -1,0 +1,81 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc("HR", "doctype", "Expense Claim")
+
+	ExpenseClaim = frappe.qb.DocType("Expense Claim")
+	Company = frappe.qb.DocType("Company")
+
+	# set currency and exchange rate
+	(
+		frappe.qb.update(ExpenseClaim)
+		.join(Company)
+		.on(ExpenseClaim.company == Company.name)
+		.set(ExpenseClaim.currency, Company.default_currency)
+		.set(ExpenseClaim.exchange_rate, 1)
+		.where(ExpenseClaim.currency.isnull() | (ExpenseClaim.currency == ""))
+	).run()
+
+	# set base fields in expense claim
+	(
+		frappe.qb.update(ExpenseClaim)
+		.join(Company)
+		.on(ExpenseClaim.company == Company.name)
+		.set(ExpenseClaim.base_total_sanctioned_amount, ExpenseClaim.total_sanctioned_amount)
+		.set(ExpenseClaim.base_total_advance_amount, ExpenseClaim.total_advance_amount)
+		.set(ExpenseClaim.base_grand_total, ExpenseClaim.grand_total)
+		.set(
+			ExpenseClaim.base_total_claimed_amount,
+			ExpenseClaim.total_claimed_amount,
+		)
+		.set(
+			ExpenseClaim.base_total_taxes_and_charges,
+			ExpenseClaim.total_taxes_and_charges,
+		)
+		.where(ExpenseClaim.currency == Company.default_currency)
+	).run()
+
+	# set base fields in expense table
+	ExpenseClaimDetail = frappe.qb.DocType("Expense Claim Detail")
+	(
+		frappe.qb.update(ExpenseClaimDetail)
+		.join(ExpenseClaim)
+		.on(ExpenseClaimDetail.parent == ExpenseClaim.name)
+		.join(Company)
+		.on(ExpenseClaim.company == Company.name)
+		.set(ExpenseClaimDetail.base_amount, ExpenseClaimDetail.amount)
+		.set(
+			ExpenseClaimDetail.base_sanctioned_amount,
+			ExpenseClaimDetail.sanctioned_amount,
+		)
+		.where(ExpenseClaim.currency == Company.default_currency)
+	).run()
+
+	# set base fields in advance table
+	ExpenseClaimAdvance = frappe.qb.DocType("Expense Claim Advance").as_("eca")
+	(
+		frappe.qb.update(ExpenseClaimAdvance)
+		.join(ExpenseClaim)
+		.on(ExpenseClaimAdvance.parent == ExpenseClaim.name)
+		.join(Company)
+		.on(ExpenseClaim.company == Company.name)
+		.set(ExpenseClaimAdvance.base_advance_paid, ExpenseClaimAdvance.advance_paid)
+		.set(ExpenseClaimAdvance.base_unclaimed_amount, ExpenseClaimAdvance.unclaimed_amount)
+		.set(ExpenseClaimAdvance.base_allocated_amount, ExpenseClaimAdvance.allocated_amount)
+		.set(ExpenseClaimAdvance.exchange_rate, 1)
+		.where(ExpenseClaim.currency == Company.default_currency)
+	).run()
+
+	# set base fields in taxes table
+	ExpenseTaxesAndCharges = frappe.qb.DocType("Expense Taxes and Charges")
+	(
+		frappe.qb.update(ExpenseTaxesAndCharges)
+		.join(ExpenseClaim)
+		.on(ExpenseTaxesAndCharges.parent == ExpenseClaim.name)
+		.join(Company)
+		.on(ExpenseClaim.company == Company.name)
+		.set(ExpenseTaxesAndCharges.base_tax_amount, ExpenseTaxesAndCharges.tax_amount)
+		.set(ExpenseTaxesAndCharges.base_total, ExpenseTaxesAndCharges.total)
+		.where(ExpenseClaim.currency == Company.default_currency)
+	).run()


### PR DESCRIPTION
all fixes from reviews in [multicurrency PR](https://github.com/frappe/hrms/pull/3609#discussion_r2601619976)

- Show/hide base currency as per the company currency & used currency in the record
   
<img width="2866" height="1486" alt="image" src="https://github.com/user-attachments/assets/618ad10f-ba83-4756-9109-4ed117591a09" />

---
- validate advance account if it's set as per the same currency of record or company currency
<img width="2878" height="1270" alt="image" src="https://github.com/user-attachments/assets/7461f1b4-e2b0-4b99-ba41-13a0c15589b8" />

---
- updated `get_expense_claim`, `get_advances`
- removed unwanted code from `validate_advances` to set child table data as it is done in other func already
- added patch to update currency & base_fields data in advance & claim records

updated `docs` : https://docs.frappe.io/hr/multicurrency-employee-advance-expense-claim#1-prerequisites

Backport of https://github.com/frappe/hrms/pull/3952