### PR TITLE
fix: prevent client control of ignore_permissions in make_salary_slip

### DIFF
--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -374,7 +374,6 @@ def make_salary_slip(
 	print_format: str | None = None,
 	for_preview: int = 0,
 	lwp_days_corrected: float | None = None,
-	ignore_permissions: bool = False,
 ) -> str | Document:
 	def postprocess(source, target):
 		if employee:
@@ -401,7 +400,7 @@ def make_salary_slip(
 		},
 		target_doc,
 		postprocess,
-		ignore_permissions=ignore_permissions,
+		ignore_permissions=False,
 		ignore_child_tables=True,
 		cached=True,
 	)


### PR DESCRIPTION
## Summary
`ignore_permissions` was exposed as a parameter in the whitelisted `make_salary_slip` function, allowing clients to bypass permission checks when making salary slips. This removes the parameter and hardcodes it to `False` to ensure permissions are always enforced.