### PR TITLE
fix: correct employee grade filter field name in Employee Attendance

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -92,6 +92,26 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			reqd: 1,
 		},
 		{
+			fieldname: "department",
+			label: __("Department"),
+			fieldtype: "Link",
+			options: "Department",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: {
+						company: company,
+					},
+				};
+			},
+		},
+		{
+			fieldname: "branch",
+			label: __("Branch"),
+			fieldtype: "Link",
+			options: "Branch",
+		},
+		{
 			fieldname: "group_by",
 			label: __("Group By"),
 			fieldtype: "Select",

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -374,6 +374,10 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 
 	if filters.employee:
 		query = query.where(Employee.name == filters.employee)
+	if filters.department and filters.department != "All Departments":
+		query = query.where(Employee.department == filters.department)
+	if filters.branch:
+		query = query.where(Employee.branch == filters.branch)
 
 	group_by = filters.group_by
 	if group_by:


### PR DESCRIPTION
**Summary**
Adds Department and Branch filter fields to the Monthly Attendance Sheet report to make it usable for organizations with a large number of employees.

Closes https://github.com/frappe/hrms/issues/3978

**Problem**
When an organization has thousands of employees, the Monthly Attendance Sheet report returns an overwhelming amount of data with no way to narrow it down by department or branch. Users had to scroll through all records to find what they needed.

**Changes**
monthly_attendance_sheet.js
Added a Department filter — a Link field to the Department doctype, scoped to the selected company via get_query
Added a Branch filter — a Link field to the Branch doctype.

monthly_attendance_sheet.py
In get_employee_related_details, added WHERE clauses to filter the employee query by department and branch when those filter values are set:

if filters.department and filters.department != "All Departments":
query = query.where(Employee.department == filters.department)
if filters.branch:
query = query.where(Employee.branch == filters.branch)

**Testing**

- Run the Monthly Attendance Sheet report without Department/Branch filters — should behave as before
- Run the report with a Department filter — only employees in that department should appear
- Run the report with a Branch filter — only employees in that branch should appear
- Run the report with both Department and Branch filters — results should be filtered by both
- Verify the Department filter's get_query restricts results to the selected company
- Test with Group By enabled alongside Department/Branch filters — grouping should still work correctly
- Test with Summarized View enabled alongside these filters


**Notes**

- The department filter guard (!= "All Departments") is intentional — it mirrors the pattern used in other HRMS reports where "All Departments" is treated as an unfiltered state.
- The Department get_query is company-scoped so users don't see departments from other companies in the dropdown.

**New Features**

- Added optional Department and Branch filters to the Monthly Attendance Sheet report for enhanced filtering capabilities
- Department filter automatically adjusts available options based on the selected Company

**Before
Without Department & Branch Filter**

<img width="1900" height="1078" alt="Monthly Attendance Sheet 1" src="https://github.com/user-attachments/assets/e1797229-dfaf-40ae-ba2b-7f1800021e6b" />

**After
With Department & Branch Filter**

<img width="1900" height="1021" alt="Monthly Attendance Sheet 2" src="https://github.com/user-attachments/assets/d1c4fd35-7c1b-4903-84d9-aa11f8b58726" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Department and Branch filters to Monthly Attendance Sheet report, enabling users to filter attendance data by organizational structure. The Department filter automatically scopes to the selected company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->