### PR TITLE
Fix org chart all companies

### DIFF
--- a/hrms/hr/page/organizational_chart/organizational_chart.js
+++ b/hrms/hr/page/organizational_chart/organizational_chart.js
@@ -1,12 +1,16 @@
 hrms.organizational_chart = hrms.organizational_chart || {};
 
 Object.assign(hrms.organizational_chart, {
+	is_all_companies(company) {
+		return company === "All Companies" || company === __("All Companies");
+	},
+
 	get_employee_count(company) {
 		const args = {
 			doctype: "Employee",
 		};
 
-		if (company) {
+		if (company && !this.is_all_companies(company)) {
 			args.filters = { company };
 		}
 

--- a/hrms/hr/page/organizational_chart/organizational_chart.py
+++ b/hrms/hr/page/organizational_chart/organizational_chart.py
@@ -1,11 +1,12 @@
 import frappe
+from frappe import _
 from frappe.query_builder.functions import Count
 
 
 @frappe.whitelist()
 def get_children(parent: str | None = None, company: str | None = None, exclude_node: str | None = None):
 	filters = [["status", "=", "Active"]]
-	if company and company != "All Companies":
+	if company and not is_all_companies(company):
 		filters.append(["company", "=", company])
 
 	if parent and company and parent != company:
@@ -32,18 +33,27 @@ def get_children(parent: str | None = None, company: str | None = None, exclude_
 	)
 
 	for employee in employees:
-		employee.connections = get_connections(employee.id, employee.lft, employee.rgt)
+		employee.connections = get_connections(employee.id, employee.lft, employee.rgt, company)
 		employee.expandable = bool(employee.connections)
 
 	return employees
 
 
-def get_connections(employee: str, lft: int, rgt: int) -> int:
+def is_all_companies(company: str | None) -> bool:
+	return company in ("All Companies", _("All Companies"))
+
+
+def get_connections(employee: str, lft: int, rgt: int, company: str | None = None) -> int:
 	Employee = frappe.qb.DocType("Employee")
 	query = (
 		frappe.qb.from_(Employee)
 		.select(Count(Employee.name))
 		.where((Employee.lft > lft) & (Employee.rgt < rgt) & (Employee.status == "Active"))
-	).run()
+	)
+
+	if company and not is_all_companies(company):
+		query = query.where(Employee.company == company)
+
+	query = query.run()
 
 	return query[0][0]

--- a/hrms/hr/page/organizational_chart/test_organizational_chart.py
+++ b/hrms/hr/page/organizational_chart/test_organizational_chart.py
@@ -35,3 +35,36 @@ class TestOrganizationalChart(HRMSTestSuite):
 		self.assertEqual(children[0].connections, 1)
 		self.assertEqual(children[1].id, emp3)
 		self.assertEqual(children[1].connections, 0)
+
+	def test_get_children_for_all_companies(self):
+		other_company = create_company("Test Org Chart Other").name
+		frappe.db.delete("Employee", {"company": other_company})
+
+		emp1 = make_employee("testemp5@mail.com", company=self.company)
+		emp2 = make_employee("testemp6@mail.com", company=other_company, reports_to=emp1)
+		emp3 = make_employee("testemp7@mail.com", company=self.company, reports_to=emp2)
+
+		children = get_children(company="All Companies")
+		root = next(child for child in children if child.id == emp1)
+		self.assertEqual(root.connections, 2)
+
+		children = get_children(parent=emp1, company="All Companies")
+		self.assertEqual(len(children), 1)
+		self.assertEqual(children[0].id, emp2)
+		self.assertEqual(children[0].connections, 1)
+
+		children = get_children(parent=emp2, company="All Companies")
+		self.assertEqual(len(children), 1)
+		self.assertEqual(children[0].id, emp3)
+
+	def test_get_children_filters_connections_by_company(self):
+		other_company = create_company("Test Org Chart Other").name
+		frappe.db.delete("Employee", {"company": other_company})
+
+		emp1 = make_employee("testemp8@mail.com", company=self.company)
+		make_employee("testemp9@mail.com", company=other_company, reports_to=emp1)
+
+		children = get_children(company=self.company)
+		self.assertEqual(len(children), 1)
+		self.assertEqual(children[0].id, emp1)
+		self.assertEqual(children[0].connections, 0)

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -64,40 +64,68 @@ hrms.HierarchyChart = class {
 		node.$link = $(`[id="${node.id}"]`);
 	}
 
+	get_company_options() {
+		return frappe
+			.call({
+				method: "frappe.client.get_list",
+				args: {
+					doctype: "Company",
+					fields: ["name"],
+					limit_page_length: 0,
+					order_by: "name",
+				},
+			})
+			.then((r) => {
+				const companies = (r.message || []).map((company) => company.name);
+				return [__("All Companies"), ...companies].join("\n");
+			});
+	}
+
+	get_default_company() {
+		return __("All Companies");
+	}
+
 	show() {
 		this.setup_actions();
 		if (this.page.main.find('[data-fieldname="company"]').length) return;
 		let me = this;
 
-		let company = this.page.add_field({
-			fieldtype: "Link",
-			options: "Company",
-			fieldname: "company",
-			placeholder: __("Select Company"),
-			default: frappe.defaults.get_default("company"),
-			only_select: true,
-			reqd: 1,
-			change: () => {
-				me.company = "";
-				$("#hierarchy-chart-wrapper").remove();
+		this.get_company_options().then((options) => {
+			let company = this.page.add_field({
+				fieldtype: "Autocomplete",
+				options,
+				fieldname: "company",
+				placeholder: __("Select Company"),
+				default: this.get_default_company(),
+				reqd: 1,
+				change: () => {
+					const selected_company = company.get_value();
 
-				if (company.get_value()) {
-					me.company = company.get_value();
+					if (!selected_company) {
+						if (me.company) {
+							company.set_input_value(me.company);
+						}
+						return;
+					}
+
+					if (me.company === selected_company) return;
+
+					me.company = selected_company;
+					$("#hierarchy-chart-wrapper").remove();
 
 					// svg for connectors
 					me.make_svg_markers();
 					me.setup_hierarchy();
 					me.render_root_nodes();
 					me.all_nodes_expanded = false;
-				} else {
-					frappe.throw(__("Please select a company first."));
-				}
-			},
-		});
+					me.setup_actions();
+				},
+			});
 
-		company.refresh();
-		$(`[data-fieldname="company"]`).trigger("change");
-		$(`[data-fieldname="company"] .link-field`).addClass("hierarchy-company-link-field");
+			company.refresh();
+			$(`[data-fieldname="company"]`).trigger("change");
+			$(`[data-fieldname="company"] .control-input`).addClass("hierarchy-company-link-field");
+		});
 	}
 
 	set_main_state(state) {
@@ -117,17 +145,23 @@ hrms.HierarchyChart = class {
 		});
 
 		this.page.add_inner_button(__("Expand All"), function () {
-			me.load_children(me.root_node, true);
+			const selected_company = me.page.fields_dict.company?.get_value() || me.company;
+			if (!selected_company) {
+				frappe.throw(__("Please select a company first."));
+			}
+
+			me.company = selected_company;
 			me.all_nodes_expanded = true;
+			me.load_children(me.root_node, true).then(() => {
+				me.page.remove_inner_button(__("Expand All"));
+				me.page.add_inner_button(__("Collapse All"), function () {
+					me.setup_hierarchy();
+					me.render_root_nodes();
+					me.all_nodes_expanded = false;
 
-			me.page.remove_inner_button(__("Expand All"));
-			me.page.add_inner_button(__("Collapse All"), function () {
-				me.setup_hierarchy();
-				me.render_root_nodes();
-				me.all_nodes_expanded = false;
-
-				me.page.remove_inner_button(__("Collapse All"));
-				me.setup_actions();
+					me.page.remove_inner_button(__("Collapse All"));
+					me.setup_actions();
+				});
 			});
 		});
 	}
@@ -294,12 +328,12 @@ hrms.HierarchyChart = class {
 		}
 
 		if (!deep) {
-			frappe.run_serially([
+			return frappe.run_serially([
 				() => this.get_child_nodes(node.id),
 				(child_nodes) => this.render_child_nodes(node, child_nodes),
 			]);
 		} else {
-			frappe.run_serially([
+			return frappe.run_serially([
 				() => frappe.dom.freeze(),
 				() => this.setup_hierarchy(),
 				() => this.render_root_nodes(true),
@@ -376,18 +410,24 @@ hrms.HierarchyChart = class {
 	}
 
 	render_children_of_all_nodes(data_list) {
-		let entry;
-		let node;
+		let pending = data_list || [];
 
-		while (data_list.length) {
-			// to avoid overlapping connectors
-			entry = data_list.shift();
-			node = this.nodes[entry.parent];
-			if (node) {
-				this.render_child_nodes_for_expanded_view(node, entry.data);
-			} else if (data_list.length) {
-				data_list.push(entry);
-			}
+		while (pending.length) {
+			let rendered = false;
+			let deferred = [];
+
+			pending.forEach((entry) => {
+				const node = this.nodes[entry.parent];
+				if (node) {
+					this.render_child_nodes_for_expanded_view(node, entry.data);
+					rendered = true;
+				} else {
+					deferred.push(entry);
+				}
+			});
+
+			if (!rendered) break;
+			pending = deferred;
 		}
 	}
 

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -82,7 +82,7 @@ hrms.HierarchyChart = class {
 	}
 
 	get_default_company() {
-		return __("All Companies");
+		return frappe.defaults.get_default("company") || __("All Companies");
 	}
 
 	show() {

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -60,23 +60,52 @@ hrms.HierarchyChartMobile = class {
 		node.$link.addClass("mobile-node");
 	}
 
+	get_company_options() {
+		return frappe
+			.call({
+				method: "frappe.client.get_list",
+				args: {
+					doctype: "Company",
+					fields: ["name"],
+					limit_page_length: 0,
+					order_by: "name",
+				},
+			})
+			.then((r) => {
+				const companies = (r.message || []).map((company) => company.name);
+				return [__("All Companies"), ...companies].join("\n");
+			});
+	}
+
+	get_default_company() {
+		return __("All Companies");
+	}
+
 	show() {
 		if (this.page.main.find('[data-fieldname="company"]').length) return;
 		let me = this;
 
-		let company = this.page.add_field({
-			fieldtype: "Link",
-			options: "Company",
-			fieldname: "company",
-			placeholder: __("Select Company"),
-			default: frappe.defaults.get_default("company"),
-			only_select: true,
-			reqd: 1,
-			change: () => {
-				me.company = "";
+		this.get_company_options().then((options) => {
+			let company = this.page.add_field({
+				fieldtype: "Autocomplete",
+				options,
+				fieldname: "company",
+				placeholder: __("Select Company"),
+				default: this.get_default_company(),
+				reqd: 1,
+				change: () => {
+					const selected_company = company.get_value();
 
-				if (company.get_value() && me.company != company.get_value()) {
-					me.company = company.get_value();
+					if (!selected_company) {
+						if (me.company) {
+							company.set_input_value(me.company);
+						}
+						return;
+					}
+
+					if (me.company === selected_company) return;
+
+					me.company = selected_company;
 
 					// svg for connectors
 					me.make_svg_markers();
@@ -89,13 +118,13 @@ hrms.HierarchyChartMobile = class {
 
 					me.setup_hierarchy();
 					me.render_root_nodes();
-				}
-			},
-		});
+				},
+			});
 
-		company.refresh();
-		$(`[data-fieldname="company"]`).trigger("change");
-		$(`[data-fieldname="company"] .link-field`).addClass("hierarchy-company-link-field");
+			company.refresh();
+			$(`[data-fieldname="company"]`).trigger("change");
+			$(`[data-fieldname="company"] .control-input`).addClass("hierarchy-company-link-field");
+		});
 	}
 
 	set_main_state(state) {

--- a/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -78,7 +78,7 @@ hrms.HierarchyChartMobile = class {
 	}
 
 	get_default_company() {
-		return __("All Companies");
+		return frappe.defaults.get_default("company") || __("All Companies");
 	}
 
 	show() {

--- a/hrms/public/scss/hierarchy_chart.scss
+++ b/hrms/public/scss/hierarchy_chart.scss
@@ -267,6 +267,7 @@
 #arrows {
 	position: absolute;
 	overflow: visible;
+	pointer-events: none;
 }
 
 .active-connector {


### PR DESCRIPTION
closes #1056 

# What problem does this solve ?
the Organizational chart does not have a view for employee across all companies

# What changed ?
This PR adds support for an `All Companies` option in the Organizational Chart

main changes:
- Adds `All Companies` as a selectable option in the company selector
- Show default company if one is chosen or default to `All Companies` when loading the page
- Ensures backend employee filtering does not treat `All Companies` as real Company document
- Ensures employee count and connection count respect the selected company scope
- Preserves existing single-company filtering
- Adds test covering
 -- `All companies` mode
 -- Single company filtering

Files changed:
  - hrms/hr/page/organizational_chart/organizational_chart.js
  - hrms/hr/page/organizational_chart/organizational_chart.py
  - hrms/hr/page/organizational_chart/test_organizational_chart.py
  - hrms/public/js/hierarchy_chart/hierarchy_chart_desktop.js
  - hrms/public/js/hierarchy_chart/hierarchy_chart_mobile.js
  - hrms/public/scss/hierarchy_chart.scss
 
 # Screenshots
 ## Before: No `All Companies` option
 
<img width="611" height="216" alt="no-all-selector" src="https://github.com/user-attachments/assets/43df8505-06f3-4f66-b71b-62cef8a28c86" />

## After:  `All Companies` option
<img width="1570" height="209" alt="all-companies-node-selected" src="https://github.com/user-attachments/assets/8bf9a755-48b1-4797-96c5-76a1d6ee4327" />

## After: Expanded chart across companies
<img width="1569" height="249" alt="after-all-companies-expanded" src="https://github.com/user-attachments/assets/2d5b7d83-456d-402d-830f-bf799ef5815c" />
