### PR TITLE
fix(pwa): skip push notification config fetch without relay

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -65,13 +65,15 @@ const registerServiceWorker = async () => {
 		let serviceWorkerURL = "/assets/hrms/frontend/sw.js"
 		let config = ""
 
-		try {
-			config = await window.frappePushNotification.fetchWebConfig()
-			serviceWorkerURL = `${serviceWorkerURL}?config=${encodeURIComponent(
-				JSON.stringify(config)
-			)}`
-		} catch (err) {
-			console.error("Failed to fetch FCM config", err)
+		if (window.frappe?.boot?.push_relay_server_url) {
+			try {
+				config = await window.frappePushNotification.fetchWebConfig()
+				serviceWorkerURL = `${serviceWorkerURL}?config=${encodeURIComponent(
+					JSON.stringify(config)
+				)}`
+			} catch (err) {
+				console.error("Failed to fetch FCM config", err)
+			}
 		}
 
 		navigator.serviceWorker


### PR DESCRIPTION
Currently, every HRMS PWA attempts to load the notification relay, even when it is not configured. This is commonly the case for self-hosted instances that are not running on Frappe Cloud.

As a result, the following error appears whenever the PWA loads:

```python
15:46:14 web.1      | Traceback (most recent call last):
15:46:14 web.1      |   File "apps/frappe/frappe/handler.py", line 75, in execute_cmd
15:46:14 web.1      |     method = get_attr(cmd)
15:46:14 web.1      |   File "apps/frappe/frappe/handler.py", line 259, in get_attr
15:46:14 web.1      |     method = frappe.get_attr(cmd)
15:46:14 web.1      |   File "apps/frappe/frappe/__init__.py", line 1117, in get_attr
15:46:14 web.1      |     throw(_("App {0} is not installed").format(app_name), AppNotInstalledError)
15:46:14 web.1      |     ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 159, in throw
15:46:14 web.1      |     msgprint(
15:46:14 web.1      |     ~~~~~~~~^
15:46:14 web.1      |           msg,
15:46:14 web.1      |      ^^^^
15:46:14 web.1      |     ...<7 lines>...
15:46:14 web.1      |           allow_dangerous_html=allow_dangerous_html,
15:46:14 web.1      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:46:14 web.1      |     )
15:46:14 web.1      |     ^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 118, in msgprint
15:46:14 web.1      |     _raise_exception()
15:46:14 web.1      |     ~~~~~~~~~~~~~~~~^^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
15:46:14 web.1      |     raise exc
15:46:14 web.1      | frappe.exceptions.AppNotInstalledError: App notification_relay is not installed
15:46:14 web.1      |
15:46:14 web.1      | During handling of the above exception, another exception occurred:
15:46:14 web.1      |
15:46:14 web.1      | Traceback (most recent call last):
15:46:14 web.1      |   File "apps/frappe/frappe/app.py", line 121, in application
15:46:14 web.1      |     response = frappe.api.handle(request)
15:46:14 web.1      |   File "apps/frappe/frappe/api/__init__.py", line 63, in handle
15:46:14 web.1      |     data = endpoint(**arguments)
15:46:14 web.1      |   File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
15:46:14 web.1      |     return frappe.handler.handle()
15:46:14 web.1      |            ~~~~~~~~~~~~~~~~~~~~~^^
15:46:14 web.1      |   File "apps/frappe/frappe/handler.py", line 53, in handle
15:46:14 web.1      |     data = execute_cmd(cmd)
15:46:14 web.1      |   File "apps/frappe/frappe/handler.py", line 77, in execute_cmd
15:46:14 web.1      |     frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, str(e)))
15:46:14 web.1      |     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 159, in throw
15:46:14 web.1      |     msgprint(
15:46:14 web.1      |     ~~~~~~~~^
15:46:14 web.1      |           msg,
15:46:14 web.1      |      ^^^^
15:46:14 web.1      |     ...<7 lines>...
15:46:14 web.1      |           allow_dangerous_html=allow_dangerous_html,
15:46:14 web.1      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:46:14 web.1      |     )
15:46:14 web.1      |     ^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 118, in msgprint
15:46:14 web.1      |     _raise_exception()
15:46:14 web.1      |     ~~~~~~~~~~~~~~~~^^
15:46:14 web.1      |   File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
15:46:14 web.1      |     raise exc
15:46:14 web.1      | frappe.exceptions.ValidationError: Failed to get method for command notification_relay.api.get_config with App notification_relay is not installed
```

Although the application continues to work correctly, this error creates unnecessary noise in the logs.

This PR adds a check to determine whether the notification relay is configured. If it is not, push notification initialization is skipped entirely.
