### PR TITLE
feat: show Holiday List Assignment in Employee connections tab

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -10,7 +10,12 @@ def get_dashboard_for_employee(data):
 			{"label": _("Attendance"), "items": ["Attendance", "Attendance Request", "Employee Checkin"]},
 			{
 				"label": _("Leave"),
-				"items": ["Leave Application", "Leave Allocation", "Leave Policy Assignment"],
+				"items": [
+					"Leave Application",
+					"Leave Allocation",
+					"Leave Policy Assignment",
+					"Holiday List Assignment",
+				],
 			},
 			{
 				"label": _("Lifecycle"),
@@ -56,7 +61,17 @@ def get_dashboard_for_employee(data):
 		]
 	)
 
-	data["non_standard_fieldnames"].update({"Bank Account": "party", "Employee Grievance": "raised_by"})
+	data["non_standard_fieldnames"].update(
+		{
+			"Bank Account": "party",
+			"Employee Grievance": "raised_by",
+			"Holiday List Assignment": "assigned_to",
+		}
+	)
+
+	if not data.get("dynamic_links"):
+		data["dynamic_links"] = {}
+	data["dynamic_links"]["assigned_to"] = ["Employee", "applicable_for"]
 	data.update(
 		{
 			"heatmap": True,


### PR DESCRIPTION
## What changed

Added **Holiday List Assignment** to the **Leave** section in the Employee document's Connections tab.

## Why

HR users had to navigate away from the Employee document to check which holiday list is assigned. Now they can see it directly from the Connections tab.


https://github.com/user-attachments/assets/e0caa37a-2772-418e-8fb4-233b382405a8

no-docs