### PR TITLE
fix: Applicable after based on calendar days instead of working days

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -187,18 +187,11 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			leave_type = frappe.get_doc("Leave Type", self.leave_type)
 			if leave_type.applicable_after > 0:
 				date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
-				leave_days = get_approved_leaves_for_period(
-					self.employee, False, date_of_joining, self.from_date
-				)
 				number_of_days = date_diff(getdate(self.from_date), date_of_joining)
 				if number_of_days >= 0:
-					holidays = 0
-					if not frappe.db.get_value("Leave Type", self.leave_type, "include_holiday"):
-						holidays = get_holidays(self.employee, date_of_joining, self.from_date)
-					number_of_days = number_of_days - leave_days - holidays
 					if number_of_days < leave_type.applicable_after:
 						frappe.throw(
-							_("{0} applicable after {1} working days").format(
+							_("{0} applicable after {1} calendar days").format(
 								self.leave_type, leave_type.applicable_after
 							)
 						)

--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -59,10 +59,10 @@
    "label": "Maximum Leave Allocation Allowed per Leave Period"
   },
   {
-   "description": "Minimum working days required since Date of Joining to apply for this leave",
+   "description": "Minimum calendar days required since Date of Joining to apply for this leave",
    "fieldname": "applicable_after",
    "fieldtype": "Int",
-   "label": "Allow Leave Application After (Working Days)"
+   "label": "Allow Leave Application After (Calendar Days)"
   },
   {
    "fieldname": "max_continuous_days_allowed",
@@ -259,7 +259,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2026-02-06 18:26:27.583525",
+ "modified": "2026-05-07 18:26:27.583525",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",


### PR DESCRIPTION
As a general norm across the world, the waiting period for a leave application is based on calendar days instead of actual working days. This PR makes that specific change

Closes: https://github.com/frappe/hrms/issues/3068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated "applicable after" validation for leave applications to use calendar days instead of working days, providing a simpler and more transparent calculation.
  * Updated error messages and field labels to reflect the calendar-days-based calculation methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->