### PR TITLE
feat: add Bulk Holiday List Assignment tool

### DIFF
--- a/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.js
+++ b/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.js
@@ -1,0 +1,159 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Bulk Holiday List Assignment", {
+	setup(frm) {
+		frm.trigger("set_queries");
+		hrms.setup_employee_filter_group(frm);
+	},
+
+	refresh(frm) {
+		frm.page.clear_indicator();
+		frm.disable_save();
+		frm.trigger("set_primary_action");
+		frm.trigger("get_employees");
+		hrms.handle_realtime_bulk_action_notification(
+			frm,
+			"completed_bulk_holiday_list_assignment",
+			"Holiday List Assignment",
+		);
+	},
+
+	holiday_list(frm) {
+		frm.trigger("set_from_date");
+	},
+
+	from_date(frm) {
+		frm.trigger("get_employees");
+	},
+
+	company(frm) {
+		frm.trigger("get_employees");
+	},
+
+	branch(frm) {
+		frm.trigger("get_employees");
+	},
+
+	department(frm) {
+		frm.trigger("get_employees");
+	},
+
+	designation(frm) {
+		frm.trigger("get_employees");
+	},
+
+	employment_type(frm) {
+		frm.trigger("get_employees");
+	},
+
+	grade(frm) {
+		frm.trigger("get_employees");
+	},
+
+	set_queries(frm) {
+		frm.set_query("department", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
+	},
+
+	set_from_date(frm) {
+		if (!frm.doc.holiday_list) return;
+		frappe.db.get_value("Holiday List", frm.doc.holiday_list, "from_date", (r) => {
+			frm.set_value("from_date", r.from_date);
+		});
+	},
+
+	set_primary_action(frm) {
+		frm.page.set_primary_action(__("Assign Holiday List"), () => {
+			frm.trigger("assign_holiday_list");
+		});
+	},
+
+	get_employees(frm) {
+		if (!frm.doc.holiday_list || !frm.doc.from_date)
+			return frm.events.render_employees_datatable(frm, []);
+
+		frm.call({
+			method: "get_employees",
+			args: {
+				advanced_filters: frm.advanced_filters || [],
+			},
+			doc: frm.doc,
+		}).then((r) => frm.events.render_employees_datatable(frm, r.message));
+	},
+
+	render_employees_datatable(frm, employees) {
+		const columns = frm.events.get_employees_datatable_columns();
+		const no_data_message = __(
+			frm.doc.holiday_list && frm.doc.from_date
+				? "There are no employees without a Holiday List Assignment on this date based on the given filters."
+				: "Please select Holiday List and Assignment Starts From date.",
+		);
+
+		hrms.render_employees_datatable(frm, columns, employees, no_data_message);
+	},
+
+	get_employees_datatable_columns() {
+		return [
+			{
+				name: "employee",
+				id: "employee",
+				content: __("Employee"),
+			},
+			{
+				name: "employee_name",
+				id: "employee_name",
+				content: __("Name"),
+			},
+			{
+				name: "department",
+				id: "department",
+				content: __("Department"),
+			},
+			{
+				name: "designation",
+				id: "designation",
+				content: __("Designation"),
+			},
+		].map((x) => ({
+			...x,
+			editable: false,
+			focusable: false,
+			dropdown: false,
+			align: "left",
+		}));
+	},
+
+	assign_holiday_list(frm) {
+		const check_map = frm.employees_datatable.rowmanager.checkMap;
+		const selected_employees = [];
+		check_map.forEach((is_checked, idx) => {
+			if (is_checked)
+				selected_employees.push(frm.employees_datatable.datamanager.data[idx].employee);
+		});
+
+		hrms.validate_mandatory_fields(frm, selected_employees);
+
+		frappe.confirm(
+			__("Assign Holiday List to {0} employee(s)?", [selected_employees.length]),
+			() => frm.events.bulk_assign_holiday_list(frm, selected_employees),
+		);
+	},
+
+	bulk_assign_holiday_list(frm, employees) {
+		frm.call({
+			method: "bulk_assign_holiday_list",
+			doc: frm.doc,
+			args: {
+				employees: employees,
+			},
+			freeze: true,
+			freeze_message: __("Assigning Holiday List"),
+		});
+	},
+});

