### PR TITLE
Fix/holiday list assignment auto attendance

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -20,7 +20,6 @@ from frappe.utils import (
 	time_diff,
 )
 
-from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.setup.doctype.holiday_list.holiday_list import is_half_holiday, is_holiday
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
@@ -30,7 +29,8 @@ from hrms.hr.doctype.employee_checkin.employee_checkin import (
 )
 from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift, get_shift_details
 from hrms.utils import get_date_range
-from hrms.utils.holiday_list import get_holiday_dates_between
+from hrms.utils.holiday_list import get_holiday_dates_between, get_holiday_dates_between_range
+from hrms.utils.holiday_list import get_holiday_list_for_employee
 
 EMPLOYEE_CHUNK_SIZE = 50
 
@@ -335,9 +335,14 @@ class ShiftType(Document):
 
 		date_range = get_date_range(start_date, end_date)
 
-		# skip marking absent on holidays
-		holiday_list = self.get_holiday_list(employee)
-		holiday_dates = get_holiday_dates_between(holiday_list, start_date, end_date)
+		# skip marking absent on holidays — use range-aware helper so that
+		# mid-period Holiday List Assignment changes are handled correctly
+		if self.holiday_list:
+			holiday_dates = get_holiday_dates_between(self.holiday_list, start_date, end_date)
+		else:
+			holiday_dates = get_holiday_dates_between_range(
+				employee, start_date, end_date, raise_exception_for_holiday_list=False
+			)
 		# skip dates with attendance
 		marked_attendance_dates = self.get_marked_attendance_dates_between(employee, start_date, end_date)
 
@@ -414,8 +419,11 @@ class ShiftType(Document):
 		return list(set(assigned_employees) - set(inactive_employees))
 
 	def get_holiday_list(self, employee: str, date=None) -> str:
-		holiday_list_name = self.holiday_list or get_holiday_list_for_employee(employee, False, as_on=date)
-		return holiday_list_name
+		# Use HRMS's HLA-aware get_holiday_list_for_employee so that Holiday List
+		# Assignments are respected (not just the static Employee.holiday_list field).
+		return self.holiday_list or get_holiday_list_for_employee(
+			employee, raise_exception=False, as_on=date
+		)
 
 	def should_mark_attendance(self, employee: str, attendance_date: str) -> bool:
 		"""Determines whether attendance should be marked on holidays or not"""

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -609,6 +609,44 @@ class TestShiftType(HRMSTestSuite):
 		)
 		self.assertIsNone(attendance)
 
