### PR TITLE
fix: add site_name to hrms page context

### DIFF
--- a/hrms/www/hrms.py
+++ b/hrms/www/hrms.py
@@ -10,6 +10,7 @@ def get_context(context):
 	context = frappe._dict()
 	context.csrf_token = csrf_token
 	context.boot = get_boot()
+	context.site_name = frappe.local.site
 	return context
 
 


### PR DESCRIPTION
## Summary

The `/hrms` page template expects a top-level `site_name` variable:

```html
window.site_name = '{{ site_name }}'
```
but `hrms/www/hrms.py` only populated `boot`, not `site_name`.

As a result, the browser received the literal Jinja placeholder instead of the actual site name, which broke the Socket.IO namespace used by the HRMS frontend realtime connection.

This change adds `site_name` to the `/hrms` page context.

## Problem
On `/hrms`, the frontend socket bootstrap reads `window.site_name` to connect to the site-specific realtime namespace.

Before this change, the rendered page contained:

```js

window.site_name = '{{ site_name }}'
```
instead of something like:

```js

window.site_name = 'my-hrms.com'
```
That caused realtime on `/hrms` to connect with an invalid namespace and fail.

## Fix
Set:

```python

context.site_name = frappe.local.site
```
in `hrms/www/hrms.py`, so the page template receives the expected value.

## Result
The `/hrms` page now renders a real site name into `window.site_name`, allowing the HRMS frontend realtime/socket connection to use the correct namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved context data availability for web pages to include site identification information, enabling better information display across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->