### PR TITLE
fix(leave_policy_assignment): half-yearly earned leave schedule for joining date based assignments

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -253,11 +253,18 @@ class LeavePolicyAssignment(Document):
 			"Yearly": (1, 12),
 		}.get(earned_leave_frequency)
 
-		periods_passed = calculate_periods_passed(
-			current_date, from_date, periods_per_year, months_per_period, consider_current_period
+		effective_from = self.effective_from if earned_leave_frequency == "Half-Yearly" else None
+		return max(
+			calculate_periods_passed(
+				current_date,
+				from_date,
+				periods_per_year,
+				months_per_period,
+				consider_current_period,
+				effective_from=effective_from,
+			),
+			0,
 		)
-
-		return periods_passed
 
 	def calculate_leaves_for_passed_period(
 		self, annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
@@ -301,6 +308,7 @@ class LeavePolicyAssignment(Document):
 		self, annual_allocation, leave_details, date_of_joining, new_leaves_allocated
 	):
 		from hrms.hr.utils import (
+			get_complete_month_count,
 			get_expected_allocation_date_for_period,
 			get_monthly_earned_leave,
 			get_sub_period_start_and_end,
@@ -326,7 +334,16 @@ class LeavePolicyAssignment(Document):
 			date_of_joining,
 			effective_from=self.effective_from,
 		)
+		if (
+			leave_details.earned_leave_frequency == "Half-Yearly"
+			and self.assignment_based_on == "Joining Date"
+			and to_date >= add_months(from_date, 12)
+		):
+			max_allocations = get_complete_month_count(to_date, from_date) // months_to_add
+		else:
+			max_allocations = 0
 		schedule = []
+		allocations_added = 0
 		if new_leaves_allocated:
 			schedule.append(
 				{
@@ -337,6 +354,7 @@ class LeavePolicyAssignment(Document):
 					"attempted": 1,
 				}
 			)
+			allocations_added += 1
 			last_allocated_date = get_sub_period_start_and_end(
 				today,
 				leave_details.earned_leave_frequency,
@@ -354,6 +372,9 @@ class LeavePolicyAssignment(Document):
 					"attempted": 1 if date_already_passed else 0,
 				}
 				schedule.append(row)
+				allocations_added += 1
+				if max_allocations and allocations_added >= max_allocations:
+					break
 			date = get_expected_allocation_date_for_period(
 				leave_details.earned_leave_frequency,
 				leave_details.allocate_on_day,
@@ -363,7 +384,7 @@ class LeavePolicyAssignment(Document):
 			)
 		if from_date < getdate(date_of_joining):
 			pro_rated_period_start, pro_rated_period_end = get_sub_period_start_and_end(
-				date_of_joining, leave_details.earned_leave_frequency
+				date_of_joining, leave_details.earned_leave_frequency, effective_from=self.effective_from
 			)
 			pro_rated_earned_leave = get_monthly_earned_leave(
 				date_of_joining,
@@ -391,12 +412,19 @@ def get_pro_rata_period_end_date(consider_current_month):
 
 
 def calculate_periods_passed(
-	current_date, from_date, periods_per_year, months_per_period, consider_current_period
+	current_date, from_date, periods_per_year, months_per_period, consider_current_period, effective_from=None
 ):
-	periods_passed = 0
+	if effective_from:
+		from hrms.hr.utils import get_complete_month_count
 
-	from_period = (from_date.year * periods_per_year) + ((from_date.month - 1) // months_per_period)
-	current_period = (current_date.year * periods_per_year) + ((current_date.month - 1) // months_per_period)
+		effective_from = getdate(effective_from)
+		from_period = get_complete_month_count(from_date, effective_from) // months_per_period
+		current_period = get_complete_month_count(current_date, effective_from) // months_per_period
+	else:
+		from_period = (from_date.year * periods_per_year) + ((from_date.month - 1) // months_per_period)
+		current_period = (current_date.year * periods_per_year) + (
+			(current_date.month - 1) // months_per_period
+		)
 
 	periods_passed = current_period - from_period
 	if consider_current_period:
@@ -410,8 +438,7 @@ def is_earned_leave_applicable_for_current_period(
 ):
 	date = getdate(frappe.flags.current_date) or getdate()
 
-	# For Half-Yearly, compute preiod relative to effective_from
-	# instead of calendar year
+	# For Half-Yearly, compute period relative to effective_from instead of calendar year
 	if earned_leave_frequency == "Half-Yearly" and effective_from:
 		from hrms.hr.utils import get_half_year_periods
 

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -339,7 +339,7 @@ class LeavePolicyAssignment(Document):
 			and self.assignment_based_on == "Joining Date"
 			and to_date >= add_months(from_date, 12)
 		):
-			max_allocations = get_complete_month_count(to_date, from_date) // months_to_add
+			max_allocations = get_complete_month_count(to_date, from_date) // months_to_add + 1
 		else:
 			max_allocations = 0
 		schedule = []

--- a/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -420,3 +420,108 @@ class TestLeavePolicyAssignment(HRMSTestSuite):
 		self.assertIn(getdate("2027-03-31"), allocation_dates)
 		self.assertNotIn(getdate("2026-06-30"), allocation_dates)
 		self.assertEqual(len(allocation_dates), 2)
+
+	def test_half_yearly_earned_leave_schedule_based_on_joining_date_mid_month_first_day(self):
+		"""
+		Employee joins: 27-May-2026 (mid-month), assignment created: 03-Jul-2026
+		Period 1: 27-May-2026 → 26-Nov-2026, Period 2: 27-Nov-2026 → 26-May-2027
+		Expected allocation dates: 03-Jul-2026 (period 1 credited on assignment date), 27-Nov-2026
+		"""
+		self.employee.date_of_joining = getdate("2026-05-27")
+		self.employee.save()
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test Half Yearly Earned Leave Joining Date First Day",
+			is_earned_leave=True,
+			earned_leave_frequency="Half-Yearly",
+			allocate_on_day="First Day",
+		)
+		annual_allocation = 18
+		leave_policy = create_leave_policy(leave_type=leave_type.name, annual_allocation=annual_allocation)
+		leave_policy.submit()
+
+		# assignment created mid-period
+		frappe.flags.current_date = getdate("2026-07-03")
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Joining Date",
+				"leave_policy": leave_policy.name,
+				"effective_from": self.employee.date_of_joining,
+				"effective_to": getdate("2027-05-26"),
+			}
+		)
+		assignment = create_assignment(self.employee.name, data)
+		assignment.submit()
+
+		allocation_name = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "name"
+		)
+		schedule = frappe.get_all(
+			"Earned Leave Schedule",
+			filters={"parent": allocation_name},
+			fields=["allocation_date"],
+			order_by="allocation_date asc",
+		)
+
+		allocation_dates = [getdate(row.allocation_date) for row in schedule]
+
+		self.assertIn(getdate("2026-07-03"), allocation_dates)
+		self.assertIn(getdate("2026-11-27"), allocation_dates)
+		self.assertNotIn(getdate("2026-06-30"), allocation_dates)
+		self.assertNotIn(getdate("2027-05-27"), allocation_dates)
+
+		# should be exactly 2 allocations, not 3
+		self.assertEqual(len(allocation_dates), 2)
+
+	def test_half_yearly_earned_leave_schedule_based_on_joining_date_mid_month_last_day(self):
+		"""
+		Employee joins: 27-May-2026 (mid-month), assignment created: 03-Jul-2026
+		Period 1: 27-May-2026 → 26-Nov-2026, Period 2: 27-Nov-2026 → 26-May-2027
+		Expected allocation dates: 26-Nov-2026, 26-May-2027
+		"""
+		self.employee.date_of_joining = getdate("2026-05-27")
+		self.employee.save()
+
+		leave_type = create_leave_type(
+			leave_type_name="_Test Half Yearly Earned Leave Joining Date Last Day",
+			is_earned_leave=True,
+			earned_leave_frequency="Half-Yearly",
+			allocate_on_day="Last Day",
+		)
+		annual_allocation = 18
+		leave_policy = create_leave_policy(leave_type=leave_type.name, annual_allocation=annual_allocation)
+		leave_policy.submit()
+
+		# assignment created mid-period
+		frappe.flags.current_date = getdate("2026-07-03")
+
+		data = frappe._dict(
+			{
+				"assignment_based_on": "Joining Date",
+				"leave_policy": leave_policy.name,
+				"effective_from": self.employee.date_of_joining,
+				"effective_to": getdate("2027-05-26"),
+			}
+		)
+		assignment = create_assignment(self.employee.name, data)
+		assignment.submit()
+
+		allocation_name = frappe.db.get_value(
+			"Leave Allocation", {"leave_policy_assignment": assignment.name}, "name"
+		)
+		schedule = frappe.get_all(
+			"Earned Leave Schedule",
+			filters={"parent": allocation_name},
+			fields=["allocation_date"],
+			order_by="allocation_date asc",
+		)
+
+		allocation_dates = [getdate(row.allocation_date) for row in schedule]
+
+		self.assertIn(getdate("2026-11-26"), allocation_dates)
+		self.assertIn(getdate("2027-05-26"), allocation_dates)
+		self.assertNotIn(getdate("2026-06-30"), allocation_dates)
+
+		# should be exactly 2 allocations, not 3
+		self.assertEqual(len(allocation_dates), 2)

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -1077,7 +1077,8 @@ def get_semester_end(date):
 def get_complete_month_count(date, effective_from):
 	"""Returns count of complete months from effective_from to date, accounting for day-of-month."""
 	month_count = (date.year - effective_from.year) * 12 + (date.month - effective_from.month)
