### PR TITLE
fix: employee image in CTC report

### DIFF
--- a/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
+++ b/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
@@ -265,10 +265,14 @@ class SalaryBreakupReport:
 
 	def get_message(self):
 		path = "hrms/payroll/report/employee_ctc_break_up/employee_profile_card.html"
+		employee_name, designation, image = frappe.get_value(
+			"Employee", self.employee, ["employee_name", "designation", "image"]
+		)
 		context = dict(
 			{
-				"employee_name": frappe.get_value("Employee", self.employee, "employee_name"),
-				"designation": frappe.get_value("Employee", self.employee, "designation"),
+				"employee_name": employee_name,
+				"designation": designation,
+				"image": image,
 				"salary_structure": self.salary_structure,
 				"per_cycle": self.payroll_frequency,
 				"annual_ctc": self.format_currency(self.ctc),


### PR DESCRIPTION
Missed this because my local setup had a cached image showing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employee photos are now displayed in the CTC break-up report, providing a more complete employee overview alongside their name and designation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->