### PR TITLE
fix: full day + half day leave on today validation

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -490,7 +490,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		for d in frappe.db.sql(
 			"""
 			select
-				name, leave_type, posting_date, from_date, to_date, total_leave_days, half_day_date
+				name, leave_type, posting_date, from_date, to_date, total_leave_days, half_day, half_day_date
 			from `tabLeave Application`
 			where employee = %(employee)s and docstatus < 2 and status in ('Open', 'Approved')
 			and to_date >= %(from_date)s and from_date <= %(to_date)s
@@ -505,6 +505,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		):
 			if (
 				cint(self.half_day) == 1
+				and cint(d.half_day) == 1
 				and getdate(self.half_day_date) == getdate(d.half_day_date)
 				and (
 					flt(self.total_leave_days) == 0.5

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -483,6 +483,29 @@ class TestLeaveApplication(HRMSTestSuite):
 		application.half_day_date = "2013-01-05"
 		application.insert()
 
+	def test_overlap_with_half_day_on_today(self):
+		self._clear_roles()
+
+		from frappe.utils.user import add_role
+
+		add_role("test@example.com", "Employee")
+		frappe.set_user("test@example.com")
+
+		# full day leave on today (half_day_date stays NULL)
+		application = self.get_application(self.leave_application)
+		application.from_date = application.to_date = nowdate()
+		application.insert()
+
+		# half day leave on the same day must overlap regardless of the date:
+		# a NULL half_day_date on the existing full day leave coerces to today via
+		# getdate(None), so the date must not be the only thing distinguishing them
+		application = self.get_application(self.leave_application)
+		application.from_date = application.to_date = nowdate()
+		application.half_day = 1
+		application.half_day_date = nowdate()
+
+		self.assertRaises(OverlapError, application.insert)
+
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_optional_leave(self):
 		leave_period = get_leave_period(current=True)

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -491,6 +491,16 @@ class TestLeaveApplication(HRMSTestSuite):
 		add_role("test@example.com", "Employee")
 		frappe.set_user("test@example.com")
 
+		# allocate leave covering today so the applications aren't rejected for
+		# being outside the allocation period
+		date = getdate()
+		make_allocation_record(
+			employee=get_employee().name,
+			leave_type="_Test Leave Type",
+			from_date=get_year_start(date),
+			to_date=get_year_ending(date),
+		)
+
 		# full day leave on today (half_day_date stays NULL)
 		application = self.get_application(self.leave_application)
 		application.from_date = application.to_date = nowdate()


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Page-format-for-ERPNext-docs

- Contribution Guide => https://github.com/frappe/erpnext/wiki/Contribution-Guidelines

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->
`LeaveApplication.validate_leave_overlap()` fails to block a clear over-allocation: an employee with an existing full-day leave on a date can still create a half-day leave on that same date, ending up with 1.5 days (12 hours) of leave booked for one day. This should always be rejected with an OverlapError, the same way two full-day leaves on the same date are.
The bug only manifests when the leave is for today's date.

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The overlap check has a deliberately lenient branch that allows two half-day leaves to coexist on the same day (e.g. first-half + second-half). The condition guarding that branch is:
```
if (
    cint(self.half_day) == 1
    and getdate(self.half_day_date) == getdate(d.half_day_date)
    and ( ... )
):
    if self.get_total_leaves_on_half_day() >= 1:
        self.throw_overlap_error(d)
else:
    self.throw_overlap_error(d)
 
```

The condition checks that the incoming application (self) is a half-day, but it never checks whether the existing overlapping application (d) is a half-day. A full-day leave stores half_day_date = NULL.

The trap is getdate(NULL): in Frappe, getdate(None) returns today's date. So when the existing leave is a full-day one (half_day_date = NULL → today) and the new half-day leave is also for today (half_day_date = today), the comparison getdate(self.half_day_date) == getdate(d.half_day_date) evaluates today == today → True, and execution wrongly enters the half-day-tolerant branch.

Inside that branch, get_total_leaves_on_half_day() counts only rows where half_day = 1. The existing full-day leave (half_day = 0) is invisible to it, so the count is 0, the >= 1 check fails, and no error is thrown — the 12-hour booking goes through.

On any non-today date, the full-day leave's NULL → today no longer equals the new leave's real date, the comparison is False, control falls to else, and the overlap is correctly rejected. That is the entire today-vs-other-date asymmetry.

> Screenshots/GIFs

> [!NOTE]
> In the Video i am using the shift+D shortcut to duplicate the leave application not editing the same 
 
**Before**:

https://github.com/user-attachments/assets/cb2724cb-3dc9-4128-8df8-87038cbfbe9c

**After**:

https://github.com/user-attachments/assets/ed52fe91-701a-4c8a-9789-1de9da1f0ce8


Fixes #4788 