### PR TITLE
fix(leave_policy_assignment): Half-Yearly earned leave allocation based on Leave Period

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -324,6 +324,7 @@ class LeavePolicyAssignment(Document):
 			leave_details.allocate_on_day,
 			from_date,
 			date_of_joining,
+			effective_from=self.effective_from,
 		)
 		schedule = []
 		if new_leaves_allocated:
@@ -412,9 +413,9 @@ def is_earned_leave_applicable_for_current_period(
 	# For Half-Yearly, compute preiod relative to effective_from
 	# instead of calendar year
 	if earned_leave_frequency == "Half-Yearly" and effective_from:
-		from hrms.hr.utils import get_period_relative_half_year
+		from hrms.hr.utils import get_half_year_periods
 
-		period_start, period_end = get_period_relative_half_year(date, effective_from)
+		period_start, period_end = get_half_year_periods(date, effective_from)
 		half_yearly_condition = (allocate_on_day == "First Day" and date >= period_start) or (
 			allocate_on_day == "Last Day" and date == period_end
 		)

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -216,7 +216,10 @@ class LeavePolicyAssignment(Document):
 
 	def get_leaves_for_passed_period(self, annual_allocation, leave_details, date_of_joining):
 		consider_current_period = is_earned_leave_applicable_for_current_period(
-			date_of_joining, leave_details.allocate_on_day, leave_details.earned_leave_frequency
+			date_of_joining,
+			leave_details.allocate_on_day,
+			leave_details.earned_leave_frequency,
+			effective_from=self.effective_from,
 		)
 		current_date, from_date = self.get_current_and_from_date(date_of_joining)
 		periods_passed = self.get_periods_passed(
@@ -276,7 +279,9 @@ class LeavePolicyAssignment(Document):
 			# calculate pro-rated leave for that month
 			# and normal monthly earned leave for remaining passed months
 			start_date, end_date = get_sub_period_start_and_end(
-				date_of_joining, leave_details.earned_leave_frequency
+				date_of_joining,
+				leave_details.earned_leave_frequency,
+				effective_from=self.effective_from,
 			)
 			leaves = get_periodically_earned_leave(
 				date_of_joining,
@@ -331,7 +336,11 @@ class LeavePolicyAssignment(Document):
 					"attempted": 1,
 				}
 			)
-			last_allocated_date = get_sub_period_start_and_end(today, leave_details.earned_leave_frequency)[1]
+			last_allocated_date = get_sub_period_start_and_end(
+				today,
+				leave_details.earned_leave_frequency,
+				effective_from=self.effective_from,
+			)[1]
 
 		while date <= to_date:
 			date_already_passed = today > date
@@ -349,6 +358,7 @@ class LeavePolicyAssignment(Document):
 				leave_details.allocate_on_day,
 				add_to_date(date, months=months_to_add),
 				date_of_joining,
+				effective_from=self.effective_from,
 			)
 		if from_date < getdate(date_of_joining):
 			pro_rated_period_start, pro_rated_period_end = get_sub_period_start_and_end(
@@ -394,13 +404,26 @@ def calculate_periods_passed(
 	return periods_passed
 
 
-def is_earned_leave_applicable_for_current_period(date_of_joining, allocate_on_day, earned_leave_frequency):
-	from hrms.hr.utils import get_semester_end, get_semester_start
-
+def is_earned_leave_applicable_for_current_period(
+	date_of_joining, allocate_on_day, earned_leave_frequency, effective_from=None
+):
 	date = getdate(frappe.flags.current_date) or getdate()
-	# If the date of assignment creation is >= the leave type's "Allocate On" date,
-	# then the current month should be considered
-	# because the employee is already entitled for the leave of that month
+
+	# For Half-Yearly, compute preiod relative to effective_from
+	# instead of calendar year
+	if earned_leave_frequency == "Half-Yearly" and effective_from:
+		from hrms.hr.utils import get_period_relative_half_year
+
+		period_start, period_end = get_period_relative_half_year(date, effective_from)
+		half_yearly_condition = (allocate_on_day == "First Day" and date >= period_start) or (
+			allocate_on_day == "Last Day" and date == period_end
+		)
+	else:
+		from hrms.hr.utils import get_semester_end, get_semester_start
+
+		half_yearly_condition = (allocate_on_day == "First Day" and date >= get_semester_start(date)) or (
+			allocate_on_day == "Last Day" and date == get_semester_end(date)
+		)
 
 	condition_map = {
 		"Monthly": (
@@ -408,16 +431,16 @@ def is_earned_leave_applicable_for_current_period(date_of_joining, allocate_on_d
 			or (allocate_on_day == "First Day" and date >= get_first_day(date))
 			or (allocate_on_day == "Last Day" and date == get_last_day(date))
 		),
-		"Quarterly": (allocate_on_day == "First Day" and date >= get_quarter_start(date))
-		or (allocate_on_day == "Last Day" and date == get_quarter_ending(date)),
-		"Half-Yearly": (allocate_on_day == "First Day" and date >= get_semester_start(date))
-		or (allocate_on_day == "Last Day" and date == get_semester_end(date)),
+		"Quarterly": (
+			(allocate_on_day == "First Day" and date >= get_quarter_start(date))
+			or (allocate_on_day == "Last Day" and date == get_quarter_ending(date))
+		),
+		"Half-Yearly": half_yearly_condition,
 		"Yearly": (
 			(allocate_on_day == "First Day" and date >= get_year_start(date))
 			or (allocate_on_day == "Last Day" and date == get_year_ending(date))
 		),
 	}
-
 	return condition_map.get(earned_leave_frequency)
 
 

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -321,3 +321,101 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		self.assertEqual(allocations[compoff.name]["new_leaves_allocated"], 3)
 		self.assertEqual(allocations[annual.name]["new_leaves_allocated"], 3)
 		self.assertNotIn(casual.name, allocations)
+
+	def test_half_yearly_earned_leave_schedule_based_on_leave_period(self):
+		"""
+		Leave Period: 01-Apr-2026 to 31-Mar-2027
+		Expected allocation dates: 30-Sep-2026, 31-Mar-2027
+		NOT: 30-Jun-2026, 31-Dec-2026
+		"""
+		leave_period = create_leave_period(getdate("2026-04-01"), getdate("2027-03-31"), "_Test Company")
+		leave_type = create_leave_type(
+			leave_type_name="_Test Half Yearly Earned Leave",
+			is_earned_leave=True,
+			earned_leave_frequency="Half-Yearly",
+			allocate_on_day="Last Day",
+		)
+		annual_allocation = 18
+		leave_policy = create_leave_policy(leave_type=leave_type.name, annual_allocation=annual_allocation)
+		leave_policy.submit()
+
+		# assignment created at the start of the leave period
+		frappe.flags.current_date = getdate("2026-04-01")
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Leave Period",
+				"leave_policy": leave_policy.name,
+				"leave_period": leave_period.name,
+			}
+		)
+		assignment = create_assignment(self.employee.name, data)
+		assignment.submit()
+
+		allocation_name = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "name"
+		)
+		schedule = frappe.get_all(
+			"Earned Leave Schedule",
+			filters={"parent": allocation_name},
+			fields=["allocation_date"],
+			order_by="allocation_date asc",
+		)
+
+		allocation_dates = [getdate(row.allocation_date) for row in schedule]
+
+		self.assertIn(getdate("2026-09-30"), allocation_dates)
+		self.assertIn(getdate("2027-03-31"), allocation_dates)
+		self.assertNotIn(getdate("2026-06-30"), allocation_dates)
+		self.assertNotIn(getdate("2026-12-31"), allocation_dates)
+
+		# should be exactly 2 allocations, not 3
+		self.assertEqual(len(allocation_dates), 2)
+
+	def test_half_yearly_earned_leave_schedule_based_on_joining_date(self):
+		"""
+		Employee joins: 01-Apr-2026
+		Expected allocation dates: 30-Sep-2026, 31-Mar-2027
+		"""
+		self.employee.date_of_joining = getdate("2026-04-01")
+		self.employee.save()
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test Half Yearly Earned Leave Joining Date",
+			is_earned_leave=True,
+			earned_leave_frequency="Half-Yearly",
+			allocate_on_day="Last Day",
+		)
+		annual_allocation = 18
+		leave_policy = create_leave_policy(leave_type=leave_type.name, annual_allocation=annual_allocation)
+		leave_policy.submit()
+
+		frappe.flags.current_date = getdate("2026-04-01")
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Joining Date",
+				"leave_policy": leave_policy.name,
+				"effective_from": self.employee.date_of_joining,
+				"effective_to": getdate("2027-03-31"),
+			}
+		)
+		assignment = create_assignment(self.employee.name, data)
+		assignment.submit()
+
+		allocation_name = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "name"
+		)
+		schedule = frappe.get_all(
+			"Earned Leave Schedule",
+			filters={"parent": allocation_name},
+			fields=["allocation_date"],
+			order_by="allocation_date asc",
+		)
+
+		allocation_dates = [getdate(row.allocation_date) for row in schedule]
+
+		self.assertIn(getdate("2026-09-30"), allocation_dates)
+		self.assertIn(getdate("2027-03-31"), allocation_dates)
+		self.assertNotIn(getdate("2026-06-30"), allocation_dates)
+		self.assertEqual(len(allocation_dates), 2)

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -176,6 +176,7 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		).submit()
 
 		today_date = getdate()
