### PR TITLE
fix: invalidate salary structure cache on document update

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -187,3 +187,7 @@ class SalaryComponent(Document):
 				"label": _("via Salary Component sync"),
 			}
 			salary_structure.save_version()
+			# db_update_all() does not invalidate cached Salary Structure documents.
+			# Clear the cache so salary slip generation picks up updated formulas
+			# and conditions immediately.
+			salary_structure.clear_cache()


### PR DESCRIPTION
## Description

Clear Salary Structure cache after `db_update_all()` updates to prevent Salary Slip generation from using stale formulas and conditions.

Fixes #4644

## Demo
[hrms_ssa_bug_fix.webm](https://github.com/user-attachments/assets/a5b5752e-6d88-473a-8139-cd7a8f956bac)
