### PR TITLE
fix: show specific error when Payable/Bank-Cash Account missing on Ex…

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -336,7 +336,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 
 		if self.is_paid and self.grand_total:
 			# payment entry
-			payment_account = get_bank_cash_account(self.mode_of_payment, self.company).get("account")
+			payment_account = self.flags.bank_cash_account or get_bank_cash_account(self.mode_of_payment, self.company).get("account")
 			gl_entry.append(
 				self.get_gl_dict(
 					{
@@ -493,7 +493,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			if not self.mode_of_payment:
 				frappe.throw(_("Mode of payment is required to make a payment").format(self.employee))
 
-			if self.grand_total and not get_bank_cash_account(self.mode_of_payment, self.company).get("account"):
+			self.flags.bank_cash_account = get_bank_cash_account(self.mode_of_payment, self.company).get("account")
+			if self.grand_total and not self.flags.bank_cash_account:
 				frappe.throw(
 					_("{0} could not be determined for Mode of Payment {1}.").format(
 						frappe.bold(_("Bank/Cash Account")), frappe.bold(self.mode_of_payment)

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -484,9 +484,21 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					)
 				)
 
+		if self.grand_total and not self.payable_account:
+			frappe.throw(
+				_("{0} is mandatory to book this expense claim.").format(frappe.bold(_("Payable Account")))
+			)
+
 		if self.is_paid:
 			if not self.mode_of_payment:
 				frappe.throw(_("Mode of payment is required to make a payment").format(self.employee))
+
+			if self.grand_total and not get_bank_cash_account(self.mode_of_payment, self.company).get("account"):
+				frappe.throw(
+					_("{0} could not be determined for Mode of Payment {1}.").format(
+						frappe.bold(_("Bank/Cash Account")), frappe.bold(self.mode_of_payment)
+					)
+				)
 
 	def calculate_total_amount(self):
 		self.total_claimed_amount = 0

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -40,6 +40,41 @@ class TestExpenseClaim(HRMSTestSuite):
 		frappe.db.set_value("Account", "Payroll Payable - _TC", "account_type", "Payable")
 		frappe.set_user("Administrator")
 
+	def test_payable_account_is_mandatory_to_book_expense_claim(self):
+		payable_account = get_payable_account(company_name)
+		expense_claim = make_expense_claim(
+			payable_account, 300, 200, company_name, "Travel Expenses - _TC3", do_not_submit=True
+		)
+		expense_claim.payable_account = None
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Payable Account",
+			expense_claim.validate_account_details,
+		)
+
+	def test_bank_or_cash_account_required_when_expense_claim_is_paid(self):
+		payable_account = get_payable_account(company_name)
+		mode_of_payment = frappe.get_doc(
+			{
+				"doctype": "Mode of Payment",
+				"mode_of_payment": f"_Test Mode without Account-{random_string(5)}",
+				"type": "Bank",
+			}
+		).insert()
+
+		expense_claim = make_expense_claim(
+			payable_account, 300, 200, company_name, "Travel Expenses - _TC3", do_not_submit=True
+		)
+		expense_claim.is_paid = 1
+		expense_claim.mode_of_payment = mode_of_payment.name
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Bank/Cash Account",
+			expense_claim.validate_account_details,
+		)
+
 	def test_total_expense_claim_for_project(self):
 		project = create_project("_Test Project 1", company="_Test Company")
 


### PR DESCRIPTION
Fixes #4152

## Problem
When submitting an Expense Claim with a missing Payable Account (or a Mode of Payment without a configured Bank/Cash account when "Is Paid" is checked), the system raised a generic, low-level error ("Account is required") from GL Entry validation. Since Expense Claim has multiple account-related fields (Payable Account, Bank/Cash Account), this didn't tell the user which field actually needed to be set.

## Fix
Added two explicit checks in `validate_account_details()` on `Expense Claim`, which already runs before GL entries are built in `get_gl_entries()`:
- If the claim has a `grand_total` and no `payable_account` is set, throw a clear error naming the Payable Account field.
- If `is_paid` is checked and the account resolved via `get_bank_cash_account(mode_of_payment, company)` is empty, throw a clear error naming the Bank/Cash Account and the selected Mode of Payment.
Both checks are purely additive validation - no existing behavior changes for claims that already have valid accounts configured.

## Testing
Verified by reading through `get_gl_entries()` / `make_gl_entries()` to confirm `validate_account_details()` runs before the GL entry dicts are constructed, so the new checks fire before the previous generic error could occur.