### PR TITLE
fix(pwa): checkin button no longer defaults to IN while loading

### DIFF
--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -15,6 +15,7 @@
 			<Button
 				class="mt-4 mb-1 drop-shadow-sm py-5 text-base"
 				id="open-checkin-modal"
+				:loading="checkins.list.loading"
 				@click="handleEmployeeCheckin"
 			>
 				<template #prefix>


### PR DESCRIPTION
### Reason
The checkin button defaulted to "IN" when tapped before the app finished loading the employee's last checkin, causing two consecutive IN's with no OUT in between
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/304d115f-bc4b-4726-968d-55fb3521acb6" />

### Changes Done
- Added a loading guard on the checkin button so it stays disabled until the last checkin has finished loading, instead of defaulting to "IN" while still loading.
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/8e16ef13-693c-4a69-9561-748b39938cf1" />
