### PR TITLE
ci: hide eo.po from translation PR review details

### DIFF
--- a/.github/workflows/review-translation-changes.yaml
+++ b/.github/workflows/review-translation-changes.yaml
@@ -23,3 +23,5 @@ jobs:
 
     steps:
       - uses: alyf-de/po-review-action@5928f84d6bc9094f9ad6e2c5780f01c0044b800e # v1.1.1
+        with:
+          hidden-po-files: eo.po


### PR DESCRIPTION
## Summary
- Hide Crowdin in-context `eo.po` files from `po-review-action` language detail tables via `hidden-po-files`.