### PR TITLE
fix(payroll): use Salary Component Account for company filtering in Employee Incentive

### DIFF
--- a/hrms/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/hrms/payroll/doctype/employee_incentive/employee_incentive.js
@@ -47,7 +47,8 @@ frappe.ui.form.on("Employee Incentive", {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function () {
 			return {
-				filters: { type: "earning" },
+				filters: { type: "earning", company: frm.doc.company },
+				query: "hrms.payroll.doctype.salary_structure.salary_structure.get_salary_component",
 			};
 		});
 	},

--- a/hrms/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/hrms/payroll/doctype/employee_incentive/employee_incentive.js
@@ -47,7 +47,7 @@ frappe.ui.form.on("Employee Incentive", {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function () {
 			return {
-				filters: { type: "earning", company: frm.doc.company },
+				filters: { component_type: "Earning", company: frm.doc.company },
 				query: "hrms.payroll.doctype.salary_structure.salary_structure.get_salary_component",
 			};
 		});


### PR DESCRIPTION
**Summary**

This PR fixes a permission error encountered while selecting a Salary Component in the Employee Incentive form.

**Closes**

Fixes #4690

**Problem**

Employee Incentive filters Salary Components based on the selected company by directly accessing the `company` field in the Salary Component DocType.

For users without permission to access `Salary Component.company`, Frappe raises the following error:
```
Permission Error

You do not have permission to access field:
Salary Component.company
```

As a result, users are unable to select Salary Components while creating Employee Incentive records.

**Root Cause**

The Salary Component query applies company-based filtering using the `Salary Component.company` field, which is subject to field-level permission checks. This causes the Salary Component lookup to fail for users who do not have access to that field.

**Solution**

Updated the Salary Component filtering logic in Employee Incentive to use the Salary Component Account DocType for company-based filtering instead of directly filtering on `Salary Component.company.`

**Before**

- Salary Component lookup could throw a Permission Error.
- Users were unable to select Salary Components in Employee Incentive.
- Company filtering relied on the restricted Salary Component.company field.

<img width="1440" height="722" alt="Screenshot 2026-06-10 at 3 15 34 PM" src="https://github.com/user-attachments/assets/d4d12cfa-ec94-4f2f-8276-7c9ff16c6287" />


**After**

- Salary Component lookup works without permission errors.
- Users can successfully select valid earning Salary Components.
- Company filtering is performed through Salary Component Account mappings.
- The Employee Incentive creation workflow functions as expected.

<img width="1440" height="753" alt="Screenshot 2026-06-10 at 3 51 05 PM" src="https://github.com/user-attachments/assets/ac8d9e50-7ae6-4cf0-bc1c-66d400fa6fa8" />



**Testing**

Verified on both HRMS v15 and v16:

- Employee Incentive form loads correctly.
- Salary Component lookup opens successfully.
- Only valid earning Salary Components are returned.
- Company-wise filtering works as expected.
- No permission errors are raised.
- Employee Incentive records can be created and saved successfully.
