### PR TITLE
feat: allow employees to view ctc break up of employee records they have access to

### DIFF
--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -374,6 +374,7 @@ def make_salary_slip(
 	print_format: str | None = None,
 	for_preview: int = 0,
 	lwp_days_corrected: float | None = None,
+	ignore_permissions: bool = False,
 ) -> str | Document:
 	def postprocess(source, target):
 		if employee:
@@ -400,6 +401,7 @@ def make_salary_slip(
 		},
 		target_doc,
 		postprocess,
+		ignore_permissions=ignore_permissions,
 		ignore_child_tables=True,
 		cached=True,
 	)

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -253,7 +253,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-14 13:33:55.869281",
+ "modified": "2026-06-05 13:20:40.794089",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",
@@ -298,6 +298,11 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Employee",
+   "select": 1
   }
  ],
  "row_format": "Dynamic",

--- a/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.json
+++ b/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.json
@@ -9,13 +9,13 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "modified": "2026-05-14 12:08:50.414476",
+ "modified": "2026-06-05 13:31:09.038894",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Employee CTC Break-up",
  "owner": "Administrator",
  "prepared_report": 0,
- "ref_doctype": "Salary Structure Assignment",
+ "ref_doctype": "Salary Slip",
  "report_name": "Employee CTC Break-up",
  "report_type": "Script Report",
  "roles": [
@@ -27,6 +27,9 @@
   },
   {
    "role": "HR User"
+  },
+  {
+   "role": "Employee"
   }
  ],
  "timeout": 0

--- a/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
+++ b/hrms/payroll/report/employee_ctc_break_up/employee_ctc_break_up.py
@@ -29,6 +29,7 @@ class SalaryBreakupReport:
 			for_preview=1,
 			as_print=False,
 			posting_date=frappe.flags.posting_date if frappe.flags.in_test else None,
+			ignore_permissions=True,
 		)
 		self.net_pay = self.salary_slip.net_pay
 		self.gross_pay = self.salary_slip.gross_pay


### PR DESCRIPTION
This gives employees permission to see their own CTC breakup. 

The only problem I see with this is if hide_descendants is checked of for employee user permission. In that case a manger will be able to see records of their descendants as well (which was anyway true for salary slip)

`no-docs`

 