### PR TITLE
ci: improve tests speed

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -61,9 +61,10 @@ mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
 # Belt-and-suspenders: also set performance variables at runtime in case
-# MARIADB_EXTRA_FLAGS was not honoured by the container image.
+# MARIADB_EXTRA_FLAGS was not honoured by the container image. Mirrors the
+# full flag set; all three are dynamic in MariaDB 11.x.
 mariadb --host 127.0.0.1 --port 3306 -u root -proot \
-    -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
+    -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0; SET GLOBAL innodb_doublewrite=0;"
 
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -12,13 +12,20 @@ paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
 lendingbranch="develop"
 
 # ---------------------------------------------------------------------------
-# Phase 1 — parallelise the three slow, independent setup steps:
-#   a) system packages   b) frappe-bench pip install   c) frappe git clone
+# Phase 1 — parallelise every slow, independent setup step:
+#   a) system packages   b) frappe-bench pip install
+#   c) shallow git clone of frappe and all dependency apps
+#
+# The dependency apps (frappe, payments, erpnext, lending) are cloned here
+# --depth 1 instead of letting `bench get-app` fetch them later. erpnext in
+# particular has a multi-GB history; a sequential full clone over the network
+# was the main reason hrms CI install ran ~2x slower than erpnext's. Phase 2
+# then installs them from these local checkouts, so no network re-clone.
 # ---------------------------------------------------------------------------
 
 sudo apt update
 
-# apt remove/install must run sequentially but can overlap with pip and clone.
+# apt remove/install must run sequentially but can overlap with pip and clones.
 sudo apt remove mysql-server mysql-client
 sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev &
 apt_pid=$!
@@ -27,11 +34,23 @@ pip install frappe-bench &
 pip_pid=$!
 
 git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1 &
-clone_pid=$!
+frappe_pid=$!
+
+git clone "https://github.com/${frappeuser}/payments" --branch "${paymentsbranch}" --depth 1 &
+payments_pid=$!
+
+git clone "https://github.com/${frappeuser}/erpnext" --branch "${erpnextbranch}" --depth 1 &
+erpnext_pid=$!
+
+git clone "https://github.com/${frappeuser}/lending" --branch "${lendingbranch}" --depth 1 &
+lending_pid=$!
 
 wait $apt_pid
 wait $pip_pid
-wait $clone_pid
+wait $frappe_pid
+wait $payments_pid
+wait $erpnext_pid
+wait $lending_pid
 
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
@@ -70,9 +89,10 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app "https://github.com/${frappeuser}/payments" --branch "$paymentsbranch"
-bench get-app "https://github.com/${frappeuser}/erpnext" --branch "$erpnextbranch" --resolve-deps
-bench get-app "https://github.com/${frappeuser}/lending" --branch "$lendingbranch"
+# Install from the local checkouts cloned in Phase 1 (no network re-clone).
+bench get-app payments ~/payments
+bench get-app erpnext ~/erpnext --resolve-deps
+bench get-app lending ~/lending
 bench get-app hrms "${GITHUB_WORKSPACE}"
 bench setup requirements --dev
 

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,12 +4,6 @@ set -e
 
 cd ~ || exit
 
-sudo apt update
-sudo apt remove mysql-server mysql-client
-sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev
-
-pip install frappe-bench
-
 githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
 frappeuser=${FRAPPE_USER:-"frappe"}
 frappebranch=${FRAPPE_BRANCH:-$githubbranch}
@@ -17,7 +11,28 @@ erpnextbranch=${ERPNEXT_BRANCH:-$githubbranch}
 paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
 lendingbranch="develop"
 
-git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1
+# ---------------------------------------------------------------------------
+# Phase 1 — parallelise the three slow, independent setup steps:
+#   a) system packages   b) frappe-bench pip install   c) frappe git clone
+# ---------------------------------------------------------------------------
+
+sudo apt update
+
+# apt remove/install must run sequentially but can overlap with pip and clone.
+sudo apt remove mysql-server mysql-client
+sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev &
+apt_pid=$!
+
+pip install frappe-bench &
+pip_pid=$!
+
+git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1 &
+clone_pid=$!
+
+wait $apt_pid
+wait $pip_pid
+wait $clone_pid
+
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site
@@ -26,6 +41,11 @@ cp -r "${GITHUB_WORKSPACE}/.github/helper/site_config.json" ~/frappe-bench/sites
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
+# Belt-and-suspenders: also set performance variables at runtime in case
+# MARIADB_EXTRA_FLAGS was not honoured by the container image.
+mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+    -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
+
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
@@ -33,7 +53,10 @@ mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON 
 mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
 
 install_whktml() {
-    wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+    # Re-use the tarball if the wkhtmltopdf cache step already restored it.
+    if [ ! -f /tmp/wkhtmltox.tar.xz ]; then
+        wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+    fi
     tar -xf /tmp/wkhtmltox.tar.xz -C /tmp
     sudo mv /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
     sudo chmod o+x /usr/local/bin/wkhtmltopdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
         image: mariadb:11.8
         env:
           MARIADB_ROOT_PASSWORD: 'root'
+          # Disable durability guarantees that are unnecessary in a throwaway CI container.
+          # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
+          # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
+          MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
         ports:
           - 3306:3306
         options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
@@ -106,6 +110,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Cache wkhtmltopdf
+        uses: actions/cache@v4
+        with:
+          path: /tmp/wkhtmltox.tar.xz
+          key: wkhtmltox-0.12.3-linux-generic-amd64
 
       - name: Install
         run: |


### PR DESCRIPTION
## Summary

Mirrors the CI test-speed improvements from [frappe/erpnext#55334](https://github.com/frappe/erpnext/pull/55334), applying the infrastructure-level changes (install script + workflow) to hrms:

- **Parallelise setup** (`install.sh`): the three slow, independent steps — `apt install`, `pip install frappe-bench`, and the frappe `git clone` — now run concurrently via background jobs + `wait`, instead of sequentially.
- **MariaDB durability flags** (`ci.yml`): set `MARIADB_EXTRA_FLAGS=--innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0` on the throwaway CI container to skip per-commit fsyncs (the biggest win). `install.sh` also sets these at runtime as a fallback in case the container image doesn't honour the env flag.
- **Cache wkhtmltopdf** (`ci.yml` + `install.sh`): cache the pinned `wkhtmltox-0.12.3` tarball across runs and skip the download when it's already present.

Notes:
- hrms uses the wkhtmltopdf **tarball** (not erpnext's `.deb`), so the cache path/key differ accordingly.
- The coverage-conditional changes from the erpnext PR are not needed here — hrms already gates coverage via `WITH_COVERAGE`/`CAPTURE_COVERAGE` and the `if: github.event_name != 'pull_request'` guard on the wrap-up job.
- The per-test data-setup refactors from that PR are out of scope; this PR only touches the install script and workflow.

## Test plan

- [ ] CI run on this PR completes successfully (green)
- [ ] Verify total test job wall-clock time is reduced vs. develop baseline
- [ ] Confirm wkhtmltopdf cache is populated on first run and restored on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Setup now runs slow install steps in parallel to speed up installation.
  * CI database configured with relaxed durability flags to improve test stability.
  * wkhtmltopdf download is cached and skipped when already present to avoid redundant fetches.
  * App installs reuse local checkouts instead of re-cloning.
  * Automated creation and grants for the test database/user and related runtime DB performance tweaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/hrms/pull/4609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->