### PR TITLE
fix: use date strings for mark attendance date

### DIFF
--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -46,7 +46,7 @@ frappe.listview_settings["Attendance"] = {
 							fieldtype: "Date",
 							fieldname: "from_date",
 							reqd: 1,
-							default: first_day_of_month.format("YYYY-MM-DD"),
+							default: frappe.datetime.obj_to_str(first_day_of_month),
 							onchange: () => me.get_unmarked_days(dialog),
 						},
 						{
@@ -65,7 +65,7 @@ frappe.listview_settings["Attendance"] = {
 							fieldtype: "Date",
 							fieldname: "to_date",
 							reqd: 1,
-							default: moment().format("YYYY-MM-DD"),
+							default: frappe.datetime.obj_to_str(moment()),
 							onchange: () => me.get_unmarked_days(dialog),
 						},
 						{

--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -46,7 +46,7 @@ frappe.listview_settings["Attendance"] = {
 							fieldtype: "Date",
 							fieldname: "from_date",
 							reqd: 1,
-							default: first_day_of_month.toDate(),
+							default: first_day_of_month.format("YYYY-MM-DD"),
 							onchange: () => me.get_unmarked_days(dialog),
 						},
 						{
@@ -65,7 +65,7 @@ frappe.listview_settings["Attendance"] = {
 							fieldtype: "Date",
 							fieldname: "to_date",
 							reqd: 1,
-							default: moment().toDate(),
+							default: moment().format("YYYY-MM-DD"),
 							onchange: () => me.get_unmarked_days(dialog),
 						},
 						{


### PR DESCRIPTION
**Description:**
In the Mark Attendance dialog, the **Start** and **End** date fields set their defaults to native JS `Date` objects via `moment().toDate()`. Frappe's `Date` control expects a string.

**Error Log:** {
    "exception": "frappe.exceptions.ValidationError: Wed Jul 01 2026 00:00:00 GMT+0530 (India Standard Time) is not a valid date string.",
    "exc_type": "ValidationError",
    "_exc_source": "hrms (app)",
    "exc": "[\"Traceback (most recent call last):\\n  File \\\"apps/frappe/frappe/utils/data.py\\\", line 139, in getdate\\n    return datetime.date.fromisoformat(string_date)\\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^\\nValueError: Invalid isoformat string: 'Wed Jul 01 2026 00:00:00 GMT+0530 (India Standard Time)'\\n\\nDuring handling of the above exception, another exception occurred:\\n\\nTraceback (most recent call last):\\n  File \\\"apps/frappe/frappe/utils/data.py\\\", line 142, in getdate\\n    return parser.parse(string_date, dayfirst=parse_day_first).date()\\n           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"env/lib/python3.14/site-packages/dateutil/parser/_parser.py\\\", line 1368, in parse\\n    return DEFAULTPARSER.parse(timestr, **kwargs)\\n           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\\n  File \\\"env/lib/python3.14/site-packages/dateutil/parser/_parser.py\\\", line 643, in parse\\n    raise ParserError(\\\"Unknown string format: %s\\\", timestr)\\ndateutil.parser._parser.ParserError: Unknown string format: Wed Jul 01 2026 00:00:00 GMT+0530 (India Standard Time)\\n\\nDuring handling of the above exception, another exception occurred:\\n\\nTraceback (most recent call last):\\n  File \\\"apps/frappe/frappe/app.py\\\", line 125, in application\\n    response = frappe.api.handle(request)\\n  File \\\"apps/frappe/frappe/api/__init__.py\\\", line 64, in handle\\n    data = endpoint(**arguments)\\n  File \\\"apps/frappe/frappe/api/v1.py\\\", line 46, in handle_rpc_call\\n    return frappe.handler.handle()\\n           ~~~~~~~~~~~~~~~~~~~~~^^\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 54, in handle\\n    data = execute_cmd(cmd)\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 87, in execute_cmd\\n    return frappe.call(method, **frappe.form_dict)\\n           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/__init__.py\\\", line 1139, in call\\n    return fn(*args, **newargs)\\n  File \\\"apps/frappe/frappe/utils/typing_validations.py\\\", line 49, in wrapper\\n    return func(*args, **kwargs)\\n  File \\\"apps/hrms/hrms/hr/doctype/attendance/attendance.py\\\", line 440, in get_unmarked_days\\n    from_date = max(getdate(from_date), joining_date or getdate(from_date))\\n                    ~~~~~~~^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/utils/data.py\\\", line 144, in getdate\\n    frappe.throw(\\n    ~~~~~~~~~~~~^\\n    \\tfrappe._(\\\"{} is not a valid date string.\\\").format(frappe.bold(string_date)),\\n     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n    \\ttitle=frappe._(\\\"Invalid Date\\\"),\\n     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n    )\\n    ^\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 159, in throw\\n    msgprint(\\n    ~~~~~~~~^\\n    \\tmsg,\\n     ^^^^\\n    ...<7 lines>...\\n    \\tallow_dangerous_html=allow_dangerous_html,\\n     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n    )\\n    ^\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 118, in msgprint\\n    _raise_exception()\\n    ~~~~~~~~~~~~~~~~^^\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 59, in _raise_exception\\n    raise exc\\nfrappe.exceptions.ValidationError: Wed Jul 01 2026 00:00:00 GMT+0530 (India Standard Time) is not a valid date string.\\n\"]",
    "_server_messages": "[\"{\\\"message\\\":\\\"<strong>Wed Jul 01 2026 00:00:00 GMT+0530 (India Standard Time)</strong> is not a valid date string.\\\",\\\"as_table\\\":false,\\\"title\\\":\\\"Invalid Date\\\",\\\"indicator\\\":\\\"red\\\",\\\"raise_exception\\\":1,\\\"__frappe_exc_id\\\":\\\"82565168f842d132551438938311a247cfb479d614e72c211d50d3b9\\\"}\"]"
}


**Before:**

[Screencast from 2026-07-16 19-10-02.webm](https://github.com/user-attachments/assets/ec53270e-992f-4a2e-97f6-d415d7b82f24)


**After:**

[Screencast from 2026-07-16 18-45-23.webm](https://github.com/user-attachments/assets/a5b476fc-195c-45bc-81bf-a457b2554378)

**Backport needed for v15, v16**