### PR TITLE
fix: correct holiday selection in salary slip calculation

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -743,7 +743,7 @@ class SalarySlip(TransactionBase):
 		return payment_days
 
 	def get_holidays_for_employee(self, start_date, end_date):
-		holiday_list = get_holiday_list_for_employee(self.employee)
+		holiday_list = get_holiday_list_for_employee(self.employee, as_on = start_date)
 		key = f"{holiday_list}:{start_date}:{end_date}"
 		holiday_dates = frappe.cache().hget(HOLIDAYS_BETWEEN_DATES, key)
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -743,7 +743,7 @@ class SalarySlip(TransactionBase):
 		return payment_days
 
 	def get_holidays_for_employee(self, start_date, end_date):
-		holiday_list = get_holiday_list_for_employee(self.employee, as_on = start_date)
+		holiday_list = get_holiday_list_for_employee(self.employee, as_on=start_date)
 		key = f"{holiday_list}:{start_date}:{end_date}"
 		holiday_dates = frappe.cache().hget(HOLIDAYS_BETWEEN_DATES, key)
 


### PR DESCRIPTION
Fix: #4676 

**Description**
This PR fixes an issue in the **Salary Slip** calculation where the system might fetch the incorrect Holiday List for an employee if their assigned Holiday List changed over time. 

Previously, `get_holiday_list_for_employee` was called without a date context, which could result in fetching the employee's current holiday list rather than the one applicable during the specific payroll period. By passing the `start_date` of the salary slip, we ensure the correct historical holiday list is used for calculating payment days.

## What changed
- Added the `as_on=start_date` parameter to `get_holiday_list_for_employee` inside `get_holidays_for_employee` in `salary_slip.py`.
- This guarantees accurate holiday fetching based on the exact start date of the Salary Slip period, preventing discrepancies in total working days/payment days.