### PR TITLE
fix(shift_type): half-day status marked absent despite valid checkins

### DIFF
--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -27,6 +27,7 @@ from hrms.hr.doctype.attendance.attendance import mark_attendance
 from hrms.hr.doctype.employee_checkin.employee_checkin import (
 	calculate_working_hours,
 	mark_attendance_and_link_log,
+	update_attendance_in_checkins,
 )
 from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift, get_shift_details
 from hrms.utils import get_date_range
@@ -444,23 +445,61 @@ class ShiftType(Document):
 		for attendance in half_day_attendances:
 			timestamp = datetime.combine(attendance.attendance_date, start_time)
 			shift_details = get_employee_shift(employee, timestamp, True)
-			if shift_details and shift_details.shift_type.name == self.name:
+			if not (shift_details and shift_details.shift_type.name == self.name):
+				continue
+
+			logs = frappe.get_all(
+				"Employee Checkin",
+				filters={
+					"employee": employee,
+					"shift": self.name,
+					"shift_start": shift_details.start_datetime,
+				},
+				fields=["name", "time", "log_type", "shift_start", "shift_end"],
+				order_by="time",
+			)
+			if logs:
+				# unreconciled checkins exist, use them instead of assuming Absent
+				attendance_status, working_hours, late_entry, early_exit, in_time, out_time = (
+					self.get_attendance(
+						logs,
+						flt(self.working_hours_threshold_for_absent),
+						flt(self.working_hours_threshold_for_half_day),
+					)
+				)
 				frappe.db.set_value(
 					"Attendance",
 					attendance.name,
-					{"shift": self.name, "half_day_status": "Absent", "modify_half_day_status": 0},
-				)
-				frappe.get_doc(
 					{
-						"doctype": "Comment",
-						"comment_type": "Comment",
-						"reference_doctype": "Attendance",
-						"reference_name": attendance.name,
-						"content": frappe._(
-							"Employee was marked Absent for other half due to missing Employee Checkins."
-						),
-					}
-				).insert(ignore_permissions=True)
+						"shift": self.name,
+						"half_day_status": "Absent" if attendance_status == "Absent" else "Present",
+						"modify_half_day_status": 0,
+						"working_hours": working_hours,
+						"late_entry": late_entry,
+						"early_exit": early_exit,
+						"in_time": in_time,
+						"out_time": out_time,
+					},
+				)
+				update_attendance_in_checkins([log.name for log in logs], attendance.name)
+				continue
+
+			frappe.db.set_value(
+				"Attendance",
+				attendance.name,
+				{"shift": self.name, "half_day_status": "Absent", "modify_half_day_status": 0},
+			)
+			frappe.get_doc(
+				{
+					"doctype": "Comment",
+					"comment_type": "Comment",
+					"reference_doctype": "Attendance",
+					"reference_name": attendance.name,
+					"content": frappe._(
+						"Employee was marked Absent for other half due to missing Employee Checkins."
+					),
+				}
+			).insert(ignore_permissions=True)
 
 
 def update_last_sync_of_checkin():

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -342,6 +342,85 @@ class TestShiftType(HRMSTestSuite):
 		attendance = frappe.db.get_value("Attendance", {"shift": shift_type.name}, "status")
 		self.assertEqual(attendance, "Absent")
 
+	def test_mark_absent_for_half_day_dates_with_existing_checkins(self):
+		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
+
+		employee = make_employee("test_half_day_reconcile@example.com", company="_Test Company")
+		shift_type = setup_shift_type(shift_type="Half Day Reconcile Test")
+		date = getdate()
+		make_shift_assignment(shift_type.name, employee, date)
+
+		make_checkin(employee, datetime.combine(date, get_time("08:00:00")))
+		make_checkin(employee, datetime.combine(date, get_time("11:00:00")))
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": date,
+				"status": "Absent",
+				"company": "_Test Company",
+			}
+		).insert()
+		attendance.submit()
+		# simulate a half day leave getting approved after the whole day was already marked absent,
+		# leaving the checkins unreconciled with the attendance
+		attendance.db_set(
+			{
+				"status": "Half Day",
+				"leave_type": "_Test Leave Type",
+				"half_day_status": "Present",
+				"modify_half_day_status": 1,
+			}
+		)
+
+		shift_type.mark_absent_for_half_day_dates(employee)
+
+		attendance.reload()
+		self.assertEqual(attendance.half_day_status, "Present")
+		self.assertEqual(attendance.modify_half_day_status, 0)
+		self.assertFalse(
+			frappe.db.exists(
+				"Comment",
+				{
+					"reference_doctype": "Attendance",
+					"reference_name": attendance.name,
+					"content": ["like", "%missing Employee Checkins%"],
+				},
+			)
+		)
+
+	def test_mark_absent_for_half_day_dates_without_checkins(self):
+		employee = make_employee("test_half_day_no_checkin@example.com", company="_Test Company")
+		shift_type = setup_shift_type(shift_type="Half Day No Checkin Test")
+		date = getdate()
+		make_shift_assignment(shift_type.name, employee, date)
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": date,
+				"status": "Absent",
+				"company": "_Test Company",
+			}
+		).insert()
+		attendance.submit()
+		attendance.db_set(
+			{
+				"status": "Half Day",
+				"leave_type": "_Test Leave Type",
+				"half_day_status": "Present",
+				"modify_half_day_status": 1,
+			}
+		)
+
+		shift_type.mark_absent_for_half_day_dates(employee)
+
+		attendance.reload()
+		self.assertEqual(attendance.half_day_status, "Absent")
+		self.assertEqual(attendance.modify_half_day_status, 0)
+
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_mark_auto_attendance_on_holiday_enabled(self):
 		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin


### PR DESCRIPTION
### Reason
When an employee took half-day leave, the system was supposed to check their actual check-in records before marking the other half of the day as present or absent. Instead it skipped that check and defaulted to absent, so employee get deducted salary for hours they'd genuinely worked.
<img width="704" height="587" alt="image" src="https://github.com/user-attachments/assets/a973bce0-d246-47e1-8e0a-cfa417bd1e58" />
<img width="704" height="487" alt="image" src="https://github.com/user-attachments/assets/b6c25abc-ac41-4635-a557-8f582cf197e0" />


### Changes Done
- `mark_absent_for_half_day_dates` function now looks up Employee Checkin records for that employee/shift/date before deciding the status, instead of assuming absence.
- If checkins exist, it recalculates the real status/working hours via the existing `get_attendance()` logic and links the checkins to the attendance; if none exist, original behavior (mark Absent) is unchanged.
<img width="704" height="587" alt="image" src="https://github.com/user-attachments/assets/dd443497-8576-4aca-aae5-57bd1baf864f" />
<img width="704" height="487" alt="image" src="https://github.com/user-attachments/assets/f901e6cd-cb19-4356-8fab-227479c1253e" />


