### PR TITLE
feat: Add regional hooks

### DIFF
--- a/hrms/__init__.py
+++ b/hrms/__init__.py
@@ -1,3 +1,6 @@
+import functools
+import inspect
+
 import frappe
 
 __version__ = "17.0.0-dev"
@@ -10,3 +13,42 @@ def refetch_resource(cache_key: str | list, user=None):
 		user=user or frappe.session.user,
 		after_commit=True,
 	)
+
+
+def get_region(company=None):
+	"""Return the country used to resolve regional overrides, based on flag,
+	company or global settings. Mirrors erpnext.get_region.
+
+	You can also set the global company flag in `frappe.flags.company`.
+	"""
+	if not company:
+		company = frappe.local.flags.company
+
+	if company:
+		return frappe.get_cached_value("Company", company, "country")
+
+	return frappe.flags.country or frappe.get_system_settings("country")
+
+
+def allow_regional(fn):
+	"""Decorator to make a function regionally overridable. Mirrors
+	erpnext.allow_regional so HRMS functions can be overridden per region via the
+	`regional_overrides` hook.
+
+	Example:
+	@hrms.allow_regional
+	def myfunction():
+	  pass"""
+
+	@functools.wraps(fn)
+	def caller(*args, **kwargs):
+		overrides = frappe.get_hooks("regional_overrides", {}).get(get_region())
+		function_path = f"{inspect.getmodule(fn).__name__}.{fn.__name__}"
+
+		if not overrides or function_path not in overrides:
+			return fn(*args, **kwargs)
+
+		# Priority given to last installed app
+		return frappe.get_attr(overrides[function_path][-1])(*args, **kwargs)
+
+	return caller

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -31,6 +31,7 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.utilities.transaction_base import TransactionBase
 
+import hrms
 from hrms.hr.utils import validate_active_employee
 from hrms.payroll.doctype.additional_salary.additional_salary import get_additional_salaries
 from hrms.payroll.doctype.employee_benefit_ledger.employee_benefit_ledger import (
@@ -941,10 +942,20 @@ class SalarySlip(TransactionBase):
 
 		set_loan_repayment(self)
 
+		# Region-specific deductions (e.g. India statutory deductions) are injected
+		# here so they are reflected in both saved slips and the preview generated
+		# by process_salary_structure, before totals are finalised below.
+		self.apply_regional_deductions()
+
 		self.set_precision_for_component_amounts()
 		self.set_net_pay()
 		if not skip_tax_breakup_computation:
 			self.compute_income_tax_breakup()
+
+	@hrms.allow_regional
+	def apply_regional_deductions(self):
+		"Hook point for region-specific salary slip deductions."
+		pass
 
 	def set_net_pay(self):
 		self.total_deduction = self.get_component_totals("deductions")


### PR DESCRIPTION
Add a regional override hook, like in ERPNext, to hook regional compliances

`no-docs`