### PR TITLE
feat: filter department and branch dropdowns by company in Monthly Attendance Sheet

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -92,6 +92,26 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			reqd: 1,
 		},
 		{
+			fieldname: "department",
+			label: __("Department"),
+			fieldtype: "Link",
+			options: "Department",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: {
+						company: company,
+					},
+				};
+			},
+		},
+		{
+			fieldname: "branch",
+			label: __("Branch"),
+			fieldtype: "Link",
+			options: "Branch",
+		},
+		{
 			fieldname: "group_by",
 			label: __("Group By"),
 			fieldtype: "Select",

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -374,6 +374,10 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 
 	if filters.employee:
 		query = query.where(Employee.name == filters.employee)
+	if filters.department and filters.department != "All Departments":
+		query = query.where(Employee.department == filters.department)
+	if filters.branch:
+		query = query.where(Employee.branch == filters.branch)
 
 	group_by = filters.group_by
 	if group_by:

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -519,6 +519,112 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 			== "L"
 		)
 
+	def test_attendance_with_department_filter(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		dept1 = create_department("Test Dept Alpha")
+		dept2 = create_department("Test Dept Beta")
+
+		emp_dept1 = make_employee("emp_dept1@example.com", company=self.company, department=dept1)
+		emp_dept2 = make_employee("emp_dept2@example.com", company=self.company, department=dept2)
+
+		mark_attendance(emp_dept1, previous_month_first, "Present")
+		mark_attendance(emp_dept2, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"department": dept1,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only emp_dept1 should appear; emp_dept2 belongs to a different department
+		self.assertIn(emp_dept1, employees_in_report)
+		self.assertNotIn(emp_dept2, employees_in_report)
+
+	def test_attendance_with_branch_filter(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		branch1 = create_branch("Test Branch Alpha")
+		branch2 = create_branch("Test Branch Beta")
+
+		emp_branch1 = make_employee("emp_branch1@example.com", company=self.company, branch=branch1)
+		emp_branch2 = make_employee("emp_branch2@example.com", company=self.company, branch=branch2)
+
+		mark_attendance(emp_branch1, previous_month_first, "Present")
+		mark_attendance(emp_branch2, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"branch": branch1,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only emp_branch1 should appear; emp_branch2 belongs to a different branch
+		self.assertIn(emp_branch1, employees_in_report)
+		self.assertNotIn(emp_branch2, employees_in_report)
+
+	def test_attendance_with_department_and_branch_filter_combined(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		dept = create_department("Test Dept Combined")
+		branch = create_branch("Test Branch Combined")
+
+		# employee matching both department and branch
+		emp_match = make_employee(
+			"emp_match@example.com", company=self.company, department=dept, branch=branch
+		)
+		# employee with correct department but wrong branch
+		emp_wrong_branch = make_employee(
+			"emp_wrong_branch@example.com",
+			company=self.company,
+			department=dept,
+			branch=create_branch("Test Branch Other"),
+		)
+		# employee with correct branch but wrong department
+		emp_wrong_dept = make_employee(
+			"emp_wrong_dept@example.com",
+			company=self.company,
+			department=create_department("Test Dept Other"),
+			branch=branch,
+		)
+
+		mark_attendance(emp_match, previous_month_first, "Present")
+		mark_attendance(emp_wrong_branch, previous_month_first, "Present")
+		mark_attendance(emp_wrong_dept, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"department": dept,
+				"branch": branch,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only the employee matching both department and branch should appear
+		self.assertIn(emp_match, employees_in_report)
+		self.assertNotIn(emp_wrong_branch, employees_in_report)
+		self.assertNotIn(emp_wrong_dept, employees_in_report)
+
 	def test_detailed_view_with_date_range_and_group_by_filter(self):
 		today = getdate()
 		mark_attendance(self.employee, today, "Absent", "Day Shift")
@@ -589,3 +695,9 @@ def execute_report_with_invalid_filters(invalid_filter_name):
 
 def date_key(date_obj):
 	return date_obj.strftime("%d-%m-%Y")
+
+
+def create_branch(branch_name):
+	if not frappe.db.exists("Branch", branch_name):
+		frappe.get_doc({"doctype": "Branch", "branch": branch_name}).insert(ignore_permissions=True)
+	return branch_name

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -15,7 +15,7 @@ from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
 )
-from hrms.tests.test_utils import create_company, get_first_day_for_prev_month
+from hrms.tests.test_utils import create_company, create_department, get_first_day_for_prev_month
 from hrms.tests.utils import HRMSTestSuite
 
 


### PR DESCRIPTION
**Summary**
Adds Department and Branch filter fields to the Monthly Attendance Sheet report to make it usable for organizations with a large number of employees.

Closes https://github.com/frappe/hrms/issues/3978

**Problem**
When an organization has thousands of employees, the Monthly Attendance Sheet report returns an overwhelming amount of data with no way to narrow it down by department or branch. Users had to scroll through all records to find what they needed.

**Changes**
monthly_attendance_sheet.js
Added a Department filter — a Link field to the Department doctype, scoped to the selected company via get_query
Added a Branch filter — a Link field to the Branch doctype.

monthly_attendance_sheet.py
In get_employee_related_details, added WHERE clauses to filter the employee query by department and branch when those filter values are set:

if filters.department and filters.department != "All Departments":
query = query.where(Employee.department == filters.department)
if filters.branch:
query = query.where(Employee.branch == filters.branch)

**Testing**


- Run the Monthly Attendance Sheet report without Department/Branch filters — should behave as before
- Run the report with a Department filter — only employees in that department should appear
- Run the report with a Branch filter — only employees in that branch should appear
- Run the report with both Department and Branch filters — results should be filtered by both
- Verify the Department filter's get_query restricts results to the selected company
- Test with Group By enabled alongside Department/Branch filters — grouping should still work correctly
- Test with Summarized View enabled alongside these filters


**Notes**


- The department filter guard (!= "All Departments") is intentional — it mirrors the pattern used in other HRMS reports where "All Departments" is treated as an unfiltered state.
- The Department get_query is company-scoped so users don't see departments from other companies in the dropdown.

**New Features**


- Added optional Department and Branch filters to the Monthly Attendance Sheet report for enhanced filtering capabilities
- Department filter automatically adjusts available options based on the selected Company

**Before
Without Department & Branch Filter**

<img width="1900" height="1078" alt="Monthly Attendance Sheet 1" src="https://github.com/user-attachments/assets/1e279791-d4d8-4927-80f9-1eab89e03e3f" />

**After
With Department & Branch Filter**

<img width="1900" height="1021" alt="Monthly Attendance Sheet 2" src="https://github.com/user-attachments/assets/a8d3f26f-4299-41b5-9c2d-6b906a6e021b" />


**New Features**

- Added Department and Branch filters to Monthly Attendance Sheet report, enabling users to filter attendance data by organizational structure. The Department filter automatically scopes to the selected company.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Department and Branch filters to the Monthly Attendance Sheet report; Department choices are scoped to the selected Company.
* **Bug Fixes / Improvements**
  * Report results now honor Department and Branch selections when retrieving employee rows.
* **Tests**
  * Added unit tests covering Department-only, Branch-only, and combined filtering scenarios (includes branch helper).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->