### PR TITLE
fix: creating payment entry for Employee Advance asks for Exchange Gain/Loss Account even for same currency

### DIFF
--- a/hrms/hr/doctype/employee_advance/test_employee_advance.py
+++ b/hrms/hr/doctype/employee_advance/test_employee_advance.py
@@ -402,6 +402,25 @@ class TestEmployeeAdvance(HRMSTestSuite):
 		self.assertEqual(advance.base_paid_amount, expected_base_paid)
 		self.assertEqual(payment_entry.paid_amount, expected_base_paid)
 
+	def test_no_exchange_gain_loss_for_same_currency_advance_payment(self):
+		from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
+
+		gain_loss_account = frappe.db.get_value("Company", "_Test Company", "exchange_gain_loss_account")
+		frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", None)
+
+		try:
+			employee_name = make_employee("_T@employee.advance", "_Test Company")
+			advance = make_employee_advance(employee_name)
+
+			# should not raise error even without exchange_gain_loss_account set at time of payment
+			pe = get_payment_entry_for_employee(advance.doctype, advance.name)
+
+			self.assertEqual(flt(pe.source_exchange_rate), 1.0)
+			self.assertEqual(flt(pe.target_exchange_rate), 1.0)
+			self.assertFalse(any(d.is_exchange_gain_loss for d in pe.deductions))
+		finally:
+			frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", gain_loss_account)
+
 	def test_status_on_discard(self):
 		employee_name = make_employee("Test_status@employee.advance", "_Test Company")
 		advance = make_employee_advance(employee_name, do_not_submit=True)

--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -143,10 +143,9 @@ def get_payment_entry_for_employee(
 	pe.received_amount = received_amount
 
 	if party_account and bank:
-		if dt == "Employee Advance":
+		pe.set_exchange_rate()  # always set source & target exchange rate
+		if dt == "Employee Advance" and pe.paid_to_account_currency != pe.paid_from_account_currency:
 			pe.target_exchange_rate = current_exchange_rate
-		else:
-			pe.set_exchange_rate()
 		pe.set_amounts()
 
 	return pe


### PR DESCRIPTION
### Reason
Creating a Payment Entry from Employee Advance was asking to set Exchange Gain/Loss account even when the advance and company currency are the same.
<img width="2120" height="468" alt="image" src="https://github.com/user-attachments/assets/a72b385b-91fc-462c-8b1d-9e0fb6470174" />

### Changes Done
- `set_exchange_rate()` is now always called before `set_amounts()` so **source_exchange_rate** is never left at 0
- This ensures **base_paid_amount** is computed correctly, resulting in zero exchange gain/loss for same-currency advances, so the account is never looked up

https://github.com/user-attachments/assets/3d773c63-96f1-486f-ad0a-7c1f3b242574

