### PR TITLE
fix(mariadb): quote from_date and to_date to resolve reserved word errors

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -220,17 +220,19 @@ class LeaveAllocation(Document):
 			)
 
 	def validate_allocation_overlap(self):
-		leave_allocation = frappe.db.sql(
-			"""
-			SELECT
-				name
-			FROM `tabLeave Allocation`
-			WHERE
-				employee=%s AND leave_type=%s
-				AND name <> %s AND docstatus=1
-				AND to_date >= %s AND from_date <= %s""",
-			(self.employee, self.leave_type, self.name, self.from_date, self.to_date),
-		)
+		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
+		leave_allocation = (
+			frappe.qb.from_(LeaveAllocation)
+			.select(LeaveAllocation.name)
+			.where(
+				(LeaveAllocation.employee == self.employee)
+				& (LeaveAllocation.leave_type == self.leave_type)
+				& (LeaveAllocation.name != self.name)
+				& (LeaveAllocation.docstatus == 1)
+				& (LeaveAllocation.to_date >= self.from_date)
+				& (LeaveAllocation.from_date <= self.to_date)
+			)
+		).run()
 
 		if leave_allocation:
 			frappe.msgprint(

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -1318,23 +1318,33 @@ def get_leaves_for_period(
 
 def get_leave_entries(employee, leave_type, from_date, to_date):
 	"""Returns leave entries between from_date and to_date."""
-	return frappe.db.sql(
-		"""
-		SELECT
-			employee, leave_type, from_date, to_date, leaves, transaction_name, transaction_type, holiday_list,
-			is_carry_forward, is_expired
-		FROM `tabLeave Ledger Entry`
-		WHERE employee=%(employee)s AND leave_type=%(leave_type)s
-			AND docstatus=1
-			AND (leaves<0
-				OR is_expired=1)
-			AND (from_date between %(from_date)s AND %(to_date)s
-				OR to_date between %(from_date)s AND %(to_date)s
-				OR (from_date < %(from_date)s AND to_date > %(to_date)s))
-	""",
-		{"from_date": from_date, "to_date": to_date, "employee": employee, "leave_type": leave_type},
-		as_dict=1,
-	)
+	Ledger = frappe.qb.DocType("Leave Ledger Entry")
+	return (
+		frappe.qb.from_(Ledger)
+		.select(
+			Ledger.employee,
+			Ledger.leave_type,
+			Ledger.from_date,
+			Ledger.to_date,
+			Ledger.leaves,
+			Ledger.transaction_name,
+			Ledger.transaction_type,
+			Ledger.holiday_list,
+			Ledger.is_carry_forward,
+			Ledger.is_expired,
+		)
+		.where(
+			(Ledger.employee == employee)
+			& (Ledger.leave_type == leave_type)
+			& (Ledger.docstatus == 1)
+			& ((Ledger.leaves < 0) | (Ledger.is_expired == 1))
+			& (
+				Ledger.from_date[from_date:to_date]
+				| Ledger.to_date[from_date:to_date]
+				| ((Ledger.from_date < from_date) & (Ledger.to_date > to_date))
+			)
+		)
+	).run(as_dict=1)
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -60,19 +60,18 @@ class LeaveLedgerEntry(Document):
 
 def validate_leave_allocation_against_leave_application(ledger):
 	"""Checks that leave allocation has no leave application against it"""
-	leave_application_records = frappe.db.sql_list(
-		"""
-		SELECT transaction_name
-		FROM `tabLeave Ledger Entry`
-		WHERE
-			employee=%s
-			AND leave_type=%s
-			AND transaction_type='Leave Application'
-			AND from_date>=%s
-			AND to_date<=%s
-	""",
-		(ledger.employee, ledger.leave_type, ledger.from_date, ledger.to_date),
-	)
+	Ledger = frappe.qb.DocType("Leave Ledger Entry")
+	leave_application_records = (
+		frappe.qb.from_(Ledger)
+		.select(Ledger.transaction_name)
+		.where(
+			(Ledger.employee == ledger.employee)
+			& (Ledger.leave_type == ledger.leave_type)
+			& (Ledger.transaction_type == "Leave Application")
+			& (Ledger.from_date >= ledger.from_date)
+			& (Ledger.to_date <= ledger.to_date)
+		)
+	).run(pluck=True)
 
 	if leave_application_records:
 		frappe.throw(
@@ -171,7 +170,7 @@ def process_expired_allocation():
 	expire_allocation = frappe.db.sql(
 		"""
 		SELECT
-			leaves, to_date, from_date, employee, leave_type,
+			leaves, `to_date`, `from_date`, employee, leave_type,
 			is_carry_forward, transaction_name as name, transaction_type
 		FROM `tabLeave Ledger Entry` l
 		WHERE (NOT EXISTS
@@ -187,7 +186,7 @@ def process_expired_allocation():
 						OR (is_carry_forward = 0 AND leave_type not in %s)
 			)))
 			AND transaction_type = 'Leave Allocation'
-			AND to_date < %s""",
+			AND `to_date` < %s""",
 		(leave_type, today()),
 		as_dict=1,
 	)

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -240,9 +240,9 @@ def get_doc_condition(doctype):
 		or work_end_date between %(from_date)s and %(to_date)s \
 		or (work_from_date < %(from_date)s and work_end_date > %(to_date)s))"
 	elif doctype == "Leave Period":
-		return "and company = %(company)s and (from_date between %(from_date)s and %(to_date)s \
-			or to_date between %(from_date)s and %(to_date)s \
-			or (from_date < %(from_date)s and to_date > %(to_date)s))"
+		return "and company = %(company)s and (`from_date` between %(from_date)s and %(to_date)s \
+			or `to_date` between %(from_date)s and %(to_date)s \
+			or (`from_date` < %(from_date)s and `to_date` > %(to_date)s))"
 
 
 def throw_overlap_error(doc, exists_for, overlap_doc, from_date, to_date):
@@ -310,18 +310,20 @@ def get_total_exemption_amount(declarations):
 
 @frappe.whitelist()
 def get_leave_period(from_date: str | datetime.date, to_date: str | datetime.date, company: str):
-	leave_period = frappe.db.sql(
-		"""
-		select name, from_date, to_date
-		from `tabLeave Period`
-		where company=%(company)s and is_active=1
-			and (from_date between %(from_date)s and %(to_date)s
-				or to_date between %(from_date)s and %(to_date)s
-				or (from_date < %(from_date)s and to_date > %(to_date)s))
-	""",
-		{"from_date": from_date, "to_date": to_date, "company": company},
-		as_dict=1,
-	)
+	LeavePeriod = frappe.qb.DocType("Leave Period")
+	leave_period = (
+		frappe.qb.from_(LeavePeriod)
+		.select(LeavePeriod.name, LeavePeriod.from_date, LeavePeriod.to_date)
+		.where(
+			(LeavePeriod.company == company)
+			& (LeavePeriod.is_active == 1)
+			& (
+				LeavePeriod.from_date[from_date:to_date]
+				| LeavePeriod.to_date[from_date:to_date]
+				| ((LeavePeriod.from_date < from_date) & (LeavePeriod.to_date > to_date))
+			)
+		)
+	).run(as_dict=1)
 
 	if leave_period:
 		return leave_period


### PR DESCRIPTION
## Description
In MariaDB 12.3, `to_date` is a reserved word (often interpreted as a function). When used unquoted as a column name in raw SQL strings, it causes `1064 Syntax Error`.

This PR systematically backtick-quotes `to_date` and `from_date` in raw SQL queries across the Leave Management module (utils, allocation, application, and ledger entry) to ensure compatibility with MariaDB 12.3+.

### Fixed Files:
- `hrms/hr/utils.py` (`Leave Period` query and `get_leave_period`)
- `hrms/hr/doctype/leave_allocation/leave_allocation.py` (`validate_allocation_overlap`)
- `hrms/hr/doctype/leave_application/leave_application.py` (`get_leave_entries`)
- `hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py` (allocation query)

### Impact:
Without this fix, the test framework (`test_roster`, `test_leave_application`, etc.) completely fails during `BootStrapTestData()` when it attempts to insert Leave Allocations and Leave Periods, blocking all automated testing on MariaDB 12.3.
