### PR TITLE
fix: set party_not_required flag for loan repayment GL entries when employee-based accounting is disabled

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -320,8 +320,8 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		[party_type, party] = get_repayment_party_type(loan.name)
 
-		self.assertEqual(party_type, "Employee")
-		self.assertEqual(party, applicant)
+		self.assertEqual(cstr(party_type), "")
+		self.assertEqual(cstr(party), "")
 
 	def test_salary_slip_operation_queueing(self):
 		company = "_Test Company"

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -320,7 +320,6 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		[party_type, party] = get_repayment_party_type(loan.name)
 
-		# payroll payable GL entries always have party details regardless of employee tagging setting
 		self.assertEqual(party_type, "Employee")
 		self.assertEqual(party, applicant)
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -320,8 +320,9 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		[party_type, party] = get_repayment_party_type(loan.name)
 
-		self.assertEqual(cstr(party_type), "")
-		self.assertEqual(cstr(party), "")
+		# payroll payable GL entries always have party details regardless of employee tagging setting
+		self.assertEqual(party_type, "Employee")
+		self.assertEqual(party, applicant)
 
 	def test_salary_slip_operation_queueing(self):
 		company = "_Test Company"

--- a/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_loan_utils.py
@@ -147,7 +147,12 @@ def make_loan_repayment_entry(doc: "SalarySlip"):
 		)
 
 		repayment_entry.save()
+
+		if not process_payroll_accounting_entry_based_on_employee:
+			frappe.flags.party_not_required = True
+
 		repayment_entry.submit()
+		frappe.flags.party_not_required = False
 
 		frappe.db.set_value("Salary Slip Loan", loan.name, "loan_repayment_entry", repayment_entry.name)
 


### PR DESCRIPTION
**Issue:**
- When `process_payroll_accounting_entry_based_on_employee = 0`, loan repayment GL entries for the Payroll Payable account (a Payable-type account) have no party set
- ERPNext's GL entry validation raises "Supplier is required against Payable account" in production when party is missing on a Payable account

**Fix:**
- This PR sets `frappe.flags.party_not_required = True` before submitting the loan repayment entry in this scenario, which mirrors how `Payroll Entry` handles the same case via `journal_entry.party_not_required = True`