### PR TITLE
Revert "fix(leave-application): prevent half-day selection on holidays"

### DIFF
--- a/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/test_employee_attendance_tool.py
@@ -4,7 +4,6 @@
 import frappe
 from frappe.utils import add_days, getdate
 
-from erpnext.setup.doctype.employee.employee import is_holiday
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
@@ -79,16 +78,13 @@ class TestEmployeeAttendanceTool(HRMSTestSuite):
 		# only half day attendance created from leave type should be fetched to update in the tool
 		employee = frappe.get_doc("Employee", self.employee1)
 		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
-		date = getdate()
-		while is_holiday(employee=employee.name, date=date):
-			date = add_days(date, -1)
 		frappe.get_doc(
 			{
 				"doctype": "Leave Allocation",
 				"employee": employee.name,
 				"employee_name": employee.employee_name,
 				"leave_type": leave_type.name,
-				"from_date": add_days(date, -2),
+				"from_date": add_days(getdate(), -2),
 				"new_leaves_allocated": 15,
 				"carry_forward": 0,
 				"to_date": add_days(getdate(), 30),
@@ -96,14 +92,16 @@ class TestEmployeeAttendanceTool(HRMSTestSuite):
 		).submit()
 		make_leave_application(
 			employee=employee.name,
-			from_date=date,
-			to_date=date,
+			from_date=getdate(),
+			to_date=getdate(),
 			leave_type=leave_type.name,
 			half_day=1,
-			half_day_date=date,
+			half_day_date=getdate(),
 		)
-		mark_attendance(self.employee2, attendance_date=date, status="Half Day", half_day_status="Absent")
-		total_employees = get_employees(date, company="_Test Company")
+		mark_attendance(
+			self.employee2, attendance_date=getdate(), status="Half Day", half_day_status="Absent"
+		)
+		total_employees = get_employees(getdate(), company="_Test Company")
 		half_marked_employees = total_employees.get("half_day_marked")
 		self.assertEqual(len(half_marked_employees), 1)
 		self.assertEqual(half_marked_employees[0].get("employee_name"), employee.employee_name)
@@ -116,12 +114,8 @@ class TestEmployeeAttendanceTool(HRMSTestSuite):
 		employee2 = frappe.get_doc("Employee", self.employee2)
 		leave_type = create_leave_type(leave_type="_Test Employee Attendance Tool", include_holidays=0)
 		date = add_days(getdate(), -1)
-		while is_holiday(employee=employee2.name, date=date) or is_holiday(
-			employee=employee4.name, date=date
-		):
-			date = add_days(date, -1)
-		create_leave_allocation(employee2, leave_type, date)
-		create_leave_allocation(employee4, leave_type, date)
+		create_leave_allocation(employee2, leave_type)
+		create_leave_allocation(employee4, leave_type)
 		make_leave_application(
 			employee=employee2.name,
 			from_date=date,
@@ -235,15 +229,14 @@ class TestEmployeeAttendanceTool(HRMSTestSuite):
 		self.assertNotIn(self.employee3.name, filtered)
 
 
-def create_leave_allocation(employee, leave_type, date=None):
-	from_date = add_days(date or getdate(), -2)
+def create_leave_allocation(employee, leave_type):
 	frappe.get_doc(
 		{
 			"doctype": "Leave Allocation",
 			"employee": employee.name,
 			"employee_name": employee.employee_name,
 			"leave_type": leave_type.name,
-			"from_date": from_date,
+			"from_date": add_days(getdate(), -2),
 			"new_leaves_allocated": 15,
 			"carry_forward": 0,
 			"to_date": add_days(getdate(), 30),

--- a/hrms/hr/doctype/leave_application/leave_application.js
+++ b/hrms/hr/doctype/leave_application/leave_application.js
@@ -168,7 +168,6 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	half_day_date(frm) {
-		frm.trigger("validate_half_day_date");
 		frm.trigger("calculate_total_days");
 	},
 
@@ -230,20 +229,7 @@ frappe.ui.form.on("Leave Application", {
 			});
 		}
 	},
-	validate_half_day_date: function (frm) {
-		if (!frm.doc.half_day_date) {
-			return;
-		}
 
-		return frm
-			.call("validate_half_day_date")
-			.then(() => {
-				frm.trigger("calculate_total_days");
-			})
-			.catch(() => {
-				frm.set_value("half_day_date", "");
-			});
-	},
 	calculate_total_days: function (frm) {
 		if (frm.doc.from_date && frm.doc.to_date && frm.doc.employee && frm.doc.leave_type) {
 			// server call is done to include holidays in leave days calculations

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -21,7 +21,7 @@ from frappe.utils import (
 )
 
 from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import daterange
-from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee, is_holiday
+from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 
 import hrms
 from hrms.api import get_current_employee_info
@@ -229,7 +229,15 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if self.from_date and self.to_date and (getdate(self.to_date) < getdate(self.from_date)):
 			frappe.throw(_("To date cannot be before from date"))
 
-		self.validate_half_day_date()
+		if (
+			self.half_day
+			and self.half_day_date
+			and (
+				getdate(self.half_day_date) < getdate(self.from_date)
+				or getdate(self.half_day_date) > getdate(self.to_date)
+			)
+		):
+			frappe.throw(_("Half Day Date should be between From Date and To Date"))
 
 		if not is_lwp(self.leave_type):
 			self.validate_dates_across_allocation()
@@ -907,17 +915,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			frappe.db.get_single_value("HR Settings", "prevent_self_leave_approval"),
 		)
 
-	@frappe.whitelist()
-	def validate_half_day_date(self) -> bool:
-		if not self.half_day:
-			return
-
-		if is_holiday(employee=self.employee, date=self.half_day_date):
-			frappe.throw(_("Half Day Date cannot be a holiday"))
-
-		if not (getdate(self.from_date) <= getdate(self.half_day_date) <= getdate(self.to_date)):
-			frappe.throw(_("Half Day Date should be between From Date and To Date"))
-
 
 def get_allocation_expiry_for_cf_leaves(
 	employee: str, leave_type: str, to_date: datetime.date, from_date: datetime.date
@@ -975,16 +972,16 @@ def get_number_of_leave_days(
 ) -> float:
 	"""Returns number of leave days between 2 dates after considering half day and holidays
 	(Based on the include_holiday setting in Leave Type)"""
-	number_of_days = date_diff(to_date, from_date) + 1
-
+	number_of_days = 0
 	if cint(half_day) == 1:
-		is_valid_half_day = (
-			half_day_date
-			and getdate(from_date) <= getdate(half_day_date) <= getdate(to_date)
-			and not is_holiday(employee=employee, date=half_day_date)
-		)
-		if is_valid_half_day:
-			number_of_days -= 0.5
+		if getdate(from_date) == getdate(to_date):
+			number_of_days = 0.5
+		elif half_day_date and getdate(from_date) <= getdate(half_day_date) <= getdate(to_date):
+			number_of_days = date_diff(to_date, from_date) + 0.5
+		else:
+			number_of_days = date_diff(to_date, from_date) + 1
+	else:
+		number_of_days = date_diff(to_date, from_date) + 1
 
 	if not frappe.db.get_value("Leave Type", leave_type, "include_holiday"):
 		number_of_days = flt(number_of_days) - flt(get_holidays(employee, from_date, to_date))

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -14,7 +14,6 @@ from frappe.utils import (
 	nowdate,
 )
 
-from erpnext.setup.doctype.employee.employee import is_holiday
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
@@ -77,16 +76,11 @@ class TestLeaveApplication(HRMSTestSuite):
 		application.to_date = "2013-01-05"
 		return application
 
-	def get_non_holiday_date(self, employee, date):
-		while is_holiday(employee=employee, date=date):
-			date = add_days(date, -1)
-		return date
-
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_validate_application_across_allocations(self):
 		# Test validation for application dates when negative balance is disabled
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Validation", doctype="Leave Type", allow_negative=False
+			dict(leave_type_name="Test Leave Validation", doctype="Leave Type", allow_negative=False)
 		).insert()
 
 		employee = get_employee()
@@ -94,14 +88,16 @@ class TestLeaveApplication(HRMSTestSuite):
 		first_sunday = get_first_sunday(self.holiday_list, for_date=get_year_start(date))
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date=add_days(first_sunday, 1),
-			to_date=add_days(first_sunday, 4),
-			company="_Test Company",
-			status="Approved",
-			leave_approver="test@example.com",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=add_days(first_sunday, 1),
+				to_date=add_days(first_sunday, 4),
+				company="_Test Company",
+				status="Approved",
+				leave_approver="test@example.com",
+			)
 		)
 		# Application period cannot be outside leave allocation period
 		self.assertRaises(frappe.ValidationError, leave_application.insert)
@@ -111,14 +107,16 @@ class TestLeaveApplication(HRMSTestSuite):
 		)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date=add_days(first_sunday, -10),
