### PR TITLE
fix: respect manual half_day_status when no leave record exists

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -228,8 +228,8 @@ class Attendance(Document):
 
 		if self.status in ("On Leave", "Half Day"):
 			if not leave_record:
-				self.modify_half_day_status = 0
-				self.half_day_status = "Absent"
+				if not self.modify_half_day_status:
+					self.half_day_status = "Absent"
 				frappe.msgprint(
 					_("No leave record found for employee {0} on {1}").format(
 						self.employee, format_date(self.attendance_date)


### PR DESCRIPTION
When an attendance is marked Half Day with no approved half-day Leave Application, the status was always forced to Absent and the modify_half_day_status flag was reset, silently discarding a value the user set manually.

Now Absent is only auto-applied when the user has not taken manual control (modify_half_day_status unchecked), so an explicit Present choice is preserved. Default and bulk marking remain unchanged.

Fixes #4866

