### PR TITLE
fix: correct employee grade filter field name in Employee Attendance 

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -32,7 +32,7 @@ def get_employees(
 		"company": company,
 		"employment_type": employment_type,
 		"designation": designation,
-		"employee_grade": employee_grade,
+		"grade": employee_grade,
 	}.items():
 		if value:
 			filters[field] = value


### PR DESCRIPTION
**Description / Problem:**
Filtering employees by `Employee Grade` in the Employee Attendance Tool throws a server error.

**Branch to merge into:**
version-15

**Problem**
Filtering employees by Employee Grade in the Employee Attendance Tool throws a server error:
pymysql.err.OperationalError: (1054, "Unknown column 'tabEmployee.employee_grade' in 'WHERE'")

**Root Cause:**
In get_employees(), the filter dictionary used "employee_grade" as the key when querying the Employee doctype:
# Before (incorrect)
"employee_grade": employee_grade,

However, the actual fieldname defined in the Employee doctype is "grade", not "employee_grade". The parameter name employee_grade (the function argument) was mistakenly used as the doctype filter key.

This is consistent with how other places in the codebase handle it — for example, leave_control_panel.py explicitly maps employee_grade → grade when building filters.

# After (correct)
**Fix:**
"grade": employee_grade,

**Test Scenarios Verified:**

- Filter employees by a valid Employee Grade — returns only employees belonging to that grade.
- Filter by Employee Grade combined with other filters (Company, Department, Branch) — returns correctly intersected results.
- Filter with a grade that has no employees — returns empty unmarked list gracefully.
- No Employee Grade filter applied — behaviour unchanged, all employees returned as before.
- Marking attendance after filtering by grade — attendance records created correctly for filtered employees.


> Screenshots/GIFs


<img width="1918" height="968" alt="Employee Attendance Tool Error" src="https://github.com/user-attachments/assets/efad18a2-3f18-4a6a-bb85-f999f7268509" />