### PR TITLE
fix(docker): install node dependencies in init.sh

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -3,6 +3,7 @@
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"
     cd frappe-bench
+    [ -d apps/frappe/node_modules ] || (cd apps/frappe && yarn install) || exit 1
     bench start
     exit 0
 fi

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,7 +14,7 @@ bench init --skip-redis-config-generation frappe-bench
 cd frappe-bench
 
 # Install Node dependencies (required for socket.io)
-cd apps/frappe && yarn install && cd ../..
+(cd apps/frappe && yarn install) || exit 1
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+# Install Node dependencies (required for socket.io, among others)
+install_node_deps() {
+    (cd apps/frappe && yarn install) || exit 1
+}
+
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"
     cd frappe-bench
-    [ -d apps/frappe/node_modules ] || (cd apps/frappe && yarn install) || exit 1
+    install_node_deps
     bench start
     exit 0
 fi
@@ -14,8 +19,7 @@ bench init --skip-redis-config-generation frappe-bench
 
 cd frappe-bench
 
-# Install Node dependencies (required for socket.io)
-(cd apps/frappe && yarn install) || exit 1
+install_node_deps
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
+
 # Install Node dependencies (required for socket.io, among others)
 install_node_deps() {
     (cd apps/frappe && yarn install) || exit 1
@@ -12,8 +14,6 @@ if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     bench start
     exit 0
 fi
-
-export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
 
 bench init --skip-redis-config-generation frappe-bench
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,11 +1,10 @@
-#!bin/bash
+#!/bin/bash
 
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"
     cd frappe-bench
     bench start
-else
-    echo "Creating new bench..."
+    exit 0
 fi
 
 export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
@@ -13,6 +12,9 @@ export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
 bench init --skip-redis-config-generation frappe-bench
 
 cd frappe-bench
+
+# Install Node dependencies (required for socket.io)
+cd apps/frappe && yarn install && cd ../..
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb


### PR DESCRIPTION
Closes #4845

## Summary

`bench init` clones the Frappe app but does not install its Node dependencies. When `bench start` later launches the socketio service, it fails because `socket.io` is missing from `apps/frappe/node_modules`.

This PR ensures `apps/frappe/node_modules` is installed before `bench start` is reached, and that the script aborts if the installation fails.

Also includes small fixes in `docker/init.sh`:
- Corrects the shebang from `#!bin/bash` to `#!/bin/bash`.
- Adds `exit 0` after the early "bench already exists" branch so the script does not fall through and attempt `bench init` again.
- Moves the NVM Node `PATH` export to the top so `yarn` is available in both the fresh-bench and existing-bench paths.

## Changes

- `docker/init.sh`:
  - Install Node dependencies after `bench init` on fresh benches.
  - Install Node dependencies on existing benches before `bench start`.
  - Abort the script if `yarn install` fails so `bench start` never runs with missing dependencies.
  - Factor the install step into a helper so both call sites are consistent.
  - Fix shebang and prevent fall-through on existing bench.
  - Export NVM Node PATH before any `yarn` invocation.

## Test plan

- [x] Run `docker compose down` and `docker compose up` in the `docker/` directory.
- [x] Verify the `frappe` container completes initialization without `Cannot find module 'socket.io'` errors.
- [x] Verify `bench start` launches web, socketio, schedule, and worker processes successfully.
- [x] Verify the site is accessible at http://localhost:8000.

Generated with [Devin](https://devin.ai)