### PR TITLE
fix: cancelled Shift Assignments silently block new shift creation via Roster API

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -228,6 +228,7 @@ def insert_shift(
 		"shift_type": shift_type,
 		"status": status,
 		"shift_location": shift_location,
+		"docstatus": ["!=", 2],
 	}
 	prev_shift = frappe.db.exists(dict({"end_date": add_days(start_date, -1)}, **filters))
 	next_shift = (

--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -60,6 +60,7 @@ class ShiftAssignment(Document):
 	def on_cancel(self):
 		self.validate_employee_checkin()
 		self.validate_attendance()
+		self.db_set("status", "Inactive", update_modified=False)
 
 	def validate_employee_checkin(self):
 		checkins = frappe.get_all(

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -38,14 +38,16 @@ class TestRoster(HRMSTestSuite):
 		)
 
 		# Create a shift assignment with a date range, submit it, then cancel it
-		original = frappe.get_doc({
-			"doctype": "Shift Assignment",
-			"employee": employee.name,
-			"company": "_Test Company",
-			"shift_type": shift_type.name,
-			"start_date": "2026-07-01",
-			"end_date": "2026-07-10",
-		})
+		original = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": employee.name,
+				"company": "_Test Company",
+				"shift_type": shift_type.name,
+				"start_date": "2026-07-01",
+				"end_date": "2026-07-10",
+			}
+		)
 		original.submit()
 		original.cancel()
 		original.reload()

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.utils import add_days, getdate
 
-from hrms.api.roster import get_shifts
+from hrms.api.roster import get_shifts, insert_shift
 from hrms.tests.utils import HRMSTestSuite
 
 
@@ -25,6 +25,58 @@ class TestRoster(HRMSTestSuite):
 		self.assertEqual(str(shifts[employee.name][0]["start_time"]), "10:00:00")
 		self.assertEqual(str(shifts[employee.name][0]["end_time"]), "18:00:00")
 		self.assertEqual(shifts[employee.name][0]["color"], "Violet")
+
+	def test_insert_shift_ignores_cancelled_assignment(self):
+		"""Cancelled Shift Assignments should not block or be mutated by insert_shift."""
+		employee_name = f"_Test Roster Cancel {frappe.generate_hash(length=8)}"
+		employee = create_employee(employee_name)
+		shift_type = create_shift_type(
+			f"_Test Cancel Shift {frappe.generate_hash(length=8)}",
+			start_time="08:00:00",
+			end_time="17:00:00",
+			color="Red",
+		)
+
+		# Create a shift assignment with a date range, submit it, then cancel it
+		original = frappe.get_doc({
+			"doctype": "Shift Assignment",
+			"employee": employee.name,
+			"company": "_Test Company",
+			"shift_type": shift_type.name,
+			"start_date": "2026-07-01",
+			"end_date": "2026-07-10",
+		})
+		original.submit()
+		original.cancel()
+		original.reload()
+		self.assertEqual(original.docstatus, 2)
+		original_end_date = original.end_date
+
+		# Attempt to insert an adjacent shift (Jul 11 = day after Jul 10)
+		insert_shift(
+			employee=employee.name,
+			company="_Test Company",
+			shift_type=shift_type.name,
+			start_date="2026-07-11",
+			end_date="2026-07-20",
+			status="Active",
+		)
+
+		# The cancelled record must remain untouched
+		original.reload()
+		self.assertEqual(original.end_date, original_end_date)
+
+		# A new, non-cancelled assignment must exist for the new range
+		new_assignment = frappe.db.exists(
+			"Shift Assignment",
+			{
+				"employee": employee.name,
+				"start_date": "2026-07-11",
+				"end_date": "2026-07-20",
+				"docstatus": ["!=", 2],
+			},
+		)
+		self.assertTrue(new_assignment)
 
 
 def create_employee(employee_name: str):


### PR DESCRIPTION
## Description
This PR fixes a bug where cancelled Shift Assignments would silently block the creation of new shifts for adjacent date ranges via the Roster API.

### Root Causes Found and Fixed:
1. **`on_cancel` does not update status field**: When a Shift Assignment is cancelled, `docstatus` changes to 2, but the `status` field incorrectly remains `'Active'`. This causes the cancelled record to match the adjacency filters in `insert_shift()`, which filter by `status='Active'`.
   **Fix**: Set status to `'Inactive'` in `on_cancel` via `db_set`.
2. **`insert_shift()` lacks docstatus filter**: The adjacency detection uses `frappe.db.exists()` without filtering out cancelled records (`docstatus=2`).
   **Fix**: Add `'docstatus': ['!=', 2]` to the filters dict.

### Impact:
`insert_shift()` is directly called by `ShiftAssignmentDialog.vue` in the Roster view. When a user cancels a shift and creates a new one for an adjacent date range:
- The cancelled record's `end_date` is silently mutated via `db.set_value`
- No new assignment is created (the else branch is never reached)
- The frontend shows 'Shift Assignment created successfully!' toast

### Reproduction:
Create a shift (Jul 1-10), submit, cancel. Call `insert_shift` for Jul 11-20. Before fix: cancelled record's end_date changes from Jul 10 to Jul 20, zero new records created. After fix: cancelled record untouched, new submitted assignment created correctly.

Includes regression test in `test_roster.py`.
