### PR TITLE
fix: include frontend and roster in asset build

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-          cache-dependency-path: apps/frappe/yarn.lock
+          cache-dependency-path: |
+            apps/frappe/yarn.lock
+            apps/hrms/yarn.lock
 
       - name: Install frappe JS dependencies
         working-directory: apps/frappe
@@ -46,7 +48,7 @@ jobs:
 
       - name: Install hrms JS dependencies
         working-directory: apps/hrms
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Link node_modules into public/
         working-directory: apps/frappe
@@ -56,9 +58,13 @@ jobs:
         working-directory: apps/frappe
         run: yarn run production
 
+      - name: Build hrms frontend and roster
+        working-directory: apps/hrms
+        run: yarn build
+
       - name: Package assets
         working-directory: apps/hrms
-        run: tar czf hrms-assets.tar.gz -C ../../sites/assets/hrms dist
+        run: tar czf hrms-assets.tar.gz -C ../../sites/assets/hrms dist frontend roster
 
       - name: Upload to rolling release
         working-directory: apps/hrms


### PR DESCRIPTION
- Removes `--ignore-scripts` so postinstall installs frontend/roster deps
- Adds `yarn build` to build the PWA and roster via Vite
- Packages `dist`, `frontend`, and `roster` in the release tarball