### PR TITLE
refactor: remove redundant execution of update_return_amount_in_emplo…

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -45,11 +45,9 @@ class AdditionalSalary(Document):
 			self.payroll_date = None
 
 	def on_submit(self):
-		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral()
 
 	def on_cancel(self):
-		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral(cancel=True)
 
 	def validate(self):
@@ -253,19 +251,6 @@ class AdditionalSalary(Document):
 				title=_("Warning"),
 				indicator="orange",
 			)
-
-	def update_return_amount_in_employee_advance(self):
-		if self.ref_doctype == "Employee Advance" and self.ref_docname:
-			return_amount = frappe.db.get_value("Employee Advance", self.ref_docname, "return_amount")
-
-			if self.docstatus == 2:
-				return_amount -= self.amount
-			else:
-				return_amount += self.amount
-
-			frappe.db.set_value("Employee Advance", self.ref_docname, "return_amount", return_amount)
-			advance = frappe.get_doc("Employee Advance", self.ref_docname)
-			advance.set_status(update=True)
 
 	def update_employee_referral(self, cancel=False):
 		if self.ref_doctype == "Employee Referral":


### PR DESCRIPTION
Description
This PR removes unnecessary execution logic related to updating the return amount on an Additional Salary.

Since the return amount is already being properly updated and handled by the Advance Payment Ledger Entry, executing the update logic separately is redundant. Removing this prevents potential overlapping updates and keeps the code cleaner and more efficient.

What changed
Removed the redundant execution block that manually updated the return amount for Additional Salary.
The system now relies entirely on the Advance Payment Ledger Entry to maintain the correct return amount, ensuring a single source of truth.