### PR TITLE
feat(attendance): auto-populate employee shift

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.js
+++ b/hrms/hr/doctype/attendance/attendance.js
@@ -27,4 +27,34 @@ frappe.ui.form.on("Attendance", {
 			);
 		}
 	},
+
+	employee(frm) {
+		if (frm.doc.employee && frm.doc.attendance_date && !frm.doc.shift) {
+			frm.trigger("set_employee_shift");
+		}
+	},
+
+	attendance_date(frm) {
+		if (frm.doc.employee && frm.doc.attendance_date && !frm.doc.shift) {
+			frm.trigger("set_employee_shift");
+		}
+	},
+
+	set_employee_shift(frm) {
+		if (!frm.doc.employee || !frm.doc.attendance_date) return;
+
+		frappe.call({
+			method: "hrms.hr.doctype.attendance.attendance.get_employee_shift",
+			args: {
+				employee: frm.doc.employee,
+				for_date: frm.doc.attendance_date || frappe.datetime.get_today(),
+				consider_default_shift: true,
+			},
+			callback(r) {
+				if (r.message && !frm.doc.shift) {
+					frm.set_value("shift", r.message);
+				}
+			},
+		});
+	},
 });

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -468,3 +468,38 @@ def get_unmarked_days(
 		from_date = add_days(from_date, 1)
 
 	return unmarked_days
+
+
+@frappe.whitelist()
+def get_employee_shift(employee: str, for_date: str | date | None = None) -> str | None:
+	if not employee:
+		return None
+
+	if employee and not frappe.has_permission("Employee", "read", employee):
+		return None
+
+	if not for_date:
+		for_date = nowdate()
+
+	for_date = getdate(for_date)
+
+	if not frappe.has_permission("Shift Assignment", "read"):
+		return None
+
+	shifts = frappe.get_all(
+		"Shift Assignment",
+		filters={
+			"employee": employee,
+			"docstatus": 1,
+			"status": "Active",
+			"start_date": ("<=", for_date),
+		},
+		fields=["shift_type", "start_date"],
+		order_by="start_date desc",
+		limit=1,
+	)
+
+	if shifts:
+		return shifts[0].shift_type
+
+	return None

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -502,4 +502,8 @@ def get_employee_shift(employee: str, for_date: str | date | None = None) -> str
 	if shifts:
 		return shifts[0].shift_type
 
+	default_shift = frappe.db.get_value("Employee", employee, "default_shift")
+	if default_shift:
+		return default_shift
+
 	return None

--- a/hrms/hr/doctype/attendance_request/attendance_request.js
+++ b/hrms/hr/doctype/attendance_request/attendance_request.js
@@ -23,4 +23,34 @@ frappe.ui.form.on("Attendance Request", {
 			});
 		}
 	},
+
+	employee(frm) {
+		if (frm.doc.employee && frm.doc.from_date && !frm.doc.shift) {
+			frm.trigger("set_employee_shift");
+		}
+	},
+
+	from_date(frm) {
+		if (frm.doc.employee && frm.doc.from_date && !frm.doc.shift) {
+			frm.trigger("set_employee_shift");
+		}
+	},
+
+	set_employee_shift(frm) {
+		if (!frm.doc.employee || !frm.doc.from_date) return;
+
+		frappe.call({
+			method: "hrms.hr.doctype.attendance.attendance.get_employee_shift",
+			args: {
+				employee: frm.doc.employee,
+				for_date: frm.doc.from_date,
+				consider_default_shift: true,
+			},
+			callback(r) {
+				if (r.message && !frm.doc.shift) {
+					frm.set_value("shift", r.message);
+				}
+			},
+		});
+	},
 });


### PR DESCRIPTION
Closes #4413
Changes:
 - Auto populate employee shift when employee or date is selected.
 - In Attendance shift is auto populated according to shift assignment for the selected employee and attendance date.
 - In Attendance request shift is auto populated according to the shift assignment for the selected employee and from date.

`no-docs`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attendance forms now auto-populate the Shift field when an employee or attendance date is entered or changed.
  * Attendance Request forms now auto-populate the Shift field when an employee or request date is entered, reducing manual input.
  * Shift lookup respects employee assignments and defaults, providing the most relevant shift for the selected date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->