### PR TITLE
fix #4676: resolve holiday list using salary slip start date

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -742,7 +742,10 @@ class SalarySlip(TransactionBase):
 		return payment_days
 
 	def get_holidays_for_employee(self, start_date, end_date):
-		holiday_list = get_holiday_list_for_employee(self.employee)
+		holiday_list = get_holiday_list_for_employee(
+			self.employee,
+			as_on=start_date,
+		)
 		key = f"{holiday_list}:{start_date}:{end_date}"
 		holiday_dates = frappe.cache().hget(HOLIDAYS_BETWEEN_DATES, key)
 


### PR DESCRIPTION
fix #4676 :

Salary Slip was resolving the employee holiday list using the current date because `get_holiday_list_for_employee()` was called without `as_on`.

This PR fixes the Salary Slip caller by passing `start_date` as `as_on` when resolving the employee holiday list.
