### PR TITLE
fix: move before migrate hook to pre-model sync patch list

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -98,7 +98,6 @@ jinja = {
 
 # before_install = "hrms.install.before_install"
 after_install = "hrms.install.after_install"
-before_migrate = "hrms.setup.make_people_workspace_standard"
 after_migrate = "hrms.setup.update_select_perm_after_install"
 
 setup_wizard_complete = "hrms.subscription_utils.update_erpnext_access"

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -1,6 +1,7 @@
 [pre_model_sync]
 hrms.patches.v15_0.check_version_compatibility_with_frappe #2023-06-27
 hrms.patches.v16_0.merge_interview_round_with_interview_type
+hrms.patches.v16_0.make_people_workspace_sidebar_standard
 
 [post_model_sync]
 hrms.patches.post_install.set_payroll_entry_status

--- a/hrms/patches/v16_0/make_people_workspace_sidebar_standard.py
+++ b/hrms/patches/v16_0/make_people_workspace_sidebar_standard.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Workspace Sidebar", "People"):
+		frappe.db.set_value("Workspace Sidebar", "People", "standard", 1)

--- a/hrms/patches/v16_0/make_people_workspace_sidebar_standard.py
+++ b/hrms/patches/v16_0/make_people_workspace_sidebar_standard.py
@@ -2,5 +2,6 @@ import frappe
 
 
 def execute():
-	if frappe.db.exists("Workspace Sidebar", "People"):
-		frappe.db.set_value("Workspace Sidebar", "People", "standard", 1)
+	if frappe.db.table_exists("Workspace Sidebar"):
+		if frappe.db.exists("Workspace Sidebar", "People"):
+			frappe.db.set_value("Workspace Sidebar", "People", "standard", 1)

--- a/hrms/patches/v16_0/merge_interview_round_with_interview_type.py
+++ b/hrms/patches/v16_0/merge_interview_round_with_interview_type.py
@@ -7,4 +7,5 @@ def execute():
 		for interview_round, interview_type in frappe.get_all(
 			"Interview Round", fields=["name", "interview_type"], as_list=True
 		):
-			rename_doc("Interview Type", interview_type, interview_round)
+			if interview_type != interview_round:
+				rename_doc("Interview Type", interview_type, interview_round)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -877,11 +877,6 @@ def add_default_hr_permissions():
 				update_permission_property(doctype, role, permlevel=0, ptype=ptype, value=value)
 
 
-def make_people_workspace_standard():
-	if frappe.db.exists("Workspace Sidebar", "People"):
-		frappe.db.set_value("Workspace Sidebar", "People", "standard", 1)
-
-
 def setup_repost_defaults():
 	accounts_settings = frappe.get_doc("Accounts Settings")
 	for x in frappe.get_hooks("repost_allowed_doctypes"):


### PR DESCRIPTION
closes #4436
closes #4437

The patch workflow should have caught #4436, will check why it didn't

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace sidebar configuration for the "People" section to ensure proper setup during workspace initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->