### PR TITLE
fix: add functionality to mark expired shift assignments as inactive

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -238,6 +238,7 @@ scheduler_events = {
 		"hrms.controllers.employee_reminders.send_work_anniversary_reminders",
 		"hrms.hr.doctype.daily_work_summary_group.daily_work_summary_group.send_summary",
 		"hrms.hr.doctype.interview.interview.send_daily_feedback_reminder",
+		"hrms.hr.doctype.shift_assignment.shift_assignment.mark_expired_shift_assignments_as_inactive",
 		"hrms.hr.doctype.job_opening.job_opening.close_expired_job_openings",
 	],
 	"daily_long": [

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -199,6 +199,25 @@ def get_events(start: str | date, end: str | date, filters: list | None = None):
 	return get_shift_events(assignments)
 
 
+def mark_expired_shift_assignments_as_inactive():
+	today = getdate()
+	shift_assignment = frappe.qb.DocType("Shift Assignment")
+
+	expired_assignments = (
+		frappe.qb.from_(shift_assignment)
+		.select(shift_assignment.name)
+		.where(
+			(shift_assignment.docstatus == 1)
+			& (shift_assignment.status == "Active")
+			& (shift_assignment.end_date.isnotnull())
+			& (shift_assignment.end_date < today)
+		)
+	).run(pluck=True)
+
+	for assignment in expired_assignments:
+		frappe.db.set_value("Shift Assignment", assignment, "status", "Inactive")
+
+
 def get_shift_assignments(start: str, end: str, filters: str | list | None = None) -> list[dict]:
 	import json
 

--- a/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/test_shift_assignment.py
@@ -15,6 +15,7 @@ from hrms.hr.doctype.shift_assignment.shift_assignment import (
 	OverlappingShiftError,
 	get_actual_start_end_datetime_of_shift,
 	get_events,
+	mark_expired_shift_assignments_as_inactive,
 )
 from hrms.hr.doctype.shift_type.test_shift_type import make_shift_assignment, setup_shift_type
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
@@ -296,3 +297,35 @@ class TestShiftAssignment(HRMSTestSuite):
 		self.assertEqual(attendance.overtime_type, shift_type.overtime_type)
 		self.assertEqual(attendance.working_hours, 11.0)
 		self.assertEqual(attendance.actual_overtime_duration, 2.0)
+
+	def test_mark_expired_shift_assignments_as_inactive(self):
+		today = getdate()
+		shift_type = setup_shift_type(shift_type="Expired Shift", start_time="08:00:00", end_time="16:00:00")
+
+		expired_employee = make_employee("test_expired_shift_assignment@example.com", company="_Test Company")
+		active_employee = make_employee("test_active_shift_assignment@example.com", company="_Test Company")
+		ongoing_employee = make_employee("test_ongoing_shift_assignment@example.com", company="_Test Company")
+
+		expired_assignment = make_shift_assignment(
+			shift_type.name,
+			expired_employee,
+			add_days(today, -7),
+			add_days(today, -1),
+		)
+		active_assignment = make_shift_assignment(
+			shift_type.name,
+			active_employee,
+			add_days(today, -1),
+			add_days(today, 2),
+		)
+		ongoing_assignment = make_shift_assignment(shift_type.name, ongoing_employee, add_days(today, -3))
+
+		mark_expired_shift_assignments_as_inactive()
+
+		expired_assignment.reload()
+		active_assignment.reload()
+		ongoing_assignment.reload()
+
+		self.assertEqual(expired_assignment.status, "Inactive")
+		self.assertEqual(active_assignment.status, "Active")
+		self.assertEqual(ongoing_assignment.status, "Active")


### PR DESCRIPTION
Changes:
- added scheduler to mark expired shift assignments as inactive.
- Before this, the shift assignment was not marked as inactive, and will be picked up by the get_shifts_for_date function.
- Now, after marking the shift assignment as inactive, it will not be picked up and mark the employee as absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift assignments with expired end dates now automatically transition to inactive status on a daily basis, ensuring shift records remain accurate without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->