### PR TITLE
fix: prevent multiple entries of Additional Salary component in Salary Slip

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1627,6 +1627,11 @@ class SalarySlip(TransactionBase):
 
 		for additional_salary in additional_salaries:
 			component_data = get_salary_component_data(additional_salary.component)
+			remove_if_zero_valued = frappe.get_cached_value(
+				"Salary Component", additional_salary.component, "remove_if_zero_valued"
+			)
+			if flt(additional_salary.amount) == 0 and remove_if_zero_valued:
+				continue
 			self.update_component_row(
 				component_data,
 				additional_salary.amount,
@@ -1827,7 +1832,7 @@ class SalarySlip(TransactionBase):
 			):
 				component_row.set(attr, component_data.get(attr))
 
-		if additional_salary and amount:
+		if additional_salary:
 			if additional_salary.overwrite:
 				component_row.additional_amount = flt(
 					flt(amount) - flt(component_row.get("default_amount", 0)),

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1932,6 +1932,7 @@ class TestSalarySlip(HRMSTestSuite):
 				"type": "Earning",
 				"is_income_tax_component": 0,
 				"amount": 350,
+				"remove_if_zero_valued": 0,
 			},
 		]
 		make_salary_component(data, False, company_list=["_Test Company"])


### PR DESCRIPTION
## Reason
- When an additional salary with amount 0 is created and the check  **Remove if Zero Valued** in salary component selected in additional salary is disabled, the payroll entry added this component thrice in the salary slip.

https://github.com/user-attachments/assets/124ad6a7-5e98-44a5-9650-bb9e6f44e1ce

## Changes done
- On additional additoinal salaries record in salary slip, add a guard to prevent adding those additional salary whose amount is 0 and Remove if Zero Valued is enabled in salary component
- Removed condition to check if amount greater than 0 while adding additional salary as 0 valued will not be added untile the Remove if Zero Valued is disbaled.

https://github.com/user-attachments/assets/371e3efa-024e-4302-9cc4-96768796b0b8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Salary components can be configured to automatically exclude zero-valued amounts from salary slips.

* **Bug Fixes**
  * Additional salary rows are handled more consistently, ensuring overwrite/default logic applies when an additional salary entry exists.

* **Tests**
  * Updated tests to cover zero-valued additional salary behavior and the configurable exclusion setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->