### PR TITLE
fix: Include Holidays description and descriptive validation message

### DIFF
--- a/hrms/hr/doctype/attendance_request/attendance_request.json
+++ b/hrms/hr/doctype/attendance_request/attendance_request.json
@@ -129,7 +129,7 @@
   },
   {
    "default": "0",
-   "description": "Check if any of the day(s) selected for request is(are) holiday(s)",
+   "description": "Select if any of the days selected for request are holidays",
    "fieldname": "include_holidays",
    "fieldtype": "Check",
    "label": "Include Holidays"
@@ -137,7 +137,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-06 15:27:42.043838",
+ "modified": "2026-04-07 11:05:03.480492",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance Request",

--- a/hrms/hr/doctype/attendance_request/attendance_request.json
+++ b/hrms/hr/doctype/attendance_request/attendance_request.json
@@ -129,6 +129,7 @@
   },
   {
    "default": "0",
+   "description": "Check if any of the day(s) selected for request is(are) holiday(s)",
    "fieldname": "include_holidays",
    "fieldtype": "Check",
    "label": "Include Holidays"
@@ -136,11 +137,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:36.343091",
+ "modified": "2026-04-06 15:27:42.043838",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance Request",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -201,6 +202,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -65,8 +65,8 @@ class AttendanceRequest(Document):
 				message_table.append(
 					[
 						format_date(warning["date"]),
-						warning["reason"],
-						warning["action"],
+						_(warning["reason"]),
+						_(warning["action"]),
 					]
 				)
 			frappe.msgprint(

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -60,11 +60,20 @@ class AttendanceRequest(Document):
 		if len(attendance_warnings) == attendance_request_days and not any(
 			warning["action"] == "Overwrite" for warning in attendance_warnings
 		):
-			frappe.throw(
-				title=_("No attendance records to create"),
-				msg=_(
-					"Please check if employee is on leave or attendance with the same status exists for selected day(s)."
-				),
+			message_table = [[_("Date"), _("Reason"), _("Action")]]
+			for warning in attendance_warnings:
+				message_table.append(
+					[
+						format_date(warning["date"]),
+						warning["reason"],
+						warning["action"],
+					]
+				)
+			frappe.msgprint(
+				title=_("No attendance records to create due to following reasons"),
+				msg=message_table,
+				as_table=True,
+				raise_exception=True,
 			)
 
 	def validate_shifts(self):


### PR DESCRIPTION
It's not very clear to users to check "Include Holidays" in order to allow marking attendance through attendance request on a holiday. Nor the existing validation message makes it very clear as to why the attendance marking is being skipped.
The table shown in the dashboard should help make things clear.

### Before
<img width="1173" height="701" alt="image" src="https://github.com/user-attachments/assets/e152ef27-d404-49fc-bba1-e3343abac397" />


### After
<img width="526" height="71" alt="image" src="https://github.com/user-attachments/assets/c4b73c03-42bb-4bcc-8607-914729643b77" />

<img width="1904" height="1035" alt="image" src="https://github.com/user-attachments/assets/579ed409-21f3-495c-9dea-07c3dd8f8553" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added descriptive text to the holiday option in Attendance Request forms to clarify selection intent.
  * Improved validation feedback when attendance can't be created: displays a table-style per-day breakdown with Date, Reason and Action, and a clearer failure title to guide next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->