### PR TITLE
fix(pwa): include socketio port in boot data

### DIFF
--- a/hrms/www/hrms.py
+++ b/hrms/www/hrms.py
@@ -25,6 +25,7 @@ def get_boot():
 	bootinfo = frappe._dict(
 		{
 			"site_name": frappe.local.site,
+			"socketio_port": frappe.conf.get("socketio_port") or 9000,
 			"push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
 			"default_route": get_default_route(),
 		}


### PR DESCRIPTION
The PWA reads `socketio_port` from the boot information. However, the port is currently not included in the boot data, so it always falls back to the default value of `9000`.

```javascript
let socketio_port = window.frappe?.boot?.socketio_port || 9000
```

This PR adds `socketio_port` to the boot data, allowing the PWA to use the configured Socket.IO port.
