### PR TITLE
fix(payroll_entry): remove spurious debug arg from db.count in onload

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -88,7 +88,7 @@ class PayrollEntry(Document):
 			return
 
 		# check if salary slips were manually submitted
-		entries = frappe.db.count("Salary Slip", {"payroll_entry": self.name, "docstatus": 1}, ["name"])
+		entries = frappe.db.count("Salary Slip", {"payroll_entry": self.name, "docstatus": 1})
 		if cint(entries) == len(self.employees):
 			self.set_onload("submitted_ss", True)
 


### PR DESCRIPTION
`frappe.db.count` signature: `count(dt, filters=None, debug=False, ...)`.

`["name"]` was passed as the third positional arg, setting `debug=True`. This triggers `frappe.log()` → `print(msg, file=sys.stderr)`, which raises `BrokenPipeError` when the process stderr pipe is broken — making any submitted Payroll Entry fail to load.

**Fix:** remove the extraneous `["name"]` argument.