-	if date.day < effective_from.day:
+	# ignore a smaller day caused by a shorter month (e.g. 31st -> 28th)
+	if date.day < effective_from.day and date != get_last_day(date):
 		month_count -= 1
 	return month_count
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -1074,27 +1074,22 @@ def get_semester_end(date):
 		return add_months(get_year_ending(date), -6)
 
 
+def get_complete_month_count(date, effective_from):
+	"""Returns count of complete months from effective_from to date, accounting for day-of-month."""
+	month_count = (date.year - effective_from.year) * 12 + (date.month - effective_from.month)
+	if date.day < effective_from.day:
+		month_count -= 1
+	return month_count
+
+
 def get_half_year_periods(date, effective_from):
-	"""
-	Compute the half-year period relative to effective_from,
-	NOT relative to the calendar year.
-
-	Example:
-		effective_from = 01-Apr-2026
-		date           = 01-Apr-2026
-		→ period_start = 01-Apr-2026, period_end = 30-Sep-2026
-
-		date           = 01-Oct-2026
-		→ period_start = 01-Oct-2026, period_end = 31-Mar-2027
-	"""
+	"""Return (start, end) of the half-year period containing date, relative to effective_from."""
 	effective_from = getdate(effective_from)
 	date = getdate(date)
 
-	# Find how many full 6-month periods have elapsed since effective_from
-	months_elapsed = (date.year - effective_from.year) * 12 + (date.month - effective_from.month)
-	periods_elapsed = months_elapsed // 6
+	half_years_passed = get_complete_month_count(date, effective_from) // 6
 
