### PR TITLE
feat(#4298): Half-Day Leave should support First/Second Half selectio…

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -20,6 +20,7 @@
   "company",
   "department",
   "attendance_request",
+  "half_day_type",
   "half_day_status",
   "details_section",
   "shift",
@@ -212,11 +213,19 @@
   },
   {
    "depends_on": "eval:doc.status==\"Half Day\";",
+   "fieldname": "half_day_type",
+   "fieldtype": "Select",
+   "label": "Half Day Type",
+   "no_copy": 1,
+   "options": "\nFirst Half\nSecond Half"
+  },
+  {
+   "depends_on": "eval:doc.status==\"Half Day\";",
    "fieldname": "half_day_status",
    "fieldtype": "Select",
    "label": "Status for Other Half",
    "no_copy": 1,
-   "options": "\nPresent\nAbsent"
+   "options": "\nPresent\nAbsent\nWork From Home\nOn Duty"
   },
   {
    "default": "0",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -229,7 +229,8 @@ class Attendance(Document):
 		if self.status in ("On Leave", "Half Day"):
 			if not leave_record:
 				self.modify_half_day_status = 0
-				self.half_day_status = "Absent"
+				if not self.half_day_status:
+					self.half_day_status = "Absent"
 				frappe.msgprint(
 					_("No leave record found for employee {0} on {1}").format(
 						self.employee, format_date(self.attendance_date)

--- a/hrms/hr/doctype/leave_application/leave_application.json
+++ b/hrms/hr/doctype/leave_application/leave_application.json
@@ -20,6 +20,8 @@
   "to_date",
   "half_day",
   "half_day_date",
+  "half_day_type",
+  "remaining_half_status",
   "total_leave_days",
   "column_break1",
   "description",
@@ -127,6 +129,22 @@
    "fieldname": "half_day_date",
    "fieldtype": "Date",
    "label": "Half Day Date"
+  },
+  {
+   "depends_on": "eval:doc.half_day==1",
+   "fieldname": "half_day_type",
+   "fieldtype": "Select",
+   "label": "Half Day Type",
+   "mandatory_depends_on": "eval:doc.half_day==1",
+   "options": "\nFirst Half\nSecond Half"
+  },
+  {
+   "default": "Present",
+   "depends_on": "eval:doc.half_day==1",
+   "fieldname": "remaining_half_status",
+   "fieldtype": "Select",
+   "label": "Remaining Half Status",
+   "options": "Present\nAbsent\nWork From Home\nOn Duty"
   },
   {
    "fieldname": "total_leave_days",

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -117,6 +117,10 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		self.validate_salary_processed_days()
 		self.validate_attendance()
 		self.set_half_day_date()
+
+		if self.half_day and self.half_day_type and not self.remaining_half_status:
+			frappe.throw(_("Remaining Half Status is required"))
+
 		if frappe.db.get_value("Leave Type", self.leave_type, "is_optional_leave"):
 			self.validate_optional_leave()
 		self.validate_applicable_after()
@@ -345,7 +349,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if attendance_name:
 			# update existing attendance, change absent to on leave or half day
 			doc = frappe.get_doc("Attendance", attendance_name)
-			half_day_status = None if status == "On Leave" else "Present"
+			half_day_status = None if status == "On Leave" else (self.remaining_half_status or "Present")
 			modify_half_day_status = 1 if doc.status == "Absent" and status == "Half Day" else 0
 			doc.db_set(
 				{
@@ -353,6 +357,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 					"leave_type": self.leave_type,
 					"leave_application": self.name,
 					"half_day_status": half_day_status,
+					"half_day_type": self.half_day_type if status == "Half Day" else None,
 					"modify_half_day_status": modify_half_day_status,
 				}
 			)
@@ -366,7 +371,8 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			doc.leave_type = self.leave_type
 			doc.leave_application = self.name
 			doc.status = status
-			doc.half_day_status = "Present" if status == "Half Day" else None
+			doc.half_day_status = (self.remaining_half_status or "Present") if status == "Half Day" else None
+			doc.half_day_type = self.half_day_type if status == "Half Day" else None
 			doc.modify_half_day_status = 1 if status == "Half Day" else 0
 			doc.flags.ignore_validate = True  # ignores check leave record validation in attendance
 			doc.insert(ignore_permissions=True)


### PR DESCRIPTION
Description
Enhancement: Half-Day Leave should support First/Second Half selection and configurable remaining half-day status.

Problem
Currently, when applying for a Half-Day Leave, the system defaults the remaining half of the day to "Present" without giving users control to choose "Work From Home" or "Absent". Additionally, modifying this manually via the Attendance doctype causes the system to override the changes and force it to "Absent" if no leave application corresponds perfectly, or "Present" upon submission.

Solution
This PR introduces explicit granular control over Half-Day leaves directly from the Leave Application, ensuring data integrity and preserving manual modifications in Attendance:

Leave Application Updates:

Added half_day_type (First Half / Second Half).
Added remaining_half_status (Present / Absent / Work From Home).
Attendance Updates:

Added half_day_type to track the specific half taken.
Expanded half_day_status to natively include Work From Home.
Backend Safeguards:

Updated create_or_update_attendance in leave_application.py to seamlessly map user-selected remaining status over to the created Attendance.
Fixed check_leave_record in attendance.py to ensure it only assigns a default "Absent" if a half_day_status is not already manually set.
Backward Compatibility
This change is fully backward compatible. If the new fields are not used (e.g., via API or old flows), ERPNext retains existing behavior, where the remaining half safely defaults to "Present". Furthermore, validation enforcing remaining_half_status only triggers when half_day_type is actively utilized.

Fixes #4298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance records now support specifying half-day type (First Half or Second Half).
  * Half-day status options expanded to include "Work From Home" and "On Duty" in addition to Present and Absent.
  * Leave applications with half-day status now allow specifying which half-day and the remaining half's status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->