### PR TITLE
feat: build and upload assets to GitHub Releases

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -1,0 +1,70 @@
+name: Build and Upload Assets
+
+on:
+  push:
+    branches:
+      - develop
+      - 'version-*'
+
+concurrency:
+  group: build-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-assets:
+    name: Build JS/CSS and upload to release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe
+          path: apps/frappe
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/checkout@v4
+        with:
+          path: apps/hrms
+
+      - name: Create bench structure
+        run: |
+          mkdir -p sites
+          printf "frappe\nhrms\n" > sites/apps.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: apps/frappe/yarn.lock
+
+      - name: Install frappe JS dependencies
+        working-directory: apps/frappe
+        run: yarn install --frozen-lockfile
+
+      - name: Install hrms JS dependencies
+        working-directory: apps/hrms
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Link node_modules into public/
+        working-directory: apps/frappe
+        run: ln -s "$PWD/node_modules" frappe/public/node_modules
+
+      - name: Build assets (production)
+        working-directory: apps/frappe
+        run: yarn run production
+
+      - name: Package assets
+        working-directory: apps/hrms
+        run: tar czf hrms-assets.tar.gz -C ../../sites/assets/hrms dist
+
+      - name: Upload to rolling release
+        working-directory: apps/hrms
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="assets-${GITHUB_REF_NAME//\//-}"
+          gh release create "$TAG" --prerelease --title "Assets: $GITHUB_REF_NAME" --notes "" 2>/dev/null || true
+          gh release upload "$TAG" hrms-assets.tar.gz --clobber


### PR DESCRIPTION
- Builds JS/CSS bundles via frappe's esbuild and uploads as GitHub Release tarballs
- Downloads pre-built assets on bench get-app/update instead of building from source