### PR TITLE
fix: warnings thrown to the user during setup

### DIFF
--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -83,9 +83,9 @@ def make_salary_components(country):
 			doc.flags.ignore_permissions = True
 			doc.flags.ignore_mandatory = True
 			doc.insert(ignore_if_duplicate=True)
-		except frappe.NameError:
-			frappe.clear_messages()
-		except frappe.DuplicateEntryError:
+		except Exception as e:
+			frappe.error_log("Error occurred while creating Salary Component", e)
+		finally:
 			frappe.clear_messages()
 
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/fc73671c-3573-40a0-998b-0b8e4fe4049d


Makes no sense to throw a bunch of warnings like these to the user which most of the times are informative and harmless and the important ones are shown again when they take a relevant action. During setup all it causes is confusion for a system they're just getting to have a sense of. Before [this diff](https://github.com/frappe/erpnext/commit/998469d5c70662fa10aa144160ecd87e36418f94#diff-c6419579e6fdd60559888cbdf454814f520296179124337e9d5b1ce2d90c5c17L62-L82) used to swallow these warnings but EPRNext decided to remove it during frappe/erpnext#53866

So now this removes the warnings from message log and true exceptions are logged for future reference.