### PR TITLE
fix(salary_slip): default amount incorrectly prorated in formula-based components

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1230,6 +1230,11 @@ class SalarySlip(TransactionBase):
 
 		# shallow copy of data to store default amounts (without payment days) for tax calculation
 		default_data = data.copy()
+		# reset to a full, un-prorated cycle so formulas like base/total_working_days*payment_days
+		# resolve consistently with the un-prorated component defaults set below
+		default_data.payment_days = default_data.total_working_days
+		default_data.leave_without_pay = 0
+		default_data.absent_days = 0
 
 		for key in ("earnings", "deductions"):
 			for d in self.get(key):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1856,6 +1856,37 @@ class TestSalarySlip(FrappeTestCase):
 
 				self.assertEqual(earning.default_amount, 19000)
 
+	@change_settings("Payroll Settings", {"payroll_based_on": "Attendance"})
+	def test_default_amount_unaffected_by_leave_without_pay(self):
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+			create_salary_structure_assignment,
+		)
+
+		emp = make_employee("test_default_amount_lwp@salary.com", company="_Test Company")
+		first_sunday = get_first_sunday()
+		mark_attendance(emp, add_days(first_sunday, 1), "Absent", ignore_validate=True)
+
+		# base = 50000
+		salary_structure = make_salary_structure_for_payment_days_based_component_dependency(
+			test_payment_days_in_formula=True
+		)
+		create_salary_structure_assignment(
+			emp, salary_structure.name, company="_Test Company", currency="INR"
+		)
+
+		ss = make_salary_slip_for_payment_days_dependency_test(
+			"test_default_amount_lwp@salary.com", salary_structure.name
+		)
+		self.assertLess(ss.payment_days, ss.total_working_days)
+
+		other_allowance = next(
+			e for e in ss.earnings if e.salary_component == "Other Allowance - Payment Days"
+		)
+
+		# default_amount = base - P_HRA = 50000 - (50000 * 0.20) = 40000, unaffected by lwp
+		self.assertEqual(other_allowance.default_amount, 40000)
+		self.assertLess(other_allowance.amount, other_allowance.default_amount)
+
 	def test_variable_tax_component(self):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
@@ -2740,7 +2771,9 @@ def make_holiday_list(
 	return holiday_list
 
 
-def make_salary_structure_for_payment_days_based_component_dependency(test_statistical_comp=False):
+def make_salary_structure_for_payment_days_based_component_dependency(
+	test_statistical_comp=False, test_payment_days_in_formula=False
+):
 	earnings = [
 		{
 			"salary_component": "Basic Salary - Payment Days",
@@ -2778,6 +2811,17 @@ def make_salary_structure_for_payment_days_based_component_dependency(test_stati
 					"depends_on_payment_days": 0,
 				},
 			]
+		)
+	if test_payment_days_in_formula:
+		earnings.append(
+			{
+				"salary_component": "Other Allowance - Payment Days",
+				"abbr": "P_OA",
+				"type": "Earning",
+				"amount_based_on_formula": 1,
+				"depends_on_payment_days": 0,
+				"formula": "(base/total_working_days*payment_days) - P_HRA",
+			}
 		)
 
 	make_salary_component(earnings, False, company_list=["_Test Company"])


### PR DESCRIPTION
### Reason
Default Amount for components whose formula uses payment days was getting affected whenever payment days differed from total working days like LWP, absences. 
<img width="2384" height="1288" alt="image" src="https://github.com/user-attachments/assets/93a15a71-7b8d-4d0b-a55f-7d5f1097ae5a" />
<img width="1924" height="828" alt="image" src="https://github.com/user-attachments/assets/092c7151-1b65-42e6-ac8f-50746421f26a" />

### Changes done
- Fixed get_data_for_eval() in Salary Slip to build the default-amount context using full, un-prorated payment days instead of the actual period's payment days, so Default Amount stays correct regardless of what's reducing payment days
<img width="2376" height="1288" alt="image" src="https://github.com/user-attachments/assets/d3816eb5-235e-4128-b2cb-76ce064a5285" />

**Note**: This was already fixed in v16 via [PR #4699](https://github.com/frappe/hrms/pull/4699), where default amount computation was moved out of the salary slip into Salary Structure Assignment, where it's calculated once assuming a full month