-	half_year_start = add_months(effective_from, periods_elapsed * 6)
+	half_year_start = add_months(effective_from, half_years_passed * 6)
 	half_year_end = add_days(add_months(half_year_start, 6), -1)
 
 	return half_year_start, half_year_end


### PR DESCRIPTION
### Reason
Half-yearly earned leave schedule was showing incorrect allocation dates and leave amounts when the assignment was based on the employee's joining date. The period boundaries were being calculated against the calendar year instead of the actual joining date.

### Changes Done
- Fixed get_half_year_periods to correctly handle dates where the day falls before the joining day (introduced in [#4694](https://github.com/frappe/hrms/pull/4694))
- Fixed Half-Yearly initial leave count to use joining date-relative period counting instead of calendar year
- Added a cap on schedule entries to prevent extra allocations and fixed pro-rated leave to use correct period boundaries

Joining Date: 27-05-2026
Period 1: 27-05-2026 → 26-11-2026
Period 2: 27-11-2026 → 26-05-2027

Allocate on First Day (assignment created on 03-07-2026)
Period 1 → First Day: 27-05-2026 → credited on assignment date → 03-07-2026 = 9
Period 2 → First Day: 27-11-2026 = 9

Allocate on Last Day (assignment created on 03-07-2026)
Period 1 → Last Day: 26-11-2026 = 9
Period 2 → Last Day: 26-05-2027 = 9

<img width="1882" height="1212" alt="image" src="https://github.com/user-attachments/assets/2a39a537-a503-44a6-ae0f-52b9b025e5e8" />

<img width="2880" height="1450" alt="image" src="https://github.com/user-attachments/assets/f3eab8c3-2072-4923-a6da-7da86cfcf3d6" />
