### PR TITLE
fix: add missing permission checks in whitelisted functions

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -779,6 +779,7 @@ def upload_base64_file(
 
 @frappe.whitelist()
 def delete_attachment(filename: str):
+	frappe.has_permission("File", "delete", filename, throw=True)
 	frappe.delete_doc("File", filename)
 
 

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -234,13 +234,16 @@ def insert_shift(
 	)
 
 	if prev_shift:
+		frappe.has_permission("Shift Assignment", "write", prev_shift, throw=True)
 		if next_shift:
+			frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 			end_date = frappe.db.get_value("Shift Assignment", next_shift, "end_date")
 			frappe.db.set_value("Shift Assignment", next_shift, "docstatus", 2)
 			frappe.delete_doc("Shift Assignment", next_shift)
 		frappe.db.set_value("Shift Assignment", prev_shift, "end_date", end_date or None)
 
 	elif next_shift:
+		frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 		frappe.db.set_value("Shift Assignment", next_shift, "start_date", start_date)
 
 	else:

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -207,6 +207,11 @@ def mark_employee_attendance(
 			half_day_employee_list = json.loads(half_day_employee_list)
 		Attendance = frappe.qb.DocType("Attendance")
 		for employee in half_day_employee_list:
+			attendance_name = frappe.db.get_value(
+				"Attendance", {"employee": employee, "attendance_date": date}
+			)
+			if attendance_name:
+				frappe.has_permission("Attendance", "write", attendance_name, throw=True)
 			frappe.qb.update(Attendance).where(
 				(Attendance.employee == employee) & (Attendance.attendance_date == date)
 			).set(Attendance.half_day_status, half_day_status).set(Attendance.shift, shift).set(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -353,6 +353,7 @@ class LeaveAllocation(Document):
 
 	@frappe.whitelist()
 	def allocate_leaves_manually(self, new_leaves: str | float, from_date: str | datetime.date | None = None):
+		self.check_permission("write")
 		if from_date and not (getdate(self.from_date) <= getdate(from_date) <= getdate(self.to_date)):
 			frappe.throw(
 				_("Cannot allocate leaves outside the allocation period {0} - {1}").format(

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -374,7 +374,6 @@ def make_salary_slip(
 	print_format: str | None = None,
 	for_preview: int = 0,
 	lwp_days_corrected: float | None = None,
-	ignore_permissions: bool = False,
 ) -> str | Document:
 	def postprocess(source, target):
 		if employee:
@@ -401,7 +400,7 @@ def make_salary_slip(
 		},
 		target_doc,
 		postprocess,
-		ignore_permissions=ignore_permissions,
+		ignore_permissions=False,
 		ignore_child_tables=True,
 		cached=True,
 	)


### PR DESCRIPTION
## Summary

Five access-control gaps found during a targeted security audit of whitelisted API functions. Each fix is surgical (1–5 lines) and adds the missing permission check that the framework requires before performing state-mutating operations.

**Total: 5 files changed, 11 insertions, 2 deletions.**

---

## Findings

### 1. `delete_attachment` — File deletion with zero permission checks
**File:** `hrms/api/__init__.py:781`

The entire function body was one line: `frappe.delete_doc("File", filename)`. Any authenticated user could delete any `File` record by name. Its sibling `upload_base64_file` in the same file correctly checks `frappe.has_permission(dt, "write", dn, throw=True)`.

**Fix:** Added `frappe.has_permission("File", "delete", filename, throw=True)` before the delete call.

---

### 2. `make_salary_slip` — Client-controlled `ignore_permissions` flag
**File:** `hrms/payroll/doctype/salary_structure/salary_structure.py:368`

The function signature exposed `ignore_permissions: bool = False` as a client-controllable parameter, passed directly to `get_mapped_doc()`. When set to `True` by the caller, all permission checks on Salary Structure reads and Salary Slip creation were bypassed. Zero `has_permission`/`only_for`/`check_permission` calls exist anywhere in the file. No internal callers pass this flag (confirmed via grep).

Same bug class as [erpnext#55915](https://github.com/frappe/erpnext/issues/55915).

**Fix:** Removed `ignore_permissions` from the function signature and hardcoded `ignore_permissions=False` in the `get_mapped_doc` call.

---

### 3. `allocate_leaves_manually` — Missing write check (sibling has it)
**File:** `hrms/hr/doctype/leave_allocation/leave_allocation.py:355`

Performs raw `self.db_set("total_leaves_allocated", ...)` with no write permission check. Its sibling method `retry_failed_allocations` in the **same class** correctly checks `frappe.has_permission(doctype="Leave Allocation", ptype="write", user=frappe.session.user)`.

**Fix:** Added `self.check_permission("write")` at the start of the method.

---

### 4. `mark_employee_attendance` — Raw QB update with zero permission checks
**File:** `hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py:170`

The half-day branch uses `frappe.qb.update(Attendance).run()` to mutate `Attendance` records (half_day_status, shift, late_entry, early_exit, modify_half_day_status), bypassing all document-level permission enforcement. Zero `has_permission`/`only_for`/`check_permission` calls exist in the entire file.

**Fix:** Added object-level `frappe.has_permission("Attendance", "write", attendance_name, throw=True)` before each QB update.

---

### 5. `insert_shift` — Permission-type mismatch (create check for write/delete ops)
**File:** `hrms/api/roster.py:212`

Checks only `Shift Assignment` `"create"` permission, then writes to and deletes existing adjacent `Shift Assignment` records via `frappe.db.set_value` and `frappe.delete_doc`. Its properly-guarded sibling `delete_shift_schedule_assignment` in the same file correctly calls `check_permission("cancel"/"delete")` per-doc.

**Fix:** Added `frappe.has_permission("Shift Assignment", "write", ...)` checks on existing records before mutating them.

---

## Testing

Each fix adds a standard Frappe permission check pattern (`frappe.has_permission(..., throw=True)` or `self.check_permission(...)`) before the state-mutating operation. These are the same patterns used by correctly-guarded sibling functions in the same files/classes.

No behavioral change for authorized users. Unauthorized users will now receive `frappe.PermissionError` instead of silent mutation.