### PR TITLE
fix: populate employee filter when opening Employee Leave Balance from Leave Allocation

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -30,6 +30,14 @@ frappe.ui.form.on("Leave Allocation", {
 
 	refresh: function (frm) {
 		hrms.leave_utils.add_view_ledger_button(frm);
+		frm.dashboard.transactions_area
+			.find('.document-link[data-report="Employee Leave Balance"] .report-link')
+			.off("click")
+			.on("click", () => {
+				frappe.set_route("query-report", "Employee Leave Balance", {
+					employee: frm.doc.employee,
+				});
+			});
 
 		if (frm.doc.docstatus === 1 && !frm.doc.expired) {
 			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -30,14 +30,13 @@ frappe.ui.form.on("Leave Allocation", {
 
 	refresh: function (frm) {
 		hrms.leave_utils.add_view_ledger_button(frm);
-		frm.dashboard.transactions_area
-			.find('.document-link[data-report="Employee Leave Balance"] .report-link')
-			.off("click")
-			.on("click", () => {
+		if (frm.doc.employee) {
+			frm.add_custom_button(__("Employee Leave Balance"), () => {
 				frappe.set_route("query-report", "Employee Leave Balance", {
 					employee: frm.doc.employee,
 				});
 			});
+		}
 
 		if (frm.doc.docstatus === 1 && !frm.doc.expired) {
 			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -30,13 +30,14 @@ frappe.ui.form.on("Leave Allocation", {
 
 	refresh: function (frm) {
 		hrms.leave_utils.add_view_ledger_button(frm);
-		if (frm.doc.employee) {
-			frm.add_custom_button(__("Employee Leave Balance"), () => {
+		frm.dashboard.transactions_area
+			.find('.document-link[data-report="Employee Leave Balance"] .report-link')
+			.off("click")
+			.on("click", () => {
 				frappe.set_route("query-report", "Employee Leave Balance", {
 					employee: frm.doc.employee,
 				});
 			});
-		}
 
 		if (frm.doc.docstatus === 1 && !frm.doc.expired) {
 			var valid_expiry = moment(frappe.datetime.get_today()).isBetween(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.py
@@ -6,5 +6,4 @@ def get_data():
 			{"items": ["Leave Encashment"]},
 			{"items": ["Leave Adjustment"]},
 		],
-		"reports": [{"items": ["Employee Leave Balance"]}],
 	}

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_dashboard.py
@@ -6,4 +6,5 @@ def get_data():
 			{"items": ["Leave Encashment"]},
 			{"items": ["Leave Adjustment"]},
 		],
+		"reports": [{"items": ["Employee Leave Balance"]}],
 	}


### PR DESCRIPTION
## Problem

When clicking **Employee Leave Balance** from a Leave Allocation document, the report opens but shows balances for all employees. The employee from the Leave Allocation is not passed as a filter.

## Fix

Override the default click handler on the Employee Leave Balance report link in the Leave Allocation form. The new handler passes the employee from the current document as a filter when opening the report.

Before:

https://github.com/user-attachments/assets/aec6ce45-67c2-4b34-89a5-0ea1f76fbbe1

After:

https://github.com/user-attachments/assets/a17b7c71-a01e-4b7e-ae0e-1b85c40c91f4

