### PR TITLE
fix: add permission check for allocate_leaves_manually

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -353,6 +353,7 @@ class LeaveAllocation(Document):
 
 	@frappe.whitelist()
 	def allocate_leaves_manually(self, new_leaves: str | float, from_date: str | datetime.date | None = None):
+		self.check_permission("write")
 		if from_date and not (getdate(self.from_date) <= getdate(from_date) <= getdate(self.to_date)):
 			frappe.throw(
 				_("Cannot allocate leaves outside the allocation period {0} - {1}").format(


### PR DESCRIPTION
## Summary
Added missing `self.check_permission("write")` to `allocate_leaves_manually` to prevent unauthorized modification of `total_leaves_allocated` via raw `db_set`.