### PR TITLE
fix(pwa): preserve leave balance before application when viewing existing leaves

### DIFF
--- a/frontend/src/views/leave/Form.vue
+++ b/frontend/src/views/leave/Form.vue
@@ -18,7 +18,7 @@
 <script setup>
 import { IonPage, IonContent } from "@ionic/vue"
 import { createResource } from "frappe-ui"
-import { ref, watch, inject } from "vue"
+import { ref, watch, inject, nextTick } from "vue"
 
 import FormView from "@/components/FormView.vue"
 
@@ -38,6 +38,23 @@ const currEmployee = ref(sessionEmployee.data.name)
 
 // reactive object to store form data
 const leaveApplication = ref({})
+
+// For existing docs, watchers fire during initial data population from the DB.
+// This flag prevents setLeaveBalance() from overwriting the stored
+// "leave balance before application" value during that initial load.
+const isFormInitialized = ref(!props.id)
+if (props.id) {
+	watch(
+		() => leaveApplication.value.name,
+		(name) => {
+			if (name && !isFormInitialized.value) {
+				nextTick(() => {
+					isFormInitialized.value = true
+				})
+			}
+		}
+	)
+}
 
 // get form fields
 const formFields = createResource({
@@ -207,6 +224,7 @@ function setTotalLeaveDays() {
 
 function setLeaveBalance() {
 	if (!areValuesSet()) return
+	if (!isFormInitialized.value) return
 
 	const leaveBalance = createResource({
 		url: "hrms.hr.doctype.leave_application.leave_application.get_leave_balance_on",


### PR DESCRIPTION
## Issue

In the Frappe HR PWA, the **Leave Balance Before Application** field always shows the **current** leave balance instead of the balance at the time the leave was applied.

**Example:** Employee had 20 days before applying for 1 days leave, which is now approved:
- **Desk** → correctly shows **20** (value stored at time of application)
- **PWA** → incorrectly shows **19** (current balance after deduction)

## Root Cause

In `frontend/src/views/leave/Form.vue`, Vue's reactive `watch()` fires not only on user interaction but also when the form is populated programmatically. When `FormView.vue` loads an existing leave in `onMounted` via `formModel.value = { ...documentResource.doc }`, it triggers the `leave_type` and `[from_date, to_date]` watchers in `Form.vue`. Both watchers call `setLeaveBalance()`, which fetches the **current** balance via `get_leave_balance_on` and overwrites the stored "Leave Balance Before Application" value from the DB.

**Why the desk is unaffected:** The desk's `leave_application.js` binds `get_leave_balance` only to explicit user-triggered field change events — it is never invoked on form load for existing documents.

## Fix

Added an `isFormInitialized` flag in `Form.vue`:
- Starts as `false` for existing docs (`props.id` is set), `true` for new docs.
- A watcher on `leaveApplication.value.name` sets it to `true` in `nextTick` once the document data is first populated from the DB.
- `setLeaveBalance()` returns early while `isFormInitialized` is `false`, skipping the initial watcher batch.
- Subsequent user-initiated field changes trigger `setLeaveBalance()` normally — no regression for new leave creation.

## Screenshots


### **Before fix**

<img width="2050" height="1043" alt="image" src="https://github.com/user-attachments/assets/aa20c76f-39c9-4e7c-811d-eb260ea61f13" />

### **After fix**

PWA (Correct Balance) 
<img width="1333" height="1107" alt="image" src="https://github.com/user-attachments/assets/0ab0d5a9-eb0d-46b3-94c3-9a82631cc333" />


## Testing Steps

1. Apply for leave via the PWA and note the leave balance shown.
2. Get the leave approved.
3. Re-open the same leave in the PWA form view.
4. Verify **Leave Balance Before Application** matches the balance from step 1, not the post-approval balance.
