### PR TITLE
refactor(expense_claim): unify claim of advance payment done via journal or payment entry using APLE

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -32,12 +32,7 @@ frappe.ui.form.on("Employee Advance", {
 			frm.doc.docstatus === 1 &&
 			flt(frm.doc.paid_amount) < flt(frm.doc.advance_amount) &&
 			frappe.model.can_create("Payment Entry") &&
-			!(
-				(frm.doc.repay_unclaimed_amount_from_salary == 1 && frm.doc.paid_amount) ||
-				(frm.doc.__onload &&
-					frm.doc.__onload.make_payment_via_journal_entry == 1 &&
-					frm.doc.paid_amount)
-			)
+			!(frm.doc.repay_unclaimed_amount_from_salary == 1 && frm.doc.paid_amount)
 		) {
 			frm.add_custom_button(
 				__("Payment"),
@@ -105,12 +100,8 @@ frappe.ui.form.on("Employee Advance", {
 	},
 
 	make_payment_entry: function (frm) {
-		let method = "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee";
-		if (frm.doc.__onload && frm.doc.__onload.make_payment_via_journal_entry) {
-			method = "hrms.hr.doctype.employee_advance.employee_advance.make_bank_entry";
-		}
 		return frappe.call({
-			method: method,
+			method: "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee",
 			args: {
 				dt: frm.doc.doctype,
 				dn: frm.doc.name,
@@ -127,7 +118,6 @@ frappe.ui.form.on("Employee Advance", {
 			method: "hrms.hr.doctype.expense_claim.expense_claim.get_expense_claim",
 			args: {
 				employee_advance: frm.doc.name,
-				payment_via_journal_entry: frm.doc.__onload.make_payment_via_journal_entry,
 			},
 			callback: function (r) {
 				const doclist = frappe.model.sync(r.message);

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -282,47 +282,6 @@ class EmployeeAdvance(Document):
 
 
 @frappe.whitelist()
-def make_bank_entry(dt: str, dn: str) -> dict:
-	doc = frappe.get_doc(dt, dn)
-	payment_account = get_same_currency_bank_cash_account(doc.company, doc.currency, doc.mode_of_payment)
-
-	je = frappe.new_doc("Journal Entry")
-	je.posting_date = nowdate()
-	je.voucher_type = "Bank Entry"
-	je.company = doc.company
-	je.remark = "Payment against Employee Advance: " + dn + "\n" + doc.purpose
-	je.multi_currency = 1 if doc.currency != erpnext.get_company_currency(doc.company) else 0
-
-	je.append(
-		"accounts",
-		{
-			"account": doc.advance_account,
-			"account_currency": doc.currency,
-			"debit_in_account_currency": flt(doc.advance_amount),
-			"reference_type": "Employee Advance",
-			"reference_name": doc.name,
-			"party_type": "Employee",
-			"cost_center": erpnext.get_default_cost_center(doc.company),
-			"party": doc.employee,
-			"is_advance": "Yes",
-		},
-	)
-
-	je.append(
-		"accounts",
-		{
-			"account": payment_account.account or payment_account.name,
-			"cost_center": erpnext.get_default_cost_center(doc.company),
-			"credit_in_account_currency": flt(doc.advance_amount),
-			"account_currency": doc.currency,
-			"account_type": payment_account.account_type,
-		},
-	)
-
-	return je.as_dict()
-
-
-@frappe.whitelist()
 def create_return_through_additional_salary(doc: str | dict | Document) -> Document:
 	import json
 

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -51,11 +51,6 @@ class EmployeeAdvance(Document):
 		]
 	# end: auto-generated types
 
-	def onload(self):
-		self.get("__onload").make_payment_via_journal_entry = frappe.db.get_single_value(
-			"Accounts Settings", "make_payment_via_journal_entry"
-		)
-
 	def validate(self):
 		validate_active_employee(self.employee)
 		self.validate_advance_account_currency()

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -11,7 +11,7 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from hrms.hr.doctype.employee_advance.employee_advance import (
 	EmployeeAdvanceOverPayment,
 	create_return_through_additional_salary,
-	make_bank_entry,
+	get_same_currency_bank_cash_account,
 	make_return_entry,
 )
 from hrms.hr.doctype.expense_claim.expense_claim import get_advances
@@ -35,7 +35,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
 
-		journal_entry = make_journal_entry_for_advance(advance)
+		journal_entry = manual_journal_entry_for_advance(advance)
 		journal_entry.submit()
 
 		advance.reload()
@@ -44,22 +44,19 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		self.assertEqual(advance.status, "Paid")
 
 		# try making over payment
-		journal_entry1 = make_journal_entry_for_advance(advance)
+		journal_entry1 = manual_journal_entry_for_advance(advance)
 		self.assertRaises(EmployeeAdvanceOverPayment, journal_entry1.submit)
 
 	def test_paid_amount_on_pe_cancellation(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
-
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
-
+		payment_entry = make_payment_entry(advance)
 		advance.reload()
 
 		self.assertEqual(advance.paid_amount, 1000)
 		self.assertEqual(advance.status, "Paid")
 
-		journal_entry.cancel()
+		payment_entry.cancel()
 		advance.reload()
 
 		self.assertEqual(advance.paid_amount, 0)
@@ -77,8 +74,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		claim = get_advances_for_claim(claim, advance.name)
 		claim.save()
@@ -107,8 +103,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		# PARTLY CLAIMED AND RETURNED status check
 		# 500 Claimed, 500 Returned
@@ -117,8 +112,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		claim = get_advances_for_claim(claim, advance.name, amount=500)
 		claim.save()
@@ -165,8 +159,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 	def test_repay_unclaimed_amount_from_salary(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		args = {"type": "Deduction"}
 		create_salary_component("Advance Salary - Deduction", **args)
@@ -229,8 +222,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 	def test_precision(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name)
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 
 		# PARTLY CLAIMED AND RETURNED
 		payable_account = get_payable_account("_Test Company")
@@ -375,13 +367,46 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		self.assertEqual(advance.status, "Cancelled")
 
 
-def make_journal_entry_for_advance(advance):
-	journal_entry = frappe.get_doc(make_bank_entry("Employee Advance", advance.name))
-	journal_entry.cheque_no = "123123"
-	journal_entry.cheque_date = nowdate()
-	journal_entry.save()
+def manual_journal_entry_for_advance(advance) -> dict:
+	doc = frappe.get_doc("Employee Advance", advance.name)
+	payment_account = get_same_currency_bank_cash_account(doc.company, doc.currency, doc.mode_of_payment)
 
-	return journal_entry
+	je = frappe.new_doc("Journal Entry")
+	je.posting_date = nowdate()
+	je.voucher_type = "Bank Entry"
+	je.company = doc.company
+	je.remark = "Payment against Employee Advance: " + advance.name + "\n" + doc.purpose
+	je.multi_currency = 1 if doc.currency != erpnext.get_company_currency(doc.company) else 0
+
+	je.append(
+		"accounts",
+		{
+			"account": doc.advance_account,
+			"account_currency": doc.currency,
+			"debit_in_account_currency": flt(doc.advance_amount),
+			"reference_type": "Employee Advance",
+			"reference_name": doc.name,
+			"party_type": "Employee",
+			"cost_center": erpnext.get_default_cost_center(doc.company),
+			"party": doc.employee,
+			"is_advance": "Yes",
+		},
+	)
+
+	je.append(
+		"accounts",
+		{
+			"account": payment_account.account or payment_account.name,
+			"cost_center": erpnext.get_default_cost_center(doc.company),
+			"credit_in_account_currency": flt(doc.advance_amount),
+			"account_currency": doc.currency,
+			"account_type": payment_account.account_type,
+		},
+	)
+	je.cheque_no = "123123"
+	je.cheque_date = nowdate()
+	je.save()
+	return je
 
 
 def make_payment_entry(advance, amount=None):

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -376,7 +376,6 @@ class TestEmployeeAdvance(HRMSTestSuite):
 
 
 def make_journal_entry_for_advance(advance):
-	frappe.db.set_single_value("Accounts Settings", "make_payment_via_journal_entry", True)
 	journal_entry = frappe.get_doc(make_bank_entry("Employee Advance", advance.name))
 	journal_entry.cheque_no = "123123"
 	journal_entry.cheque_date = nowdate()
@@ -386,7 +385,6 @@ def make_journal_entry_for_advance(advance):
 
 
 def make_payment_entry(advance, amount=None):
-	frappe.db.set_single_value("Accounts Settings", "make_payment_via_journal_entry", False)
 	from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
 
 	payment_entry = get_payment_entry_for_employee(advance.doctype, advance.name)

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -270,16 +270,7 @@ frappe.ui.form.on("Expense Claim", {
 		}
 
 		if (!frm.doc.__islocal && frm.doc.docstatus === 1) {
-			let entry_doctype, entry_reference_doctype, entry_reference_name;
-			if (frm.doc.__onload.make_payment_via_journal_entry) {
-				entry_doctype = "Journal Entry";
-				entry_reference_doctype = "Journal Entry Account.reference_type";
-				entry_reference_name = "Journal Entry.reference_name";
-			} else {
-				entry_doctype = "Payment Entry";
-				entry_reference_doctype = "Payment Entry Reference.reference_doctype";
-				entry_reference_name = "Payment Entry Reference.reference_name";
-			}
+			const entry_doctype = "Payment Entry";
 
 			if (
 				cint(frm.doc.total_amount_reimbursed) > 0 &&
@@ -366,12 +357,8 @@ frappe.ui.form.on("Expense Claim", {
 		});
 	},
 	make_payment_entry: function (frm) {
-		let method = "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee";
-		if (frm.doc.__onload && frm.doc.__onload.make_payment_via_journal_entry) {
-			method = "hrms.hr.doctype.expense_claim.expense_claim.make_bank_entry";
-		}
 		return frappe.call({
-			method: method,
+			method: "hrms.overrides.employee_payment_entry.get_payment_entry_for_employee",
 			args: {
 				dt: frm.doc.doctype,
 				dn: frm.doc.name,

--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -486,8 +486,8 @@ frappe.ui.form.on("Expense Claim", {
 							row.return_amount = flt(d.return_amount);
 							row.allocated_amount = d.allocated_amount;
 							row.exchange_rate = d.exchange_rate;
-							row.payment_entry = d.payment_entry;
-							row.payment_entry_reference = d.payment_entry_reference;
+							row.reference_type = d.reference_type;
+							row.reference_name = d.reference_name;
 						});
 						refresh_field("advances");
 					}
@@ -589,8 +589,8 @@ frappe.ui.form.on("Expense Claim Advance", {
 						child.return_amount = flt(r.message[0].return_amount);
 						child.allocated_amount = flt(r.message[0].allocated_amount);
 						child.exchange_rate = r.message[0].exchange_rate;
-						child.payment_entry = r.message[0].payment_entry;
-						child.payment_entry_reference = r.message[0].payment_entry_reference;
+						child.reference_type = r.message[0].reference_type;
+						child.reference_name = r.message[0].reference_name;
 						set_in_company_currency(
 							frm,
 							child,

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -19,7 +19,6 @@ from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.accounts.utils import (
 	create_gain_loss_journal,
 	unlink_ref_doc_from_payment_entries,
-	update_reference_in_payment_entry,
 )
 from erpnext.controllers.accounts_controller import AccountsController
 
@@ -206,8 +205,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		update_reimbursed_amount(self)
 		self.update_claimed_amount_in_employee_advance()
 		self.create_exchange_gain_loss_je()
-		if not frappe.db.get_single_value("Accounts Settings", "make_payment_via_journal_entry"):
-			self.update_against_claim_in_pe()
 
 	def on_update_after_submit(self):
 		if self.check_if_fields_updated([], {"taxes": ("account_head",), "expenses": ()}):
@@ -305,36 +302,30 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				)
 			)
 
-		make_payment_via_je = frappe.db.get_single_value(
-			"Accounts Settings", "make_payment_via_journal_entry"
-		)
 		# gl entry against advance
 		for data in self.advances:
 			if data.allocated_amount:
-				gl_dict = {
-					"account": data.advance_account,
-					"credit": data.base_allocated_amount,
-					"credit_in_account_currency": data.allocated_amount,
-					"credit_in_transaction_currency": data.allocated_amount,
-					"against": ",".join([d.default_account for d in self.expenses]),
-					"party_type": "Employee",
-					"party": self.employee,
-					"voucher_type": self.doctype,
-					"voucher_no": self.name,
-					"advance_voucher_type": "Employee Advance",
-					"advance_voucher_no": data.employee_advance,
-					"transaction_exchange_rate": self.exchange_rate,
-					"cost_center": self.cost_center,
-					"project": self.project,
-				}
-				if not make_payment_via_je:
-					gl_dict.update(
+				gl_entry.append(
+					self.get_gl_dict(
 						{
-							"against_voucher_type": "Payment Entry",
-							"against_voucher": data.payment_entry,
-						}
+							"account": data.advance_account,
+							"credit": data.base_allocated_amount,
+							"credit_in_account_currency": data.allocated_amount,
+							"credit_in_transaction_currency": data.allocated_amount,
+							"against": ",".join([d.default_account for d in self.expenses]),
+							"party_type": "Employee",
+							"party": self.employee,
+							"against_voucher_type": data.reference_type,
+							"against_voucher": data.reference_name,
+							"advance_voucher_type": data.reference_type,
+							"advance_voucher_no": data.reference_name,
+							"transaction_exchange_rate": self.exchange_rate,
+							"cost_center": self.cost_center,
+							"project": self.project,
+						},
+						account_currency=self.currency,
 					)
-				gl_entry.append(self.get_gl_dict(gl_dict, account_currency=self.currency))
+				)
 
 		self.add_tax_gl_entries(gl_entry)
 
@@ -592,35 +583,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					"account"
 				]
 
-	def update_against_claim_in_pe(self):
-		reference_against_pe = []
-		for advance in self.advances:
-			if flt(advance.allocated_amount) > 0:
-				args = frappe._dict(
-					{
-						"voucher_type": "Payment Entry",
-						"voucher_no": advance.payment_entry,
-						"against_voucher_type": self.doctype,
-						"against_voucher": self.name,
-						"voucher_detail_no": advance.payment_entry_reference,
-						"account": advance.advance_account,
-						"party_type": "Employee",
-						"party": self.employee,
-						"is_advance": "Yes",
-						"dr_or_cr": "credit_in_account_currency",
-						"unadjusted_amount": flt(advance.advance_paid),
-						"allocated_amount": flt(advance.allocated_amount),
-						"precision": advance.precision("advance_paid"),
-						"exchange_rate": advance.exchange_rate,
-						"difference_posting_date": advance.posting_date,
-					}
-				)
-				reference_against_pe.append(args)
-		if reference_against_pe:
-			for pe_ref in reference_against_pe:
-				payment_entry = frappe.get_doc("Payment Entry", pe_ref.voucher_no)
-				update_reference_in_payment_entry(pe_ref, payment_entry, skip_ref_details_update_for_pe=True)
-
 
 def update_reimbursed_amount(doc):
 	total_amount_reimbursed = get_total_reimbursed_amount(doc)
@@ -785,11 +747,7 @@ def get_advances(expense_claim: str | dict | Document, advance_id: str | None = 
 
 	advances = query.run(as_dict=True)
 
-	payment_via_journal_entry = frappe.db.get_single_value(
-		"Accounts Settings", "make_payment_via_journal_entry"
-	)
 	for advance in advances:
-		advance.update({"payment_via_journal_entry": payment_via_journal_entry})
 		get_expense_claim_advances(expense_claim_doc, advance)
 	return expense_claim_doc.advances
 
@@ -828,25 +786,61 @@ def get_expense_claim(employee_advance: str | dict, payment_via_journal_entry: s
 
 
 def get_expense_claim_advances(expense_claim, employee_advance):
-	return_amount = flt(employee_advance.return_amount)
-	if int(employee_advance.payment_via_journal_entry):
-		paid_amount = flt(employee_advance.paid_amount)
-		claimed_amount = flt(employee_advance.claimed_amount)
-		exchange_rate = frappe.db.get_value(
-			"Advance Payment Ledger Entry",
-			{
-				"voucher_type": "Journal Entry",
-				"against_voucher_type": "Employee Advance",
-				"against_voucher_no": employee_advance.name,
-				"delinked": False,
-				"amount": paid_amount,
-			},
+	advance_payments = frappe.get_all(
+		"Advance Payment Ledger Entry",
+		filters={
+			"company": expense_claim.company,
+			"against_voucher_type": "Employee Advance",
+			"against_voucher_no": employee_advance.name,
+			"event": "Submit",
+			"delinked": False,
+		},
+		fields=[
+			"voucher_type",
+			"voucher_no",
+			"amount",
+			"base_amount",
 			"exchange_rate",
+		],
+	)
+
+	if not advance_payments:
+		return
+
+	advance_payments.sort(key=lambda x: x.get("voucher_no"))
+	advance_payment_voucher_nos = [payment["voucher_no"] for payment in advance_payments]
+
+	claimed_payments = frappe.get_all(
+		"Advance Payment Ledger Entry",
+		filters={
+			"company": expense_claim.company,
+			"event": "Adjustment",
+			"against_voucher_no": ["in", advance_payment_voucher_nos],
+			"delinked": False,
+		},
+		fields=[
+			"against_voucher_type",
+			"against_voucher_no",
+			"amount",
+		],
+	)
+
+	adjustment_map = {}
+	for adjustment_entry in claimed_payments:
+		payment_reference = (adjustment_entry["against_voucher_type"], adjustment_entry["against_voucher_no"])
+		adjustment_map[payment_reference] = adjustment_map.get(payment_reference, 0) + abs(
+			adjustment_entry["amount"]
 		)
-		allocated_amount = get_allocation_amount(
-			paid_amount=paid_amount, claimed_amount=claimed_amount, return_amount=return_amount
-		)
+
+	for advance in advance_payments:
+		paid_amount = flt(advance["amount"])
+		claimed_amount = adjustment_map.get((advance["voucher_type"], advance["voucher_no"]), 0)
 		unclaimed_amount = paid_amount - claimed_amount
+		return_amount = flt(employee_advance.return_amount)
+		allocated_amount = get_allocation_amount(
+			paid_amount=(paid_amount), claimed_amount=(claimed_amount), return_amount=(return_amount)
+		)
+
 		expense_claim.append(
 			"advances",
 			{
@@ -854,68 +848,15 @@ def get_expense_claim_advances(expense_claim, employee_advance):
 				"employee_advance": employee_advance.name,
 				"posting_date": employee_advance.posting_date,
 				"advance_paid": paid_amount,
-				"base_advance_paid": flt(employee_advance.base_paid_amount),
+				"base_advance_paid": flt(advance["base_amount"]),
 				"unclaimed_amount": unclaimed_amount,
 				"allocated_amount": allocated_amount,
 				"return_amount": return_amount,
-				"exchange_rate": exchange_rate,
+				"exchange_rate": advance["exchange_rate"],
+				"reference_type": advance["voucher_type"],
+				"reference_name": advance["voucher_no"],
 			},
 		)
-	else:
-		pe = frappe.qb.DocType("Payment Entry")
-		pe_ref = frappe.qb.DocType("Payment Entry Reference")
-		payment_entries = (
-			frappe.qb.from_(pe)
-			.inner_join(pe_ref)
-			.on(pe_ref.parent == pe.name)
-			.select(
-				(pe.name).as_("payment_entry"),
-				(pe.total_allocated_amount).as_("advance_paid"),
-				(pe.unallocated_amount),
-				(pe.base_total_allocated_amount).as_("base_advance_paid"),
-				(pe.target_exchange_rate).as_("exchange_rate"),
-				(pe_ref.name).as_("pe_ref_name"),
-				(pe_ref.outstanding_amount),
-				(pe_ref.allocated_amount).as_("pe_ref_allocated_amount"),
-			)
-			.where(
-				(pe.docstatus == 1)
-				& (pe_ref.reference_doctype == "Employee Advance")
-				& (pe_ref.reference_name == employee_advance.name)
-				& (pe_ref.allocated_amount > 0)
-			)
-		).run(as_dict=True)
-
-		for pe in payment_entries:
-			advance_paid = flt(pe.advance_paid) + flt(pe.unallocated_amount)
-			unclaimed_amount = flt(pe.advance_paid)
-			if flt(pe.pe_ref_allocated_amount):
-				unclaimed_amount = flt(pe.pe_ref_allocated_amount) + flt(pe.unallocated_amount)
-			allocated_amount = get_allocation_amount(
-				paid_amount=flt(pe.advance_paid),
-				claimed_amount=(flt(pe.advance_paid) - unclaimed_amount),
-				return_amount=(return_amount),
-			)
-
-			expense_claim.append(
-				"advances",
-				{
-					"advance_account": employee_advance.advance_account,
-					"employee_advance": employee_advance.name,
-					"posting_date": employee_advance.posting_date,
-					"advance_paid": advance_paid,
-					"base_advance_paid": advance_paid * pe.exchange_rate,
-					"unclaimed_amount": unclaimed_amount,
-					"allocated_amount": allocated_amount,
-					"return_amount": return_amount,
-					"exchange_rate": pe.exchange_rate,
-					"payment_entry": pe.payment_entry,
-					"payment_entry_reference": pe.pe_ref_name
-					if flt(pe.advance_paid) >= advance_paid
-					else None,
-					"purpose": employee_advance.purpose,
-				},
-			)
 
 
 def update_payment_for_expense_claim(doc, method=None):

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -644,50 +644,6 @@ def get_outstanding_amount_for_claim(claim):
 
 
 @frappe.whitelist()
-def make_bank_entry(dt: str, dn: str) -> dict:
-	from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
-
-	expense_claim = frappe.get_doc(dt, dn)
-	default_bank_cash_account = get_default_bank_cash_account(expense_claim.company, "Bank")
-	if not default_bank_cash_account:
-		default_bank_cash_account = get_default_bank_cash_account(expense_claim.company, "Cash")
-
-	payable_amount = get_outstanding_amount_for_claim(expense_claim)
-
-	je = frappe.new_doc("Journal Entry")
-	je.voucher_type = "Bank Entry"
-	je.company = expense_claim.company
-	je.remark = "Payment against Expense Claim: " + dn
-
-	je.append(
-		"accounts",
-		{
-			"account": expense_claim.payable_account,
-			"debit_in_account_currency": payable_amount,
-			"reference_type": "Expense Claim",
-			"party_type": "Employee",
-			"party": expense_claim.employee,
-			"cost_center": erpnext.get_default_cost_center(expense_claim.company),
-			"reference_name": expense_claim.name,
-		},
-	)
-
-	je.append(
-		"accounts",
-		{
-			"account": default_bank_cash_account.account,
-			"credit_in_account_currency": payable_amount,
-			"balance": default_bank_cash_account.balance,
-			"account_currency": default_bank_cash_account.account_currency,
-			"cost_center": erpnext.get_default_cost_center(expense_claim.company),
-			"account_type": default_bank_cash_account.account_type,
-		},
-	)
-
-	return je.as_dict()
-
-
-@frappe.whitelist()
 def get_expense_claim_account_and_cost_center(expense_claim_type: str, company: str) -> dict:
 	data = get_expense_claim_account(expense_claim_type, company)
 	cost_center = erpnext.get_default_cost_center(company)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -94,9 +94,6 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 	# end: auto-generated types
 
 	def onload(self):
-		self.get("__onload").make_payment_via_journal_entry = frappe.db.get_single_value(
-			"Accounts Settings", "make_payment_via_journal_entry"
-		)
 		self.set_onload(
 			"self_expense_approval_not_allowed",
 			frappe.db.get_single_value("HR Settings", "prevent_self_expense_approval"),
@@ -753,7 +750,7 @@ def get_advances(expense_claim: str | dict | Document, advance_id: str | None = 
 
 
 @frappe.whitelist()
-def get_expense_claim(employee_advance: str | dict, payment_via_journal_entry: str | int | bool) -> Document:
+def get_expense_claim(employee_advance: str | dict) -> Document:
 	if isinstance(employee_advance, str):
 		employee_advance = frappe.get_doc("Employee Advance", employee_advance)
 
@@ -774,13 +771,6 @@ def get_expense_claim(employee_advance: str | dict, payment_via_journal_entry: s
 	)
 	expense_claim.cost_center = default_cost_center
 	expense_claim.is_paid = 1 if flt(employee_advance.paid_amount) else 0
-
-	employee_advance.update(
-		{
-			"payment_via_journal_entry": payment_via_journal_entry,
-		}
-	)
-
 	get_expense_claim_advances(expense_claim, employee_advance)
 	return expense_claim
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -741,19 +741,13 @@ def get_expense_claim_advances(expense_claim, employee_advance):
 			"event": "Submit",
 			"delinked": False,
 		},
-		fields=[
-			"voucher_type",
-			"voucher_no",
-			"amount",
-			"base_amount",
-			"exchange_rate",
-		],
+		fields=["voucher_type", "voucher_no", "amount", "base_amount", "exchange_rate", "creation"],
 	)
 
 	if not advance_payments:
 		return
 
-	advance_payments.sort(key=lambda x: x.get("voucher_no"))
+	advance_payments.sort(key=lambda x: x.get("creation"))
 	advance_payment_voucher_nos = [payment["voucher_no"] for payment in advance_payments]
 
 	claimed_payments = frappe.get_all(

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -7,7 +7,6 @@ from frappe.utils import flt, nowdate, random_string, today
 import erpnext
 from erpnext import get_company_currency
 from erpnext.accounts.doctype.account.test_account import create_account
-from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.setup.utils import get_exchange_rate
 
@@ -193,7 +192,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			manual_journal_entry_for_advance,
+			make_payment_entry,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -204,8 +203,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		pe = manual_journal_entry_for_advance(advance)
-		pe.submit()
+		pe = make_payment_entry(advance)
 
 		# claim for already paid out advances
 		claim = get_advances_for_claim(claim, advance.name)
@@ -214,12 +212,19 @@ class TestExpenseClaim(HRMSTestSuite):
 
 		self.assertEqual(claim.grand_total, 0)
 		self.assertEqual(claim.status, "Paid")
+		advance_row = claim.advances[0]
+		self.assertEqual(advance_row.employee_advance, advance.name)
+		self.assertEqual(advance_row.reference_type, "Payment Entry")
+		self.assertEqual(advance_row.reference_name, pe.name)
+		self.assertEqual(advance_row.advance_paid, 1000)
+		self.assertEqual(advance_row.unclaimed_amount, 1000)
+		self.assertEqual(advance_row.allocated_amount, 1000)
 
 	def test_advance_amount_allocation_against_claim_with_taxes(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			manual_journal_entry_for_advance,
+			make_payment_entry,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -238,8 +243,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		claim.save()
 
 		advance = make_employee_advance(claim.employee)
-		pe = manual_journal_entry_for_advance(advance)
-		pe.submit()
+		make_payment_entry(advance)
 
 		# claim for already paid out advances
 		claim = get_advances_for_claim(claim, advance.name, 763)
@@ -253,7 +257,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			manual_journal_entry_for_advance,
+			make_payment_entry,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -265,8 +269,7 @@ class TestExpenseClaim(HRMSTestSuite):
 
 		# link advance for partial amount
 		advance = make_employee_advance(claim.employee, {"advance_amount": 500})
-		pe = manual_journal_entry_for_advance(advance)
-		pe.submit()
+		make_payment_entry(advance)
 
 		claim = get_advances_for_claim(claim, advance.name)
 		claim.save()
@@ -281,13 +284,18 @@ class TestExpenseClaim(HRMSTestSuite):
 
 		self.assertEqual(claim.total_amount_reimbursed, 500)
 		self.assertEqual(claim.status, "Paid")
+		self.assertEqual(claim.total_claimed_amount, 1000)
+		advance_row = claim.advances[0]
+		self.assertEqual(advance_row.advance_paid, 500)
+		self.assertEqual(advance_row.unclaimed_amount, 500)
+		self.assertEqual(advance_row.allocated_amount, 500)
 
 	def test_expense_claim_with_deducted_returned_advance(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			create_return_through_additional_salary,
 			get_advances_for_claim,
 			make_employee_advance,
-			manual_journal_entry_for_advance,
+			make_payment_entry,
 		)
 		from hrms.hr.doctype.expense_claim.expense_claim import get_allocation_amount
 		from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
@@ -296,8 +304,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		# create employee and employee advance
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = manual_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 		advance.reload()
 
 		# set up salary components and structure
@@ -339,6 +346,10 @@ class TestExpenseClaim(HRMSTestSuite):
 			),
 			600,
 		)
+		advance_row = claim.advances[0]
+		self.assertEqual(advance_row.advance_paid, 1000)
+		self.assertEqual(advance_row.return_amount, 400)
+		self.assertEqual(advance_row.allocated_amount, 200)
 
 	def test_expense_claim_gl_entry(self):
 		payable_account = get_payable_account(company_name)
@@ -952,6 +963,53 @@ class TestExpenseClaim(HRMSTestSuite):
 		expense_claim.discard()
 		expense_claim.reload()
 		self.assertEqual(expense_claim.status, "Cancelled")
+
+	def test_expense_claim_advance_payment_via_journal_entrry(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			get_advances_for_claim,
+			make_employee_advance,
+			manual_journal_entry_for_advance,
+		)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account,
+			1000,
+			1000,
+			"_Test Company",
+			"Travel Expenses - _TC",
+			do_not_submit=True,
+		)
+
+		advance = make_employee_advance(claim.employee)
+		je = manual_journal_entry_for_advance(advance)
+		je.submit()
+		advance.reload()
+		self.assertEqual(advance.status, "Paid")
+
+		claim = get_advances_for_claim(claim, advance.name)
+		claim.save().submit()
+		claim.reload()
+		advance.reload()
+
+		self.assertEqual(claim.status, "Paid")
+		self.assertEqual(advance.status, "Claimed")
+		self.assertEqual(len(claim.advances), 1)
+
+		advance_row = claim.advances[0]
+		self.assertEqual(advance_row.employee_advance, advance.name)
+		self.assertEqual(advance_row.reference_type, "Journal Entry")
+		self.assertEqual(advance_row.reference_name, je.name)
+		self.assertEqual(advance_row.advance_paid, 1000)
+		self.assertEqual(advance_row.unclaimed_amount, 1000)
+		self.assertEqual(advance_row.allocated_amount, 1000)
+
+		claim.cancel()
+		claim.reload()
+		advance.reload()
+
+		self.assertEqual(advance.status, "Paid")
+		self.assertEqual(advance.claimed_amount, 0)
 
 
 def get_payable_account(company):

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -193,7 +193,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			make_journal_entry_for_advance,
+			manual_journal_entry_for_advance,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -204,7 +204,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		)
 
 		advance = make_employee_advance(claim.employee)
-		pe = make_journal_entry_for_advance(advance)
+		pe = manual_journal_entry_for_advance(advance)
 		pe.submit()
 
 		# claim for already paid out advances
@@ -219,7 +219,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			make_journal_entry_for_advance,
+			manual_journal_entry_for_advance,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -238,7 +238,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		claim.save()
 
 		advance = make_employee_advance(claim.employee)
-		pe = make_journal_entry_for_advance(advance)
+		pe = manual_journal_entry_for_advance(advance)
 		pe.submit()
 
 		# claim for already paid out advances
@@ -253,7 +253,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,
-			make_journal_entry_for_advance,
+			manual_journal_entry_for_advance,
 		)
 
 		frappe.db.delete("Employee Advance")
@@ -265,7 +265,7 @@ class TestExpenseClaim(HRMSTestSuite):
 
 		# link advance for partial amount
 		advance = make_employee_advance(claim.employee, {"advance_amount": 500})
-		pe = make_journal_entry_for_advance(advance)
+		pe = manual_journal_entry_for_advance(advance)
 		pe.submit()
 
 		claim = get_advances_for_claim(claim, advance.name)
@@ -287,7 +287,7 @@ class TestExpenseClaim(HRMSTestSuite):
 			create_return_through_additional_salary,
 			get_advances_for_claim,
 			make_employee_advance,
-			make_journal_entry_for_advance,
+			manual_journal_entry_for_advance,
 		)
 		from hrms.hr.doctype.expense_claim.expense_claim import get_allocation_amount
 		from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
@@ -296,7 +296,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		# create employee and employee advance
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = make_journal_entry_for_advance(advance)
+		journal_entry = manual_journal_entry_for_advance(advance)
 		journal_entry.submit()
 		advance.reload()
 

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -964,7 +964,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		expense_claim.reload()
 		self.assertEqual(expense_claim.status, "Cancelled")
 
-	def test_expense_claim_advance_payment_via_journal_entrry(self):
+	def test_expense_claim_advance_payment_via_journal_entry(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
 			make_employee_advance,

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt, nowdate, random_string, today
 
+import erpnext
 from erpnext import get_company_currency
 from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
@@ -13,7 +14,6 @@ from erpnext.setup.utils import get_exchange_rate
 from hrms.hr.doctype.expense_claim.expense_claim import (
 	MismatchError,
 	get_outstanding_amount_for_claim,
-	make_bank_entry,
 	make_expense_claim_for_delivery_trip,
 )
 from hrms.tests.utils import HRMSTestSuite
@@ -135,7 +135,7 @@ class TestExpenseClaim(HRMSTestSuite):
 				employee1 = entry.party
 
 			if not entry.party_type:
-				entry.credit += 200
+				entry.credit = flt(entry.credit) + 200
 				entry.credit_in_account_currency += 200
 
 		je.append(
@@ -1056,15 +1056,51 @@ def make_claim_payment_entry(expense_claim, amount):
 
 
 def make_journal_entry(expense_claim, do_not_submit=False):
-	je_dict = make_bank_entry("Expense Claim", expense_claim.name)
-	je = frappe.get_doc(je_dict)
+	from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
+
+	expense_claim = frappe.get_doc("Expense Claim", expense_claim.name)
+	default_bank_cash_account = get_default_bank_cash_account(expense_claim.company, "Bank")
+	if not default_bank_cash_account:
+		default_bank_cash_account = get_default_bank_cash_account(expense_claim.company, "Cash")
+
+	payable_amount = get_outstanding_amount_for_claim(expense_claim)
+
+	je = frappe.new_doc("Journal Entry")
+	je.voucher_type = "Bank Entry"
+	je.company = expense_claim.company
+	je.remark = "Payment against Expense Claim: " + expense_claim.name
+
+	je.append(
+		"accounts",
+		{
+			"account": expense_claim.payable_account,
+			"debit_in_account_currency": payable_amount,
+			"reference_type": "Expense Claim",
+			"party_type": "Employee",
+			"party": expense_claim.employee,
+			"cost_center": erpnext.get_default_cost_center(expense_claim.company),
+			"reference_name": expense_claim.name,
+		},
+	)
+
+	je.append(
+		"accounts",
+		{
+			"account": default_bank_cash_account.account,
+			"credit_in_account_currency": payable_amount,
+			"balance": default_bank_cash_account.balance,
+			"account_currency": default_bank_cash_account.account_currency,
+			"cost_center": erpnext.get_default_cost_center(expense_claim.company),
+			"account_type": default_bank_cash_account.account_type,
+		},
+	)
+
 	je.posting_date = nowdate()
 	je.cheque_no = random_string(5)
 	je.cheque_date = nowdate()
 
 	if not do_not_submit:
 		je.submit()
-
 	return je
 
 

--- a/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+++ b/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
@@ -81,7 +81,6 @@
    "oldfieldtype": "Currency",
    "options": "currency",
    "print_width": "120px",
-   "read_only": 1,
    "width": "120px"
   },
   {
@@ -183,7 +182,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-05-07 17:10:55.068753",
+ "modified": "2026-05-08 15:51:23.314675",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Advance",

--- a/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
+++ b/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "employee_advance",
-  "payment_entry",
+  "reference_type",
+  "reference_name",
   "posting_date",
   "advance_paid",
   "base_advance_paid",
@@ -155,14 +156,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "payment_entry",
-   "fieldtype": "Link",
-   "label": "Payment Entry",
-   "no_copy": 1,
-   "options": "Payment Entry",
-   "read_only": 1
-  },
-  {
    "fieldname": "payment_entry_reference",
    "fieldtype": "Data",
    "hidden": 1,
@@ -170,11 +163,27 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "reference_type",
+   "fieldtype": "Select",
+   "label": "Reference Type",
+   "no_copy": 1,
+   "options": "\nPayment Entry\nJournal Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Name",
+   "no_copy": 1,
+   "options": "reference_type",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-11-12 19:48:47.708734",
+ "modified": "2026-05-07 17:10:55.068753",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Advance",

--- a/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.py
+++ b/hrms/hr/doctype/expense_claim_advance/expense_claim_advance.py
@@ -26,9 +26,10 @@ class ExpenseClaimAdvance(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		payment_entry: DF.Link | None
 		payment_entry_reference: DF.Data | None
 		posting_date: DF.Date | None
+		reference_name: DF.DynamicLink | None
+		reference_type: DF.Literal["", "Payment Entry", "Journal Entry"]
 		return_amount: DF.Currency
 		unclaimed_amount: DF.Currency
 	# end: auto-generated types

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -46,3 +46,4 @@ hrms.patches.v16_0.set_base_paid_amount_in_employee_advance
 hrms.patches.v16_0.set_currency_and_base_fields_in_expense_claim
 hrms.patches.v16_0.remove_ess_user_type_limit
 hrms.patches.v16_0.add_default_hr_role_permissions
+hrms.patches.v16_0.set_reference_fields_in_expense_claim_advance

--- a/hrms/patches/v16_0/set_reference_fields_in_expense_claim_advance.py
+++ b/hrms/patches/v16_0/set_reference_fields_in_expense_claim_advance.py
@@ -1,0 +1,16 @@
+import frappe
+from frappe.query_builder.functions import IfNull
+
+
+def execute():
+	ExpenseClaimAdvance = frappe.qb.DocType("Expense Claim Advance")
+
+	(
+		frappe.qb.update(ExpenseClaimAdvance)
+		.set(ExpenseClaimAdvance.reference_name, ExpenseClaimAdvance.payment_entry)
+		.set(ExpenseClaimAdvance.reference_type, "Payment Entry")
+		.where(
+			(IfNull(ExpenseClaimAdvance.payment_entry, "") != "")
+			& (IfNull(ExpenseClaimAdvance.reference_name, "") == "")
+		)
+	).run()

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -15,7 +15,7 @@ from hrms.hr.doctype.employee_advance.employee_advance import (
 )
 from hrms.hr.doctype.employee_advance.test_employee_advance import (
 	make_employee_advance,
-	make_journal_entry_for_advance,
+	make_payment_entry,
 )
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
@@ -574,8 +574,7 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		# create employee advance
 		advance = make_employee_advance(employee, {"repay_unclaimed_amount_from_salary": 1})
-		journal_entry = make_journal_entry_for_advance(advance)
-		journal_entry.submit()
+		make_payment_entry(advance)
 		advance.reload()
 
 		# return advance through additional salary (deduction)


### PR DESCRIPTION
### Reason
Expense Claim advance allocation was dependent on Payment Entry references from v16, which caused inconsistencies for advances paid via Journal Entry and introduced issues in cancellation flows. 
This refactor moves allocation tracking from document-level references to Advance Payment Ledger Entry (**APLE**)

### Changes Done
- Refactored advance allocation flow in Expense Claim to use APLE as single source of truth.
- Unified advance claim handling for both Payment Entry and Journal Entry based payments.
- Removed dependency on Payment Entry Reference based tracking.
- Simplified advance allocation calculation using APLE Submit and Adjustment entries.


___

TODO
 - [x] change logic to get payments info from APLE
 - [x] remove make_payment_via_je check and the flow of creating journal entry form both forms
 - [x] update test cases
 - [x] add patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized payment flow to use Payment Entry for Employee Advances and Expense Claims; advances now store reference_type and reference_name for clearer linkage.
* **Bug Fixes**
  * Refined Payment button visibility so it appears only in appropriate advance states.
* **Chores**
  * Patch added to backfill new reference fields on existing advance rows.
* **Tests**
  * Test suites updated to mirror new payment/advance behaviors and reference-field handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4494)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->