### PR TITLE
fix(job_applicant): set source to Website Listing for web form submissions

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -79,6 +79,9 @@ class JobApplicant(Document):
 					_("Cannot create a Job Applicant against a closed Job Opening"), title=_("Not Allowed")
 				)
 
+		if frappe.flags.in_web_form and not self.source:
+			self.source = "Website Listing"
+
 	def set_status_for_employee_referral(self):
 		emp_ref = frappe.get_doc("Employee Referral", self.employee_referral)
 		if self.status in ["Open", "Replied", "Hold"]:


### PR DESCRIPTION
## What

When a job applicant applies through the website using the Apply Now button, the `source` field on the Job Applicant is now automatically set to `Website Listing`.

## Why

The `source` field was left blank for all web form submissions. This made it hard to tell where applicants came from. Setting it automatically removes the need for manual input.

## How

Added a check in `before_insert` on the `JobApplicant` controller. If the document is being created through a web form (`frappe.flags.in_web_form` is `True`) and `source` is not already set, it defaults to `Website Listing`. Manually created applicants with a source already set are not affected.