### PR TITLE
fix(report): update validation for region india for professional tax …

### DIFF
--- a/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
+++ b/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
@@ -18,12 +18,12 @@ def execute(filters=None):
 	return columns, data
 
 
-def validate_company_region(self):
-	if self.company and get_region(self.company) != "India":
+def validate_company_region(filters=None):
+	if filters and filters.company and get_region(filters.company) != "India":
 		frappe.throw(
 			_(
 				"The company {0} is not in India. Professional Tax Deductions Report is only available for companies in India."
-			).format(frappe.bold(self.company))
+			).format(frappe.bold(filters.company))
 		)
 
 

--- a/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
+++ b/hrms/payroll/report/professional_tax_deductions/professional_tax_deductions.py
@@ -5,14 +5,26 @@
 import frappe
 from frappe import _
 
+from erpnext import get_region
+
 from hrms.payroll.report.provident_fund_deductions.provident_fund_deductions import get_conditions
 
 
 def execute(filters=None):
+	validate_company_region(filters)
 	data = get_data(filters)
 	columns = get_columns(filters) if len(data) else []
 
 	return columns, data
+
+
+def validate_company_region(self):
+	if self.company and get_region(self.company) != "India":
+		frappe.throw(
+			_(
+				"The company {0} is not in India. Professional Tax Deductions Report is only available for companies in India."
+			).format(frappe.bold(self.company))
+		)
 
 
 def get_columns(filters):


### PR DESCRIPTION
**Issue:** The field component type is created for the company, which is in the India region, so the professional tax deduction report mainly looks for the field in the salary component to get the data, so  if the company region is other than India, it does not create the field in the salary component. And throws an MySQL operational error for an unknown column in the Professional Tax Deduction report.


**Before:**

[Screencast from 2026-04-24 10-52-18.webm](https://github.com/user-attachments/assets/e70dfc22-00e3-4eb0-ac8d-392e5bfd3ba5)


**After:**

[Screencast from 2026-04-24 10-51-31.webm](https://github.com/user-attachments/assets/dd991e49-15b7-42f8-8e1b-00a8283dcfe3)


Backport needed for v-15, v-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Professional Tax Deductions report now validates that the selected company is India-based before generating results. If the company is not India-based, the report halts and displays a clear, localized error message naming the company. This upfront check prevents incorrect or irrelevant output and guides users to choose an appropriate company.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->