### PR TITLE
fix: implement close warning for job openings and related validation.

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -45,6 +45,35 @@ frappe.ui.form.on("Job Opening", {
 	company: function (frm) {
 		frm.set_value("designation", "");
 	},
+	status: function (frm) {
+		frm.close_warning_confirmed = false;
+	},
+	before_save: function (frm) {
+		frm.trigger("confirm_close_if_needed");
+	},
+	after_save: function (frm) {
+		frm.close_warning_confirmed = false;
+	},
+	confirm_close_if_needed: function (frm) {
+		if (frm.is_new() || frm.close_warning_confirmed || frm.doc.status !== "Closed") {
+			return;
+		}
+
+		frappe.validated = false;
+
+		frm.call("get_close_warning").then((r) => {
+			if (!r.message) {
+				frm.close_warning_confirmed = true;
+				frm.save();
+				return;
+			}
+
+			frappe.confirm(r.message, () => {
+				frm.close_warning_confirmed = true;
+				frm.save();
+			});
+		});
+	},
 
 	job_opening_template: function (frm) {
 		if (!frm.doc.job_opening_template) return;

--- a/hrms/hr/doctype/job_opening/job_opening.py
+++ b/hrms/hr/doctype/job_opening/job_opening.py
@@ -90,7 +90,26 @@ class JobOpening(WebsiteGenerator):
 		if self.status == "Closed":
 			self.validate_from_to_dates("posted_on", "closed_on")
 
+	@frappe.whitelist()
+	def get_close_warning(self):
+		if not self.is_opening_being_closed():
+			return
+
+		if not self.staffing_plan:
+			return
+
+		return _(
+			"Closing this Job Opening for {1} may not be according to the Staffing Plan {0}.<br><br>"
+			"Do you want to close this Job Opening?"
+		).format(
+			frappe.bold(get_link_to_form("Staffing Plan", self.staffing_plan)),
+			frappe.bold(self.designation),
+		)
+
 	def validate_current_vacancies(self):
+		if self.status == "Closed":
+			return
+
 		if not self.staffing_plan:
 			staffing_plan = get_active_staffing_plan_details(self.company, self.designation)
 			if staffing_plan:
@@ -122,6 +141,12 @@ class JobOpening(WebsiteGenerator):
 					),
 					title=_("Vacancies fulfilled"),
 				)
+
+	def is_opening_being_closed(self):
+		if self.is_new() or self.status != "Closed":
+			return False
+
+		return frappe.db.get_value(self.doctype, self.name, "status") == "Open"
 
 	def update_job_requisition_status(self):
 		if self.status == "Closed" and self.job_requisition:

--- a/hrms/hr/doctype/job_opening/test_job_opening.py
+++ b/hrms/hr/doctype/job_opening/test_job_opening.py
@@ -49,6 +49,70 @@ class TestJobOpening(HRMSTestSuite):
 		opening_1.status = "Closed"
 		opening_1.save()
 
+	def test_close_job_opening_after_employee_creation(self):
+		staffing_plan = frappe.get_doc(
+			{
+				"doctype": "Staffing Plan",
+				"company": "_Test Opening Company",
+				"name": "Test",
+				"from_date": getdate(),
+				"to_date": add_days(getdate(), 10),
+			}
+		)
+
+		staffing_plan.append(
+			"staffing_details",
+			{"designation": "Designer", "vacancies": 1, "estimated_cost_per_position": 50000},
+		)
+		staffing_plan.insert()
+		staffing_plan.submit()
+
+		opening = get_job_opening()
+		opening.insert()
+
+		make_employee(
+			"test_job_opening_after_hiring@example.com",
+			company="_Test Opening Company",
+			designation="Designer",
+		)
+
+		opening.status = "Closed"
+		close_warning = opening.get_close_warning()
+		self.assertIn("may not be according to the Staffing Plan", close_warning)
+		self.assertNotIn("<table", close_warning)
+		self.assertIn("Designer", close_warning)
+		self.assertIn("<strong><a", close_warning)
+		opening.save()
+
+		self.assertEqual(opening.status, "Closed")
+
+	def test_close_job_opening_under_staffing_plan_shows_warning(self):
+		staffing_plan = frappe.get_doc(
+			{
+				"doctype": "Staffing Plan",
+				"company": "_Test Opening Company",
+				"name": "Test",
+				"from_date": getdate(),
+				"to_date": add_days(getdate(), 10),
+			}
+		)
+
+		staffing_plan.append(
+			"staffing_details",
+			{"designation": "Designer", "vacancies": 3, "estimated_cost_per_position": 50000},
+		)
+		staffing_plan.insert()
+		staffing_plan.submit()
+
+		opening = get_job_opening(job_title="Designer Under Plan")
+		opening.insert()
+
+		opening.status = "Closed"
+		self.assertIn("may not be according to the Staffing Plan", opening.get_close_warning())
+		opening.save()
+
+		self.assertEqual(opening.status, "Closed")
+
 	def test_close_expired_job_openings(self):
 		today = getdate()
 


### PR DESCRIPTION
Changes 
- Allow closing a Job Opening even when Staffing Plan positions are already fulfilled.
- Show confirmation warning before closing any Job Opening linked to a Staffing Plan.
- Keep existing validation when reopening a closed Job Opening.
- Add test for under-filled Staffing Plan close warning.
<img width="2838" height="2067" alt="image" src="https://github.com/user-attachments/assets/b4397476-4011-4c9c-aad3-0dcfa81a9a15" />