+		frappe.flags.pop("current_date", None)
 
 		leave_policy_assignment = frappe.new_doc("Leave Policy Assignment")
 		leave_policy_assignment.employee = self.employee.name

--- a/hrms/hr/doctype/leave_type/test_leave_type.py
+++ b/hrms/hr/doctype/leave_type/test_leave_type.py
@@ -34,6 +34,9 @@ def create_leave_type(**args):
 	if leave_type.is_ppl:
 		leave_type.fraction_of_daily_salary_per_leave = args.fraction_of_daily_salary_per_leave or 0.5
 
+	if leave_type.is_earned_leave and args.earned_leave_frequency:
+		leave_type.earned_leave_frequency = args.earned_leave_frequency
+
 	leave_type.insert()
 
 	return leave_type

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -370,7 +370,11 @@ def allocate_earned_leaves():
 			else:
 				date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 				allocation_date = get_expected_allocation_date_for_period(
-					e_leave_type.earned_leave_frequency, e_leave_type.allocate_on_day, today, date_of_joining
+					e_leave_type.earned_leave_frequency,
+					e_leave_type.allocate_on_day,
+					today,
+					date_of_joining,
+					effective_from=None,
 				)
 				annual_allocation = get_annual_allocation_from_policy(allocation, e_leave_type)
 				earned_leaves = calculate_upcoming_earned_leave(allocation, e_leave_type, date_of_joining)
