### PR TITLE
fix(PWA): render Text Editor component for rich text fields instead of Input field

### DIFF
--- a/frontend/src/components/FormField.vue
+++ b/frontend/src/components/FormField.vue
@@ -34,9 +34,19 @@
 			@update:modelValue="(v) => emit('update:modelValue', v)"
 		/>
 
+		<TextEditor
+			v-else-if="props.fieldtype === 'Text Editor'"
+			:content="modelValue"
+			:placeholder="__('Enter {0}', [props.label])"
+			@change="(v) => emit('update:modelValue', v)"
+			:fixedMenu="true"
+			:editable="!isReadOnly"
+			editor-class="prose-sm border-b border-x border-gray-200 rounded-b-sm p-1 min-h-[4rem]"
+		/>
+
 		<!-- Text -->
 		<Input
-			v-else-if="['Text Editor', 'Small Text', 'Text', 'Long Text'].includes(props.fieldtype)"
+			v-else-if="['Small Text', 'Text', 'Long Text'].includes(props.fieldtype)"
 			type="textarea"
 			:value="modelValue"
 			:placeholder="__('Enter {0}', [props.label])"
@@ -140,7 +150,7 @@
 </template>
 
 <script setup>
-import { Autocomplete, DateTimePicker, ErrorMessage, Input } from "frappe-ui"
+import { Autocomplete, DateTimePicker, ErrorMessage, Input, TextEditor } from "frappe-ui"
 import { computed, onMounted, inject } from "vue"
 
 import Link from "@/components/Link.vue"


### PR DESCRIPTION
**Before:**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c16907f3-09d6-4dca-840d-da55c7487f25" />

**After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/eacb8cc4-ad2f-4b70-bfe8-dc1786676c43" />

Closes: https://github.com/frappe/hrms/issues/4300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text Editor field type now uses a dedicated editor component instead of a basic text input, providing a better editing experience. The new editor includes a fixed toolbar interface for improved usability and easier access to editing tools. The implementation maintains proper support for read-only modes and respects user access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->