### PR TITLE
fix: resolve socketio_port at runtime instead of bundling common_site_config.json

### DIFF
--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,5 +1,4 @@
 import { io } from "socket.io-client"
-import { socketio_port } from "../../../../sites/common_site_config.json"
 
 import { getCachedListResource } from "frappe-ui/src/resources/listResource"
 import { getCachedResource } from "frappe-ui/src/resources/resources"
@@ -7,6 +6,7 @@ import { getCachedResource } from "frappe-ui/src/resources/resources"
 export function initSocket() {
 	let host = window.location.hostname
 	let siteName = window.site_name
+	let socketio_port = window.frappe?.boot?.socketio_port || 9000
 	let port = window.location.port ? `:${socketio_port}` : ""
 	let protocol = port ? "http" : "https"
 	let url = `${protocol}://${host}${port}/${siteName}`


### PR DESCRIPTION
The "Build and Upload Assets" workflow fails with:

[vite-plugin-pwa:build] src/socket.js: Could not resolve
"../../../../sites/common_site_config.json" from "src/socket.js"

frontend/src/socket.js did a static, build-time import of the bench's common_site_config.json:

import { socketio_port } from "../../../../sites/common_site_config.json"

It now reads from frappe.boot instead