### PR TITLE
fix(salary_detail): Condition & formula section auto collapse

### DIFF
--- a/hrms/payroll/doctype/salary_detail/salary_detail.json
+++ b/hrms/payroll/doctype/salary_detail/salary_detail.json
@@ -123,7 +123,7 @@
   },
   {
    "collapsible": 1,
-   "depends_on": "eval:doc.is_flexible_benefit != 1",
+   "depends_on": "eval:doc.is_flexible_benefit !== 1",
    "fieldname": "section_break_2",
    "fieldtype": "Section Break",
    "label": "Condition and formula"
@@ -141,7 +141,6 @@
    "depends_on": "eval:doc.parenttype=='Salary Structure'",
    "fieldname": "amount_based_on_formula",
    "fieldtype": "Check",
-   "in_list_view": 1,
    "label": "Amount based on formula"
   },
   {
@@ -149,7 +148,6 @@
    "depends_on": "eval:doc.amount_based_on_formula!==0 && doc.parenttype==='Salary Structure'",
    "fieldname": "formula",
    "fieldtype": "Code",
-   "in_list_view": 1,
    "label": "Formula",
    "options": "PythonExpression"
   },
@@ -278,7 +276,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-09-01 14:32:39.449384",
+ "modified": "2026-04-08 18:01:31.551466",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",


### PR DESCRIPTION
## Reason
- User when try to enable the check Amount based on formula or while typing formula the section collapses even before updating fields

https://github.com/user-attachments/assets/83a808a6-5e42-4a71-9a38-312b2eca29b2



## Changes done
- Removed In list view filter which was causing to auto collapse the section, also both child table fields don't show in list view

https://github.com/user-attachments/assets/b8ec595b-ea8d-4129-91e6-f275af653989

Closes: https://github.com/frappe/hrms/issues/4344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Salary Detail documents no longer display "Amount based on formula" and "Formula" fields in list views, reducing visual clutter for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->