### PR TITLE
fix(income_tax_computation): incorrect gross earnings in report due to taxable earnings till date from prior year SSA

### DIFF
--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.py
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.py
@@ -99,6 +99,7 @@ class IncomeTaxComputationReport:
 			},
 			fields=[
 				"employee",
+				"from_date",
 				"income_tax_slab",
 				"salary_structure",
 				"taxable_earnings_till_date",
@@ -115,14 +116,22 @@ class IncomeTaxComputationReport:
 				)
 
 				if tax_slab and not tax_slab.disabled:
+					# opening entries are valid only when the SSA was created within the payroll period
+					opening_entries_applicable = getdate(d.from_date) >= getdate(
+						self.payroll_period_start_date
+					)
 					employee_ss_assignments.setdefault(
 						d.employee,
 						{
 							"salary_structure": d.salary_structure,
 							"income_tax_slab": d.income_tax_slab,
 							"allow_tax_exemption": tax_slab.allow_tax_exemption,
-							"taxable_earnings_till_date": d.taxable_earnings_till_date or 0.0,
-							"tax_deducted_till_date": d.tax_deducted_till_date or 0.0,
+							"taxable_earnings_till_date": flt(d.taxable_earnings_till_date)
+							if opening_entries_applicable
+							else 0.0,
+							"tax_deducted_till_date": flt(d.tax_deducted_till_date)
+							if opening_entries_applicable
+							else 0.0,
 						},
 					)
 		return employee_ss_assignments


### PR DESCRIPTION
### Reason
In **Income Tax Computation** report, `taxable_earnings_till_date` and `tax_deducted_till_date` from the Salary Structure Assignment were being unconditionally added to Gross Earnings, even when the Salary Structure Assignment (SSA) belongs to a prior fiscal year. This caused incorrect Gross Earnings for employees who were already on the payroll at the start of the current period.

<img width="1030" height="680" alt="image" src="https://github.com/user-attachments/assets/3dc1ae6d-501d-418e-b967-78b130ec3875" />

Taxable earning addded in same payroll period
<img width="2082" height="508" alt="image" src="https://github.com/user-attachments/assets/7edaf14a-e0a5-4045-b0be-47c67b5cfed7" />

Again added in next payroll period i.e In 2026-2027 which is not correct
<img width="2098" height="480" alt="image" src="https://github.com/user-attachments/assets/e4f80166-45f9-4116-ad3c-d68090a7ce9e" />


### Changes Done
- Fetched from_date from the Salary Structure Assignment alongside other fields
- Added a check to only consider `taxable_earnings_till_date` and `tax_deducted_till_date` when the SSA's from_date falls within the current payroll period

Fixed
<img width="2092" height="480" alt="image" src="https://github.com/user-attachments/assets/d502aedf-0c2c-4051-a247-8c21a43a09f8" />


**Note:** v16 hides the Opening Balances section in the SSA form when not applicable, but existing stale values on older SSAs are still read by the report — this fix handles that case