-			to_date=add_days(first_sunday, 1),
-			company="_Test Company",
-			status="Approved",
-			leave_approver="test@example.com",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=add_days(first_sunday, -10),
+				to_date=add_days(first_sunday, 1),
+				company="_Test Company",
+				status="Approved",
+				leave_approver="test@example.com",
+			)
 		)
 
 		# Application period cannot be across two allocation records
@@ -129,7 +127,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		# CASE 1: Validation when allow negative is disabled
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Validation", force=1)
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Validation", doctype="Leave Type", allow_negative=False
+			dict(leave_type_name="Test Leave Validation", doctype="Leave Type", allow_negative=False)
 		).insert()
 
 		employee = get_employee()
@@ -144,14 +142,16 @@ class TestLeaveApplication(HRMSTestSuite):
 			leaves=2,
 		)
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date=add_days(first_sunday, 1),
-			to_date=add_days(first_sunday, 3),
-			company="_Test Company",
-			status="Approved",
-			leave_approver="test@example.com",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=add_days(first_sunday, 1),
+				to_date=add_days(first_sunday, 3),
+				company="_Test Company",
+				status="Approved",
+				leave_approver="test@example.com",
+			)
 		)
 		self.assertRaises(InsufficientLeaveBalanceError, leave_application.insert)
 
