### PR TITLE
fix(pwa-link): Link field clears when selected value is outside default options page

### DIFF
--- a/frontend/src/components/Link.vue
+++ b/frontend/src/components/Link.vue
@@ -60,7 +60,7 @@ const options = createResource({
 	},
 	method: "POST",
 	transform: (data) => {
-		return data.map((doc) => {
+		const mapped = data.map((doc) => {
 			let title = null
 			if (doc.label && doc.label !== doc.value){
 				title = doc.label
@@ -72,6 +72,11 @@ const options = createResource({
 				value: doc.value,
 			}
 		})
+
+		if (props.modelValue && !mapped.find((o) => o.value === props.modelValue)) {
+			mapped.unshift({ label: props.modelValue, value: props.modelValue })
+		}
+		return mapped
 	},
 })
 
@@ -105,5 +110,20 @@ watch(
 watch(
 	() => props.filters,
 	() => reloadOptions(''),
+)
+
+watch(
+	() => props.modelValue,
+	(newVal, oldVal) => {
+		if (!newVal && oldVal) {
+			// value cleared — reload so the dropdown shows the full default list
+			searchText.value = ""
+			reloadOptions("")
+		} else if (newVal && newVal !== oldVal) {
+			// reload so transform can inject it if it's outside the default page
+			const inOptions = (options.data || []).find((o) => o.value === newVal)
+			if (options.data && !inOptions) reloadOptions("")
+		}
+	}
 )
 </script>


### PR DESCRIPTION
### Reason
- When a link field has more records than the default shown, selecting a value via search caused the field to flash blank and revert. The same issue occurred on existing documents where the saved value fell outside the default page.


### Fix
- Fixed by injecting the current value into the options list in the transform so Autocomplete can always resolve it, and reloading the default list when the value is cleared or set externally.

https://github.com/user-attachments/assets/8a0f406e-9609-4be8-9eaa-ec8e0b4e8816


Closes: https://github.com/frappe/hrms/issues/4779

**Note:** This is a known limitation of frappe-ui's Autocomplete component (v0.1.105) and is already resolved in latest frappe-ui version