### PR TITLE
fix: remove duplicate HRMS menus during workspace cleanup

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -40,7 +40,7 @@ hrms.patches.v15_0.add_leave_type_permission_for_ess
 hrms.patches.v15_0.remove_ess_user_type_limit
 hrms.patches.v15_0.update_approver_custom_fields
 hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
-hrms.patches.v16_0.delete_old_workspaces #2026-01-09
+hrms.patches.v16_0.delete_old_workspaces #2026-07-09
 hrms.patches.v16_0.create_holiday_list_assignments
 hrms.patches.v16_0.set_base_paid_amount_in_employee_advance
 hrms.patches.v16_0.set_currency_and_base_fields_in_expense_claim

--- a/hrms/patches/v16_0/delete_old_workspaces.py
+++ b/hrms/patches/v16_0/delete_old_workspaces.py
@@ -5,11 +5,20 @@ def execute():
 	old_workspaces = ["Expense Claims", "Salary Payout", "Employee Lifecycle", "Overview", "Attendance", "HR"]
 
 	for workspace in old_workspaces:
-		if frappe.db.exists("Workspace", {"name": workspace, "public": 1, "for_user": ("is", "Not Set")}):
-			frappe.delete_doc("Workspace", workspace, force=True)
-		if sidebar := frappe.db.exists(
-			"Workspace Sidebar", {"name": workspace, "for_user": ("is", "Not Set")}
+		if workspace_doc := frappe.db.get_value(
+			"Workspace", workspace, ["name", "public", "for_user"], as_dict=True
 		):
-			frappe.delete_doc("Workspace Sidebar", sidebar)
-		if icon := frappe.db.exists("Desktop Icon", {"link_type": "Workspace", "link_to": workspace}):
+			if workspace_doc.public and not workspace_doc.for_user:
+				frappe.delete_doc("Workspace", workspace, force=True)
+
+		if sidebar := frappe.db.get_value("Workspace Sidebar", workspace, ["name", "for_user"], as_dict=True):
+			if not sidebar.for_user:
+				frappe.delete_doc("Workspace Sidebar", sidebar.name)
+
+		old_icons = frappe.get_all(
+			"Desktop Icon",
+			filters={"link_to": workspace, "link_type": ["in", ["Workspace", "Workspace Sidebar"]]},
+			pluck="name",
+		)
+		for icon in old_icons:
 			frappe.delete_doc("Desktop Icon", icon)

--- a/hrms/patches/v16_0/delete_old_workspaces.py
+++ b/hrms/patches/v16_0/delete_old_workspaces.py
@@ -5,20 +5,25 @@ def execute():
 	old_workspaces = ["Expense Claims", "Salary Payout", "Employee Lifecycle", "Overview", "Attendance", "HR"]
 
 	for workspace in old_workspaces:
+		deleted_link_types = []
+
 		if workspace_doc := frappe.db.get_value(
 			"Workspace", workspace, ["name", "public", "for_user"], as_dict=True
 		):
 			if workspace_doc.public and not workspace_doc.for_user:
 				frappe.delete_doc("Workspace", workspace, force=True)
+				deleted_link_types.append("Workspace")
 
 		if sidebar := frappe.db.get_value("Workspace Sidebar", workspace, ["name", "for_user"], as_dict=True):
 			if not sidebar.for_user:
 				frappe.delete_doc("Workspace Sidebar", sidebar.name)
+				deleted_link_types.append("Workspace Sidebar")
 
-		old_icons = frappe.get_all(
-			"Desktop Icon",
-			filters={"link_to": workspace, "link_type": ["in", ["Workspace", "Workspace Sidebar"]]},
-			pluck="name",
-		)
-		for icon in old_icons:
-			frappe.delete_doc("Desktop Icon", icon)
+		if deleted_link_types:
+			old_icons = frappe.get_all(
+				"Desktop Icon",
+				filters={"link_to": workspace, "link_type": ["in", deleted_link_types]},
+				pluck="name",
+			)
+			for icon in old_icons:
+				frappe.delete_doc("Desktop Icon", icon)

--- a/hrms/patches/v16_0/delete_old_workspaces.py
+++ b/hrms/patches/v16_0/delete_old_workspaces.py
@@ -5,24 +5,28 @@ def execute():
 	old_workspaces = ["Expense Claims", "Salary Payout", "Employee Lifecycle", "Overview", "Attendance", "HR"]
 
 	for workspace in old_workspaces:
-		deleted_link_types = []
+		icon_link_types = []
 
 		if workspace_doc := frappe.db.get_value(
 			"Workspace", workspace, ["name", "public", "for_user"], as_dict=True
 		):
 			if workspace_doc.public and not workspace_doc.for_user:
 				frappe.delete_doc("Workspace", workspace, force=True)
-				deleted_link_types.append("Workspace")
+				icon_link_types.append("Workspace")
+		else:
+			icon_link_types.append("Workspace")
 
 		if sidebar := frappe.db.get_value("Workspace Sidebar", workspace, ["name", "for_user"], as_dict=True):
 			if not sidebar.for_user:
 				frappe.delete_doc("Workspace Sidebar", sidebar.name)
-				deleted_link_types.append("Workspace Sidebar")
+				icon_link_types.append("Workspace Sidebar")
+		else:
+			icon_link_types.append("Workspace Sidebar")
 
-		if deleted_link_types:
+		if icon_link_types:
 			old_icons = frappe.get_all(
 				"Desktop Icon",
-				filters={"link_to": workspace, "link_type": ["in", deleted_link_types]},
+				filters={"link_to": workspace, "link_type": ["in", icon_link_types]},
 				pluck="name",
 			)
 			for icon in old_icons:


### PR DESCRIPTION
### Summary

Fixes frappe/frappe#40935.

### Root Cause

The cleanup patch only removed stale `Desktop Icon` records with `link_type = "Workspace"`, so stale entries using `Workspace Sidebar` were left behind and duplicate HRMS menus could appear.

### Fix

- Remove stale public workspaces and workspace sidebars that are not user-specific.
- Remove stale desktop icons with both `Workspace` and `Workspace Sidebar` link types.
- Update the patch entry so the cleanup runs again on sites that already executed the previous patch.

### Verification

- Reproduced the duplicate menu scenario using stale HRMS workspace records.
- Ran `bench --site development.localhost migrate`.
- Verified that stale duplicate menus were removed while current HRMS menus remained unchanged.
