### PR TITLE
Fixed expense account filter and added payment entry link in Leave Encashment

### DIFF
--- a/hrms/hr/doctype/leave_encashment/leave_encashment.js
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.js
@@ -43,6 +43,16 @@ frappe.ui.form.on("Leave Encashment", {
 				},
 			};
 		});
+
+		frm.set_query("expense_account", function () {
+			return {
+				filters: {
+					is_group: 0,
+					root_type: "Expense",
+					company: frm.doc.company,
+				},
+			};
+		});
 	},
 	refresh: function (frm) {
 		cur_frm.set_intro("");

--- a/hrms/hr/doctype/leave_encashment/leave_encashment.json
+++ b/hrms/hr/doctype/leave_encashment/leave_encashment.json
@@ -257,8 +257,17 @@
   }
  ],
  "is_submittable": 1,
- "links": [],
- "modified": "2025-02-21 13:11:01.939992",
+ "links": [
+  {
+   "group": "Payment",
+   "is_child_table": 1,
+   "link_doctype": "Payment Entry Reference",
+   "link_fieldname": "reference_name",
+   "parent_doctype": "Payment Entry",
+   "table_fieldname": "references"
+  }
+ ],
+ "modified": "2026-06-24 11:34:04.610000",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Encashment",


### PR DESCRIPTION
## Summary
- Filter the Expense Account field in Leave Encashment by company and expense accounts only, same as Default Account in Expense Claim Type.
- Add a Payment Entry connection in Leave Encashment, so users can see payments made for it, same as other claim doctypes.

<img width="1436" height="678" alt="image" src="https://github.com/user-attachments/assets/ec6d5b61-0a1a-4354-a1c8-8dbbca1a4024" />


<img width="2432" height="2006" alt="image" src="https://github.com/user-attachments/assets/427614fb-0b9f-4e20-9895-56df366feeb0" />
