### PR TITLE
fix(employee_advance): replace return amount direct update via additional salary with validation & add scheduled amount banner

### DIFF
--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -175,6 +175,9 @@ frappe.ui.form.on("Employee Advance", {
 			args: {
 				employee_advance: frm.doc.name,
 			},
+			error() {
+				frm.dashboard.clear_headline();
+			},
 			callback(r) {
 				const advance_return_data = r.message || {};
 

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -84,6 +84,14 @@ frappe.ui.form.on("Employee Advance", {
 				);
 			}
 		}
+		if (frm.doc.status === "Returned") {
+			frm.dashboard.clear_headline();
+			return;
+		}
+
+		if (frm.doc.docstatus === 1) {
+			frm.trigger("render_employee_advance_return_banner");
+		}
 	},
 
 	make_deduction_via_additional_salary: function (frm) {
@@ -159,5 +167,44 @@ frappe.ui.form.on("Employee Advance", {
 		}
 		frm.toggle_display("base_paid_amount", frm.doc.currency != company_currency);
 		frm.refresh_fields();
+	},
+
+	render_employee_advance_return_banner(frm) {
+		frappe.call({
+			method: "hrms.hr.doctype.employee_advance.employee_advance.get_employee_advance_return",
+			args: {
+				employee_advance: frm.doc.name,
+			},
+			callback(r) {
+				const advance_return_data = r.message || {};
+
+				if (!advance_return_data.has_return_scheduled) {
+					frm.dashboard.clear_headline();
+					return;
+				}
+
+				const filters = {
+					ref_doctype: "Employee Advance",
+					ref_docname: frm.doc.name,
+					docstatus: 1,
+				};
+
+				const url =
+					"/app/list/additional-salary?" + new URLSearchParams(filters).toString();
+
+				frm.dashboard.set_headline(
+					__(
+						"Employee Advance return is scheduled via Additional Salary: {0} | <a href='{1}'>View deductions</a>",
+						[
+							format_currency(
+								advance_return_data.total_return_scheduled,
+								frm.doc.currency,
+							),
+							url,
+						],
+					),
+				);
+			},
+		});
 	},
 });

