### PR TITLE
fix(leave_allocation): handle expired leave allocation

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -28,6 +28,10 @@ frappe.ui.form.on("Leave Allocation", {
 	refresh: function (frm) {
 		hrms.leave_utils.add_view_ledger_button(frm);
 
+		if (frm.doc.expired) {
+			frm.set_df_property("new_leaves_allocated", "hidden", 1);
+		}
+
 		if (frm.doc.docstatus === 1 && !frm.doc.expired) {
 			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(
 				frm.doc.from_date,
@@ -50,7 +54,7 @@ frappe.ui.form.on("Leave Allocation", {
 		if (!frm.doc.__islocal && frm.doc.leave_policy_assignment) {
 			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
 				if (!r?.is_earned_leave) return;
-				frm.set_df_property("new_leaves_allocated", "hidden", 1);
+				frm.set_df_property("new_leaves_allocated", "read_only", 1);
 				frm.trigger("add_allocate_leaves_button");
 			});
 		}

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -131,7 +131,7 @@ frappe.ui.form.on("Leave Allocation", {
 				if (!r.exc) {
 					frappe.msgprint(__("Allocation Expired!"));
 				}
-				frm.refresh();
+				frm.reload_doc();
 			},
 		});
 	},

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -50,7 +50,7 @@ frappe.ui.form.on("Leave Allocation", {
 		if (!frm.doc.__islocal && frm.doc.leave_policy_assignment) {
 			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
 				if (!r?.is_earned_leave) return;
-				frm.set_df_property("new_leaves_allocated", "read_only", 1);
+				frm.set_df_property("new_leaves_allocated", "hidden", 1);
 				frm.trigger("add_allocate_leaves_button");
 			});
 		}

--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -9,7 +9,10 @@ from hrms.hr.doctype.leave_allocation.leave_allocation import (
 	BackDatedAllocationError,
 	OverAllocationError,
 )
-from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
+from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
+	expire_allocation,
+	process_expired_allocation,
+)
 from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
 
 
@@ -613,6 +616,32 @@ class TestLeaveAllocation(FrappeTestCase):
 		leave_allocation.new_leaves_allocated = leave_application.total_leave_days - 1
 		leave_allocation.total_leaves_allocated = leave_application.total_leave_days - 1
 		self.assertRaises(frappe.ValidationError, leave_allocation.submit)
+
+	def test_reallocation_after_expired_allocation(self):
+		from hrms.hr.doctype.leave_allocation.test_earned_leaves import make_policy_assignment
+
+		create_leave_type(leave_type_name="_Test_Expired_Reallocation")
+
+		leave_policy_assignment = make_policy_assignment(self.employee)[0]
+		leave_allocation = frappe.get_doc(
+			"Leave Allocation", {"leave_policy_assignment": leave_policy_assignment}
+		)
+
+		# expire allocation
+		expire_allocation(leave_allocation)
+		leave_allocation.reload()
+		self.assertEqual(leave_allocation.new_leaves_allocated, 0)
+		self.assertEqual(leave_allocation.total_leaves_allocated, 0)
+
+		# allocate 6 new leaves after expiry
+		leave_allocation.allocate_leaves_manually(6)
+		leave_allocation.reload()
+		self.assertEqual(leave_allocation.total_leaves_allocated, 6)
+
+		# allocate 3 more leaves
+		leave_allocation.allocate_leaves_manually(3)
+		leave_allocation.reload()
+		self.assertEqual(leave_allocation.total_leaves_allocated, 9)
 
 
 def create_leave_allocation(**args):

--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -636,11 +636,13 @@ class TestLeaveAllocation(FrappeTestCase):
 		# allocate 6 new leaves after expiry
 		leave_allocation.allocate_leaves_manually(6)
 		leave_allocation.reload()
+		self.assertEqual(leave_allocation.new_leaves_allocated, 0)
 		self.assertEqual(leave_allocation.total_leaves_allocated, 6)
 
 		# allocate 3 more leaves
 		leave_allocation.allocate_leaves_manually(3)
 		leave_allocation.reload()
+		self.assertEqual(leave_allocation.new_leaves_allocated, 0)
 		self.assertEqual(leave_allocation.total_leaves_allocated, 9)
 
 

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -219,7 +219,15 @@ def expire_allocation(allocation, expiry_date=None):
 		)
 		create_leave_ledger_entry(allocation, args)
 
-	frappe.db.set_value("Leave Allocation", allocation.name, "expired", 1)
+	frappe.db.set_value(
+		"Leave Allocation",
+		allocation.name,
+		{
+			"expired": 1,
+			"new_leaves_allocated": 0,
+			"total_leaves_allocated": 0
+		}
+	)
 
 
 def expire_carried_forward_allocation(allocation):

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import datetime
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -195,7 +197,7 @@ def get_remaining_leaves(allocation):
 
 
 @frappe.whitelist()
-def expire_allocation(allocation: str | Document, expiry_date: str | None = None):
+def expire_allocation(allocation: str | Document | frappe._dict, expiry_date: datetime.date | None = None):
 	"""expires non-carry forwarded allocation"""
 	import json
 

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -195,7 +195,7 @@ def get_remaining_leaves(allocation):
 
 
 @frappe.whitelist()
-def expire_allocation(allocation, expiry_date=None):
+def expire_allocation(allocation: str | Document, expiry_date: str | None = None):
 	"""expires non-carry forwarded allocation"""
 	import json
 

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -222,11 +222,7 @@ def expire_allocation(allocation, expiry_date=None):
 	frappe.db.set_value(
 		"Leave Allocation",
 		allocation.name,
-		{
-			"expired": 1,
-			"new_leaves_allocated": 0,
-			"total_leaves_allocated": 0
-		}
+		{"expired": 1, "new_leaves_allocated": 0, "total_leaves_allocated": 0},
 	)
 
 


### PR DESCRIPTION
### Reason
- Expired leave allocations are still showing new_leaves_allocated and total_leaves_allocated values even after expiry making it difficult to understand the new allocation after expiry

https://github.com/user-attachments/assets/98c4ca11-a3a1-4c04-b612-a157d86f3936


### Changes Done
- Reset new_leaves_allocated and total_leaves_allocated to 0 when allocations expire. Also hide the new_leaves_allocated field for earned leave allocations as only the total_leaves_allocated field is updated
- Reload doc after leave expiry as there is a document sync error just after the expiration

https://github.com/user-attachments/assets/ab38aca3-ded5-4fa4-9fb3-ffc12dcf7a34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expired leave allocations now hide the allocated-leaves input, reset both new and total allocated leave counts to zero, and ensure the form reloads to show updated values.

* **Tests**
  * Added an automated test verifying that expiration clears allocations and that subsequent manual reallocations update totals while new-allocation stays cleared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->