### PR TITLE
fix(employee): Employee naming series visibility based on HR Settings

### DIFF
--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -27,6 +27,11 @@ frappe.ui.form.on("Employee", {
 			});
 		}
 		frm.set_df_property("holiday_list", "hidden", 1);
+
+		// hide naming series field based on hr settings
+		frappe.db.get_single_value("HR Settings", "emp_created_by").then((value) => {
+			frm.toggle_display("naming_series", value === "Naming Series");
+		});
 	},
 
 	date_of_birth(frm) {


### PR DESCRIPTION
### Reason
The `naming_series` field was still visible in the Employee form even when **Employee Naming By** was set to options other than Naming Series in HR Settings. 
Even though a Property Setter was applied via Customize Form to hide the field, it was still visible causing confusion for users.

https://github.com/user-attachments/assets/80aa1115-0c71-4981-b392-a0d90fb9c2b1



### Changes done
- Added conditional UI handling for `naming_series` field visibility using client-side form refresh logic to avoid modifying DocType metadata

https://github.com/user-attachments/assets/025edd21-cf3f-4397-a93a-66a6fd0eeddd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The naming series field visibility in the Employee form can now be dynamically controlled through HR Settings, allowing your organization to configure when this field is displayed based on your naming series creation method.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->