### PR TITLE
feat(job_applicant): Hiring Pipeline Kanban view for Job Applicant

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -4,6 +4,8 @@
 # For license information, please see license.txt
 
 
+import json
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -83,6 +85,31 @@ class JobApplicant(Document):
 			emp_ref.db_set("status", "In Process")
 		elif self.status in ["Accepted", "Rejected"]:
 			emp_ref.db_set("status", self.status)
+
+
+KANBAN_COLUMNS = ["Open", "Replied", "Shortlisted", "Accepted"]
+
+
+@frappe.whitelist()
+def create_kanban_board(board_name: str) -> dict:
+	frappe.has_permission("Job Applicant", throw=True)
+
+	if frappe.db.exists("Kanban Board", board_name):
+		return frappe.get_doc("Kanban Board", board_name).as_dict()
+
+	board = frappe.new_doc("Kanban Board")
+	board.kanban_board_name = board_name
+	board.reference_doctype = "Job Applicant"
+	board.field_name = "status"
+	board.private = 0
+	board.fields = json.dumps(["designation", "applicant_rating"])
+	board.show_labels = 1
+
+	for column_name in KANBAN_COLUMNS:
+		board.append("columns", {"column_name": column_name, "status": "Active"})
+
+	board.insert(ignore_permissions=True)
+	return board.as_dict()
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/job_applicant/job_applicant_list.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant_list.js
@@ -66,9 +66,14 @@ document.addEventListener("click", function (e) {
 	const current_fraction = kanban_rating_from_stars(rating_el, OUT_OF);
 	const new_fraction = current_fraction === clicked_fraction ? 0 : clicked_fraction;
 
-	frappe.db.set_value("Job Applicant", docname, "applicant_rating", new_fraction).then(() => {
-		kanban_apply_stars(rating_el, new_fraction, OUT_OF);
-	});
+	frappe.db
+		.set_value("Job Applicant", docname, "applicant_rating", new_fraction)
+		.then(() => {
+			kanban_apply_stars(rating_el, new_fraction, OUT_OF);
+		})
+		.catch(() => {
+			kanban_apply_stars(rating_el, current_fraction, OUT_OF);
+		});
 });
 
 function kanban_rating_from_stars(rating_el, out_of) {
@@ -114,7 +119,7 @@ function patch_kanban_dialog_for_job_applicant() {
 		}
 		frappe
 			.xcall("hrms.hr.doctype.job_applicant.job_applicant.create_kanban_board", {
-				board_name: __("Hiring Pipeline"),
+				board_name: "Hiring Pipeline",
 			})
 			.then((board) => {
 				frappe.set_route("List", "Job Applicant", "Kanban", board.kanban_board_name);

--- a/hrms/hr/doctype/job_applicant/job_applicant_list.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant_list.js
@@ -2,10 +2,17 @@
 // MIT License. See license.txt
 
 frappe.listview_settings["Job Applicant"] = {
-	add_fields: ["status"],
+	add_fields: ["status", "applicant_rating", "designation"],
+
+	onload: function () {
+		patch_kanban_dialog_for_job_applicant();
+	},
+
 	get_indicator: function (doc) {
-		if (doc.status == "Accepted") {
+		if (doc.status === "Accepted") {
 			return [__(doc.status), "green", "status,=," + doc.status];
+		} else if (doc.status === "Shortlisted") {
+			return [__(doc.status), "blue", "status,=," + doc.status];
 		} else if (["Open", "Replied"].includes(doc.status)) {
 			return [__(doc.status), "orange", "status,=," + doc.status];
 		} else if (["Hold", "Rejected"].includes(doc.status)) {
@@ -13,3 +20,106 @@ frappe.listview_settings["Job Applicant"] = {
 		}
 	},
 };
+
+// Replaces the inline textarea UX with a direct frappe.new_doc() call so the
+// status of the column is pre-filled and the user lands straight on the form.
+document.addEventListener(
+	"click",
+	function (e) {
+		const add_card_btn = e.target.closest(".kanban .add-card");
+		if (!add_card_btn) return;
+
+		const route = frappe.get_route();
+		if (route[0] !== "List" || route[1] !== "Job Applicant" || route[2] !== "Kanban") return;
+
+		e.stopImmediatePropagation();
+		e.preventDefault();
+
+		const column_title = add_card_btn.closest(".kanban-column").dataset.columnValue;
+		frappe.new_doc("Job Applicant", { status: column_title });
+	},
+	true, // capture phase
+);
+
+// Allow rating stars to be clicked directly on kanban cards.
+// Clicking the same value again toggles the rating back to 0 (matches desk behaviour).
+document.addEventListener("click", function (e) {
+	const star_svg = e.target.closest(".kanban .kanban-card-doc .rating svg");
+	if (!star_svg) return;
+
+	const route = frappe.get_route();
+	if (route[0] !== "List" || route[1] !== "Job Applicant" || route[2] !== "Kanban") return;
+
+	e.stopPropagation();
+
+	const OUT_OF = 5;
+	const star_index = parseInt(star_svg.getAttribute("data-rating"), 10);
+	const rect = star_svg.getBoundingClientRect();
+	const is_left_half = e.clientX - rect.left < rect.width / 2;
+	const clicked_fraction = (is_left_half ? star_index - 0.5 : star_index) / OUT_OF;
+
+	const card_wrapper = star_svg.closest(".kanban-card-wrapper");
+	if (!card_wrapper) return;
+	const docname = decodeURIComponent(card_wrapper.dataset.name);
+
+	const rating_el = star_svg.closest(".rating");
+	const current_fraction = kanban_rating_from_stars(rating_el, OUT_OF);
+	const new_fraction = current_fraction === clicked_fraction ? 0 : clicked_fraction;
+
+	frappe.db.set_value("Job Applicant", docname, "applicant_rating", new_fraction).then(() => {
+		kanban_apply_stars(rating_el, new_fraction, OUT_OF);
+	});
+});
+
+function kanban_rating_from_stars(rating_el, out_of) {
+	let value = 0;
+	rating_el.querySelectorAll("svg").forEach((svg, i) => {
+		const has_left = svg.querySelector(".left-half").classList.contains("star-click");
+		const has_right = svg.querySelector(".right-half").classList.contains("star-click");
+		if (has_left && has_right) value = (i + 1) / out_of;
+		else if (has_left) value = (i + 0.5) / out_of;
+	});
+	return value;
+}
+
+function kanban_apply_stars(rating_el, fraction, out_of) {
+	const filled = fraction * out_of;
+	rating_el.querySelectorAll("svg").forEach((svg, i) => {
+		const n = i + 1;
+		const left = svg.querySelector(".left-half");
+		const right = svg.querySelector(".right-half");
+		if (n <= filled && filled % 1 === 0) {
+			left.classList.add("star-click");
+			right.classList.add("star-click");
+		} else if (n <= Math.floor(filled)) {
+			left.classList.add("star-click");
+			right.classList.add("star-click");
+		} else if (n - 0.5 <= filled) {
+			left.classList.add("star-click");
+			right.classList.remove("star-click");
+		} else {
+			left.classList.remove("star-click");
+			right.classList.remove("star-click");
+		}
+	});
+}
+
+function patch_kanban_dialog_for_job_applicant() {
+	if (frappe.views.KanbanView._job_applicant_kanban_patched) return;
+
+	const _original = frappe.views.KanbanView.show_kanban_dialog;
+	frappe.views.KanbanView.show_kanban_dialog = function (doctype) {
+		if (doctype !== "Job Applicant") {
+			return _original.call(this, doctype);
+		}
+		frappe
+			.xcall("hrms.hr.doctype.job_applicant.job_applicant.create_kanban_board", {
+				board_name: __("Hiring Pipeline"),
+			})
+			.then((board) => {
+				frappe.set_route("List", "Job Applicant", "Kanban", board.kanban_board_name);
+			});
+	};
+
+	frappe.views.KanbanView._job_applicant_kanban_patched = true;
+}

--- a/hrms/workspace_sidebar/recruitment.json
+++ b/hrms/workspace_sidebar/recruitment.json
@@ -33,6 +33,19 @@
   {
    "child": 0,
    "collapsible": 1,
+   "icon": "kanban",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Hiring Pipeline",
+   "link_type": "URL",
+   "open_in_new_tab": 1,
+   "show_arrow": 0,
+   "type": "Link",
+   "url": "/desk/job-applicant/view/kanban"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
    "icon": "user-round-plus",
    "indent": 0,
    "keep_closed": 0,
@@ -241,7 +254,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-04-14 12:19:55.146861",
+ "modified": "2026-06-30 12:36:28.958158",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Recruitment",


### PR DESCRIPTION
- Adds a Hiring Pipeline Kanban view for Job Applicants with 4 default columns (Open → Replied → Shortlisted → Accepted). 
- Clicking "Kanban" auto-creates the board
- Cards added from any column open a new Job Applicant form with that status pre-filled
- Reviewers can rate applicants with half-star precision directly from the board without opening the form. 
- "Hiring Pipeline" shortcut is also added to the Recruitment sidebar

<img width="2874" height="1576" alt="image" src="https://github.com/user-attachments/assets/fca6758d-a0cc-4065-97ea-e48bd565b595" />

`no-docs`