### PR TITLE
feat(job_applicant): schedule interview dialog on job applicant form

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -168,12 +168,14 @@ frappe.ui.form.on("Job Applicant", {
 					label: __("From Time"),
 					fieldname: "from_time",
 					fieldtype: "Time",
+					reqd: 1,
 				},
 				{ fieldtype: "Column Break" },
 				{
 					label: __("To Time"),
 					fieldname: "to_time",
 					fieldtype: "Time",
+					reqd: 1,
 				},
 				{
 					fieldtype: "Section Break",

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -68,8 +68,8 @@ frappe.ui.form.on("Job Applicant", {
 				});
 			}
 			if (frm.doc.status !== "Rejected" && frm.doc.status !== "Accepted") {
-				frm.add_custom_button(__("Create Interview"), function () {
-					frm.events.create_dialog(frm);
+				frm.add_custom_button(__("Schedule Interview"), () => {
+					frm.events.show_schedule_interview_dialog(frm);
 				});
 			}
 		}
@@ -121,42 +121,96 @@ frappe.ui.form.on("Job Applicant", {
 		);
 	},
 
-	create_dialog: function (frm) {
+	show_schedule_interview_dialog: function (frm) {
+		frappe.model.with_doctype("Interview Detail", () => frm.events.show_schedule_dialog(frm));
+	},
+
+	show_schedule_dialog: function (frm) {
 		let d = new frappe.ui.Dialog({
-			title: __("Enter Interview Type"),
+			title: __("Schedule Interview"),
 			fields: [
 				{
-					label: "Interview Type",
+					label: __("Interview Type"),
 					fieldname: "interview_type",
 					fieldtype: "Link",
 					options: "Interview Type",
-					get_query: function () {
-						return {
-							filters: [["designation", "=", frm.doc.designation]],
-						};
+					reqd: 1,
+					get_query: () => ({
+						filters: frm.doc.designation
+							? [["designation", "in", [frm.doc.designation, ""]]]
+							: [],
+					}),
+					onchange() {
+						const interview_type = d.get_value("interview_type");
+						if (!interview_type) return;
+						frappe.call({
+							method: "hrms.hr.doctype.interview.interview.get_interviewers",
+							args: { interview_type },
+							callback(r) {
+								d.set_value(
+									"interviewers",
+									(r.message || []).map((i) => ({ interviewer: i.interviewer })),
+								);
+							},
+						});
 					},
 				},
+				{ fieldtype: "Column Break" },
+				{
+					label: __("Scheduled On"),
+					fieldname: "scheduled_on",
+					fieldtype: "Date",
+					reqd: 1,
+					default: frappe.datetime.get_today(),
+				},
+				{ fieldtype: "Section Break" },
+				{
+					label: __("From Time"),
+					fieldname: "from_time",
+					fieldtype: "Time",
+				},
+				{ fieldtype: "Column Break" },
+				{
+					label: __("To Time"),
+					fieldname: "to_time",
+					fieldtype: "Time",
+				},
+				{
+					fieldtype: "Section Break",
+					label: __("Interviewers"),
+				},
+				{
+					fieldname: "interviewers",
+					fieldtype: "Table MultiSelect",
+					options: "Interview Detail",
+					label: __("Interviewers"),
+				},
 			],
-			primary_action_label: __("Create Interview"),
+			primary_action_label: __("Schedule"),
 			primary_action(values) {
-				frm.events.create_interview(frm, values);
-				d.hide();
+				frappe.call({
+					method: "hrms.hr.doctype.job_applicant.job_applicant.schedule_interview",
+					args: {
+						job_applicant: frm.doc.name,
+						interview_type: values.interview_type,
+						scheduled_on: values.scheduled_on,
+						from_time: values.from_time || null,
+						to_time: values.to_time || null,
+						interviewers: values.interviewers || [],
+					},
+					callback(r) {
+						if (r.message) {
+							frappe.show_alert({
+								message: __("Interview scheduled successfully"),
+								indicator: "green",
+							});
+							d.hide();
+							frm.events.get_interview_for_dashboard(frm);
+						}
+					},
+				});
 			},
 		});
 		d.show();
-	},
-
-	create_interview: function (frm, values) {
-		frappe.call({
-			method: "hrms.hr.doctype.job_applicant.job_applicant.create_interview",
-			args: {
-				job_applicant: frm.doc.name,
-				interview_type: values.interview_type,
-			},
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			},
-		});
 	},
 });

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -155,6 +155,12 @@ frappe.ui.form.on("Job Applicant", {
 						});
 					},
 				},
