### PR TITLE
fix: avoid company abbreviation collision in attendance test

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -323,13 +323,13 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(leaves[2], 1)
 
 	def test_attendance_with_company_filter(self):
-		create_company("HRMS Test Parent Company", is_group=1)
-		create_company("HRMS Test Child Company", is_group=1, parent_company="HRMS Test Parent Company")
-		create_company("HRMS Test Grandchild Company", parent_company="HRMS Test Child Company")
+		create_company("Test Parent Company", is_group=1, abbr="TPC-HR")
+		create_company("Test Child Company", is_group=1, parent_company="Test Parent Company", abbr="TCC-HR")
+		create_company("Test Grandchild Company", parent_company="Test Child Company", abbr="TGC-HR")
 
-		employee1 = make_employee("test_employee@parent.com", company="HRMS Test Parent Company")
-		employee2 = make_employee("test_employee@child.com", company="HRMS Test Child Company")
-		employee3 = make_employee("test_employee@grandchild.com", company="HRMS Test Grandchild Company")
+		employee1 = make_employee("test_employee@parent.com", company="Test Parent Company")
+		employee2 = make_employee("test_employee@child.com", company="Test Child Company")
+		employee3 = make_employee("test_employee@grandchild.com", company="Test Grandchild Company")
 
 		previous_month_first = get_first_day_for_prev_month()
 		mark_attendance(employee1, previous_month_first, "Present")
@@ -340,7 +340,7 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 			{
 				"month": previous_month_first.month,
 				"year": previous_month_first.year,
-				"company": "HRMS Test Parent Company",
+				"company": "Test Parent Company",
 				"include_company_descendants": 1,
 				"filter_based_on": self.filter_based_on,
 			}

--- a/hrms/tests/test_utils.py
+++ b/hrms/tests/test_utils.py
@@ -86,7 +86,12 @@ def add_date_to_holiday_list(date: str, holiday_list: str, is_half_day: bool = 0
 	holiday_list.save()
 
 
-def create_company(name: str = "_Test Company", is_group: 0 | 1 = 0, parent_company: str | None = None):
+def create_company(
+	name: str = "_Test Company",
+	is_group: 0 | 1 = 0,
+	parent_company: str | None = None,
+	abbr: str | None = None,
+):
 	if frappe.db.exists("Company", name):
 		return frappe.get_doc("Company", name)
 
@@ -94,6 +99,7 @@ def create_company(name: str = "_Test Company", is_group: 0 | 1 = 0, parent_comp
 		{
 			"doctype": "Company",
 			"company_name": name,
+			"abbr": abbr,
 			"default_currency": "INR",
 			"country": "India",
 			"is_group": is_group,


### PR DESCRIPTION
Changes:
- Changed test_utils create_company method to include abbr as an optional field.
- Changed abbr for the place where the error was occurring.