### PR TITLE
fix: Avoid lambda in safe_eval (backport #4955)

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2425,7 +2425,7 @@ def _check_attributes(code: str) -> None:
 		if attribute in code:
 			raise SyntaxError(f'Illegal rule {frappe.bold(code)}. Cannot use "{attribute}"')
 
-	BLOCKED_NODES = (ast.NamedExpr,)
+	BLOCKED_NODES = (ast.NamedExpr, ast.Lambda)
 
 	tree = ast.parse(code, mode="eval")
 	for node in ast.walk(tree):


### PR DESCRIPTION
Had to backport manually from #4955 because there are major refactors done between the two versions