### PR TITLE
chore: fix payroll reviewer handle in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence.
 
 hrms/hr/ @ruchamahabal @asmitahase
-hrms/payroll/ @ruchamahabal @AyshaHakeem @iamraheelkhan
+hrms/payroll/ @ruchamahabal @AyshaHakeem @iamkhanraheel
 
 frontend/ @ruchamahabal @asmitahase
 roster/ @ruchamahabal @asmitahase


### PR DESCRIPTION
Fixes the GitHub handle for the payroll reviewer in CODEOWNERS.

`@iamraheelkhan` → `@iamkhanraheel`