### PR TITLE
fix: currency format

### DIFF
--- a/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
+++ b/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.utils import flt, get_link_to_form
-from frappe.utils.formatters import format_value
+from frappe.utils.formatters import fmt_money
 from frappe.utils.jinja import render_template
 
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
@@ -201,7 +201,7 @@ class SalaryBreakupReport:
 			component["indent"] = 1
 
 	def format_currency(self, amount):
-		return format_value(amount, currency=self.currency)
+		return fmt_money(amount, precision=2, currency=self.currency)
 
 	def get_columns(self) -> list[dict]:
 		"""Return columns for the report.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced currency formatting in the Employee CTC Break-up report to ensure consistent and accurate display of monetary values across payroll reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->