### PR TITLE
fix: Improve option handling in ShiftAssignmentDialog

### DIFF
--- a/roster/src/components/Link.vue
+++ b/roster/src/components/Link.vue
@@ -17,7 +17,7 @@
 
 <script setup>
 import { createResource, Autocomplete, debounce } from "frappe-ui";
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 
 const props = defineProps({
 	doctype: {
@@ -100,13 +100,16 @@ const handleQueryUpdate = debounce((newQuery) => {
 	reloadOptions(val);
 }, 300);
 
+onMounted(() => {
+	reloadOptions(props.modelValue || "");
+});
+
 watch(
 	() => props.doctype,
 	() => {
 		if (!props.doctype || props.doctype === options.doctype) return;
 		reloadOptions("");
 	},
-	{ immediate: true },
 );
 
 watch(

--- a/roster/src/components/ShiftAssignmentDialog.vue
+++ b/roster/src/components/ShiftAssignmentDialog.vue
@@ -295,18 +295,13 @@ const showShiftScheduleSettings = computed(() => {
 	return true;
 });
 
-const employees = computed(() => {
-	return props.employees.map((employee) => ({
-		label: `${employee.name}: ${employee.employee_name}`,
-		value: employee.name,
-		employee_name: employee.employee_name,
-	}));
-});
-
 watch(
 	() => props.isDialogOpen,
 	(val) => {
-		if (!val) return;
+		if (!val) {
+			Object.assign(form, formObject);
+			return;
+		}
 
 		showDeleteDialog.value = false;
 


### PR DESCRIPTION
Changes: 
- fixed bug where data is not being set properly to the fields

Previous working:

https://github.com/user-attachments/assets/e93b5fc9-d513-4c78-97b0-26e353cbef5d

After changes

https://github.com/user-attachments/assets/186e2fa6-6469-42dc-95b0-0d9db8d0c674



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed shift assignment dialog to reset form state when the dialog is closed.

* **Improvements**
  * Autocomplete now loads options immediately when first shown based on the current value.
  * Simplified how autocomplete result titles are derived for clearer, more consistent labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->