@@ -526,11 +530,14 @@ def get_monthly_earned_leave(
 	return earned_leaves
 
 
-def get_sub_period_start_and_end(date, frequency):
+def get_sub_period_start_and_end(date, frequency, effective_from=None):
+	if frequency == "Half-Yearly" and effective_from:
+		return get_half_year_periods(date, effective_from)
+
 	return {
 		"Monthly": (get_first_day(date), get_last_day(date)),
 		"Quarterly": (get_quarter_start(date), get_quarter_ending(date)),
-		"Half-Yearly": (get_semester_start(date), get_semester_end(date)),
+		"Half-Yearly": (get_semester_start(date), get_semester_end(date)),  # fallback only
 		"Yearly": (get_year_start(date), get_year_ending(date)),
 	}.get(frequency)
 
@@ -605,11 +612,26 @@ def create_additional_leave_ledger_entry(allocation, leaves, date):
 	allocation.create_leave_ledger_entry()
 
 
-def get_expected_allocation_date_for_period(frequency, allocate_on_day, date, date_of_joining=None):
+def get_expected_allocation_date_for_period(
+	frequency, allocate_on_day, date, date_of_joining=None, effective_from=None
+):
 	try:
 		doj = date_of_joining.replace(month=date.month, year=date.year)
-	except ValueError:
+	except (ValueError, AttributeError):
 		doj = datetime.date(date.year, date.month, calendar.monthrange(date.year, date.month)[1])
+
+	if frequency == "Half-Yearly" and effective_from:
+		period_start, period_end = get_half_year_periods(date, effective_from)
+		half_yearly_dates = {
+			"First Day": period_start,
+			"Last Day": period_end,
+		}
+	else:
+		half_yearly_dates = {
+			"First Day": get_semester_start(date),
+			"Last Day": get_semester_end(date),
+		}
+
 	return {
 		"Monthly": {
 			"First Day": get_first_day(date),
@@ -620,7 +642,7 @@ def get_expected_allocation_date_for_period(frequency, allocate_on_day, date, da
 			"First Day": get_quarter_start(date),
 			"Last Day": get_quarter_ending(date),
 		},
-		"Half-Yearly": {"First Day": get_semester_start(date), "Last Day": get_semester_end(date)},
+		"Half-Yearly": half_yearly_dates,
 		"Yearly": {"First Day": get_year_start(date), "Last Day": get_year_ending(date)},
 	}[frequency][allocate_on_day]
 
@@ -1050,3 +1072,29 @@ def get_semester_end(date):
 		return get_year_ending(date)
 	else:
 		return add_months(get_year_ending(date), -6)
+
+
+def get_half_year_periods(date, effective_from):
+	"""
+	Compute the half-year period relative to effective_from,
+	NOT relative to the calendar year.
+
+	Example:
+		effective_from = 01-Apr-2026
+		date           = 01-Apr-2026
+		→ period_start = 01-Apr-2026, period_end = 30-Sep-2026
+
+		date           = 01-Oct-2026
+		→ period_start = 01-Oct-2026, period_end = 31-Mar-2027
+	"""
+	effective_from = getdate(effective_from)
+	date = getdate(date)
+
+	# Find how many full 6-month periods have elapsed since effective_from
+	months_elapsed = (date.year - effective_from.year) * 12 + (date.month - effective_from.month)
+	periods_elapsed = months_elapsed // 6
+
+	half_year_start = add_months(effective_from, periods_elapsed * 6)
+	half_year_end = add_days(add_months(half_year_start, 6), -1)
+
+	return half_year_start, half_year_end


### PR DESCRIPTION
### Reason
Half-yearly earned leave allocation dates were being calculated based on the **calendar year** (Jan–Jun and Jul–Dec) instead of the configured **Leave period**.

**Configuration**
Leave Period: 01-04-2026 to 31-03-2027
Leave Type: Earned Leave
Earned Leave Frequency: Half-Yearly
Allocate on Day: Last Day

**Expected Behavior**
Since the leave period runs from 01-Apr-2026 to 31-Mar-2027, half-yearly allocation should occur at:
30-Sep-2026
31-Mar-2027

**Actual Behavior**
The system allocates earned leave on:
30-Jun-2026


### Changes Done
- Added `get_half_year_periods` to calculate half-year start/end relative to the leave period instead of the calendar year
- Updated `get_expected_allocation_date_for_period`, `get_sub_period_start_and_end`, and `is_earned_leave_applicable_for_current_period` to use the new function for half-yearly frequency
<img width="2868" height="1482" alt="image" src="https://github.com/user-attachments/assets/9ef9065a-cf7a-43c6-b966-6d212d658fc9" />