--- a/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.json
+++ b/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.json
@@ -1,0 +1,149 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-07-05 13:19:31.621731",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "set_assignment_details_section",
+  "holiday_list",
+  "from_date",
+  "quick_filters_section",
+  "company",
+  "branch",
+  "department",
+  "column_break_jcpq",
+  "designation",
+  "employment_type",
+  "grade",
+  "advanced_filters_section",
+  "filter_list",
+  "select_employees_section",
+  "employees_html"
+ ],
+ "fields": [
+  {
+   "fieldname": "set_assignment_details_section",
+   "fieldtype": "Section Break",
+   "label": "Set Assignment Details"
+  },
+  {
+   "fieldname": "holiday_list",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Holiday List",
+   "options": "Holiday List",
+   "reqd": 1
+  },
+  {
+   "depends_on": "holiday_list",
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Assignment Starts From",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "quick_filters_section",
+   "fieldtype": "Section Break",
+   "label": "Quick Filters"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "branch",
+   "fieldtype": "Link",
+   "label": "Branch",
+   "options": "Branch"
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "label": "Department",
+   "options": "Department"
+  },
+  {
+   "fieldname": "column_break_jcpq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation"
+  },
+  {
+   "fieldname": "employment_type",
+   "fieldtype": "Link",
+   "label": "Employment Type",
+   "options": "Employment Type"
+  },
+  {
+   "fieldname": "grade",
+   "fieldtype": "Link",
+   "label": "Employee Grade",
+   "options": "Employee Grade"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "advanced_filters_section",
+   "fieldtype": "Section Break",
+   "label": "Advanced Filters"
+  },
+  {
+   "fieldname": "filter_list",
+   "fieldtype": "HTML",
+   "label": "Filter List"
+  },
+  {
+   "fieldname": "select_employees_section",
+   "fieldtype": "Section Break",
+   "label": "Select Employees"
+  },
+  {
+   "fieldname": "employees_html",
+   "fieldtype": "HTML",
+   "label": "Employees HTML"
+  }
+ ],
+ "grid_page_length": 50,
+ "hide_toolbar": 1,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-07-05 13:19:31.621731",
+ "modified_by": "Administrator",
+ "module": "HR",
+ "name": "Bulk Holiday List Assignment",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "HR User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.py
+++ b/hrms/hr/doctype/bulk_holiday_list_assignment/bulk_holiday_list_assignment.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.query_builder.terms import SubQuery
+from frappe.utils import get_link_to_form, getdate
+
+from hrms.hr.utils import validate_bulk_tool_fields
+
+
+class BulkHolidayListAssignment(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		branch: DF.Link | None
+		company: DF.Link | None
+		department: DF.Link | None
+		designation: DF.Link | None
+		employment_type: DF.Link | None
+		from_date: DF.Date
+		grade: DF.Link | None
+		holiday_list: DF.Link
+	# end: auto-generated types
+
+	def validate_assignment_start_date(self):
+		holiday_list_start, holiday_list_end = frappe.db.get_value(
+			"Holiday List", self.holiday_list, ["from_date", "to_date"]
+		)
+		assignment_start_date = getdate(self.from_date)
+		if (assignment_start_date < holiday_list_start) or (assignment_start_date > holiday_list_end):
+			frappe.throw(_("Assignment start date cannot be outside holiday list dates"))
+
+	@frappe.whitelist()
+	def get_employees(self, advanced_filters: list) -> list:
+		quick_filter_fields = [
+			"company",
+			"branch",
+			"department",
+			"designation",
+			"employment_type",
+			"grade",
+		]
+		filters = [[d, "=", self.get(d)] for d in quick_filter_fields if self.get(d)]
+		filters += advanced_filters
+		filters.append(["status", "=", "Active"])
+
+		holiday_list_start, holiday_list_end = frappe.db.get_value(
+			"Holiday List", self.holiday_list, ["from_date", "to_date"]
+		)
+
+		Assignment = frappe.qb.DocType("Holiday List Assignment")
+		employees_with_assignments = SubQuery(
+			frappe.qb.from_(Assignment)
+			.select(Assignment.assigned_to)
+			.distinct()
+			.where(
+				(Assignment.applicable_for == "Employee")
+				& (Assignment.from_date[holiday_list_start:holiday_list_end])
+				& (Assignment.docstatus == 1)
+			)
+		)
+
+		Employee = frappe.qb.DocType("Employee")
+		query = frappe.qb.get_query(
+			Employee,
+			fields=[Employee.employee, Employee.employee_name, Employee.department, Employee.designation],
+			filters=filters,
+		).where(Employee.employee.notin(employees_with_assignments))
+		return query.run(as_dict=True)
+
+	@frappe.whitelist()
+	def bulk_assign_holiday_list(self, employees: list) -> None:
+		mandatory_fields = ["holiday_list", "from_date"]
+		validate_bulk_tool_fields(self, mandatory_fields, employees)
+		self.validate_assignment_start_date()
+
+		if len(employees) <= 30:
+			return self._bulk_assign_holiday_list(employees)
+
+		frappe.enqueue(self._bulk_assign_holiday_list, timeout=3000, employees=employees)
+		frappe.msgprint(
+			_("Creation of Holiday List Assignments has been queued. It may take a few minutes."),
+			alert=True,
+			indicator="blue",
+		)
+
+	def _bulk_assign_holiday_list(self, employees: list) -> None:
+		success, failure = [], []
+		count = 0
+		savepoint = "before_holiday_list_assignment"
+
+		for employee in employees:
+			try:
+				frappe.db.savepoint(savepoint)
+				assignment = frappe.new_doc("Holiday List Assignment")
+				assignment.applicable_for = "Employee"
+				assignment.assigned_to = employee
+				assignment.holiday_list = self.holiday_list
+				assignment.from_date = self.from_date
+				assignment.insert()
+				assignment.submit()
+			except Exception:
+				frappe.db.rollback(save_point=savepoint)
+				frappe.log_error(
+					f"Bulk Assignment - Holiday List Assignment failed for employee {employee}.",
+					reference_doctype="Holiday List Assignment",
+				)
+				failure.append(employee)
+			else:
+				success.append(
+					{
+						"doc": get_link_to_form("Holiday List Assignment", assignment.name),
+						"employee": employee,
+					}
+				)
+
+			count += 1
+			frappe.publish_progress(count * 100 / len(employees), title=_("Assigning Holiday List..."))
+
+		frappe.publish_realtime(
+			"completed_bulk_holiday_list_assignment",
+			message={"success": success, "failure": failure},
+			doctype="Bulk Holiday List Assignment",
+			after_commit=True,
+		)

--- a/hrms/hr/doctype/bulk_holiday_list_assignment/test_bulk_holiday_list_assignment.py
+++ b/hrms/hr/doctype/bulk_holiday_list_assignment/test_bulk_holiday_list_assignment.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.utils import add_days, getdate
+
+from erpnext.setup.doctype.employee.test_employee import make_employee
+from erpnext.setup.doctype.holiday_list.test_holiday_list import make_holiday_list
+
+from hrms.hr.doctype.bulk_holiday_list_assignment.bulk_holiday_list_assignment import (
+	BulkHolidayListAssignment,
+)
+from hrms.tests.test_utils import create_company, create_department
+from hrms.tests.utils import HRMSTestSuite
+
+
+class TestBulkHolidayListAssignment(HRMSTestSuite):
+	def setUp(self):
+		create_company()
+		self.department = create_department("Accounts")
+
+		self.today = getdate()
+		self.holiday_list = make_holiday_list(
+			"Bulk Assignment Test Holiday List",
+			from_date=add_days(self.today, -10),
+			to_date=add_days(self.today, 10),
+		).name
+
+		self.emp1 = make_employee(
+			"employee1@bhla.com", company="_Test Company", department=self.department
+		)
+		self.emp2 = make_employee(
+			"employee2@bhla.com", company="_Test Company", department=self.department
+		)
+		# no department
+		self.emp3 = make_employee("employee3@bhla.com", company="_Test Company")
+
+	def make_assignment(self, employee, holiday_list, from_date):
+		frappe.get_doc(
+			{
+				"doctype": "Holiday List Assignment",
+				"applicable_for": "Employee",
+				"assigned_to": employee,
+				"holiday_list": holiday_list,
+				"from_date": from_date,
+			}
+		).submit()
+
+	def test_get_employees(self):
+		# assignment falls within the chosen holiday list's period
+		self.make_assignment(self.emp2, self.holiday_list, add_days(self.today, -5))
+
+		args = {
+			"doctype": "Bulk Holiday List Assignment",
+			"holiday_list": self.holiday_list,
+			"from_date": self.today,
+			"department": self.department,
+		}
+		bulk_assignment = BulkHolidayListAssignment(args)
+		employee_names = [d.employee for d in bulk_assignment.get_employees([])]
+
+		# employee already has an assignment within this holiday list's period
+		self.assertNotIn(self.emp2, employee_names)
+		# department quick filter applied
+		self.assertNotIn(self.emp3, employee_names)
+		self.assertIn(self.emp1, employee_names)
+		self.assertEqual(len(employee_names), 1)
+
+	def test_get_employees_ignores_assignment_outside_chosen_holiday_list_period(self):
+		# an assignment that starts before the chosen holiday list's period
+		# even begins should not count as "already assigned" for this period
+		earlier_holiday_list = make_holiday_list(
+			"Bulk Assignment Earlier Holiday List",
+			from_date=add_days(self.today, -30),
+			to_date=add_days(self.today, -20),
+		).name
+		self.make_assignment(self.emp1, earlier_holiday_list, add_days(self.today, -25))
+
+		args = {
+			"doctype": "Bulk Holiday List Assignment",
+			"holiday_list": self.holiday_list,
+			"from_date": self.today,
+			"department": self.department,
+		}
+		bulk_assignment = BulkHolidayListAssignment(args)
+		employee_names = [d.employee for d in bulk_assignment.get_employees([])]
+
+		self.assertIn(self.emp1, employee_names)
+
+	def test_bulk_assign_holiday_list(self):
+		args = {
+			"doctype": "Bulk Holiday List Assignment",
+			"holiday_list": self.holiday_list,
+			"from_date": self.today,
+		}
+		bulk_assignment = BulkHolidayListAssignment(args)
+		bulk_assignment.bulk_assign_holiday_list([self.emp1, self.emp2])
+
+		for employee in [self.emp1, self.emp2]:
+			assignment = frappe.get_value(
+				"Holiday List Assignment",
+				{"assigned_to": employee, "docstatus": 1},
+				["holiday_list", "from_date", "applicable_for"],
+				as_dict=1,
+			)
+			self.assertEqual(assignment.holiday_list, self.holiday_list)
+			self.assertEqual(assignment.from_date, self.today)
+			self.assertEqual(assignment.applicable_for, "Employee")


### PR DESCRIPTION
Bulk-assign a Holiday List to employees who don't already have one covering the selected holiday list's period, modeled on Bulk Salary Structure Assignment and Leave Control Panel.