@@ -167,10 +167,12 @@ class TestLeaveApplication(HRMSTestSuite):
 		# creates separate leave ledger entries
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Validation", force=1)
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Validation",
-			doctype="Leave Type",
-			allow_negative=True,
-			include_holiday=True,
+			dict(
+				leave_type_name="Test Leave Validation",
+				doctype="Leave Type",
+				allow_negative=True,
+				include_holiday=True,
+			)
 		).insert()
 
 		employee = get_employee()
@@ -282,7 +284,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		# Case 1: leave type with 'Include holidays within leaves as leaves' enabled
 		frappe.delete_doc_if_exists("Leave Type", "Test Include Holidays", force=1)
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Include Holidays", doctype="Leave Type", include_holiday=True
+			dict(leave_type_name="Test Include Holidays", doctype="Leave Type", include_holiday=True)
 		).insert()
 
 		date = getdate()
@@ -495,30 +497,36 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		if not frappe.db.exists("Holiday List", holiday_list):
 			frappe.get_doc(
-				doctype="Holiday List",
-				holiday_list_name=holiday_list,
-				from_date=add_months(today, -6),
-				to_date=add_months(today, 6),
-				holidays=[dict(holiday_date=optional_leave_date, description="Test")],
+				dict(
+					doctype="Holiday List",
+					holiday_list_name=holiday_list,
+					from_date=add_months(today, -6),
+					to_date=add_months(today, 6),
+					holidays=[dict(holiday_date=optional_leave_date, description="Test")],
+				)
 			).insert()
 
 		frappe.db.set_value("Leave Period", leave_period.name, "optional_holiday_list", holiday_list)
 		leave_type = "Test Optional Type"
 		if not frappe.db.exists("Leave Type", leave_type):
-			frappe.get_doc(leave_type_name=leave_type, doctype="Leave Type", is_optional_leave=1).insert()
+			frappe.get_doc(
+				dict(leave_type_name=leave_type, doctype="Leave Type", is_optional_leave=1)
+			).insert()
 
 		allocate_leaves(employee, leave_period, leave_type, 10)
 
 		date = add_days(first_sunday, 2)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			company="_Test Company",
-			description="_Test Reason",
-			leave_type=leave_type,
-			from_date=date,
-			to_date=date,
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				company="_Test Company",
+				description="_Test Reason",
+				leave_type=leave_type,
+				from_date=date,
+				to_date=date,
+			)
 		)
 
 		# can only apply on optional holidays
