### PR TITLE
fix: guard whitelisted method calls on new Job Applicant/Interview

### DIFF
--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -16,6 +16,7 @@ frappe.ui.form.on("Interview", {
 		});
 
 		frm.trigger("add_custom_buttons");
+		if (frm.doc.__islocal) return;
 
 		frappe.run_serially([
 			() => frm.trigger("load_skills_average_rating"),
@@ -231,8 +232,6 @@ frappe.ui.form.on("Interview", {
 	},
 
 	load_skills_average_rating(frm) {
-		if (frm.doc.__islocal) return;
-
 		frappe
 			.call({
 				method: "hrms.hr.doctype.interview.interview.get_skill_wise_average_rating",
@@ -244,8 +243,6 @@ frappe.ui.form.on("Interview", {
 	},
 
 	load_feedback(frm) {
-		if (frm.doc.__islocal) return;
-
 		frappe
 			.call({
 				method: "hrms.hr.doctype.interview.interview.get_feedback",

--- a/hrms/hr/doctype/interview/interview.js
+++ b/hrms/hr/doctype/interview/interview.js
@@ -231,6 +231,8 @@ frappe.ui.form.on("Interview", {
 	},
 
 	load_skills_average_rating(frm) {
+		if (frm.doc.__islocal) return;
+
 		frappe
 			.call({
 				method: "hrms.hr.doctype.interview.interview.get_skill_wise_average_rating",
@@ -242,6 +244,8 @@ frappe.ui.form.on("Interview", {
 	},
 
 	load_feedback(frm) {
+		if (frm.doc.__islocal) return;
+
 		frappe
 			.call({
 				method: "hrms.hr.doctype.interview.interview.get_feedback",

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -97,6 +97,8 @@ frappe.ui.form.on("Job Applicant", {
 	},
 
 	get_interview_for_dashboard: function (frm) {
+		if (frm.doc.__islocal) return;
+
 		$("div").remove(".form-dashboard-section.custom");
 		frappe.call({
 			method: "hrms.hr.doctype.job_applicant.job_applicant.get_interview_details",


### PR DESCRIPTION
### Issue

Opening a new **Job Applicant** or **Interview** form shows a `DoesNotExistError` popup - `"Job Applicant new-job-applicant-xxxx not found"` - for non-admin users. Administrators don't see it.

On `refresh`, the forms call `get_interview_details` / `get_skill_wise_average_rating` / `get_feedback` with the current doc's name. On a new form that name is a local, unsaved id (`new-job-applicant-xxxx`). Since #4768 these methods run `frappe.has_permission("...", "read", <name>, throw=True)`, which loads the doc to do the row-level check. The doc doesn't exist yet → `DoesNotExistError`. Administrators bypass the load, so only non-admins hit it.

### Fix

Guard the dashboard/feedback loaders so they don't fire on an unsaved form:

- `job_applicant.js` → `get_interview_for_dashboard`
- `interview.js` → `load_skills_average_rating`, `load_feedback`

Each returns early via `if (frm.doc.__islocal) return;`. New forms no longer make the call; saved forms are unchanged.

### Before Fix
[Screencast from 2026-07-12 20-21-06.webm](https://github.com/user-attachments/assets/11ec4e9c-2f6c-4ae5-888c-4e91055067c7)

### After Fix
[Screencast from 2026-07-12 20-24-08.webm](https://github.com/user-attachments/assets/d8449d57-b30b-435c-8a47-6a82626653bf)


**Support Ticket**: [72998](https://support.frappe.io/helpdesk/tickets/72998)
