### PR TITLE
fix: add missing permission check for delete_attachment

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -779,6 +779,7 @@ def upload_base64_file(
 
 @frappe.whitelist()
 def delete_attachment(filename: str):
+	frappe.has_permission("File", "delete", filename, throw=True)
 	frappe.delete_doc("File", filename)
 
 


### PR DESCRIPTION
## Summary
Added missing `frappe.has_permission("File", "delete", filename, throw=True)` check to `delete_attachment` to ensure users cannot delete files they don't have access to.