### PR TITLE
fix: add permission check for insert_shift mutations

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -238,6 +238,7 @@ def insert_shift(
 		if next_shift:
 			frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 			end_date = frappe.db.get_value("Shift Assignment", next_shift, "end_date")
+			frappe.has_permission("Shift Assignment", "delete", next_shift, throw=True)
 			frappe.db.set_value("Shift Assignment", next_shift, "docstatus", 2)
 			frappe.delete_doc("Shift Assignment", next_shift)
 		frappe.db.set_value("Shift Assignment", prev_shift, "end_date", end_date or None)

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -234,13 +234,16 @@ def insert_shift(
 	)
 
 	if prev_shift:
+		frappe.has_permission("Shift Assignment", "write", prev_shift, throw=True)
 		if next_shift:
+			frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 			end_date = frappe.db.get_value("Shift Assignment", next_shift, "end_date")
 			frappe.db.set_value("Shift Assignment", next_shift, "docstatus", 2)
 			frappe.delete_doc("Shift Assignment", next_shift)
 		frappe.db.set_value("Shift Assignment", prev_shift, "end_date", end_date or None)
 
 	elif next_shift:
+		frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 		frappe.db.set_value("Shift Assignment", next_shift, "start_date", start_date)
 
 	else:


### PR DESCRIPTION
## Summary
`insert_shift` checked only `create` permission, but then performed write (`db.set_value`) and delete (`delete_doc`) operations on existing adjacent Shift Assignment records. This adds the required `frappe.has_permission("Shift Assignment", "write", ..., throw=True)` checks before mutating existing records.