### PR TITLE
fix: remove invalid company filter from Salary Component in Employee Incentive

### DIFF
--- a/hrms/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/hrms/payroll/doctype/employee_incentive/employee_incentive.js
@@ -47,7 +47,7 @@ frappe.ui.form.on("Employee Incentive", {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function () {
 			return {
-				filters: { type: "earning", company: frm.doc.company },
+				filters: { type: "earning" },
 			};
 		});
 	},


### PR DESCRIPTION
## Description
This PR fixes an issue in the **Employee Incentive** functionality where filtering by `company` was incorrectly applied to the `Salary Component` selection. 

Since the `Salary Component` DocType does not contain a `company` field, applying this filter resulted in an error/invalid query when trying to select a component.

## What changed
- Removed the `company` filter from the `Salary Component` query/get_query logic within Employee Incentive.
- Salary Components can now be successfully selected without throwing a missing field error.

## Screenshots
**Before (Error when filtering):**
<img width="1687" height="599" alt="image" src="https://github.com/user-attachments/assets/a066875f-88b0-4589-9453-9e0198de8d43" />

**After (Working correctly):**
<img width="1671" height="576" alt="image" src="https://github.com/user-attachments/assets/f941c884-5787-4323-a894-b2e6e50050d7" />
