### PR TITLE
fix: Add component abbreviation to component name in CTC break-up report

### DIFF
--- a/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
+++ b/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
@@ -66,7 +66,7 @@ class SalaryBreakupReport:
 		self.calculate_yearly_amounts_and_percent_of_ctc()
 		self.indent_salary_components()
 		self.separate_salary_components_by_type()
-		self.set_type_and_formula()
+		self.set_abbr_type_and_formula()
 		self.set_totals_row_for_component_types()
 		self.set_net_and_gross_earning_rows()
 
@@ -130,8 +130,9 @@ class SalaryBreakupReport:
 			component for component in self.salary_components if component.get("is_tax_component")
 		]
 
-	def set_type_and_formula(self):
+	def set_abbr_type_and_formula(self):
 		for component in self.earning_components + self.deduction_components:
+			component["salary_component"] = f"{component.get("salary_component")} ({component.get("abbr")})"
 			component["type"] = "Formula" if component.get("amount_based_on_formula") else "Fixed"
 			component["formula"] = (
 				component.get("formula") or "-"

--- a/hrms/payroll/report/employee_ctc_break_up/test_employee_ctc_breakup.py
+++ b/hrms/payroll/report/employee_ctc_break_up/test_employee_ctc_breakup.py
@@ -160,7 +160,7 @@ class TestEmployeeCTCBreakup(HRMSTestSuite):
 		self.assertEqual(earning_components_totals.get("percent_of_ctc"), 100)
 
 		basic_earning_component = earning_components[1]
-		self.assertEqual(basic_earning_component.get("salary_component"), "Basic Salary")
+		self.assertEqual(basic_earning_component.get("salary_component"), "Basic Salary (BS)")
 		self.assertEqual(basic_earning_component.get("type"), "Formula")
 		self.assertEqual(basic_earning_component.get("formula"), "base")
 		self.assertEqual(basic_earning_component.get("per_cycle"), 60000)
@@ -168,7 +168,7 @@ class TestEmployeeCTCBreakup(HRMSTestSuite):
 		self.assertEqual(basic_earning_component.get("percent_of_ctc"), 64.52)
 
 		hra_earning_component = earning_components[2]
-		self.assertEqual(hra_earning_component.get("salary_component"), "HRA")
+		self.assertEqual(hra_earning_component.get("salary_component"), "HRA (H)")
 		self.assertEqual(hra_earning_component.get("type"), "Fixed")
 		self.assertEqual(hra_earning_component.get("formula"), 3000)
 		self.assertEqual(hra_earning_component.get("per_cycle"), 3000)
@@ -176,7 +176,9 @@ class TestEmployeeCTCBreakup(HRMSTestSuite):
 		self.assertEqual(hra_earning_component.get("percent_of_ctc"), 3.23)
 
 		special_allowance_earning_component = earning_components[3]
-		self.assertEqual(special_allowance_earning_component.get("salary_component"), "Special Allowance")
+		self.assertEqual(
+			special_allowance_earning_component.get("salary_component"), "Special Allowance (SA)"
+		)
 		self.assertEqual(special_allowance_earning_component.get("type"), "Formula")
 		self.assertEqual(special_allowance_earning_component.get("formula"), "BS\n*.5")
 		self.assertEqual(special_allowance_earning_component.get("per_cycle"), 30000)
@@ -192,7 +194,9 @@ class TestEmployeeCTCBreakup(HRMSTestSuite):
 		self.assertEqual(deduction_components_totals.get("percent_of_ctc"), 0.22)
 
 		professional_tax_deduction_component = deduction_components[1]
-		self.assertEqual(professional_tax_deduction_component.get("salary_component"), "Professional Tax")
+		self.assertEqual(
+			professional_tax_deduction_component.get("salary_component"), "Professional Tax (PT)"
+		)
 		self.assertEqual(professional_tax_deduction_component.get("type"), "Fixed")
 		self.assertEqual(professional_tax_deduction_component.get("formula"), 200)
 		self.assertEqual(professional_tax_deduction_component.get("per_cycle"), 200)


### PR DESCRIPTION
Sometimes salary components use salary components in the formula and show up as the abbreviation of the salary component, so it's helpful to have the abbreviation right next to the salary component
<img width="3072" height="1856" alt="Screenshot From 2026-06-04 18-10-30" src="https://github.com/user-attachments/assets/51526f98-d492-4f44-900b-3a3c0c84e15f" />
