### PR TITLE
fix(payroll): remove salary component when condition becomes false on…

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1280,6 +1280,17 @@ class SalarySlip(TransactionBase):
 		#   - self.default_data: full-cycle values            -> the `default_amount`
 		# (proration cascades through dependent formulas, e.g. SA = BS * 0.5 inherits BS's proration).
 		amount = self.eval_condition_and_formula(struct_row, self.data)
+		if amount is None:
+			self.set(
+				component_type,
+				[
+					d
+					for d in self.get(component_type)
+					if not (d.salary_component == struct_row.salary_component and not d.additional_salary)
+				],
+			)
+			self.data[struct_row.abbr] = 0
+			return
 		if struct_row.statistical_component or struct_row.accrual_component:
 			# update statistical component amount in reference data based on payment days
 			# since row for statistical component is not added to salary slip

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -2171,6 +2171,73 @@ class TestSalarySlip(HRMSTestSuite):
 		self.assertIn("Allowance", earnings)
 		self.assertEqual(earnings["Allowance"], 0.0)
 
+	def test_remove_component_when_condition_becomes_false(self):
+		emp_id = make_employee(
+			"test_condition_change@salary.com",
+			company="_Test Company",
+			**{"date_of_joining": add_days(nowdate(), -30)},
+		)
+
+		ss = make_employee_salary_slip(emp_id, "Monthly")
+		ss.save()
+
+		self.assertTrue(
+			frappe.db.exists(
+				"Salary Detail",
+				{
+					"parent": ss.name,
+					"parenttype": "Salary Slip",
+					"parentfield": "earnings",
+					"salary_component": "Basic Salary",
+				},
+			),
+			msg="Basic Salary should be present when condition is True",
+		)
+
+		salary_structure = frappe.db.get_value(
+			"Salary Structure Assignment",
+			{"employee": emp_id, "docstatus": 1},
+			"salary_structure",
+		)
+
+		row_name = frappe.db.get_value(
+			"Salary Detail",
+			{
+				"parent": salary_structure,
+				"parenttype": "Salary Structure",
+				"parentfield": "earnings",
+				"salary_component": "Basic Salary",
+			},
+		)
+
+		# make the component's condition evaluate to False
+		frappe.db.set_value(
+			"Salary Detail",
+			row_name,
+			"condition",
+			"False",
+		)
+		# clear cached structure so recalculation sees the new condition
+		frappe.clear_document_cache("Salary Structure", salary_structure)
+
+		# fresh doc (not reload()) so cached components are re-evaluated
+		ss = frappe.get_doc("Salary Slip", ss.name)
+		ss.get_emp_and_working_day_details()
+		ss.save()
+
+		self.assertFalse(
+			frappe.db.exists(
+				"Salary Detail",
+				{
+					"parent": ss.name,
+					"parenttype": "Salary Slip",
+					"parentfield": "earnings",
+					"salary_component": "Basic Salary",
+				},
+			),
+			msg="Basic Salary should be removed when condition becomes False",
+		)
+
 
 class TestSalarySlipSafeEval(HRMSTestSuite):
 	def test_safe_eval_for_salary_slip(self):


### PR DESCRIPTION
## Problem

When a Salary Component's condition evaluates to `false`, newly created Salary Slips correctly exclude it. However, if the component already exists on a previously saved (draft) Salary Slip, recalculating the slip leaves the component in place with its original amount, causing it to continue affecting salary totals.

Components that become ineligible through a formula returning zero (with **Remove if zero valued** enabled) are already removed correctly during recalculation, resulting in inconsistent behavior between condition-based and zero-value-based exclusions.

Fixes: https://github.com/frappe/hrms/issues/4679

## Root Cause

During Salary Slip recalculation, existing earning and deduction rows are compared against the newly computed components from the Salary Structure. Salary Components whose conditions evaluate to `false` are skipped during computation, but any previously existing rows for those components are not removed from the Salary Slip. As a result, stale component rows remain and continue contributing to salary calculations.

## Changes

- Remove existing earning and deduction rows whose Salary Component conditions now evaluate to `false` before applying recalculated component data.
- Align condition-based component removal behavior with the existing **Remove if zero valued** functionality.
- Ensure recalculated Salary Slips accurately reflect current Salary Component eligibility.

## How to Test

1. Create a deduction-type Salary Component.
2. Enable **Amount based on formula** and set the formula to `100`.
3. Enable **Remove if zero valued**.
4. Add the component to a Salary Structure and assign it to an employee.
5. Create and save a Salary Slip. Verify that the component appears on the slip.
6. Edit the Salary Component and add a condition that evaluates to `false` (for example: `date >= "2099-01-01"`).
7. Reopen the same draft Salary Slip and save/recalculate it.

### Expected Result

The Salary Component is removed from the Salary Slip and no longer affects totals.

### Before Fix

The Salary Component remained on the Salary Slip with its previous amount and continued affecting salary calculations.

## Recordings

### Before Fix

[salary_slip_comp_before_fix.webm](https://github.com/user-attachments/assets/990139cd-83ab-43cf-a6a6-e9e352060e6e)

### After Fix

[salary_slip_comp_after_fix.webm](https://github.com/user-attachments/assets/45ed9ea1-f230-4449-b610-82b9579444ee)
