### PR TITLE
ci: enabling safe auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - "**.csv"
       - "**.po"
       - "**.pot"
+      - 'crowdin.yml'
+      - '.mergify.yml'
+      - '**.vue'
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"

--- a/.github/workflows/ci_faux.yml
+++ b/.github/workflows/ci_faux.yml
@@ -1,0 +1,34 @@
+# Tests are skipped for these files but github doesn't allow "passing" hence this is required.
+
+name: Skipped Tests
+
+on:
+  pull_request:
+    paths:
+      - "**.js"
+      - "**.css"
+      - "**.svg"
+      - "**.md"
+      - "**.html"
+      - 'crowdin.yml'
+      - '.coderabbit.yml'
+      - '.mergify.yml'
+      - 'crowdin.yml'
+      - '.mergify.yml'
+      - '**.vue'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: [1, 2, 3]
+
+    name: Python Unit Tests
+
+    steps:
+      - name: Pass skipped tests unconditionally
+        run: "echo Skipped"

--- a/.github/workflows/ci_faux.yml
+++ b/.github/workflows/ci_faux.yml
@@ -5,14 +5,13 @@ name: Skipped Tests
 on:
   pull_request:
     paths:
-      - "**.js"
       - "**.css"
-      - "**.svg"
+      - "**.js"
       - "**.md"
       - "**.html"
-      - 'crowdin.yml'
-      - '.coderabbit.yml'
-      - '.mergify.yml'
+      - "**.csv"
+      - "**.po"
+      - "**.pot"
       - 'crowdin.yml'
       - '.mergify.yml'
       - '**.vue'

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -10,6 +10,10 @@ on:
       - '**.csv'
       - 'crowdin.yml'
       - '.mergify.yml'
+      - '**.vue'
+      - '**.pot'
+      - '**.po'
+
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/patch_faux.yml
+++ b/.github/workflows/patch_faux.yml
@@ -1,0 +1,30 @@
+# Tests are skipped for these files but github doesn't allow "passing" hence this is required.
+
+name: Skipped Patch Test
+
+on:
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.css'
+      - '**.md'
+      - '**.html'
+      - '**.csv'
+      - 'crowdin.yml'
+      - '.mergify.yml'
+      - '**.vue'
+      - '**.pot'
+      - '**.po'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    name: Patch Test
+
+    steps:
+      - name: Pass skipped tests unconditionally
+        run: "echo Skipped"


### PR DESCRIPTION
Auto-merge relies on required ci workflows passing successfully. Not all required workflows need to be executed for all files, like python tests can be skipped on .js, .vue file etc, but if they are marked as required in branch protection rules, github expects these workflows to be executed. Hence the faux ones do nothing but run on skipped files and give a green light to github.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI triggers to skip workflow runs when changes are limited to configuration, translation, or front-end template/content files.
  * Added lightweight placeholder test workflows that report success for intentionally skipped scenarios, reducing noisy CI runs and improving pipeline efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->