### PR TITLE
fix: exclude disabled users from approver list

### DIFF
--- a/hrms/hr/doctype/department_approver/department_approver.py
+++ b/hrms/hr/doctype/department_approver/department_approver.py
@@ -58,19 +58,27 @@ def get_approvers(doctype: str, txt: str, searchfield: str, start: int, page_len
 		)
 
 	if filters.get("doctype") == "Leave Application" and employee.leave_approver:
-		approvers.append(
-			frappe.db.get_value("User", employee.leave_approver, ["name", "first_name", "last_name"])
+		approver = frappe.db.get_value(
+			"User", {"name": employee.leave_approver, "enabled": 1}, ["name", "first_name", "last_name"]
 		)
+		if approver:
+			approvers.append(approver)
 
 	if filters.get("doctype") == "Expense Claim" and employee.expense_approver:
-		approvers.append(
-			frappe.db.get_value("User", employee.expense_approver, ["name", "first_name", "last_name"])
+		approver = frappe.db.get_value(
+			"User", {"name": employee.expense_approver, "enabled": 1}, ["name", "first_name", "last_name"]
 		)
+		if approver:
+			approvers.append(approver)
 
 	if filters.get("doctype") == "Shift Request" and employee.shift_request_approver:
-		approvers.append(
-			frappe.db.get_value("User", employee.shift_request_approver, ["name", "first_name", "last_name"])
+		approver = frappe.db.get_value(
+			"User",
+			{"name": employee.shift_request_approver, "enabled": 1},
+			["name", "first_name", "last_name"],
 		)
+		if approver:
+			approvers.append(approver)
 
 	if filters.get("doctype") == "Leave Application":
 		parentfield = "leave_approvers"
@@ -88,6 +96,7 @@ def get_approvers(doctype: str, txt: str, searchfield: str, start: int, page_len
 				tabUser user, `tabDepartment Approver` approver where
 				approver.parent = %s
 				and user.name like %s
+				and user.enabled = 1
 				and approver.parentfield = %s
 				and approver.approver=user.name""",
 				(d, "%" + txt + "%", parentfield),

--- a/hrms/hr/doctype/department_approver/department_approver.py
+++ b/hrms/hr/doctype/department_approver/department_approver.py
@@ -90,18 +90,22 @@ def get_approvers(doctype: str, txt: str, searchfield: str, start: int, page_len
 		parentfield = "shift_request_approver"
 		field_name = "Shift Request Approver"
 	if department_list:
+		User = frappe.qb.DocType("User")
+		DeptApprover = frappe.qb.DocType("Department Approver")
+
 		for d in department_list:
-			approvers += frappe.db.sql(
-				"""select user.name, user.first_name, user.last_name from
-				tabUser user, `tabDepartment Approver` approver where
-				approver.parent = %s
-				and user.name like %s
-				and user.enabled = 1
-				and approver.parentfield = %s
-				and approver.approver=user.name""",
-				(d, "%" + txt + "%", parentfield),
-				as_list=True,
-			)
+			approvers += (
+				frappe.qb.from_(DeptApprover)
+				.join(User)
+				.on(DeptApprover.approver == User.name)
+				.select(User.name, User.first_name, User.last_name)
+				.where(
+					(DeptApprover.parent == d[0])
+					& (DeptApprover.parentfield == parentfield)
+					& (User.name.like(f"%{txt}%"))
+					& (User.enabled == 1)
+				)
+			).run(as_list=True)
 
 	if len(approvers) == 0:
 		error_msg = _("Please set {0} for the Employee: {1}").format(


### PR DESCRIPTION
**Description:** Approver searches in get_approvers() return disabled Users for leave, expense, and shift approvals. Filter both the direct employee approvers and the department-tree approvers on `enabled = 1` so deactivated users are no longer selectable.

**Before:**

[Screencast from 2026-07-16 12-53-05.webm](https://github.com/user-attachments/assets/172ec13a-a06a-451e-aff8-eb7f2f58aea3)


**After:**

[Screencast from 2026-07-16 12-49-50.webm](https://github.com/user-attachments/assets/8b0c058e-3bf2-44e5-94ff-56fc4a87cbc8)


**Backport needed for v15, v16**