--- a/hrms/hr/doctype/employee_advance/employee_advance.js
+++ b/hrms/hr/doctype/employee_advance/employee_advance.js
@@ -194,13 +194,14 @@ frappe.ui.form.on("Employee Advance", {
 
 				frm.dashboard.set_headline(
 					__(
-						"Employee Advance return is scheduled via Additional Salary: {0} | <a href='{1}'>View deductions</a>",
+						"Employee Advance return is scheduled via Additional Salary: {0} | <a href='{1}'> {2} </a>",
 						[
 							format_currency(
 								advance_return_data.total_return_scheduled,
 								frm.doc.currency,
 							),
 							url,
+							__("View Additional Salary entries").bold(),
 						],
 					),
 				);

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.query_builder.functions import Abs, Sum
+from frappe.query_builder.functions import Abs, Count, Sum
 from frappe.utils import flt, get_link_to_form, nowdate
 
 import erpnext
@@ -405,18 +405,17 @@ def get_employee_advance_return(employee_advance: str):
 	return_entries = (
 		frappe.qb.from_(AdditionalSalary)
 		.select(
-			AdditionalSalary.name,
-			AdditionalSalary.amount,
+			Sum(AdditionalSalary.amount).as_("total_return_scheduled"),
+			Count(AdditionalSalary.name).as_("return_entry_count"),
 		)
 		.where(
 			(AdditionalSalary.ref_doctype == "Employee Advance")
 			& (AdditionalSalary.ref_docname == employee_advance)
 			& (AdditionalSalary.docstatus == 1)
 		)
-	).run(as_dict=True) or []
+	).run(as_dict=True)
 
-	total_return_scheduled = sum(flt(d.amount) for d in return_entries)
 	return {
-		"total_return_scheduled": total_return_scheduled,
-		"has_return_scheduled": len(return_entries) > 0,
+		"total_return_scheduled": flt(return_entries[0].total_return_scheduled),
+		"has_return_scheduled": bool(return_entries[0].return_entry_count),
 	}

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -397,3 +397,26 @@ def get_voucher_type(mode_of_payment=None):
 			voucher_type = "Bank Entry"
 
 	return voucher_type
+
+
+@frappe.whitelist()
+def get_employee_advance_return(employee_advance: str):
+	AdditionalSalary = frappe.qb.DocType("Additional Salary")
+	return_entries = (
+		frappe.qb.from_(AdditionalSalary)
+		.select(
+			AdditionalSalary.name,
+			AdditionalSalary.amount,
+		)
+		.where(
+			(AdditionalSalary.ref_doctype == "Employee Advance")
+			& (AdditionalSalary.ref_docname == employee_advance)
+			& (AdditionalSalary.docstatus == 1)
+		)
+	).run(as_dict=True) or []
+
+	total_return_scheduled = sum(flt(d.amount) for d in return_entries)
+	return {
+		"total_return_scheduled": total_return_scheduled,
+		"has_return_scheduled": len(return_entries) > 0,
+	}

--- a/hrms/hr/doctype/employee_advance/employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/employee_advance.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.query_builder.functions import Abs, Count, Sum
+from frappe.query_builder.functions import Abs, Sum
 from frappe.utils import flt, get_link_to_form, nowdate
 
 import erpnext
@@ -401,13 +401,12 @@ def get_voucher_type(mode_of_payment=None):
 
 @frappe.whitelist()
 def get_employee_advance_return(employee_advance: str):
+	frappe.has_permission("Employee Advance", ptype="read", doc=employee_advance, throw=True)
+
 	AdditionalSalary = frappe.qb.DocType("Additional Salary")
 	return_entries = (
 		frappe.qb.from_(AdditionalSalary)
-		.select(
-			Sum(AdditionalSalary.amount).as_("total_return_scheduled"),
-			Count(AdditionalSalary.name).as_("return_entry_count"),
-		)
+		.select(Sum(AdditionalSalary.amount).as_("total_return_scheduled"))
 		.where(
 			(AdditionalSalary.ref_doctype == "Employee Advance")
 			& (AdditionalSalary.ref_docname == employee_advance)
@@ -415,7 +414,11 @@ def get_employee_advance_return(employee_advance: str):
 		)
 	).run(as_dict=True)
 
+	total_return_scheduled = flt(return_entries[0].total_return_scheduled)
+	already_returned = flt(frappe.db.get_value("Employee Advance", employee_advance, "return_amount"))
+	pending_scheduled = max(0, total_return_scheduled - already_returned)
+
 	return {
-		"total_return_scheduled": flt(return_entries[0].total_return_scheduled),
-		"has_return_scheduled": bool(return_entries[0].return_entry_count),
+		"total_return_scheduled": pending_scheduled,
+		"has_return_scheduled": bool(pending_scheduled),
 	}

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -19,6 +19,8 @@ from hrms.hr.doctype.expense_claim.test_expense_claim import (
 	get_payable_account,
 	make_expense_claim,
 )
+from hrms.payroll.doctype.payroll_entry.payroll_entry import get_start_end_dates
+from hrms.payroll.doctype.payroll_entry.test_payroll_entry import make_payroll_entry, setup_salary_structure
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
 from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 from hrms.tests.utils import HRMSTestSuite
@@ -156,7 +158,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		advances = [entry.employee_advance for entry in advances]
 		self.assertTrue(advance.name in advances)
 
-	def test_repay_unclaimed_amount_from_salary(self):
+	def test_additional_salary_based_advance_repayment_flow(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
 		make_payment_entry(advance)
@@ -179,9 +181,6 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		additional_salary.insert()
 		additional_salary.submit()
 
-		advance.reload()
-		self.assertEqual(advance.return_amount, 700)
-
 		# additional salary for remaining 300
 		additional_salary = create_return_through_additional_salary(advance)
 		additional_salary.salary_component = "Advance Salary - Deduction"
@@ -190,15 +189,88 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		additional_salary.insert()
 		additional_salary.submit()
 
+		# Employee Advance should not be updated directly
 		advance.reload()
-		self.assertEqual(advance.return_amount, 1000)
-		self.assertEqual(advance.status, "Returned")
-
-		# update advance return amount on additional salary cancellation
-		additional_salary.cancel()
-		advance.reload()
-		self.assertEqual(advance.return_amount, 700)
+		self.assertEqual(advance.return_amount, 0)
 		self.assertEqual(advance.status, "Paid")
+
+		# should not allow scheduling more than available amount
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = "Advance Salary - Deduction"
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = 100
+
+		self.assertRaises(frappe.ValidationError, additional_salary.insert)
+
+	def test_advance_return_on_payroll_submission(self):
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.db.set_value("Account", company_doc.default_payroll_payable_account, "account_type", "Payable")
+		employee = make_employee("test_repay_unclaimed_amount@payroll.com", company=company_doc.name)
+
+		setup_salary_structure(employee, company_doc)
+
+		advance = make_employee_advance(
+			employee,
+			{"repay_unclaimed_amount_from_salary": 1},
+		)
+		make_payment_entry(advance)
+		advance.reload()
+
+		# Advance deduction component
+		component = create_salary_component(
+			"Advance Salary",
+			**{"type": "Deduction"},
+		)
+		component.append(
+			"accounts",
+			{
+				"company": company_doc.name,
+				"account": "Employee Advances - _TC",
+			},
+		)
+		component.save()
+
+		# Create Additional Salary for repayment
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = component.name
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = advance.paid_amount
+		additional_salary.submit()
+
+		# Process payroll
+		dates = get_start_end_dates("Monthly", nowdate())
+		payroll_entry = make_payroll_entry(
+			start_date=dates.start_date,
+			end_date=dates.end_date,
+			payable_account=company_doc.default_payroll_payable_account,
+			currency=company_doc.default_currency,
+			company=company_doc.name,
+			cost_center="Main - _TC",
+		)
+
+		salary_slip_name = frappe.db.get_value(
+			"Salary Slip",
+			{
+				"payroll_entry": payroll_entry.name,
+				"employee": employee,
+			},
+			"name",
+		)
+		self.assertIsNotNone(salary_slip_name)
+		salary_slip = frappe.get_doc("Salary Slip", salary_slip_name)
+
+		# Verify advance deduction in salary slip
+		deduction_row = next(
+			(row for row in salary_slip.deductions if row.salary_component == component.name), None
+		)
+		self.assertIsNotNone(
+			deduction_row,
+			"Salary advance deduction not found",
+		)
+		self.assertEqual(flt(deduction_row.amount), flt(advance.paid_amount))
+		self.assertEqual(deduction_row.additional_salary, additional_salary.name)
+		advance.reload()
+		self.assertEqual(advance.status, "Returned")
 
 	def test_payment_entry_against_advance(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")

--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe import _dict
 from frappe.utils import flt, nowdate
 
 import erpnext
@@ -32,6 +33,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		self.update_company_in_fiscal_year()
 		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
 		frappe.db.set_value("Account", "_Test Employee Advance - _TC", "account_type", "Receivable")
+		frappe.db.set_value("Account", "Payroll Payable - _TC", "account_type", "Payable")
 
 	def test_paid_amount_and_status(self):
 		employee_name = make_employee("_T@employee.advance", "_Test Company")
@@ -204,10 +206,7 @@ class TestEmployeeAdvance(HRMSTestSuite):
 
 	def test_advance_return_on_payroll_submission(self):
 		company_doc = frappe.get_doc("Company", "_Test Company")
-		frappe.db.set_value("Account", company_doc.default_payroll_payable_account, "account_type", "Payable")
 		employee = make_employee("test_repay_unclaimed_amount@payroll.com", company=company_doc.name)
-
-		setup_salary_structure(employee, company_doc)
 
 		advance = make_employee_advance(
 			employee,
@@ -216,42 +215,11 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		make_payment_entry(advance)
 		advance.reload()
 
-		# Advance deduction component
-		component = create_salary_component(
-			"Advance Salary",
-			**{"type": "Deduction"},
-		)
-		component.append(
-			"accounts",
-			{
-				"company": company_doc.name,
-				"account": "Employee Advances - _TC",
-			},
-		)
-		component.save()
-
-		# Create Additional Salary for repayment
-		additional_salary = create_return_through_additional_salary(advance)
-		additional_salary.salary_component = component.name
-		additional_salary.payroll_date = nowdate()
-		additional_salary.amount = advance.paid_amount
-		additional_salary.submit()
-
-		# Process payroll
-		dates = get_start_end_dates("Monthly", nowdate())
-		payroll_entry = make_payroll_entry(
-			start_date=dates.start_date,
-			end_date=dates.end_date,
-			payable_account=company_doc.default_payroll_payable_account,
-			currency=company_doc.default_currency,
-			company=company_doc.name,
-			cost_center="Main - _TC",
-		)
-
+		payroll_details = create_payroll_for_advance_return(employee, company_doc, advance)
 		salary_slip_name = frappe.db.get_value(
 			"Salary Slip",
 			{
-				"payroll_entry": payroll_entry.name,
+				"payroll_entry": payroll_details.payroll_entry,
 				"employee": employee,
 			},
 			"name",
@@ -261,14 +229,19 @@ class TestEmployeeAdvance(HRMSTestSuite):
 
 		# Verify advance deduction in salary slip
 		deduction_row = next(
-			(row for row in salary_slip.deductions if row.salary_component == component.name), None
+			(
+				row
+				for row in salary_slip.deductions
+				if row.salary_component == payroll_details.advance_component
+			),
+			None,
 		)
 		self.assertIsNotNone(
 			deduction_row,
 			"Salary advance deduction not found",
 		)
 		self.assertEqual(flt(deduction_row.amount), flt(advance.paid_amount))
-		self.assertEqual(deduction_row.additional_salary, additional_salary.name)
+		self.assertEqual(deduction_row.additional_salary, payroll_details.additional_salary)
 		advance.reload()
 		self.assertEqual(advance.status, "Returned")
 
@@ -537,4 +510,47 @@ def create_advance_account(account_name, account_currency):
 		company="_Test Company",
 		account_currency=account_currency,
 		account_type="Receivable",
+	)
+
+
+def create_payroll_for_advance_return(employee, company, advance, return_amount=None):
+	# Advance deduction component
+	component = create_salary_component(
+		"Advance Salary",
+		**{"type": "Deduction"},
+	)
+	component.append(
+		"accounts",
+		{
+			"company": company.name,
+			"account": "Employee Advances - _TC",
+		},
+	)
+	component.save()
+
+	setup_salary_structure(employee, company)
+
+	# Create Additional Salary for repayment
+	additional_salary = create_return_through_additional_salary(advance)
+	additional_salary.salary_component = component.name
+	additional_salary.payroll_date = nowdate()
+	additional_salary.amount = return_amount or advance.paid_amount
+	additional_salary.submit()
+
+	# Process payroll
+	dates = get_start_end_dates("Monthly", nowdate())
+	payroll_entry = make_payroll_entry(
+		start_date=dates.start_date,
+		end_date=dates.end_date,
+		payable_account=company.default_payroll_payable_account,
+		currency=company.default_currency,
+		company=company.name,
+		cost_center="Main - _TC",
+	)
+	return _dict(
+		{
+			"payroll_entry": payroll_entry.name,
+			"advance_component": component.name,
+			"additional_salary": additional_salary.name,
+		}
 	)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -743,6 +743,7 @@ def get_expense_claim_advances(expense_claim, employee_advance):
 			"against_voucher_no": employee_advance.name,
 			"event": "Submit",
 			"delinked": False,
+			"amount": [">", 0],
 		},
 		fields=["voucher_type", "voucher_no", "amount", "base_amount", "exchange_rate", "creation"],
 	)

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -36,6 +36,7 @@ class TestExpenseClaim(HRMSTestSuite):
 
 			frappe.db.set_value("Company", company_name, "default_cost_center", cost_center)
 		frappe.db.set_value("Account", "Employee Advances - _TC", "account_type", "Receivable")
+		frappe.db.set_value("Account", "Payroll Payable - _TC", "account_type", "Payable")
 		frappe.set_user("Administrator")
 
 	def test_total_expense_claim_for_project(self):
@@ -313,45 +314,34 @@ class TestExpenseClaim(HRMSTestSuite):
 
 	def test_expense_claim_with_deducted_returned_advance(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
-			create_return_through_additional_salary,
+			create_payroll_for_advance_return,
 			get_advances_for_claim,
 			make_employee_advance,
 			make_payment_entry,
 		)
 		from hrms.hr.doctype.expense_claim.expense_claim import get_allocation_amount
-		from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
-		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
+		company_doc = frappe.get_doc("Company", "_Test Company")
 		# create employee and employee advance
-		employee_name = make_employee("_T@employee.advance", "_Test Company")
+		employee_name = make_employee("_T@employee.advance", company_doc.name)
 		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
 		make_payment_entry(advance)
 		advance.reload()
 
-		# set up salary components and structure
-		create_salary_component("Advance Salary - Deduction", type="Deduction")
-		make_salary_structure(
-			"Test Additional Salary for Advance Return",
-			"Monthly",
-			employee=employee_name,
-			company="_Test Company",
-		)
-
-		# create additional salary for advance return
-		additional_salary = create_return_through_additional_salary(advance)
-		additional_salary.salary_component = "Advance Salary - Deduction"
-		additional_salary.payroll_date = nowdate()
-		additional_salary.amount = 400
-		additional_salary.insert()
-		additional_salary.submit()
+		create_payroll_for_advance_return(employee_name, company_doc, advance, return_amount=400)
 		advance.reload()
-
 		self.assertEqual(advance.return_amount, 400)
 
 		# create an expense claim
-		payable_account = get_payable_account("_Test Company")
+		payable_account = get_payable_account(company_doc.name)
 		claim = make_expense_claim(
-			payable_account, 200, 200, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+			payable_account,
+			200,
+			200,
+			company_doc.name,
+			"Travel Expenses - _TC",
+			do_not_submit=True,
+			employee=employee_name,
 		)
 
 		# link advance to the claim

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _, bold
 from frappe.model.document import Document
-from frappe.utils import comma_and, date_diff, flt, formatdate, get_link_to_form, getdate
+from frappe.utils import comma_and, date_diff, flt, fmt_money, formatdate, get_link_to_form, getdate
 
 from hrms.hr.utils import validate_active_employee
 
@@ -258,17 +258,14 @@ class AdditionalSalary(Document):
 	def validate_employee_advance_return(self):
 		if self.ref_doctype != "Employee Advance" or not self.ref_docname:
 			return
+
 		precision = self.precision("amount")
 		advance = frappe.get_doc("Employee Advance", self.ref_docname)
-		available_return_amount = flt(advance.paid_amount - advance.claimed_amount, precision)
 
 		AdditionalSalary = frappe.qb.DocType("Additional Salary")
 		scheduled_deductions = (
 			frappe.qb.from_(AdditionalSalary)
-			.select(
-				AdditionalSalary.name,
-				AdditionalSalary.amount,
-			)
+			.select(AdditionalSalary.name, AdditionalSalary.amount)
 			.where(
 				(AdditionalSalary.ref_doctype == "Employee Advance")
 				& (AdditionalSalary.ref_docname == self.ref_docname)
@@ -277,19 +274,34 @@ class AdditionalSalary(Document):
 			)
 		).run(as_dict=True) or []
 
-		scheduled_return_amount = sum(flt(d.amount, precision) for d in scheduled_deductions)
-		remaining_return_amount = available_return_amount - scheduled_return_amount
+		available_return_amount = flt(advance.paid_amount - advance.claimed_amount, precision)
+		scheduled_return_amount = flt(sum(flt(d.amount, precision) for d in scheduled_deductions), precision)
+		remaining_return_amount = flt(available_return_amount - scheduled_return_amount, precision)
 
-		if flt(self.amount, precision) > flt(remaining_return_amount, precision):
-			frappe.throw(
-				_(
-					"The available balance for Employee Advance {0} has already been scheduled for deduction in {1}."
-				).format(
-					get_link_to_form("Employee Advance", self.ref_docname),
-					comma_and([get_link_to_form("Additional Salary", d.name) for d in scheduled_deductions]),
-				),
-				title=_("Amount Exceeds Available Balance"),
+		if flt(self.amount, precision) <= remaining_return_amount:
+			return
+
+		# scheduled via AS but not yet processed through payroll
+		pending_scheduled = max(0, flt(scheduled_return_amount - advance.return_amount, precision))
+
+		if pending_scheduled > 0:
+			msg = _(
+				"Employee Advance {0} has {1} available for return. {2} has already been scheduled for deduction in {3}."
+			).format(
+				get_link_to_form("Employee Advance", self.ref_docname),
+				fmt_money(remaining_return_amount, currency=self.currency),
+				fmt_money(pending_scheduled, currency=self.currency),
+				comma_and([get_link_to_form("Additional Salary", d.name) for d in scheduled_deductions]),
 			)
+		else:
+			msg = _(
+				"The amount exceeds the available balance for Employee Advance {0}. Available amount for return: {1}."
+			).format(
+				get_link_to_form("Employee Advance", self.ref_docname),
+				fmt_money(remaining_return_amount, currency=self.currency),
+			)
+
+		frappe.throw(msg, title=_("Amount Exceeds Available Balance"))
 
 	def update_employee_referral(self, cancel=False):
 		if self.ref_doctype == "Employee Referral":

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -45,11 +45,9 @@ class AdditionalSalary(Document):
 			self.payroll_date = None
 
 	def on_submit(self):
-		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral()
 
 	def on_cancel(self):
-		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral(cancel=True)
 
 	def validate(self):
@@ -253,19 +251,6 @@ class AdditionalSalary(Document):
 				title=_("Warning"),
 				indicator="orange",
 			)
-
-	def update_return_amount_in_employee_advance(self):
-		if self.ref_doctype == "Employee Advance" and self.ref_docname:
-			return_amount = frappe.db.get_value("Employee Advance", self.ref_docname, "return_amount")
-
-			if self.docstatus == 2:
-				return_amount -= self.amount
-			else:
-				return_amount += self.amount
-
-			frappe.db.set_value("Employee Advance", self.ref_docname, "return_amount", return_amount)
-			advance = frappe.get_doc("Employee Advance", self.ref_docname)
-			advance.set_status(update=True)
 
 	def update_employee_referral(self, cancel=False):
 		if self.ref_doctype == "Employee Referral":

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _, bold
 from frappe.model.document import Document
-from frappe.utils import comma_and, date_diff, formatdate, get_link_to_form, getdate
+from frappe.utils import comma_and, date_diff, flt, formatdate, get_link_to_form, getdate
 
 from hrms.hr.utils import validate_active_employee
 
@@ -62,6 +62,9 @@ class AdditionalSalary(Document):
 
 		if self.amount < 0:
 			frappe.throw(_("Amount should not be less than zero"))
+
+		if self.ref_doctype == "Employee Advance":
+			self.validate_employee_advance_return()
 
 	def validate_salary_structure(self):
 		salary_structure = frappe.db.get_value(
@@ -250,6 +253,42 @@ class AdditionalSalary(Document):
 				).format(frappe.bold(self.salary_component)),
 				title=_("Warning"),
 				indicator="orange",
+			)
+
+	def validate_employee_advance_return(self):
+		if self.ref_doctype != "Employee Advance" or not self.ref_docname:
+			return
+		precision = self.precision("amount")
+		advance = frappe.get_doc("Employee Advance", self.ref_docname)
+		available_return_amount = flt(advance.paid_amount - advance.claimed_amount, precision)
+
+		AdditionalSalary = frappe.qb.DocType("Additional Salary")
+		scheduled_deductions = (
+			frappe.qb.from_(AdditionalSalary)
+			.select(
+				AdditionalSalary.name,
+				AdditionalSalary.amount,
+			)
+			.where(
+				(AdditionalSalary.ref_doctype == "Employee Advance")
+				& (AdditionalSalary.ref_docname == self.ref_docname)
+				& (AdditionalSalary.docstatus == 1)
+				& (AdditionalSalary.name != self.name)
+			)
+		).run(as_dict=True) or []
+
+		scheduled_return_amount = sum(flt(d.amount, precision) for d in scheduled_deductions)
+		remaining_return_amount = available_return_amount - scheduled_return_amount
+
+		if flt(self.amount, precision) > flt(remaining_return_amount, precision):
+			frappe.throw(
+				_(
+					"The available balance for Employee Advance {0} has already been scheduled for deduction in {1}."
+				).format(
+					get_link_to_form("Employee Advance", self.ref_docname),
+					comma_and([get_link_to_form("Additional Salary", d.name) for d in scheduled_deductions]),
+				),
+				title=_("Amount Exceeds Available Balance"),
 			)
 
 	def update_employee_referral(self, cancel=False):

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -13,10 +13,6 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from hrms.hr.doctype.employee_advance.employee_advance import (
 	create_return_through_additional_salary,
 )
-from hrms.hr.doctype.employee_advance.test_employee_advance import (
-	make_employee_advance,
-	make_payment_entry,
-)
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
 	get_end_date,
@@ -602,6 +598,11 @@ class TestPayrollEntry(HRMSTestSuite):
 					self.assertEqual(account.party, None)
 
 	def test_advance_deduction_in_accrual_journal_entry(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
 		company_doc = frappe.get_doc("Company", "_Test Company")
 		employee = make_employee("test_employee@payroll.com", company=company_doc.name)
 


### PR DESCRIPTION
### Reason
Employee Advance returns scheduled through Additional Salary were directly updating the Employee Advance return_amount, causing inconsistencies with the Advance Payment Ledger flow, duplicate updates, and incorrect advance status calculations 
More details: https://github.com/frappe/hrms/issues/3645

### Changes Done
- Removed direct updates to Employee Advance return_amount from Additional Salary. Advance return amounts are now updated only when Payroll is generated and successfully submits Journal Entry
- Added validation to prevent scheduling Employee Advance deductions through Additional Salary beyond the available advance amount.

<img width="2876" height="1204" alt="image" src="https://github.com/user-attachments/assets/8a9cf9b1-266f-4ef7-862c-194f9563912d" />

- Added a dashboard banner on Employee Advance to show the amount scheduled for return via Additional Salary, along with a link to the related Additional Salary entries.

<img width="2868" height="1310" alt="image" src="https://github.com/user-attachments/assets/4b082207-9bdc-4a86-85d5-cc953fc6c1db" />



Closes: https://github.com/frappe/hrms/issues/3645

