### PR TITLE
fix(pwa-link): link field dropdown label in PWA 

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -61,7 +61,12 @@ const options = createResource({
 	method: "POST",
 	transform: (data) => {
 		return data.map((doc) => {
-			const title = doc?.description?.split(",")?.[0]
+			let title = null
+			if (doc.label && doc.label !== doc.value){
+				title = doc.label
+			} else if (doc.description) {
+				title = doc.description.split(",")[0]
+			}
 			return {
 				label: title ? `${title} : ${doc.value}` : doc.value,
 				value: doc.value,

--- a/roster/src/components/Link.vue
+++ b/roster/src/components/Link.vue
@@ -69,7 +69,12 @@ const options = createResource({
 	method: "POST",
 	transform: (data) => {
 		return data.map((doc) => {
-			const title = doc?.description?.split(",")?.[0];
+			let title = null;
+			if (doc.label && doc.label !== doc.value) {
+				title = doc.label;
+			} else if (doc.description) {
+				title = doc.description.split(",")[0];
+			}
 			return {
 				label: title ? `${title} : ${doc.value}` : doc.value,
 				value: doc.value,


### PR DESCRIPTION
### Reason
Link field dropdown was showing inconsistent or duplicate labels in some link field
<img width="280" height="572" alt="image" src="https://github.com/user-attachments/assets/ad3c44fe-6aa7-43cd-8f69-e17ad25480c4" />


### Changes
- Improved label selection logic to prioritize `label` or fallback to `description`, ensuring consistent display across all link fields in PWA
- Did the same changes in Roster page of Frappe HR

<img width="280" height="572" alt="image" src="https://github.com/user-attachments/assets/f00365c0-db38-421b-8ad3-f9278b853efe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label formatting for resource items to display more descriptive information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->