@@ -537,7 +545,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		leave_period = get_leave_period(current=True)
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Type", force=1)
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Type", doctype="Leave Type", max_leaves_allowed=5
+			dict(leave_type_name="Test Leave Type", doctype="Leave Type", max_leaves_allowed=5)
 		).insert()
 
 		date = add_days(nowdate(), -7)
@@ -545,28 +553,32 @@ class TestLeaveApplication(HRMSTestSuite):
 		allocate_leaves(employee, leave_period, leave_type.name, 5)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			description="_Test Reason",
-			from_date=date,
-			to_date=add_days(date, 2),
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				description="_Test Reason",
+				from_date=date,
+				to_date=add_days(date, 2),
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 		leave_application.submit()
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			description="_Test Reason",
-			from_date=add_days(date, 4),
-			to_date=add_days(date, 8),
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				description="_Test Reason",
+				from_date=add_days(date, 4),
+				to_date=add_days(date, 8),
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 		self.assertRaises(frappe.ValidationError, leave_application.insert)
 
@@ -575,41 +587,47 @@ class TestLeaveApplication(HRMSTestSuite):
 		leave_period = get_leave_period(current=True)
 
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Type", doctype="Leave Type", applicable_after=15
+			dict(leave_type_name="Test Leave Type", doctype="Leave Type", applicable_after=15)
 		).insert()
 		date = add_days(nowdate(), -7)
 		frappe.db.set_value("Employee", employee.name, "date_of_joining", date)
 		allocate_leaves(employee, leave_period, leave_type.name, 10)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			description="_Test Reason",
-			from_date=date,
-			to_date=add_days(date, 4),
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				description="_Test Reason",
+				from_date=date,
+				to_date=add_days(date, 4),
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 
 		self.assertRaises(frappe.ValidationError, leave_application.insert)
 
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Type 1", force=1)
-		leave_type_1 = frappe.get_doc(leave_type_name="Test Leave Type 1", doctype="Leave Type").insert()
+		leave_type_1 = frappe.get_doc(
+			dict(leave_type_name="Test Leave Type 1", doctype="Leave Type")
+		).insert()
 
 		allocate_leaves(employee, leave_period, leave_type_1.name, 10)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type_1.name,
-			description="_Test Reason",
-			from_date=date,
-			to_date=add_days(date, 4),
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type_1.name,
+				description="_Test Reason",
+				from_date=date,
+				to_date=add_days(date, 4),
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 
 		self.assertTrue(leave_application.insert())
@@ -620,10 +638,12 @@ class TestLeaveApplication(HRMSTestSuite):
 		leave_period = get_leave_period(current=True)
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Type", force=1)
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Leave Type",
-			doctype="Leave Type",
-			max_leaves_allowed=15,
-			max_continuous_days_allowed=3,
+			dict(
+				leave_type_name="Test Leave Type",
+				doctype="Leave Type",
+				max_leaves_allowed=15,
+				max_continuous_days_allowed=3,
+			)
 		).insert()
 
 		date = add_days(nowdate(), -7)
@@ -631,15 +651,17 @@ class TestLeaveApplication(HRMSTestSuite):
 		allocate_leaves(employee, leave_period, leave_type.name, 10)
 
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			description="_Test Reason",
-			from_date=date,
-			to_date=add_days(date, 4),
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				description="_Test Reason",
+				from_date=date,
+				to_date=add_days(date, 4),
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 
 		self.assertRaises(frappe.ValidationError, leave_application.insert)
@@ -648,9 +670,11 @@ class TestLeaveApplication(HRMSTestSuite):
 	def test_max_consecutive_leaves_across_leave_applications(self):
 		employee = get_employee()
 		leave_type = frappe.get_doc(
-			leave_type_name="Test Consecutive Leave Type",
-			doctype="Leave Type",
-			max_continuous_days_allowed=10,
+			dict(
+				leave_type_name="Test Consecutive Leave Type",
+				doctype="Leave Type",
+				max_continuous_days_allowed=10,
+			)
 		).insert()
 		make_allocation_record(
 			employee=employee.name, leave_type=leave_type.name, from_date="2013-01-01", to_date="2013-12-31"
@@ -658,37 +682,43 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		# before
 		frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date="2013-01-30",
-			to_date="2013-02-03",
-			company="_Test Company",
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-01-30",
+				to_date="2013-02-03",
+				company="_Test Company",
+				status="Approved",
+			)
 		).insert()
 
 		# after
 		frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date="2013-02-06",
