### PR TITLE
fix: remove duplicate navigation buttons on Job Applicant

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -18,7 +18,6 @@ frappe.ui.form.on("Job Applicant", {
 		frm.events.show_resume(frm);
 		frm.events.create_custom_buttons(frm);
 		frm.events.get_interview_for_dashboard(frm);
-		frm.toolbar.make_navigation();
 	},
 
 	show_resume: function (frm) {


### PR DESCRIPTION
On the **Job Applicant** form, calling `frm.toolbar.make_navigation()` manually inside the `refresh` trigger causes the framework to initialize and render document navigation buttons (like Next/Previous document links) twice. This results in duplicate navigation buttons appearing in the form toolbar.

This pull request removes the redundant manual call to `frm.toolbar.make_navigation()`. Since the Frappe framework handles standard toolbar navigation rendering automatically during the form loading cycle, removing this line successfully resolves the duplicate button issue without affecting standard navigation functionality.

### Screenshots/GIFs

Before:
<img width="1439" height="739" alt="image" src="https://github.com/user-attachments/assets/7453c89f-17c9-4877-a5a5-052b6ff99ec5" />



After:

<img width="1245" height="717" alt="image" src="https://github.com/user-attachments/assets/dea0fcd5-2eb2-461f-a04a-af045e6e3048" />
