### PR TITLE
fix: pass apps.json to image build via secret mount

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -40,8 +40,6 @@ jobs:
           
       - name: Set Branch
         run: |
-          export APPS_JSON_PATH='${{ github.workspace }}/.github/helper/apps.json'
-          echo "APPS_JSON_BASE64=$(cat $APPS_JSON_PATH | base64 -w 0)" >> $GITHUB_ENV
           echo "FRAPPE_BRANCH=version-15" >> $GITHUB_ENV
 
       - name: Set Image Tag
@@ -63,4 +61,5 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
           build-args: |
             "FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH }}"
-            "APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }}"
+          secret-files: |
+            apps_json=${{ github.workspace }}/.github/helper/apps.json


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Page-format-for-ERPNext-docs

- Contribution Guide => https://github.com/frappe/erpnext/wiki/Contribution-Guidelines

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

The version-15 and stable images built by this workflow ship frappe only, with no erpnext, payments or hrms.

```
docker run --rm --entrypoint ls ghcr.io/frappe/hrms:version-15 apps
# -> frappe
```

> Explain the **details** for making this change. What existing problem does the pull request solve?


The workflow checks out frappe/frappe_docker at its default branch and builds images/layered/Containerfile. That Containerfile reads the apps list from a BuildKit secret, not a build-arg:

```Dockerfile
RUN --mount=type=secret,id=apps_json,target=/opt/frappe/apps.json,uid=1000,gid=1000 \
  export APP_INSTALL_ARGS="" && \
  if [ -f /opt/frappe/apps.json ] && [ -s /opt/frappe/apps.json ]; then \
    export APP_INSTALL_ARGS="--apps_path=/opt/frappe/apps.json"; \
  fi && \
  bench init ${APP_INSTALL_ARGS} --frappe-branch=${FRAPPE_BRANCH}
```

It no longer consumes APPS_JSON_BASE64. This workflow still passes the app list as that build-arg, so it's silently ignored: the secret file is absent, APP_INSTALL_ARGS stays empty, and bench init runs frappe-only. The build still succeeds, so the regression (since https://github.com/frappe/frappe_docker/pull/1861) is silent.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

<img width="250" height="212" alt="never gonna give you up" src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHkzencyZGY1bmVxemVidG05NnVmenNkeHprZ2NiMDEzOGxlZzg4MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ju7l5y9osyymQ/giphy.gif" />