-			to_date="2013-02-10",
-			company="_Test Company",
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date="2013-02-06",
+				to_date="2013-02-10",
+				company="_Test Company",
+				status="Approved",
+			)
 		).insert()
 
 		# current
 		from_date = getdate("2013-02-04")
 		to_date = getdate("2013-02-05")
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date=from_date,
-			to_date=to_date,
-			company="_Test Company",
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=from_date,
+				to_date=to_date,
+				company="_Test Company",
+				status="Approved",
+			)
 		)
 
 		# 11 consecutive leaves
@@ -716,28 +746,32 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		leave_type = "Sick Leave"
 		if not frappe.db.exists("Leave Type", leave_type):
-			frappe.get_doc(leave_type_name=leave_type, doctype="Leave Type").insert()
+			frappe.get_doc(dict(leave_type_name=leave_type, doctype="Leave Type")).insert()
 
 		allocation = frappe.get_doc(
-			doctype="Leave Allocation",
-			employee=employee.name,
-			leave_type=leave_type,
-			from_date="2018-10-01",
-			to_date="2018-10-10",
-			new_leaves_allocated=1,
+			dict(
+				doctype="Leave Allocation",
+				employee=employee.name,
+				leave_type=leave_type,
+				from_date="2018-10-01",
+				to_date="2018-10-10",
+				new_leaves_allocated=1,
+			)
 		)
 		allocation.insert(ignore_permissions=True)
 		allocation.submit()
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type,
-			description="_Test Reason",
-			from_date="2018-10-02",
-			to_date="2018-10-02",
-			company="_Test Company",
-			status="Approved",
-			leave_approver="test@example.com",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type,
+				description="_Test Reason",
+				from_date="2018-10-02",
+				to_date="2018-10-02",
+				company="_Test Company",
+				status="Approved",
+				leave_approver="test@example.com",
+			)
 		)
 		self.assertTrue(leave_application.insert())
 		leave_application.submit()
@@ -779,7 +813,6 @@ class TestLeaveApplication(HRMSTestSuite):
 		leave_application.cancel()
 		self.assertFalse(frappe.db.exists("Leave Ledger Entry", {"transaction_name": leave_application.name}))
 
-	@assign_holiday_list("Holiday List w/o Weekly Offs", "_Test Company")
 	def test_ledger_entry_creation_on_intermediate_allocation_expiry(self):
 		employee = get_employee()
 		leave_type = create_leave_type(
@@ -791,22 +824,20 @@ class TestLeaveApplication(HRMSTestSuite):
 
 		create_carry_forwarded_allocation(employee, leave_type)
 
-		half_day_date = add_days(nowdate(), -3)
-		from_date = add_days(half_day_date, 0)
-		to_date = add_days(half_day_date, 10)
-
 		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type=leave_type.name,
-			from_date=from_date,
-			to_date=to_date,
-			half_day=1,
-			half_day_date=half_day_date,
-			description="_Test Reason",
-			company="_Test Company",
-			docstatus=1,
-			status="Approved",
+			dict(
+				doctype="Leave Application",
+				employee=employee.name,
+				leave_type=leave_type.name,
+				from_date=add_days(nowdate(), -3),
+				to_date=add_days(nowdate(), 7),
+				half_day=1,
+				half_day_date=add_days(nowdate(), -3),
+				description="_Test Reason",
+				company="_Test Company",
+				docstatus=1,
+				status="Approved",
+			)
 		)
 		leave_application.submit()
 
@@ -818,7 +849,7 @@ class TestLeaveApplication(HRMSTestSuite):
 		self.assertEqual(leave_ledger_entry[0].employee, leave_application.employee)
 		self.assertEqual(leave_ledger_entry[0].leave_type, leave_application.leave_type)
 		self.assertEqual(leave_ledger_entry[0].leaves, -8.5)
-		self.assertEqual(leave_ledger_entry[1].leaves, -2.0)
+		self.assertEqual(leave_ledger_entry[1].leaves, -2)
 
 	def test_leave_application_creation_after_expiry(self):
 		# test leave balance for carry forwarded allocation
