### PR TITLE
fix(hr): allow zero allocations for negative leave types

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -283,6 +283,7 @@ class LeaveAllocation(Document):
 			not self.total_leaves_allocated
 			and not frappe.db.get_value("Leave Type", self.leave_type, "is_earned_leave")
 			and not frappe.db.get_value("Leave Type", self.leave_type, "is_compensatory")
+			and not frappe.db.get_value("Leave Type", self.leave_type, "allow_negative")
 		):
 			frappe.throw(_("Total leaves allocated is mandatory for Leave Type {0}").format(self.leave_type))
 

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -511,6 +511,7 @@ def get_leave_type_details():
 			"is_lwp",
 			"is_earned_leave",
 			"is_compensatory",
+			"allow_negative",
 			"allocate_on_day",
 			"is_carry_forward",
 			"expire_carry_forwarded_leaves_after_days",

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -147,7 +147,11 @@ class LeavePolicyAssignment(Document):
 			else []
 		)
 
-		if new_leaves_allocated == 0 and not leave_details.is_earned_leave:
+		if (
+			new_leaves_allocated == 0
+			and not leave_details.is_earned_leave
+			and not leave_details.allow_negative
+		):
 			text = _(
 				"Leave allocation is skipped for {0}, because number of leaves to be allocated is 0."
 			).format(frappe.bold(leave_details.name))

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -258,6 +258,8 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		sick = create_leave_type(
 			leave_type_name="_Test Sick Leave", non_encashable_leaves=0, max_leaves_allowed=2
 		)
+		sick.allow_negative = 1
+		sick.save()
 		casual = create_leave_type(
 			leave_type_name="_Test Casual Leave", non_encashable_leaves=0, max_leaves_allowed=12
 		)
@@ -304,17 +306,18 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 			fields=["content"],
 		)
 
-		self.assertEqual(len(comments), 2)
+		self.assertEqual(len(comments), 1)
 		self.assertIn(casual.name, comments[0]["content"])
-		self.assertIn(sick.name, comments[1]["content"])
 
 		allocations = frappe.get_all(
 			"Leave Allocation",
 			filters={"leave_policy_assignment": assignment.name},
-			fields=["leave_type", "new_leaves_allocated"],
+			fields=["leave_type", "new_leaves_allocated", "total_leaves_allocated"],
 		)
+		allocations = {allocation["leave_type"]: allocation for allocation in allocations}
 
-		self.assertEqual(allocations[0]["leave_type"], compoff.name)
-		self.assertEqual(allocations[0]["new_leaves_allocated"], 3)
-		self.assertEqual(allocations[1]["leave_type"], annual.name)
-		self.assertEqual(allocations[1]["new_leaves_allocated"], 3)
+		self.assertEqual(allocations[sick.name]["new_leaves_allocated"], 0)
+		self.assertEqual(allocations[sick.name]["total_leaves_allocated"], 0)
+		self.assertEqual(allocations[compoff.name]["new_leaves_allocated"], 3)
+		self.assertEqual(allocations[annual.name]["new_leaves_allocated"], 3)
+		self.assertNotIn(casual.name, allocations)


### PR DESCRIPTION
This PR updates Leave Policy Assignment behavior so leave types with `allow_negative = 1` can still receive a Leave Allocation when the calculated allocation is `0`.

Previously, Leave Policy Assignment skipped all non-earned leave types when `new_leaves_allocated == 0`. That meant leave types configured with `allow_negative = 1` and `annual_allocation = 0` were not assigned to employees at all, so they were unavailable in Leave Application for this employee.

## Changes

- Allow Leave Policy Assignment to create zero-leave allocations for leave types with `allow_negative = 1`.
- Allow `Leave Allocation.total_leaves_allocated = 0` when the linked Leave Type allows negative balance.
- Update zero-allocation policy assignment test coverage to verify:
  - normal zero-allocation leave types are still skipped
  - allow-negative zero-allocation leave types create an allocation
  - the created allocation has `new_leaves_allocated = 0` and `total_leaves_allocated = 0`

## Why
This supports policies where certain leave types should be assignable to employees without granting an annual entitlement, while still allowing employees to apply for them using negative balance behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for leave allocations now respects leave types that allow negative balances, preventing spurious "total leaves" errors.
  * Leave policy assignment skips creating zero-value allocations only when negative balances are disallowed, avoiding unintended allocations.

* **Tests**
  * Updated tests to reflect revised allocation and comment behaviors for varied leave type configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4518)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->