### PR TITLE
feat(job_requisition): Alert users before saving duplicate job requisitions

### DIFF
--- a/hrms/hr/doctype/job_requisition/job_requisition.js
+++ b/hrms/hr/doctype/job_requisition/job_requisition.js
@@ -81,4 +81,30 @@ frappe.ui.form.on("Job Requisition", {
 			frm.page.set_inner_btn_group_as_primary(__("Actions"));
 		}
 	},
+	before_save: function (frm) {
+		frm.trigger("handle_duplicate_check");
+	},
+	handle_duplicate_check: function (frm) {
+		if (!frm.is_new() || frm.duplicate_confirmed) return;
+		frappe.validated = false;
+
+		frm.call("check_duplicate_job_requisition").then((r) => {
+			if (!r.message) {
+				frm.duplicate_confirmed = true;
+				frm.save();
+				return;
+			}
+
+			frappe.confirm(
+				__(
+					"A Job Requisition already exists for {0} requested by {1} for the same department.<br> Do you want to continue?",
+					[frm.doc.designation.bold(), frm.doc.requested_by.bold()],
+				),
+				() => {
+					frm.duplicate_confirmed = true;
+					frm.save();
+				},
+			);
+		});
+	},
 });

--- a/hrms/hr/doctype/job_requisition/job_requisition.py
+++ b/hrms/hr/doctype/job_requisition/job_requisition.py
@@ -37,11 +37,15 @@ class JobRequisition(Document):
 	# end: auto-generated types
 
 	def validate(self):
-		self.validate_duplicates()
 		self.set_time_to_fill()
 
-	def validate_duplicates(self):
-		duplicate = frappe.db.exists(
+	def set_time_to_fill(self):
+		if self.status == "Filled" and self.completed_on:
+			self.time_to_fill = time_diff_in_seconds(self.completed_on, self.posting_date)
+
+	@frappe.whitelist()
+	def check_duplicate_job_requisition(self):
+		return frappe.db.exists(
 			"Job Requisition",
 			{
 				"designation": self.designation,
@@ -51,20 +55,6 @@ class JobRequisition(Document):
 				"name": ("!=", self.name),
 			},
 		)
-
-		if duplicate:
-			frappe.throw(
-				_("A Job Requisition for {0} requested by {1} already exists: {2}").format(
-					frappe.bold(self.designation),
-					frappe.bold(self.requested_by),
-					get_link_to_form("Job Requisition", duplicate),
-				),
-				title=_("Duplicate Job Requisition"),
-			)
-
-	def set_time_to_fill(self):
-		if self.status == "Filled" and self.completed_on:
-			self.time_to_fill = time_diff_in_seconds(self.completed_on, self.posting_date)
 
 	@frappe.whitelist()
 	def associate_job_opening(self, job_opening: str) -> None:


### PR DESCRIPTION
### Reason
- To prevent creation of duplicate Job Requisition records while still allowing users to proceed if needed

<img width="2872" height="1168" alt="image" src="https://github.com/user-attachments/assets/0f8c3f91-8eb2-4458-9b73-067873237cf5" />
 

### Changes done
- Added duplicate check before saving new records
- Shows a confirmation dialog if a duplicate record is found and allows saving only after user confirmation
- Ensures existing records are not affected

https://github.com/user-attachments/assets/f8298dc2-793c-4713-85c4-db6a6030fdce

 

Closes: https://github.com/frappe/hrms/issues/4445 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added duplicate job requisition detection. Users are prompted to confirm when creating requisitions that match existing records by position, department, and requestor before saving.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->