### PR TITLE
fix(expense_claim): handle partial advance settlement in expense claims

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -116,6 +116,9 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		if self.task and not self.project:
 			self.project = frappe.db.get_value("Task", self.task, "project")
 
+		if flt(self.grand_total) > 0 and self.total_advance_amount:
+			self.is_paid = 0
+
 	def set_status(self, update=False):
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]
 

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -255,26 +255,47 @@ class TestExpenseClaim(HRMSTestSuite):
 
 	def test_expense_claim_partially_paid_via_advance(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
-			get_advances_for_claim,
 			make_employee_advance,
 			make_payment_entry,
 		)
+		from hrms.hr.doctype.expense_claim.expense_claim import get_expense_claim
 
 		frappe.db.delete("Employee Advance")
 
-		payable_account = get_payable_account("_Test Company")
-		claim = make_expense_claim(
-			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
-		)
-
-		# link advance for partial amount
-		advance = make_employee_advance(claim.employee, {"advance_amount": 500})
+		employee = make_employee("test_partial_advance_claim@expenseclaim.com", "_Test Company")
+		advance = make_employee_advance(employee, {"advance_amount": 500})
 		make_payment_entry(advance)
 
-		claim = get_advances_for_claim(claim, advance.name)
+		currency, cost_center = frappe.db.get_value(
+			"Company", "_Test Company", ["default_currency", "cost_center"]
+		)
+		claim = get_expense_claim(advance.name)  # function call to create claim from employee advance form
+		claim.update(
+			{
+				"payable_account": get_payable_account("_Test Company"),
+				"currency": currency,
+				"exchange_rate": 1,
+				"approval_status": "Approved",
+			}
+		)
+		claim.append(
+			"expenses",
+			{
+				"expense_type": "Travel",
+				"default_account": "Travel Expenses - _TC",
+				"amount": 1000,
+				"sanctioned_amount": 1000,
+				"cost_center": cost_center,
+			},
+		)
+
+		# assert is_paid to be checked true as claim is done via advance actions button
+		self.assertTrue(claim.is_paid)
 		claim.save()
 		claim.submit()
 
+		# assert is_paid to be checked false as claim amount is greater than advance
+		self.assertFalse(claim.is_paid)
 		self.assertEqual(claim.grand_total, 500)
 		self.assertEqual(claim.status, "Unpaid")
 


### PR DESCRIPTION
### Reason
- Expense Claims created from Employee Advance were incorrectly marked as "Paid" even when the advance amount only partially covered the claimed amount. As a result outstanding payable amount was ignored and payment action was not available

https://github.com/user-attachments/assets/b817c399-fdfe-4cfd-a008-974fda1a881d

### Changes Done
- Expense Claims with partial Employee Advance coverage are now correctly marked as “Unpaid” instead of “Paid”, ensuring any remaining balance is available for reimbursement flow.

https://github.com/user-attachments/assets/af781f89-f14b-4924-84a9-9b9882426578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expense claim status logic corrected so claims with advances aren’t prematurely marked as paid when advances remain unsettled.

* **Tests**
  * Updated expense claim tests to cover advance-linked scenarios and verify is_paid behavior before and after submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->