### PR TITLE
Fix/payroll entry canceling for hr manager

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -218,9 +218,13 @@ class PayrollEntry(Document):
 			)
 			# cancel linked payment ledger entry
 			for pl in journal_entry_payment_ledgers:
-				frappe.get_doc("Payment Ledger Entry", pl).cancel()
+				payment_ledger_entry = frappe.get_doc("Payment Ledger Entry", pl)
+				payment_ledger_entry.flags.ignore_permissions = True
+				payment_ledger_entry.cancel()
 
-			frappe.get_doc("Journal Entry", je).cancel()
+			journal_entry = frappe.get_doc("Journal Entry", je)
+			journal_entry.flags.ignore_permissions = True
+			journal_entry.cancel()
 
 	def cancel_linked_payment_ledger_entries(self):
 		payment_ledgers = frappe.get_all(
@@ -231,7 +235,9 @@ class PayrollEntry(Document):
 
 		# cancel payment ledger entry
 		for pl in payment_ledgers:
-			frappe.get_doc("Payment Ledger Entry", pl).cancel()
+			payment_ledger_entry = frappe.get_doc("Payment Ledger Entry", pl)
+			payment_ledger_entry.flags.ignore_permissions = True
+			payment_ledger_entry.cancel()
 
 	def get_linked_salary_slips(self):
 		return frappe.get_all("Salary Slip", {"payroll_entry": self.name}, ["name", "docstatus"])

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -444,6 +444,41 @@ class TestPayrollEntry(HRMSTestSuite):
 		journal_entries = get_linked_journal_entries(payroll_entry.name, docstatus=2)
 		self.assertEqual(len(journal_entries), 2)
 
+	def test_payroll_entry_cancellation_with_hr_manager(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		employee = make_employee("test_hr_manager_employee@payroll.com", company=company_doc.name)
+
+		setup_salary_structure(employee, company_doc)
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = make_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company=company_doc.name,
+			cost_center="Main - _TC",
+			payment_account="Cash - _TC",
+		)
+
+		hr_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "test_hr_manager@payroll.com",
+				"first_name": "Test HR Manager",
+				"enabled": 1,
+			}
+		).insert(ignore_if_duplicate=True)
+		hr_user.add_roles("HR Manager")
+		frappe.set_user(hr_user.name)
+
+		payroll_entry.submit()
+		self.assertEqual(payroll_entry.status, "Submitted")
+
+		payroll_entry.cancel()
+		self.assertEqual(payroll_entry.status, "Cancelled")
+
+		frappe.set_user("Administrator")
+
 	def test_payroll_entry_status(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee("test_employee@payroll.com", company=company_doc.name)


### PR DESCRIPTION
Changes:
- Added ignore permissions for cancellation of Journal Entry and Payment Ledger Entry.
- Added test case for HR Manager role user canceling the Payroll entry.

Previous:
- HR Manager gets error related to permissions for Journal Entry and Payment Ledger Entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payroll entry cancellation so linked accounting records are reliably cancelled even when additional permission handling is required, preventing orphaned ledger or journal records.

* **Tests**
  * Added a test verifying payroll entry submission and cancellation flows function correctly for users with HR Manager role, ensuring status transitions from Submitted to Cancelled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->