### PR TITLE
refactor: remove redundant create_test_contact_and_address

### DIFF
--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -504,11 +504,9 @@ class TestExpenseClaim(HRMSTestSuite):
 			create_driver,
 			create_vehicle,
 		)
-		from erpnext.tests.utils import create_test_contact_and_address
 
 		driver = create_driver()
 		create_vehicle()
-		create_test_contact_and_address()
 		address = create_address(driver)
 
 		delivery_trip = create_delivery_trip(driver, address, company="_Test Company")


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/54406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated install helper to pin a specific branch and repository for app installs, streamlining setup behavior.

* **Tests**
  * Simplified an expense-claim test by removing redundant contact/address setup, keeping delivery trip and assertion logic intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->