### PR TITLE
fix(pwa): remove unused currency precision request

### DIFF
--- a/frontend/src/data/currencies.js
+++ b/frontend/src/data/currencies.js
@@ -21,13 +21,3 @@ export function getCompanyCurrencySymbol(company) {
 export function getCurrencySymbol(currency) {
 	return currencySymbols?.data?.[currency]
 }
-
-export const currencyPrecision = createResource({
-	url: "frappe.client.get_single_value",
-	params: {
-		doctype: "System Settings",
-		field: "currency_precision"
-	},
-	auto: true,
-	initialData: 2
-});


### PR DESCRIPTION
This causes an error when the PWA loads makes every employee attempt to read **System Settings**,  because of `auto: true`.

The generic Frappe endpoint correctly requires read permission for that DocType, which regular employees should not have.

This appears to be unused legacy code. The related functionality was likely removed at some point, while this request was left behind.

This PR removes the unused request.

Error:
```javascript
frappe-ui-KwweBxbp.js:1  POST http://erp.localhost:8006/api/method/frappe.client.get_single_value 403 (FORBIDDEN)
(anonymous) @ request.js:30
(anonymous) @ frappeRequest.js:4
(anonymous) @ resources.js:99
(anonymous) @ frappe-ui-KwweBxbp.js:1
qe @ frappe-ui-KwweBxbp.js:1
fetch @ resources.js:53
createResource @ resources.js:207
(anonymous) @ currencies.js:25
frappe-ui-KwweBxbp.js:1 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1147, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/client.py", line 161, in get_single_value
    frappe.throw(_("No permission for {0}").format(_(doctype)), frappe.PermissionError)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/messages.py", line 159, in throw
    msgprint(
    ~~~~~~~~^
    	msg,
     ^^^^
    ...<7 lines>...
    	allow_dangerous_html=allow_dangerous_html,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/utils/messages.py", line 118, in msgprint
    _raise_exception()
    ~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
    raise exc
frappe.exceptions.PermissionError: No permission for System Settings
```