### PR TITLE
Fix typos in user-facing error message and test comment

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -589,7 +589,7 @@ class TestLeaveAllocation(HRMSTestSuite):
 	def test_quarterly_earned_leaves_allocated_by_the_scheduler(self):
 		frappe.flags.current_date = get_year_start(getdate())
 
-		# created policy assignment at the begining of the year so allocated leaces should be 0
+		# created policy assignment at the beginning of the year so allocated leaves should be 0
 		assignment = make_policy_assignment(
 			self.employee2,
 			allocate_on_day="First Day",

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -162,7 +162,7 @@ class ShiftType(Document):
 					return "Attendance has been marked as per employee check-ins."
 				except Exception as e:
 					error_log = frappe.log_error(e)
-					return f"An error occured during marking attendance. Refer the full error log {get_link_to_form('Error Log',error_log.name,label='here')}"
+					return f"An error occurred during marking attendance. Refer the full error log {get_link_to_form('Error Log',error_log.name,label='here')}"
 		else:
 			self._process(logs)
 


### PR DESCRIPTION

**Repo:** frappe/hrms (⭐ 7766)
**Type:** bugfix
**Files changed:** 2
**Lines:** +2/-2

## What
Corrects the misspelling "occured" → "occurred" in the user-facing error message returned by Shift Type auto-attendance processing, and fixes "begining"/"leaces" → "beginning"/"leaves" in a test comment in `test_earned_leaves.py`.

## Why
The typo "occured" appears in a string shown to end users when auto-attendance marking fails — a small but visible polish issue. The test comment typos obscure the intent of the test setup. Both are trivial, safe corrections that improve the perceived quality of the product and code.

## Testing
No behavioral change. The modified error string is only emitted in an exception branch; grep confirms no other code or test asserts against the old spelling. Test comment change is a no-op.

## Risk
Low — string literal content change only; no logic or API touched.
