### PR TITLE
feat #4472 : add holiday list assignment to employee connections tab

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -10,7 +10,12 @@ def get_dashboard_for_employee(data):
 			{"label": _("Attendance"), "items": ["Attendance", "Attendance Request", "Employee Checkin"]},
 			{
 				"label": _("Leave"),
-				"items": ["Leave Application", "Leave Allocation", "Leave Policy Assignment", "Holiday List Assignment"],
+				"items": [
+					"Leave Application",
+					"Leave Allocation",
+					"Leave Policy Assignment",
+					"Holiday List Assignment",
+				],
 			},
 			{
 				"label": _("Lifecycle"),
@@ -56,7 +61,9 @@ def get_dashboard_for_employee(data):
 		]
 	)
 
-	data["non_standard_fieldnames"].update({"Bank Account": "party", "Employee Grievance": "raised_by", "Holiday List Assignment": "assigned_to"})
+	data["non_standard_fieldnames"].update(
+		{"Bank Account": "party", "Employee Grievance": "raised_by", "Holiday List Assignment": "assigned_to"}
+	)
 	data.update(
 		{
 			"heatmap": True,

--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -10,7 +10,7 @@ def get_dashboard_for_employee(data):
 			{"label": _("Attendance"), "items": ["Attendance", "Attendance Request", "Employee Checkin"]},
 			{
 				"label": _("Leave"),
-				"items": ["Leave Application", "Leave Allocation", "Leave Policy Assignment"],
+				"items": ["Leave Application", "Leave Allocation", "Leave Policy Assignment", "Holiday List Assignment"],
 			},
 			{
 				"label": _("Lifecycle"),
@@ -56,7 +56,7 @@ def get_dashboard_for_employee(data):
 		]
 	)
 
-	data["non_standard_fieldnames"].update({"Bank Account": "party", "Employee Grievance": "raised_by"})
+	data["non_standard_fieldnames"].update({"Bank Account": "party", "Employee Grievance": "raised_by", "Holiday List Assignment": "assigned_to"})
 	data.update(
 		{
 			"heatmap": True,


### PR DESCRIPTION
For https://github.com/frappe/hrms/issues/4472 
Added UI: 
Employee Doctype

- Add Holiday Assignment under the Connections tab.

Before Changes: No Holiday Assignment List in connections tab under leave section
<img width="1914" height="998" alt="image" src="https://github.com/user-attachments/assets/70364451-0709-4683-a301-820b9d5a9078" />

After Changes: Holiday List Assignment in Leave section under connections tab
<img width="1919" height="996" alt="image" src="https://github.com/user-attachments/assets/059cb49f-af5c-4c6e-bb42-991f6b7a1e1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Holiday List Assignment" now appears in the Leave section of the employee dashboard.
  * Assignment details for Holiday List Assignment are now displayed and correctly associated with the relevant employee view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->