### PR TITLE
feat: add create button for leave policy assignment

### DIFF
--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.js
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.js
@@ -95,6 +95,9 @@ frappe.ui.form.on("Leave Control Panel", {
 	},
 
 	set_leave_details(frm) {
+		// the policy may be pre-filled by the caller (eg. Leave Policy > Create > Bulk Assignment)
+		const leave_policy = frm.doc.leave_policy;
+
 		frm.call("get_latest_leave_period").then((r) => {
 			frm.set_value({
 				dates_based_on: "Leave Period",
@@ -105,7 +108,7 @@ frappe.ui.form.on("Leave Control Panel", {
 				allocate_based_on_leave_policy: 1,
 				leave_type: null,
 				no_of_days: 0,
-				leave_policy: null,
+				leave_policy: leave_policy || null,
 				company: frm.doc.company,
 			});
 		});

--- a/hrms/hr/doctype/leave_policy/leave_policy.js
+++ b/hrms/hr/doctype/leave_policy/leave_policy.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Leave Policy", {
 	refresh: function (frm) {
-		if (frm.is_new()) return;
+		if (frm.doc.docstatus !== 1) return;
 
 		frm.add_custom_button(
 			__("Single Assignment"),
@@ -18,9 +18,11 @@ frappe.ui.form.on("Leave Policy", {
 		frm.add_custom_button(
 			__("Bulk Assignment"),
 			function () {
-				const doc = frappe.model.get_new_doc("Leave Control Panel");
-				doc.leave_policy = frm.doc.name;
-				frappe.set_route("Form", "Leave Control Panel", doc.name);
+				frappe.model.with_doctype("Leave Control Panel", () => {
+					const doc = frappe.model.get_new_doc("Leave Control Panel");
+					doc.leave_policy = frm.doc.name;
+					frappe.set_route("Form", "Leave Control Panel", doc.name);
+				});
 			},
 			__("Create"),
 		);

--- a/hrms/hr/doctype/leave_policy/leave_policy.js
+++ b/hrms/hr/doctype/leave_policy/leave_policy.js
@@ -1,7 +1,31 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Leave Policy", {});
+frappe.ui.form.on("Leave Policy", {
+	refresh: function (frm) {
+		if (frm.is_new()) return;
+
+		frm.add_custom_button(
+			__("Single Assignment"),
+			function () {
+				frappe.new_doc("Leave Policy Assignment", {
+					leave_policy: frm.doc.name,
+				});
+			},
+			__("Create"),
+		);
+
+		frm.add_custom_button(
+			__("Bulk Assignment"),
+			function () {
+				frappe.set_route("Form", "Leave Control Panel").then(() => {
+					cur_frm.set_value("leave_policy", frm.doc.name);
+				});
+			},
+			__("Create"),
+		);
+	},
+});
 
 frappe.ui.form.on("Leave Policy Detail", {
 	leave_type: function (frm, cdt, cdn) {

--- a/hrms/hr/doctype/leave_policy/leave_policy.js
+++ b/hrms/hr/doctype/leave_policy/leave_policy.js
@@ -18,9 +18,8 @@ frappe.ui.form.on("Leave Policy", {
 		frm.add_custom_button(
 			__("Bulk Assignment"),
 			function () {
-				frappe.set_route("Form", "Leave Control Panel").then(() => {
-					cur_frm.set_value("leave_policy", frm.doc.name);
-				});
+				frappe.route_options = { leave_policy: frm.doc.name };
+				frappe.set_route("Form", "Leave Control Panel");
 			},
 			__("Create"),
 		);

--- a/hrms/hr/doctype/leave_policy/leave_policy.js
+++ b/hrms/hr/doctype/leave_policy/leave_policy.js
@@ -18,11 +18,14 @@ frappe.ui.form.on("Leave Policy", {
 		frm.add_custom_button(
 			__("Bulk Assignment"),
 			function () {
-				frappe.route_options = { leave_policy: frm.doc.name };
-				frappe.set_route("Form", "Leave Control Panel");
+				const doc = frappe.model.get_new_doc("Leave Control Panel");
+				doc.leave_policy = frm.doc.name;
+				frappe.set_route("Form", "Leave Control Panel", doc.name);
 			},
 			__("Create"),
 		);
+
+		frm.page.set_inner_btn_group_as_primary(__("Create"));
 	},
 });
 


### PR DESCRIPTION
**Description:** Added create button group on the Leave Policy doctype with two options:

- Single Assignment -opens a new Leave Policy Assignment.
- Bulk Assignment - opens the Leave Control Panel.

**Before:**

<img width="1920" height="1008" alt="Screenshot from 2026-07-06 17-33-42" src="https://github.com/user-attachments/assets/f3c36e4f-5145-4761-8c9c-365297aed393" />


**After:**

[Screencast from 2026-07-06 17-33-08.webm](https://github.com/user-attachments/assets/bf5ba6d7-71d4-4360-b4e4-889692c818c5)


Backport needed for v-15, v-16