### PR TITLE
fix: add write/delete permission checks in insert_shift

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -234,13 +234,16 @@ def insert_shift(
 	)
 
 	if prev_shift:
+		frappe.has_permission("Shift Assignment", "write", prev_shift, throw=True)
 		if next_shift:
+			frappe.has_permission("Shift Assignment", "delete", next_shift, throw=True)
 			end_date = frappe.db.get_value("Shift Assignment", next_shift, "end_date")
 			frappe.db.set_value("Shift Assignment", next_shift, "docstatus", 2)
 			frappe.delete_doc("Shift Assignment", next_shift)
 		frappe.db.set_value("Shift Assignment", prev_shift, "end_date", end_date or None)
 
 	elif next_shift:
+		frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 		frappe.db.set_value("Shift Assignment", next_shift, "start_date", start_date)
 
 	else:


### PR DESCRIPTION
## Description

`insert_shift` only checks `Shift Assignment` `create` permission but then modifies (`set_value`) and deletes (`delete_doc`) existing adjacent Shift Assignment records without verifying `write`/`delete` permissions on those specific documents.

## Fix
Added `frappe.has_permission` checks for `write` on `prev_shift` and `next_shift` before modifying them, and `delete` on `next_shift` before deleting it. This is consistent with sibling functions in the same file that already perform object-level permission checks.