@@ -988,34 +1019,6 @@ class TestLeaveApplication(HRMSTestSuite):
 		self.assertEqual(leave_allocation["expired_leaves"], 0)
 		self.assertEqual(leave_allocation["leaves_pending_approval"], 1)
 		self.assertEqual(leave_allocation["remaining_leaves"], 26)
-
-	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
-	def test_half_day_date_cannot_be_holiday(self):
-		employee = get_employee()
-		date = getdate()
-		make_allocation_record(
-			employee=employee.name,
-			leave_type="_Test Leave Type",
-			from_date=get_year_start(date),
-			to_date=get_year_ending(date),
-		)
-
-		holiday_date = add_days(get_year_start(date), 1)
-		add_date_to_holiday_list(holiday_date, self.holiday_list)
-
-		leave_application = frappe.get_doc(
-			doctype="Leave Application",
-			employee=employee.name,
-			leave_type="_Test Leave Type",
-			from_date=holiday_date,
-			to_date=holiday_date,
-			half_day=1,
-			half_day_date=holiday_date,
-			company="_Test Company",
-			status="Approved",
-		)
-
-		self.assertRaises(frappe.ValidationError, leave_application.insert)
 
 	@assign_holiday_list("Holiday List w/o Weekly Offs", "_Test Company")
 	def test_leave_details_with_expired_cf_leaves(self):
@@ -1232,15 +1235,14 @@ class TestLeaveApplication(HRMSTestSuite):
 		attendance_name = mark_attendance(
 			employee=employee.name, attendance_date=nowdate(), status="Half Day", half_day_status="Absent"
 		)
-		half_day_date = self.get_non_holiday_date(employee.name, nowdate())
 		leave_application = make_leave_application(
 			employee.name,
-			half_day_date,
-			half_day_date,
+			nowdate(),
+			nowdate(),
 			leave_type.name,
 			submit=True,
 			half_day=1,
-			half_day_date=half_day_date,
+			half_day_date=nowdate(),
 		)
 		attendance = frappe.get_value(
 			"Attendance",
@@ -1265,15 +1267,14 @@ class TestLeaveApplication(HRMSTestSuite):
 		# when existing attendance is absent
 		attendance_name = mark_attendance(employee=employee.name, attendance_date=nowdate(), status="Absent")
 
-		half_day_date = self.get_non_holiday_date(employee.name, nowdate())
 		leave_application = make_leave_application(
 			employee.name,
-			add_days(half_day_date, -3),
-			add_days(half_day_date, 3),
+			add_days(nowdate(), -3),
+			add_days(nowdate(), 3),
 			leave_type.name,
 			submit=True,
 			half_day=1,
-			half_day_date=half_day_date,
+			half_day_date=nowdate(),
 		)
 		attendance = frappe.get_value(
 			"Attendance",
@@ -1296,15 +1297,14 @@ class TestLeaveApplication(HRMSTestSuite):
 		)
 		create_carry_forwarded_allocation(employee, leave_type)
 		# attendance from one half leave
-		half_day_date = self.get_non_holiday_date(employee.name, nowdate())
 		first_leave_application = make_leave_application(
 			employee.name,
-			half_day_date,
-			half_day_date,
+			nowdate(),
+			nowdate(),
 			leave_type.name,
 			submit=True,
 			half_day=1,
-			half_day_date=half_day_date,
+			half_day_date=nowdate(),
 		)
 		half_day_status_after_first_application = frappe.get_value(
 			"Attendance",
@@ -1315,12 +1315,12 @@ class TestLeaveApplication(HRMSTestSuite):
 		self.assertEqual(half_day_status_after_first_application, "Present")
 		second_leave_application = make_leave_application(
 			employee.name,
-			half_day_date,
-			half_day_date,
+			nowdate(),
+			nowdate(),
 			leave_type.name,
 			submit=True,
 			half_day=1,
-			half_day_date=half_day_date,
+			half_day_date=nowdate(),
 		)
 		half_day_status_after_second_application = frappe.get_value(
 			"Attendance",


### PR DESCRIPTION
Reverts frappe/hrms#4141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified half-day date validation to verify dates fall within the leave period.
  * Half-day leave dates can now be assigned on holidays.
  * Updated half-day leave day calculation methodology.
  * Removed real-time validation feedback for half-day date selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->