### PR TITLE
fix(test): missing repost defaults

### DIFF
--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -589,13 +589,6 @@ class TestExpenseClaim(HRMSTestSuite):
 		self.assertEqual(expense_claim.status, "Unpaid")
 
 	def test_repost(self):
-		# Update repost settings
-		allowed_types = ["Expense Claim"]
-		repost_settings = frappe.get_doc("Repost Accounting Ledger Settings")
-		for x in allowed_types:
-			repost_settings.append("allowed_types", {"document_type": x, "allowed": True})
-		repost_settings.save()
-
 		payable_account = get_payable_account(company_name)
 		taxes = generate_taxes(rate=10)
 		expense_claim = make_expense_claim(

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -18,6 +18,7 @@ def after_install():
 	update_hr_defaults()
 	add_non_standard_user_types()
 	set_single_defaults()
+	setup_repost_defaults()
 	create_default_role_profiles()
 	run_post_install_patches()
 
@@ -855,3 +856,10 @@ def get_salary_slip_loan_fields():
 def make_people_workspace_standard():
 	if frappe.db.exists("Workspace Sidebar", "People"):
 		frappe.db.set_value("Workspace Sidebar", "People", "standard", 1)
+
+
+def setup_repost_defaults():
+	accounts_settings = frappe.get_doc("Accounts Settings")
+	for x in frappe.get_hooks("repost_allowed_doctypes"):
+		accounts_settings.append("repost_allowed_types", {"document_type": x})
+	accounts_settings.save()


### PR DESCRIPTION
https://github.com/frappe/hrms/pull/4398

```
======================================================================
 ERROR  test_repost (hrms.hr.doctype.expense_claim.test_expense_claim.TestExpenseClaim.test_repost)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/hrms/hrms/hr/doctype/expense_claim/test_expense_claim.py", line 631, in test_repost
    repost_doc.save().submit()
    ~~~~~~~~~~~~~~~^^
    expected_data = [{'total_debit': 110.0, 'total_credit': 110.0}]
    expense_claim = <ExpenseClaim: doctype=Expense Claim HR-EXP-2026-00001 docstatus=1>
    gl_entries = [{'name': '5363283bfe'}]
    ledger_balance = [{'total_debit': 110.0, 'total_credit': 0.0}]
    payable_account = 'Creditors - _TC3'
    repost_doc = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
    self = <hrms.hr.doctype.expense_claim.test_expense_claim.TestExpenseClaim testMethod=test_repost>
    taxes = {'taxes': [{'account_head': 'Output Tax CGST - _TC3', 'cost_center': 'Main - _TC3', 'rate': 10, 'description': 'CGST', 'doctype': 'Expense Taxes and Charges'}]}
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 676, in save
    return self._save(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 698, in _save
    return self.insert()
           ~~~~~~~~~~~^^
    ignore_permissions = None
    ignore_version = None
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 605, in insert
    self.run_before_save_methods()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1630, in run_before_save_methods
    self.run_method("validate")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1479, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7fc2b0061010>
    kwargs = {}
    method = 'validate'
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1876, in composer
    return composed(self, method, *args, **kwargs)
    args = ()
    compose = <function Document.hook.<locals>.compose at 0x7fc2b00f6770>
    composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x7fc2b00f6b90>
    doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type', 'frappe.core.doctype.permission_log.permission_log.make_perm_log', 'frappe.search.sqlite_search.update_doc_index'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.search.sqlite_search.delete_doc_index'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.file.utils.attach_files_to_document'], 'on_change': ['frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone'], 'after_delete': ['frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'validate': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.apply', 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job']}, 'Event': {'after_insert': ['frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar', 'erpnext.crm.utils.link_events_with_prospect'], 'on_update': ['frappe.integrations.doctype.google_calendar.google_calendar.update_event_in_google_calendar'], 'on_trash': ['frappe.integrations.doctype.google_calendar.google_calendar.delete_event_from_google_calendar']}, 'Contact': {'after_insert': ['frappe.integrations.doctype.google_contacts.google_contacts.insert_contacts_to_google_contacts', 'erpnext.telephony.doctype.call_log.call_log.link_existing_conversations'], 'on_update': ['frappe.integrations.doctype.google_contacts.google_contacts.update_contacts_to_google_contacts'], 'on_trash': ['erpnext.support.doctype.issue.issue.update_issue'], 'validate': ['erpnext.crm.utils.update_lead_phone_numbers']}, 'DocType': {'on_update': ['frappe.cache_manager.build_domain_restricted_doctype_cache']}, 'Page': {'on_update': ['frappe.cache_manager.build_domain_restricted_page_cache']}, 'Sales Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'lending.overrides.sales_invoice.validate'], 'on_submit': ['erpnext.regional.italy.utils.sales_invoice_on_submit', 'lending.overrides.sales_invoice.generate_demand', 'lending.overrides.sales_invoice.update_waived_amount_in_demand', 'lending.overrides.sales_invoice.make_partner_charge_gl_entries', 'lending.overrides.sales_invoice.make_suspense_gl_entry_for_charges'], 'on_cancel': ['erpnext.regional.italy.utils.sales_invoice_on_cancel', 'lending.overrides.sales_invoice.cancel_demand'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Purchase Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm', 'erpnext.regional.united_arab_emirates.utils.validate_returns']}, 'Journal Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'hrms.hr.doctype.expense_claim.expense_claim.validate_expense_claim_in_jv'], 'on_cancel': ['lending.overrides.journal_entry.add_ignore_linked_doctypes_for_jv', 'hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim', 'hrms.payroll.doctype.salary_slip.salary_slip.unlink_ref_doc_from_salary_slip', 'hrms.hr.doctype.full_and_final_statement.full_and_final_statement.update_full_and_final_statement_status', 'hrms.payroll.doctype.salary_withholding.salary_withholding.update_salary_withholding_payment_status'], 'on_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim', 'hrms.hr.doctype.full_and_final_statement.full_and_final_statement.update_full_and_final_statement_status', 'hrms.payroll.doctype.salary_withholding.salary_withholding.update_salary_withholding_payment_status'], 'on_update_after_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim']}, 'Bank Clearance': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty'], 'on_cancel': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty']}, 'Dunning': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Invoice Discounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Payment Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_trash': ['erpnext.regional.check_deletion_permission'], 'on_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim'], 'on_cancel': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim'], 'on_update_after_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim']}, 'Period Closing Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Process Deferred Accounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Capitalization': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Repair': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Delivery Note': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Landed Cost Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Purchase Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Reconciliation': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Subcontracting Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'User': {'after_insert': ['frappe.contacts.doctype.contact.contact.update_contact'], 'validate': ['erpnext.setup.doctype.employee.employee.validate_employee_role', 'erpnext.setup.doctype.employee.employee.validate_employee_role', 'hrms.overrides.employee_master.update_approver_user_roles'], 'on_update': ['erpnext.portal.utils.set_default_role']}, 'Communication': {'on_update': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update', 'erpnext.support.doctype.issue.issue.set_first_response_time'], 'after_insert': ['erpnext.crm.utils.link_communications_with_prospect', 'erpnext.crm.utils.update_modified_timestamp']}, 'Address': {'validate': ['erpnext.regional.italy.utils.set_state_code']}, 'Email Unsubscribe': {'after_insert': ['erpnext.crm.doctype.email_campaign.email_campaign.unsubscribe_recipient']}, 'Integration Request': {'validate': ['erpnext.accounts.doctype.payment_request.payment_request.validate_payment']}, 'Company': {'validate': ['lending.overrides.company.validate_loan_tables', 'hrms.overrides.company.validate_default_accounts'], 'on_update': ['hrms.overrides.company.make_company_fixtures', 'hrms.overrides.company.set_default_hr_accounts'], 'on_trash': ['hrms.overrides.company.handle_linked_docs']}, 'Custom Field': {'before_insert': ['lending.overrides.custom_field.update_dimensions']}, 'Holiday List': {'on_update': ['hrms.utils.holiday_list.invalidate_cache'], 'on_trash': ['hrms.utils.holiday_list.invalidate_cache']}, 'Timesheet': {'validate': ['hrms.hr.utils.validate_active_employee']}, 'Unreconcile Payment': {'on_submit': ['hrms.hr.doctype.expense_claim.expense_claim.update_payment_for_expense_claim']}, 'Loan': {'validate': ['hrms.hr.utils.validate_loan_repay_from_salary']}, 'Employee': {'validate': ['hrms.overrides.employee_master.validate_onboarding_process'], 'on_update': ['hrms.overrides.employee_master.update_approver_role', 'hrms.overrides.employee_master.publish_update'], 'after_insert': ['hrms.overrides.employee_master.update_job_applicant_and_offer'], 'on_trash': ['hrms.overrides.employee_master.update_employee_transfer'], 'after_delete': ['hrms.overrides.employee_master.publish_update']}, 'Project': {'validate': ['hrms.controllers.employee_boarding_controller.update_employee_boarding_status']}, 'Task': {'on_update': ['hrms.controllers.employee_boarding_controller.update_task']}}
    f = <function Document.run_method.<locals>.fn at 0x7fc2b0061010>
    handler = 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job'
    hooks = [<function apply at 0x7fc2b2d10eb0>, <function check_for_running_deletion_job at 0x7fc2b2d131c0>]
    kwargs = {}
    method = 'validate'
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1854, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ~~^^^^^^^^^^^^^^^^^^^^^^^
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7fc2b00607d0>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7fc2b0061010>
    hooks = (<function apply at 0x7fc2b2d10eb0>, <function check_for_running_deletion_job at 0x7fc2b2d131c0>)
    kwargs = {}
    method = 'validate'
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1476, in fn
    return method_object(*args, **kwargs)
    args = ()
    kwargs = {}
    method = 'validate'
    method_object = <bound method RepostAccountingLedger.validate of <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>>
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py", line 37, in validate
    self.validate_vouchers()
    ~~~~~~~~~~~~~~~~~~~~~~^^
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py", line 75, in validate_vouchers
    validate_docs_for_voucher_types([x.voucher_type for x in self.vouchers])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    self = <RepostAccountingLedger: doctype=Repost Accounting Ledger lplhusgfms>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py", line 273, in validate_docs_for_voucher_types
    frappe.throw(
    ~~~~~~~~~~~~^
    	_(
     ^^
    ...<6 lines>...
    	)
     ^
    )
    ^
    allowed_types = []
    disallowed_types = {'Expense Claim'}
    doc_voucher_types = ['Expense Claim']
    message = 'is'
    voucher_types = {'Expense Claim'}
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 159, in throw
    msgprint(
    ~~~~~~~~^
    	msg,
     ^^^^
    ...<7 lines>...
    	allow_dangerous_html=allow_dangerous_html,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
    allow_dangerous_html = False
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = '<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings">Accounts Settings</a>.'
    primary_action = None
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 118, in msgprint
    _raise_exception()
    ~~~~~~~~~~~~~~~~^^
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7fc2b0062da0>
    alert = False
    allow_dangerous_html = False
    as_list = False
    as_table = False
    clean_html = <function clean_html at 0x7fc2bd2b99b0>
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/inspect.py'>
    is_minimizable = False
    msg = '<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings">Accounts Settings</a>.'
    out = {'message': '<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings" rel="noopener noreferrer">Accounts Settings</a>.', 'as_table': False, 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'afcd89c728c7a2cab815996b1a83d3ed0746c66f90638741c466f171'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
    raise exc
    exc = ValidationError('<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings">Accounts Settings</a>.')
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/inspect.py'>
    msg = '<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings">Accounts Settings</a>.'
    out = {'message': '<strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it \'<strong>Allowed Doctype</strong>\' table in <a href="http://test_site:8000/desk/accounts-settings" rel="noopener noreferrer">Accounts Settings</a>.', 'as_table': False, 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'afcd89c728c7a2cab815996b1a83d3ed0746c66f90638741c466f171'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: <strong>Expense Claim</strong> is not allowed to be reposted. You can enable it by adding it '<strong>Allowed Doctype</strong>' table in <a href="http://test_site:8000/desk/accounts-settings">Accounts Settings</a>.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * System installation now automatically populates "Accounts Settings" with repost-allowed document types during the initial setup flow. These defaults are applied during installation so repost-allowed types appear in Accounts Settings immediately after setup, reducing the need for manual configuration and ensuring consistent initial settings across new installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->