+				{
+					label: __("From Time"),
+					fieldname: "from_time",
+					fieldtype: "Time",
+					reqd: 1,
+				},
 				{ fieldtype: "Column Break" },
 				{
 					label: __("Scheduled On"),
@@ -163,14 +169,6 @@ frappe.ui.form.on("Job Applicant", {
 					reqd: 1,
 					default: frappe.datetime.get_today(),
 				},
-				{ fieldtype: "Section Break" },
-				{
-					label: __("From Time"),
-					fieldname: "from_time",
-					fieldtype: "Time",
-					reqd: 1,
-				},
-				{ fieldtype: "Column Break" },
 				{
 					label: __("To Time"),
 					fieldname: "to_time",
@@ -185,7 +183,6 @@ frappe.ui.form.on("Job Applicant", {
 					fieldname: "interviewers",
 					fieldtype: "Table MultiSelect",
 					options: "Interview Detail",
-					label: __("Interviewers"),
 				},
 			],
 			primary_action_label: __("Schedule"),

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -152,6 +152,7 @@ def schedule_interview(
 	interviewers: str | list | None = None,
 ) -> str:
 	frappe.has_permission("Interview", ptype="create", throw=True)
+	frappe.has_permission("Job Applicant", ptype="read", doc=job_applicant, throw=True)
 
 	applicant = frappe.get_doc("Job Applicant", job_applicant)
 

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -143,6 +143,49 @@ def create_interview(job_applicant: str, interview_type: str) -> Document:
 
 
 @frappe.whitelist()
+def schedule_interview(
+	job_applicant: str,
+	interview_type: str,
+	scheduled_on: str,
+	from_time: str | None = None,
+	to_time: str | None = None,
+	interviewers: str | list | None = None,
+) -> str:
+	frappe.has_permission("Interview", ptype="create", throw=True)
+
+	applicant = frappe.get_doc("Job Applicant", job_applicant)
+
+	round_designation = frappe.db.get_value("Interview Type", interview_type, "designation")
+	if round_designation and applicant.designation and round_designation != applicant.designation:
+		frappe.throw(
+			_("Interview Type {0} is only applicable for Designation {1}").format(
+				frappe.bold(interview_type), frappe.bold(round_designation)
+			)
+		)
+
+	interview = frappe.new_doc("Interview")
+	interview.interview_type = interview_type
+	interview.job_applicant = applicant.name
+	interview.designation = applicant.designation
+	interview.resume_link = applicant.resume_link
+	interview.job_opening = applicant.job_title
+	interview.scheduled_on = scheduled_on
+	interview.from_time = from_time
+	interview.to_time = to_time
+
+	if isinstance(interviewers, str):
+		interviewers = json.loads(interviewers)
+
+	for entry in interviewers or []:
+		if entry.get("interviewer"):
+			interview.append("interview_details", {"interviewer": entry["interviewer"]})
+
+	interview.insert(ignore_permissions=True)
+
+	return interview.name
+
+
+@frappe.whitelist()
 def get_interview_details(job_applicant: str) -> dict:
 	frappe.has_permission("Job Applicant", "read", job_applicant, throw=True)
 	interview_details = frappe.db.get_all(


### PR DESCRIPTION
### Reason
Clicking "Create Interview" on a Job Applicant navigated away to a blank Interview form, breaking the workflow

### Changes Done
- Replaced the "Create Interview" button with "Schedule Interview" which opens a dialog collecting all details (interview type, date, from/to time, interviewers) in one place
- Interviewers are auto-populated from the Interview Type on selection, saving an extra lookup step
- Interview is created and saved directly from the dialog without navigating away from the Job Applicant form 
<img width="2876" height="1216" alt="image" src="https://github.com/user-attachments/assets/68a4e2a6-b9eb-4133-89eb-731768c29097" />


Closes: https://github.com/frappe/hrms/issues/2015