+	def test_skip_marking_absent_on_weekly_off_via_holiday_list_assignment(self):
+		"""
+		Tests that Absent is not marked on Weekly Off days when the employee's
+		holiday list is resolved through a Holiday List Assignment (Employee.holiday_list
+		is intentionally left blank). Previously, Shift Type imported ERPNext's
+		get_holiday_list_for_employee which ignored HLA records, causing Absent to be
+		stamped on every day including Weekly Offs.
+		"""
+		from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+			create_holiday_list_assignment,
+		)
+
+		employee = make_employee(
+			"test_employee_hla_weekly_off@example.com",
+			company="_Test Company",
+		)
+		# leave Employee.holiday_list blank; rely on HLA
+		frappe.db.set_value("Employee", employee, "holiday_list", None)
+
+		# assign holiday list via HLA (Sundays are weekly offs in self.holiday_list)
+		create_holiday_list_assignment("Employee", employee, self.holiday_list)
+
+		shift_type = setup_shift_type(shift_type="Test Absent HLA Weekly Off")
+		shift_type.holiday_list = None  # force resolution through employee's HLA
+		shift_type.save()
+
+		first_sunday = get_first_sunday(self.holiday_list, for_date=getdate())
+		make_shift_assignment(shift_type.name, employee, first_sunday)
+
+		shift_type.process_auto_attendance()
+
+		# Weekly Off day must not receive an Absent attendance record
+		attendance = frappe.db.get_value(
+			"Attendance",
+			{"attendance_date": first_sunday, "employee": employee},
+		)
+		self.assertIsNone(attendance)
+
 	def test_skip_absent_marking_for_a_fallback_default_shift(self):
 		"""
 		Tests if an employee is not marked absent for default shift

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -443,13 +443,77 @@ def get_holiday_map(filters: Filters) -> dict[str, list[dict]]:
 	return holiday_map
 
 
+def get_employee_holidays_for_period(
+	employee: str, filters: Filters, holiday_map: dict, default_holiday_list: str
+) -> list:
+	"""Returns merged holidays for an employee over the filter period,
+	correctly resolving Holiday List Assignments (including mid-period changes).
+	"""
+	from hrms.utils.holiday_list import get_holiday_list_for_employee
+
+	dates = get_dates_in_period(filters)
+	if not dates:
+		return []
+
+	start_date = getdate(dates[0])
+	end_date = getdate(dates[-1])
+
+	start_hl = (
+		get_holiday_list_for_employee(employee, raise_exception=False, as_on=start_date)
+		or default_holiday_list
+	)
+	end_hl = (
+		get_holiday_list_for_employee(employee, raise_exception=False, as_on=end_date)
+		or default_holiday_list
+	)
+
+	if not start_hl:
+		return []
+
+	if start_hl == end_hl:
+		return holiday_map.get(start_hl, [])
+
+	# Holiday list changed mid-period — fetch the transition assignments
+	HLA = frappe.qb.DocType("Holiday List Assignment")
+	assignments = (
+		frappe.qb.from_(HLA)
+		.select(HLA.holiday_list, HLA.from_date)
+		.where(HLA.assigned_to == employee)
+		.where(HLA.from_date.between(start_date, end_date))
+		.where(HLA.docstatus == 1)
+		.orderby(HLA.from_date)
+	).run(as_dict=True)
+
+	merged = []
+	seen_dates = set()
+	prev_date = start_date
+	prev_hl = start_hl
+
+	for assignment in assignments:
+		transition = getdate(assignment.from_date)
+		for holiday in holiday_map.get(prev_hl, []):
+			hdate = getdate(holiday.holiday_date)
+			if prev_date <= hdate < transition and hdate not in seen_dates:
+				merged.append(holiday)
+				seen_dates.add(hdate)
+		prev_date = transition
+		prev_hl = assignment.holiday_list
+
+	for holiday in holiday_map.get(prev_hl, []):
+		hdate = getdate(holiday.holiday_date)
+		if prev_date <= hdate <= end_date and hdate not in seen_dates:
+			merged.append(holiday)
+			seen_dates.add(hdate)
+
+	return merged
+
+
 def get_rows(employee_details: dict, filters: Filters, holiday_map: dict, attendance_map: dict) -> list[dict]:
 	records = []
 	default_holiday_list = frappe.get_cached_value("Company", filters.company, "default_holiday_list")
 
 	for employee, details in employee_details.items():
-		emp_holiday_list = details.holiday_list or default_holiday_list
-		holidays = holiday_map.get(emp_holiday_list)
+		holidays = get_employee_holidays_for_period(employee, filters, holiday_map, default_holiday_list)
 
 		if filters.summarized_view:
 			attendance = get_attendance_status_for_summarized_view(

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -6,7 +6,10 @@ from frappe.utils import add_days, get_year_ending, get_year_start, getdate
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
-from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import assign_holiday_list
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	assign_holiday_list,
+	create_holiday_list_assignment,
+)
 from hrms.hr.doctype.leave_allocation.leave_allocation import OverlapError
 from hrms.hr.doctype.leave_application.test_leave_application import make_allocation_record
 from hrms.hr.doctype.shift_type.test_shift_type import setup_shift_type
@@ -15,7 +18,7 @@ from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
 )
-from hrms.tests.test_utils import create_company, create_department, get_first_day_for_prev_month
+from hrms.tests.test_utils import create_company, create_department, get_first_day_for_prev_month, get_first_sunday
 from hrms.tests.utils import HRMSTestSuite
 
 
@@ -396,6 +399,52 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(absent[0], 1)
 		self.assertEqual(present[1], 1)
 		self.assertEqual(leaves[2], 1)
+
+	def test_holiday_list_assignment_reflected_in_report(self):
+		"""
+		Tests that Weekly Off / Holiday markers from a Holiday List Assignment are
+		shown in the Monthly Attendance Sheet when Employee.holiday_list is blank.
+		Previously the report read Employee.holiday_list (static field) and ignored
+		Holiday List Assignment records entirely.
+		"""
+		previous_month_first = get_first_day_for_prev_month()
+		date = getdate()
+		from_date = get_year_start(date)
+		to_date = get_year_ending(date)
+		holiday_list = make_holiday_list(list_name="Test HLA Report Holiday List", from_date=from_date, to_date=to_date)
+
+		employee = make_employee("test_hla_report@example.com", company=self.company)
+		# leave Employee.holiday_list blank; rely on HLA
+		frappe.db.set_value("Employee", employee, "holiday_list", None)
+
+		# assign holiday list via HLA
+		create_holiday_list_assignment("Employee", employee, holiday_list)
+
+		# mark attendance on one working day
+		mark_attendance(employee, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"employee": employee,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+		self.assertTrue(report[1], "Expected at least one row in the report")
+
+		row = report[1][0]
+
+		# find the first Sunday (weekly off) in the previous month from this holiday list
+		first_sunday = get_first_sunday(holiday_list, for_date=previous_month_first)
+		if first_sunday and first_sunday.month == previous_month_first.month:
+			self.assertEqual(
+				row[date_key(first_sunday)],
+				"WO",
+				"Weekly Off from Holiday List Assignment must be shown as WO in the report",
+			)
 
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validations(self):


### PR DESCRIPTION
## Problem
                                                                                                                                          
  Two related issues caused by Holiday List Assignment (HLA) records being ignored:                                                       
   
  ### 1. Shift Type → Mark Attendance marks Absent on Weekly Off / Holiday days                                                           
                                                            
  `shift_type.py` was importing `get_holiday_list_for_employee` from **ERPNext**                                                          
  (the old version that reads only the static `Employee.holiday_list` field).
                                                                                                                                          
  When an employee's holiday list is managed via HLA records (and
  `Employee.holiday_list` is blank), the function returned `None`, so                                                                     
  `get_dates_for_attendance()` excluded zero holiday/weekly-off dates —
  causing **Absent to be stamped on every day, including Weekly Offs and Holidays**.                                                      
   
  ### 2. Monthly Attendance Sheet ignores Holiday List Assignments                                                                        
                                                            
  The report resolved the employee's holiday list via `details.holiday_list`                                                              
  (the static Employee field), falling back to the company default. HLA records
  were never consulted, so employees using HLA had no holiday markers (H/WO) at all.                                                      
                                                                                                                                          
  ## Fix                                                                                                                                  
                                                                                                                                          
  **`shift_type.py`**                                       
  - Removed ERPNext import; now imports `get_holiday_list_for_employee` from
    `hrms.utils.holiday_list` (the HLA-aware version)                                                                                     
  - `get_holiday_list()` now resolves correctly via HLA for the given date
  - `get_dates_for_attendance()` calls `get_holiday_dates_between_range(employee, ...)`                                                   
    when no shift-level holiday list is set — handles mid-period HLA transitions                                                          
    (e.g. FY2025 list → FY2026 list within the same date range)                                                                           
                                                                                                                                          
  **`monthly_attendance_sheet.py`**                                                                                                       
  - Added `get_employee_holidays_for_period()` helper that uses
    `get_holiday_list_for_employee()` from `hrms.utils.holiday_list` with `as_on`                                                         
    date, and merges holidays from multiple lists if the assignment changes                                                               
    mid-period                                                                                                                            
                                                                                                                                          
  ## How to Test                                                                                                                          
                                                            
  1. Leave `Employee.holiday_list` blank
  2. Create a submitted **Holiday List Assignment** for the employee
  3. Run **Shift Type → Mark Attendance** — Weekly Offs and Holidays should                                                               
     no longer be marked Absent
  4. Open **Monthly Attendance Sheet** — H / WO markers now appear correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Monthly Attendance Sheet now correctly accounts for holiday list changes that occur during the reporting period.

* **Bug Fixes**
  * Fixed weekly-off/holiday recognition so absences are not incorrectly marked when holidays are applied via holiday list assignments.

* **Refactor**
  * Streamlined holiday resolution logic for shift attendance to ensure consistent, HRMS-aware results.

* **Tests**
  * Added tests verifying holiday list assignments are respected in attendance processing and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->