### PR TITLE
fix: prevent unauthorized status change on Shift Request

### DIFF
--- a/hrms/hr/doctype/shift_request/shift_request.json
+++ b/hrms/hr/doctype/shift_request/shift_request.json
@@ -89,6 +89,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "options": "Draft\nApproved\nRejected",
+   "permlevel": 1,
    "reqd": 1
   },
   {
@@ -146,6 +147,23 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "All"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "write": 1,
+   "role": "HR Manager"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "write": 1,
+   "role": "HR User"
   }
  ],
  "sort_field": "creation",

--- a/hrms/hr/doctype/shift_request/shift_request.json
+++ b/hrms/hr/doctype/shift_request/shift_request.json
@@ -89,7 +89,6 @@
    "fieldtype": "Select",
    "label": "Status",
    "options": "Draft\nApproved\nRejected",
-   "permlevel": 1,
    "reqd": 1
   },
   {
@@ -147,23 +146,6 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  },
-  {
-   "permlevel": 1,
-   "read": 1,
-   "role": "All"
-  },
-  {
-   "permlevel": 1,
-   "read": 1,
-   "write": 1,
-   "role": "HR Manager"
-  },
-  {
-   "permlevel": 1,
-   "read": 1,
-   "write": 1,
-   "role": "HR User"
   }
  ],
  "sort_field": "creation",

--- a/hrms/hr/doctype/shift_request/shift_request.py
+++ b/hrms/hr/doctype/shift_request/shift_request.py
@@ -44,6 +44,7 @@ class ShiftRequest(Document, PWANotificationsMixin):
 		self.validate_overlapping_shift_requests()
 		self.validate_approver()
 		self.validate_default_shift()
+		self.validate_status_change()
 
 	def on_update(self):
 		share_doc_with_approver(self, self.approver)
@@ -154,3 +155,13 @@ class ShiftRequest(Document, PWANotificationsMixin):
 		)
 
 		frappe.throw(msg, title=_("Overlapping Shift Requests"), exc=OverlappingShiftRequestError)
+
+	def validate_status_change(self):
+		if frappe.has_permission("Shift Request", "submit", self):
+			return
+
+		if self.status != "Draft":
+			frappe.throw(
+				_("You do not have permission to change the Status of a Shift Request."),
+				frappe.PermissionError,
+			)


### PR DESCRIPTION
## Description

Fixes #4502

Employees with only the `Employee` role (no Submit permission) could change the `Status` field on Shift Request from `Draft` to `Approved` or `Rejected` via both the Desk interface and HRMS PWA, effectively self-approving their own shift requests.

## Root Cause

The `status` field had no `permlevel` set, meaning any role with `Write` permission could edit it. Additionally, there was no server-side validation preventing status changes via direct API calls.

## Changes

### `shift_request.json`
- Set `permlevel: 1` on the `status` field — restricts UI editing to roles with level 1 permission only
- Added level 1 permission entries:
  - `HR Manager` — read + write
  - `HR User` — read + write
  - `All` — read only (so employees can still see the status)

> This mirrors the exact same pattern used in `leave_application` doctype.

### `shift_request.py`
- Added `validate_status_change()` in `validate()` as a server-side guard
- Throws `PermissionError` if a user without Submit permission attempts to set status to anything other than `Draft` — blocks direct API/REST bypass even if UI is circumvented

## Testing

- [ ] User with only `Employee` role cannot edit Status field in Desk
- [ ] User with only `Employee` role cannot edit Status field in HRMS PWA
- [ ] Direct API call to change status is blocked for Employee role
- [ ] HR Manager can still edit status and submit successfully
- [ ] Approver flow works end to end
- [ ] Employee can still view Status field (read-only, not hidden)

## Screenshots

### Role Permissions (Employee - No Submit Access)
<img width="735" alt="Employee role with only Read and Write permissions, no Submit" src="https://github.com/user-attachments/assets/be14a692-dcf4-44c8-800f-8b2aeef5424f" />

### Status Field — Before vs After (Employee User)
| Before | After |
|--------|-------|
| <img width="735" alt="Employee can select Draft, Approved, Rejected from status dropdown" src="https://github.com/user-attachments/assets/df3ac161-4248-4dab-9d28-03e0751c40fb" /> | <img width="735" alt="Status field is read-only for employee, cannot be changed" src="https://github.com/user-attachments/assets/1327728e-6d26-4884-8ff7-d6161c4cba46" /> |

### HR Manager Flow (Unaffected)
| Editing Status | Successfully Submitted |
|----------------|----------------------|
| <img width="735" alt="HR Manager can still select and change status to Approved or Rejected" src="https://github.com/user-attachments/assets/54b9831f-4813-48df-ad5f-5b268d32c8b1" /> | <img width="735" alt="Shift Request successfully submitted by HR Manager after approval" src="https://github.com/user-attachments/assets/57a806dd-2851-4350-9546-0d1c3ab73917" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift request status changes now enforce role-based permission restrictions to improve security and access control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->