### PR TITLE
fix(pwa): resolve blank employee number and reports_to in Profile

### DIFF
--- a/frontend/src/components/EmployeeAvatar.vue
+++ b/frontend/src/components/EmployeeAvatar.vue
@@ -7,7 +7,7 @@
 			:size="props.size"
 		/>
 		<div class="text-base text-gray-800 grow">
-			{{ employee?.employee_name }}
+			{{ employee?.employee_name || props.employeeID }}
 		</div>
 	</div>
 

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -124,7 +124,7 @@
 							const [label, fieldtype] = getFieldInfo(field)
 							return {
 								fieldname: field,
-								value: employeeDoc.doc[field],
+								value: getFieldValue(field),
 								label: label,
 								fieldtype: fieldtype,
 							}
@@ -138,7 +138,7 @@
 </template>
 
 <script setup>
-import { computed, inject, ref, onMounted, onBeforeUnmount } from "vue"
+import { computed, inject, ref, watch, onMounted, onBeforeUnmount } from "vue"
 import { useRouter } from "vue-router"
 import { IonPage, IonContent } from "@ionic/vue"
 import { FeatherIcon, createDocumentResource, createResource, toast } from "frappe-ui"
@@ -244,6 +244,19 @@ const employeeDoc = createDocumentResource({
 	},
 })
 
+const reportsToName = createResource({
+	url: "hrms.api.get_reports_to_employee_name",
+})
+
+watch(
+	() => employeeDoc.doc?.reports_to,
+	(reports_to) => {
+		if (reports_to) {
+			reportsToName.submit({ employee: reports_to })
+		}
+	}
+)
+
 const employeeDocType = createResource({
 	url: "hrms.api.get_doctype_fields",
 	params: { doctype: DOCTYPE },
@@ -255,6 +268,16 @@ const getFieldInfo = (fieldname) => {
 		(field) => field.fieldname === fieldname
 	)
 	return [__(field?.label, null, "Employee"), field?.fieldtype]
+}
+
+const getFieldValue = (fieldname) => {
+	if (fieldname === "employee_number" && !employeeDoc.doc[fieldname]) {
+		return employeeDoc.doc["name"]
+	}
+	if (fieldname === "reports_to") {
+		return reportsToName.data || employeeDoc.doc[fieldname]
+	}
+	return employeeDoc.doc[fieldname]
 }
 
 const logout = async () => {

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -78,6 +78,17 @@ def get_all_employees() -> list[dict]:
 	)
 
 
+@frappe.whitelist()
+def get_reports_to_employee_name(employee: str) -> str:
+	reports_to = frappe.db.get_value(
+		"Employee", {"user_id": frappe.session.user, "status": "Active"}, "reports_to"
+	)
+	if not reports_to or reports_to != employee:
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	return frappe.db.get_value("Employee", employee, "employee_name") or ""
+
+
 def get_current_employee() -> str:
 	employee = get_current_employee_info().get("name")
 	if not employee:


### PR DESCRIPTION
### Reason
In the PWA Profile page, `employee_number` and `reports_to` fields were showing blank.
When **Employee Naming By** is set to **Naming Series** in HR Settings, the `employee_number` field is hidden on the desk since the naming series auto-generates the employee ID — leaving the field empty. This caused it to appear blank in the PWA.

For `reports_to`, an employee should always be able to see who they report to as configured in their record, but permission restrictions on other employee records prevented the manager's name from being resolved in the PWA.

### Changes Done
- Show employee ID as fallback when `employee_number` is not set
- Resolve and display the manager's name for the `reports_to` field
<img width="304" height="480" alt="image" src="https://github.com/user-attachments/assets/6f88cda9-e97f-4940-b5f3-0d39abaa4796" />

<img width="304" height="480" alt="image" src="https://github.com/user-attachments/assets/f3db2aca-4476-4316-bcb4-2f88e30897b2" />
