### PR TITLE
fix: include expense claim line projects in project total expense claim

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -248,8 +248,16 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			).run()[0][0]
 
 			task.save()
-		elif self.project:
-			frappe.get_doc("Project", self.project).update_project()
+
+		for project in self.get_linked_projects():
+			frappe.get_doc("Project", project).update_project()
+
+	def get_linked_projects(self):
+		projects = set()
+		if self.project:
+			projects.add(self.project)
+		projects.update(expense.project for expense in self.expenses if expense.project)
+		return projects
 
 	def make_gl_entries(self, cancel=False):
 		if flt(self.total_sanctioned_amount) > 0:

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -70,6 +70,56 @@ class TestExpenseClaim(HRMSTestSuite):
 		self.assertEqual(frappe.db.get_value("Task", task, "total_expense_claim"), 200)
 		self.assertEqual(frappe.db.get_value("Project", project, "total_expense_claim"), 200)
 
+	def test_total_expense_claim_for_project_set_on_expense_line(self):
+		project = create_project("_Test Project Line 1", company="_Test Company")
+
+		payable_account = get_payable_account(company_name)
+
+		expense_claim = make_expense_claim(
+			payable_account, 300, 200, company_name, "Travel Expenses - _TC3", do_not_submit=True
+		)
+		expense_claim.expenses[0].project = project
+		expense_claim.submit()
+
+		self.assertEqual(frappe.db.get_value("Project", project, "total_expense_claim"), 200)
+
+		expense_claim.cancel()
+
+		self.assertEqual(frappe.db.get_value("Project", project, "total_expense_claim"), 0)
+
+	def test_total_expense_claim_for_project_at_document_and_line_level(self):
+		document_project = create_project("_Test Project Doc Level", company="_Test Company")
+		line_project = create_project("_Test Project Line 2", company="_Test Company")
+
+		payable_account = get_payable_account(company_name)
+		cost_center = frappe.db.get_value("Company", company_name, "cost_center")
+
+		expense_claim = make_expense_claim(
+			payable_account,
+			300,
+			200,
+			company_name,
+			"Travel Expenses - _TC3",
+			project=document_project,
+			do_not_submit=True,
+		)
+		expense_claim.append(
+			"expenses",
+			{
+				"expense_type": "Travel",
+				"default_account": "Travel Expenses - _TC3",
+				"currency": expense_claim.currency,
+				"amount": 500,
+				"sanctioned_amount": 500,
+				"cost_center": cost_center,
+				"project": line_project,
+			},
+		)
+		expense_claim.submit()
+
+		self.assertEqual(frappe.db.get_value("Project", document_project, "total_expense_claim"), 200)
+		self.assertEqual(frappe.db.get_value("Project", line_project, "total_expense_claim"), 500)
+
 	def test_expense_claim_status_as_payment_from_journal_entry(self):
 		# Via Journal Entry
 		payable_account = get_payable_account(company_name)

--- a/hrms/overrides/employee_project.py
+++ b/hrms/overrides/employee_project.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-from frappe.query_builder.functions import Max, Min, Sum
+from frappe.query_builder.functions import Coalesce, Max, Min, NullIf, Sum
 from frappe.utils import flt
 
 from erpnext.projects.doctype.project.project import Project
@@ -24,10 +24,16 @@ class EmployeeProject(Project):
 
 	def update_costing(self):
 		ExpenseClaim = frappe.qb.DocType("Expense Claim")
+		ExpenseClaimDetail = frappe.qb.DocType("Expense Claim Detail")
 		self.total_expense_claim = (
-			frappe.qb.from_(ExpenseClaim)
-			.select(Sum(ExpenseClaim.total_sanctioned_amount))
-			.where((ExpenseClaim.docstatus == 1) & (ExpenseClaim.project == self.name))
+			frappe.qb.from_(ExpenseClaimDetail)
+			.inner_join(ExpenseClaim)
+			.on(ExpenseClaimDetail.parent == ExpenseClaim.name)
+			.select(Sum(ExpenseClaimDetail.sanctioned_amount))
+			.where(
+				(ExpenseClaim.docstatus == 1)
+				& (Coalesce(NullIf(ExpenseClaimDetail.project, ""), ExpenseClaim.project) == self.name)
+			)
 		).run()[0][0]
 
 		TimesheetDetail = frappe.qb.DocType("Timesheet Detail")


### PR DESCRIPTION
**Issue Statement:**

"Total Expense Claim (via Expense Claims)" field in Project does not include expense claim lines linked to the project.

**Issue Detailed Description:**
The "Total Expense Claim (via Expense Claims)" field on the Project doctype only takes into account expense claims where the project is set at the document level. Expense claim lines (Expense Claim Detail) linked to a project are ignored in the calculation, even though the official documentation (https://docs.frappe.io/erpnext/project-expense-claims) states that setting the project on an expense claim line should be enough for the amount to be included in this field.

**Steps to Replicate the issue:**

1. Create an Expense Claim without setting a project at the document level.
2. In one of the expense lines, set the Project field to "Project A".
3. Submit the Expense Claim.
4. Open "Project A" and check the "Total Expense Claim (via Expense Claims)" field.

**Before:**

[Screencast from 2026-07-08 13-29-02.webm](https://github.com/user-attachments/assets/3339819c-8c46-4bf6-9bf3-8498446c71ec)

**After:**

[Uploading Screencast from 2026-07-08 13-29-54.webm…]()
