### PR TITLE
fix: restrict future dates attendance

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.js
+++ b/hrms/hr/doctype/attendance/attendance.js
@@ -13,6 +13,8 @@ frappe.ui.form.on("Attendance", {
 			};
 		});
 
+		frm.trigger("set_max_attendance_date");
+
 		if (frm.doc.docstatus === 1 && frm.doc.status === "Absent") {
 			frm.add_custom_button(
 				__("Attendance Request"),
@@ -38,6 +40,24 @@ frappe.ui.form.on("Attendance", {
 		if (frm.doc.employee && frm.doc.attendance_date && !frm.doc.shift) {
 			frm.trigger("set_employee_shift");
 		}
+	},
+
+	status(frm) {
+		frm.trigger("set_max_attendance_date");
+	},
+
+	set_max_attendance_date(frm) {
+		const datepicker = frm.fields_dict.attendance_date?.datepicker;
+		if (!datepicker) return;
+
+		// leaves and attendance requests can be applied for in advance
+		const allow_future_date = frm.doc.status === "On Leave" || frm.doc.attendance_request;
+
+		datepicker.update({
+			maxDate: allow_future_date
+				? ""
+				: frappe.datetime.str_to_obj(frappe.datetime.get_today()),
+		});
 	},
 
 	set_employee_shift(frm) {

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -38,6 +38,10 @@ class OverlappingShiftAttendanceError(frappe.ValidationError):
 	pass
 
 
+class FutureAttendanceError(frappe.ValidationError):
+	pass
+
+
 class Attendance(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -92,6 +96,8 @@ class Attendance(Document):
 	def validate_attendance_date(self):
 		date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
 
+		self.validate_future_attendance_date()
+
 		if date_of_joining and getdate(self.attendance_date) < getdate(date_of_joining):
 			frappe.throw(
 				_("Attendance date {0} can not be less than employee {1}'s joining date: {2}").format(
@@ -99,6 +105,19 @@ class Attendance(Document):
 					frappe.bold(self.employee),
 					frappe.bold(format_date(date_of_joining)),
 				)
+			)
+
+	def validate_future_attendance_date(self):
+		if self.leave_application or self.attendance_request or self.status == "On Leave":
+			return
+
+		if getdate(self.attendance_date) > getdate():
+			frappe.throw(
+				_("Attendance can not be marked for the future date {0}").format(
+					frappe.bold(format_date(self.attendance_date))
+				),
+				title=_("Future Attendance"),
+				exc=FutureAttendanceError,
 			)
 
 	def validate_duplicate_record(self):
@@ -387,7 +406,11 @@ def mark_bulk_attendance(data: str | dict):
 		return
 	today = getdate()
 	if any(getdate(d) > today for d in data.unmarked_days):
-		frappe.throw(_("Future dates not allowed"))
+		frappe.throw(
+			_("Attendance can not be marked for future dates"),
+			title=_("Future Attendance"),
+			exc=FutureAttendanceError,
+		)
 	if len(data.unmarked_days) > 10 or frappe.flags.test_bg_job:
 		job_id = f"process_bulk_attendance_for_employee_{data.employee}"
 		job = frappe.enqueue(

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -385,7 +385,8 @@ def mark_bulk_attendance(data: str | dict):
 	if not data.unmarked_days:
 		frappe.throw(_("Please select a date."))
 		return
-	if any(getdate(d) > getdate(nowdate()) for d in data.unmarked_days):
+	today = getdate()
+	if any(getdate(d) > today for d in data.unmarked_days):
 		frappe.throw(_("Future dates not allowed"))
 	if len(data.unmarked_days) > 10 or frappe.flags.test_bg_job:
 		job_id = f"process_bulk_attendance_for_employee_{data.employee}"
@@ -440,7 +441,7 @@ def get_unmarked_days(
 	)
 
 	from_date = max(getdate(from_date), joining_date or getdate(from_date))
-	to_date = min(getdate(to_date), relieving_date or getdate(to_date), getdate(nowdate()))
+	to_date = min(getdate(to_date), relieving_date or getdate(to_date), getdate())
 
 	records = frappe.get_all(
 		"Attendance",

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -385,6 +385,8 @@ def mark_bulk_attendance(data: str | dict):
 	if not data.unmarked_days:
 		frappe.throw(_("Please select a date."))
 		return
+	if any(getdate(d) > getdate(nowdate()) for d in data.unmarked_days):
+		frappe.throw(_("Future dates not allowed"))
 	if len(data.unmarked_days) > 10 or frappe.flags.test_bg_job:
 		job_id = f"process_bulk_attendance_for_employee_{data.employee}"
 		job = frappe.enqueue(
@@ -438,7 +440,7 @@ def get_unmarked_days(
 	)
 
 	from_date = max(getdate(from_date), joining_date or getdate(from_date))
-	to_date = min(getdate(to_date), relieving_date or getdate(to_date))
+	to_date = min(getdate(to_date), relieving_date or getdate(to_date), getdate(nowdate()))
 
 	records = frappe.get_all(
 		"Attendance",

--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -138,15 +138,28 @@ frappe.listview_settings["Attendance"] = {
 		dialog.no_unmarked_days_left = false;
 		fields.exclude_holidays.value = false;
 
-		fields.to_date.datepicker.update({
-			maxDate: moment().toDate(),
-		});
+		for (const fieldname of ["from_date", "to_date"]) {
+			fields[fieldname].datepicker.update({
+				maxDate: moment().toDate(),
+			});
+		}
 
 		this.get_unmarked_days(dialog);
 	},
 
 	get_unmarked_days: function (dialog) {
 		let fields = dialog.fields_dict;
+
+		const today = frappe.datetime.get_today();
+		for (const fieldname of ["from_date", "to_date"]) {
+			const field = fields[fieldname];
+			if (field.value && field.value > today) {
+				frappe.msgprint(__("Future dates not allowed"));
+				field.set_value(today);
+				return;
+			}
+		}
+
 		if (fields.employee.value && fields.from_date.value && fields.to_date.value) {
 			dialog.set_df_property("days_section", "hidden", 0);
 			dialog.set_df_property("status", "hidden", 0);

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -21,6 +21,7 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import (
 	DuplicateAttendanceError,
+	FutureAttendanceError,
 	OverlappingShiftAttendanceError,
 	get_events,
 	get_unmarked_days,
@@ -148,6 +149,57 @@ class TestAttendance(HRMSTestSuite):
 			"Attendance", {"employee": employee, "attendance_date": date, "status": "Absent"}
 		)
 		self.assertEqual(attendance, fetch_attendance)
+
+	def test_future_attendance_not_allowed(self):
+		employee = make_employee("test_future_attendance@example.com", company="_Test Company")
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": add_days(getdate(), 1),
+				"status": "Present",
+				"company": "_Test Company",
+			}
+		)
+
+		self.assertRaises(FutureAttendanceError, attendance.insert)
+
+	def test_future_attendance_allowed_via_attendance_request(self):
+		"Attendance requests (WFH/On Duty) can be raised in advance"
+		from hrms.hr.doctype.attendance_request.test_attendance_request import create_attendance_request
+
+		employee = make_employee("test_future_attendance_request@example.com", company="_Test Company")
+		next_day = add_days(getdate(), 1)
+
+		attendance_request = create_attendance_request(
+			employee=employee,
+			reason="Work From Home",
+			company="_Test Company",
+			from_date=next_day,
+			to_date=next_day,
+		)
+
+		attendance = frappe.get_value(
+			"Attendance",
+			{"attendance_request": attendance_request.name, "docstatus": 1},
+			["attendance_date", "status"],
+			as_dict=True,
+		)
+		self.assertEqual(attendance.attendance_date, next_day)
+		self.assertEqual(attendance.status, "Work From Home")
+
+	def test_bulk_attendance_marking_for_future_dates(self):
+		employee = make_employee("test_bulk_future_attendance@example.com", company="_Test Company")
+		data = frappe._dict(
+			unmarked_days=[getdate(), add_days(getdate(), 1)],
+			employee=employee,
+			status="Present",
+			shift="",
+		)
+
+		self.assertRaises(FutureAttendanceError, mark_bulk_attendance, data)
+		self.assertFalse(frappe.db.exists("Attendance", {"employee": employee}))
 
 	def test_unmarked_days(self):
 		first_sunday = get_first_sunday(self.holiday_list, for_date=get_last_day(add_months(getdate(), -1)))

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.js
@@ -4,6 +4,10 @@ frappe.ui.form.on("Employee Attendance Tool", {
 		frm.trigger("reset_tool_actions");
 		hide_field("select_employees_section");
 		hide_field("marked_attendance_section");
+
+		frm.fields_dict.date.datepicker?.update({
+			maxDate: frappe.datetime.str_to_obj(frappe.datetime.get_today()),
+		});
 	},
 
 	onload(frm) {

--- a/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -649,13 +649,13 @@ class TestEmployeeCheckin(HRMSTestSuite):
 		shift_start = datetime.combine(getdate(), get_time("08:00:00"))
 		log = make_checkin(emp, timestamp)
 		# when attendance is not linked, shift start changes with time
-		log.time = add_days(timestamp, 1)
+		log.time = add_days(timestamp, -1)
 		log.save()
 		log.reload()
-		self.assertEqual(log.shift_start, add_days(shift_start, 1))
+		self.assertEqual(log.shift_start, add_days(shift_start, -1))
 
 		# when attendance is linked, don't allow to modify either time or shift parameters
-		mark_attendance_and_link_log([log], "Absent", add_days(timestamp, 1))
+		mark_attendance_and_link_log([log], "Absent", add_days(timestamp, -1))
 		log.reload()
 		log.time = timestamp
 		self.assertRaises(frappe.ValidationError, log.save)

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -375,6 +375,9 @@ class ShiftType(Document):
 		else:
 			# no shift found
 			return None, None
+
+		end_date = min(end_date, getdate())
+
 		return start_date, end_date
 
 	def get_marked_attendance_dates_between(self, employee: str, start_date: str, end_date: str) -> list[str]:

--- a/hrms/hr/report/employees_working_on_a_holiday/test_employees_working_on_a_holiday.py
+++ b/hrms/hr/report/employees_working_on_a_holiday/test_employees_working_on_a_holiday.py
@@ -11,7 +11,6 @@ from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import
 )
 from hrms.hr.report.employees_working_on_a_holiday.employees_working_on_a_holiday import execute
 from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
-from hrms.tests.test_utils import get_first_sunday
 from hrms.tests.utils import HRMSTestSuite
 
 
@@ -22,7 +21,10 @@ class TestEmployeesWorkingOnAHoliday(HRMSTestSuite):
 
 	def test_report(self):
 		date = getdate()
-		from_date = get_year_start(date)
+		last_sunday = add_days(date, -((date.weekday() + 1) % 7 or 7))
+		first_sunday = add_days(last_sunday, -14)
+
+		from_date = get_year_start(first_sunday)
 		to_date = get_year_ending(date)
 		sunday_off = make_holiday_list("Sunday Off", from_date, to_date, True)
 		monday_off = make_holiday_list("Monday Off", from_date, to_date, True, ["Monday"])
@@ -35,7 +37,6 @@ class TestEmployeesWorkingOnAHoliday(HRMSTestSuite):
 		emp3 = make_employee("testemp3@tuesday.com", company=self.company)
 		create_holiday_list_assignment("Employee", emp3, tuesday_off)
 
-		first_sunday = get_first_sunday()
 		# i realise this might not be the first monday and tuesday but doesn't matter for this test
 		first_monday = add_days(first_sunday, 1)
 		first_tuesday = add_days(first_monday, 1)

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -489,18 +489,19 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(row["total_early_exits"], 1)
 
 	def test_detailed_view_with_date_range_filter(self):
-		today = getdate()
-		mark_attendance(self.employee, today, "Absent", "Day Shift")
-		mark_attendance(self.employee, today + relativedelta(days=1), "Present", "Day Shift")
+		# attendance can not be marked for future dates
+		first_date = add_days(getdate(), -3)
+		mark_attendance(self.employee, first_date, "Absent", "Day Shift")
+		mark_attendance(self.employee, first_date + relativedelta(days=1), "Present", "Day Shift")
 
 		# attendance without shift
-		mark_attendance(self.employee, today + relativedelta(days=2), "On Leave")
-		mark_attendance(self.employee, today + relativedelta(days=3), "Present")
+		mark_attendance(self.employee, first_date + relativedelta(days=2), "On Leave")
+		mark_attendance(self.employee, first_date + relativedelta(days=3), "Present")
 		filters = frappe._dict(
 			{
 				"filter_based_on": "Date Range",
-				"start_date": add_days(today, -1),
-				"end_date": add_days(today, 30),
+				"start_date": add_days(first_date, -1),
+				"end_date": add_days(first_date, 30),
 				"company": self.company,
 			}
 		)
@@ -509,16 +510,16 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		row_without_shift = report[1][1]
 
 		self.assertEqual(day_shift_row["shift"], "Day Shift")
-		self.assertEqual(day_shift_row[date_key(today)], "A")  # absent on the 1st day of the month
-		self.assertEqual(day_shift_row[date_key(add_days(today, 1))], "P")  # present on the 2nd day
+		self.assertEqual(day_shift_row[date_key(first_date)], "A")  # absent on the 1st day of the month
+		self.assertEqual(day_shift_row[date_key(add_days(first_date, 1))], "P")  # present on the 2nd day
 
 		self.assertEqual(row_without_shift["shift"], "")
-		self.assertEqual(row_without_shift[date_key(add_days(today, 3))], "P")  # present on the 4th day
+		self.assertEqual(row_without_shift[date_key(add_days(first_date, 3))], "P")  # present on the 4th day
 
 		# leave should be shown against every shift
 		self.assertTrue(
-			day_shift_row[date_key(add_days(today, 2))]
-			== row_without_shift[date_key(add_days(today, 2))]
+			day_shift_row[date_key(add_days(first_date, 2))]
+			== row_without_shift[date_key(add_days(first_date, 2))]
 			== "L"
 		)
 
@@ -728,18 +729,19 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(row["total_holidays"], 2)
 
 	def test_detailed_view_with_date_range_and_group_by_filter(self):
-		today = getdate()
-		mark_attendance(self.employee, today, "Absent", "Day Shift")
-		mark_attendance(self.employee, today + relativedelta(days=1), "Present", "Day Shift")
+		# attendance can not be marked for future dates
+		first_date = add_days(getdate(), -3)
+		mark_attendance(self.employee, first_date, "Absent", "Day Shift")
+		mark_attendance(self.employee, first_date + relativedelta(days=1), "Present", "Day Shift")
 
 		# attendance without shift
-		mark_attendance(self.employee, today + relativedelta(days=2), "On Leave")
-		mark_attendance(self.employee, today + relativedelta(days=3), "Present")
+		mark_attendance(self.employee, first_date + relativedelta(days=2), "On Leave")
+		mark_attendance(self.employee, first_date + relativedelta(days=3), "Present")
 		filters = frappe._dict(
 			{
 				"filter_based_on": "Date Range",
-				"start_date": add_days(today, -1),
-				"end_date": add_days(today, 30),
+				"start_date": add_days(first_date, -1),
+				"end_date": add_days(first_date, 30),
 				"company": self.company,
 				"group_by": "Department",
 			}
@@ -749,16 +751,16 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		row_without_shift = report[1][2]
 
 		self.assertEqual(day_shift_row["shift"], "Day Shift")
-		self.assertEqual(day_shift_row[date_key(today)], "A")  # absent on the 1st day of the month
-		self.assertEqual(day_shift_row[date_key(add_days(today, 1))], "P")  # present on the 2nd day
+		self.assertEqual(day_shift_row[date_key(first_date)], "A")  # absent on the 1st day of the month
+		self.assertEqual(day_shift_row[date_key(add_days(first_date, 1))], "P")  # present on the 2nd day
 
 		self.assertEqual(row_without_shift["shift"], "")
-		self.assertEqual(row_without_shift[date_key(add_days(today, 3))], "P")  # present on the 4th day
+		self.assertEqual(row_without_shift[date_key(add_days(first_date, 3))], "P")  # present on the 4th day
 
 		# leave should be shown against every shift
 		self.assertTrue(
-			day_shift_row[date_key(add_days(today, 2))]
-			== row_without_shift[date_key(add_days(today, 2))]
+			day_shift_row[date_key(add_days(first_date, 2))]
+			== row_without_shift[date_key(add_days(first_date, 2))]
 			== "L"
 		)
 


### PR DESCRIPTION
**Description:** Attendance could be marked for dates that have not happened yet.

The bulk-marking dialog was the obvious entry point, but it was not the only one. Because there was no validation on the Attendance doctype itself, a user could still mark a future date as Present from the Attendance form, from the Employee Attendance Tool, or over the API. Shift auto-attendance could also mark employees Absent for future days whenever Last Sync of Checkin ran ahead of today.

Marking someone Present or Absent for a day they have not worked yet is wrong on its own, and it also feeds payroll: those records are counted as payment days on the Salary Slip.

Closes: #5125 

**Before:**

[Screencast from 2026-08-06 12-30-51.webm](https://github.com/user-attachments/assets/aecc0187-1ebe-4287-addb-c4f41f2f2701)

**After:**

[Screencast from 2026-08-06 12-26-48.webm](https://github.com/user-attachments/assets/74a516eb-a4c5-4133-9186-b066f57d6acf)


**Backport needed for v15, v16**