### PR TITLE
make reason_for_adjustment optional in create_leave_adjustment method

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -436,7 +436,7 @@ class LeaveAllocation(Document):
 		adjustment_type: str,
 		leaves_to_adjust: str | float,
 		posting_date: str | datetime.date,
-		reason_for_adjustment: str,
+		reason_for_adjustment: str | None = None,
 	) -> None:
 		leave_adjustment = frappe.new_doc(
 			"Leave Adjustment",


### PR DESCRIPTION
When **Adjust Allocation** from Action in **Leave Allocation**
If the **Reason for adjustment** field is left _blank_, the `create_leave_adjustment` function will return an error.

<img width="889" height="867" alt="image" src="https://github.com/user-attachments/assets/e1401580-8cd1-45a8-92aa-3237701ae237" />

<img width="885" height="300" alt="image" src="https://github.com/user-attachments/assets/42f8473b-9d38-4fec-a55e-31e0f55971c4" />

backport version-16-hotfix