### PR TITLE
ci: skip updating to v14 since it's EOL

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -112,40 +112,12 @@ jobs:
           jq 'del(.install_apps)' ~/frappe-bench/sites/test_site/site_config.json > tmp.json
           mv tmp.json ~/frappe-bench/sites/test_site/site_config.json
 
-          wget https://frappe.io/files/erpnext-hr-v13.sql.gz
-          bench --site test_site --force restore ~/frappe-bench/erpnext-hr-v13.sql.gz
+          wget https://frappe.io/files/frappe-hr-v14-p.sql.gz
+          bench --site test_site --force restore ~/frappe-bench/frappe-hr-v14-p.sql.gz
 
           git -C "apps/frappe" remote set-url upstream https://github.com/frappe/frappe.git
           git -C "apps/erpnext" remote set-url upstream https://github.com/frappe/erpnext.git
           git -C "apps/hrms" remote set-url upstream https://github.com/frappe/hrms.git
-
-
-          function update_to_version() {
-            version=$1
-
-            branch_name="version-$version-hotfix"
-            echo "Updating to v$version"
-
-            # Fetch and checkout branches
-            git -C "apps/frappe" fetch --depth 1 upstream $branch_name:$branch_name
-            git -C "apps/erpnext" fetch --depth 1 upstream $branch_name:$branch_name
-            git -C "apps/hrms" fetch --depth 1 upstream $branch_name:$branch_name
-            git -C "apps/frappe" checkout -q -f $branch_name
-            git -C "apps/erpnext" checkout -q -f $branch_name
-            git -C "apps/hrms" checkout -q -f $branch_name
-
-            # Resetup env and install apps
-            pgrep honcho | xargs kill
-            rm -rf ~/frappe-bench/env
-            bench -v setup env
-            bench pip install -e ./apps/erpnext
-            bench pip install -e ./apps/hrms
-            bench start &>> ~/frappe-bench/bench_start.log &
-
-            bench --site test_site migrate
-          }
-
-          update_to_version 14
 
           echo "Updating to latest version"
           git -C "apps/frappe" fetch --depth 1 upstream "${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test infrastructure now restores the test site from an updated prebuilt database snapshot.
  * Simplified automated workflow by removing a previous version-specific upgrade step; CI now relies on the standard update and migration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->