### PR TITLE
fix: Better perm checks for HRMS

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -274,6 +274,8 @@ def get_filters(
 
 @frappe.whitelist()
 def get_shift_request_approvers(employee: str) -> str | list[str]:
+	frappe.has_permission("Employee", "read", employee, throw=True)
+
 	shift_request_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -282,6 +284,7 @@ def get_shift_request_approvers(employee: str) -> str | list[str]:
 
 	department_approvers = []
 	if department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		department_approvers = get_department_approvers(department, "shift_request_approver")
 		if not shift_request_approver:
 			shift_request_approver = frappe.db.get_value(
@@ -408,6 +411,8 @@ def get_holidays_for_employee(employee: str) -> list[dict]:
 	if not holiday_list:
 		return []
 
+	frappe.has_permission("Holiday List", "read", holiday_list, throw=True)
+
 	Holiday = frappe.qb.DocType("Holiday")
 	holidays = (
 		frappe.qb.from_(Holiday)
@@ -424,6 +429,7 @@ def get_holidays_for_employee(employee: str) -> list[dict]:
 
 @frappe.whitelist()
 def get_leave_approval_details(employee: str) -> dict:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	leave_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -431,6 +437,7 @@ def get_leave_approval_details(employee: str) -> dict:
 	)
 
 	if not leave_approver and department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		leave_approver = frappe.db.get_value(
 			"Department Approver",
 			{"parent": department, "parentfield": "leave_approvers", "idx": 1},
@@ -487,6 +494,7 @@ def get_leave_types(employee: str, date: str) -> list:
 
 	date = date or getdate()
 
+	# Get leave details validate leave access internally
 	leave_details = get_leave_details(employee, date)
 	leave_types = list(leave_details["leave_allocation"].keys()) + leave_details["lwps"]
 
@@ -600,6 +608,7 @@ def get_expense_claim_types() -> list[dict]:
 
 @frappe.whitelist()
 def get_expense_approval_details(employee: str) -> dict:
+	frappe.has_permission("Employee", "read", employee, throw=True)
 	expense_approver, department = frappe.get_cached_value(
 		"Employee",
 		employee,
@@ -607,6 +616,7 @@ def get_expense_approval_details(employee: str) -> dict:
 	)
 
 	if not expense_approver and department:
+		frappe.has_permission("Department", "read", department, throw=True)
 		expense_approver = frappe.db.get_value(
 			"Department Approver",
 			{"parent": department, "parentfield": "expense_approvers", "idx": 1},
@@ -750,6 +760,8 @@ def upload_base64_file(
 			file_content = file_content.getvalue()
 	else:
 		file_content = decoded_content
+
+	frappe.has_permission(dt, "write", dn, throw=True)
 
 	return frappe.get_doc(
 		{

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -273,6 +273,8 @@ def get_leaves(month_start: str, month_end: str, employee_filters: dict[str, str
 	LeaveApplication = frappe.qb.DocType("Leave Application")
 	Employee = frappe.qb.DocType("Employee")
 
+	frappe.has_permission("Leave Application", "read", throw=True)
+
 	query = (
 		frappe.qb.select(
 			LeaveApplication.name.as_("leave"),

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -342,7 +342,6 @@ class OvertimeSlip(Document):
 		return make_salary_slip(
 			salary_structure,
 			employee=self.employee,
-			ignore_permissions=True,
 			posting_date=self.start_date,
 		)
 

--- a/hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py
+++ b/hrms/hr/report/employee_hours_utilization_based_on_timesheet/employee_hours_utilization_based_on_timesheet.py
@@ -127,30 +127,32 @@ class EmployeeHoursReport:
 		self.stats_by_employee = filtered_data
 
 	def generate_filtered_time_logs(self):
-		additional_filters = ""
+		Timesheet = frappe.qb.DocType("Timesheet")
+		TimesheetDetail = frappe.qb.DocType("Timesheet Detail")
 
-		filter_fields = ["employee", "project", "company"]
-
-		for field in filter_fields:
-			if self.filters.get(field):
-				if field == "project":
-					additional_filters += f" AND ttd.{field} = {self.filters.get(field)!r}"
-				else:
-					additional_filters += f" AND tt.{field} = {self.filters.get(field)!r}"
-
-		# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-		self.filtered_time_logs = frappe.db.sql(
-			f"""
-			SELECT tt.employee AS employee, ttd.hours AS hours, ttd.is_billable AS is_billable, ttd.project AS project
-			FROM `tabTimesheet Detail` AS ttd
-			JOIN `tabTimesheet` AS tt
-				ON ttd.parent = tt.name
-			WHERE tt.employee IS NOT NULL
-			AND tt.start_date BETWEEN '{self.filters.from_date}' AND '{self.filters.to_date}'
-			AND tt.end_date BETWEEN '{self.filters.from_date}' AND '{self.filters.to_date}'
-			{additional_filters}
-		"""
+		query = (
+			frappe.qb.from_(TimesheetDetail)
+			.join(Timesheet)
+			.on(TimesheetDetail.parent == Timesheet.name)
+			.select(
+				Timesheet.employee.as_("employee"),
+				TimesheetDetail.hours.as_("hours"),
+				TimesheetDetail.is_billable.as_("is_billable"),
+				TimesheetDetail.project.as_("project"),
+			)
+			.where(Timesheet.employee.isnotnull())
+			.where(Timesheet.start_date[self.from_date : self.to_date])
+			.where(Timesheet.end_date[self.from_date : self.to_date])
 		)
+
+		for field in ("employee", "company"):
+			if self.filters.get(field):
+				query = query.where(Timesheet[field] == self.filters.get(field))
+
+		if self.filters.get("project"):
+			query = query.where(TimesheetDetail.project == self.filters.get("project"))
+
+		self.filtered_time_logs = query.run()
 
 	def generate_stats_by_employee(self):
 		self.stats_by_employee = frappe._dict()

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -124,6 +124,9 @@ def get_timeline_data(doctype: str, name: str) -> dict:
 
 	out = {}
 
+	frappe.has_permission(doctype, "read", name, throw=True)
+	frappe.has_permission("Attendance", "read", throw=True)
+
 	open_count = get_open_count(doctype, name)
 	out["count"] = open_count["count"]
 

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -373,7 +373,6 @@ def make_salary_slip(
 	as_print: bool = False,
 	print_format: str | None = None,
 	for_preview: int = 0,
-	ignore_permissions: bool = False,
 	lwp_days_corrected: float | None = None,
 ) -> str | Document:
 	def postprocess(source, target):
@@ -402,7 +401,6 @@ def make_salary_slip(
 		target_doc,
 		postprocess,
 		ignore_child_tables=True,
-		ignore_permissions=ignore_permissions,
 		cached=True,
 	)
 

--- a/hrms/regional/india/utils.py
+++ b/hrms/regional/india/utils.py
@@ -108,7 +108,6 @@ def get_component_amt_from_salary_slip(employee, salary_structure, basic_compone
 		salary_structure,
 		employee=employee,
 		for_preview=1,
-		ignore_permissions=True,
 		posting_date=from_date,
 	)
 

--- a/hrms/subscription_utils.py
+++ b/hrms/subscription_utils.py
@@ -63,7 +63,7 @@ def get_active_employees() -> int:
 	return frappe.db.count("Employee", {"status": "Active"})
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def subscription_updated(app: str, plan: str):
 	if app in ["hrms", "erpnext"] and plan:
 		update_erpnext_access()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Several HR APIs and reports now enforce read/write permissions (shift requests, holidays, leaves, expense approvals, timeline data, file uploads).
  * Salary slip creation no longer bypasses permission checks.
  * Guest access to active employee data has been restricted.

* **Refactor**
  * Timesheet-based hours report query rebuilt with modern query builder for clearer, more reliable data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->