### PR TITLE
Feat/group company employee analytics

### DIFF
--- a/hrms/hr/report/employee_analytics/employee_analytics.py
+++ b/hrms/hr/report/employee_analytics/employee_analytics.py
@@ -18,10 +18,11 @@ def execute(filters=None):
 		frappe.throw(_("{0} is mandatory").format(_("Company")))
 
 	columns = get_columns()
-	employees = get_employees(filters)
+	companies = get_companies(filters.get("company"))
+	employees = get_employees(filters, companies)
 	parameters = get_parameters(filters)
 
-	chart = get_chart_data(parameters, filters)
+	chart = get_chart_data(parameters, filters, companies)
 	return columns, employees, None, chart
 
 
@@ -38,11 +39,20 @@ def get_columns():
 	]
 
 
-def get_employees(filters):
+def get_companies(company):
+	child_companies = frappe.get_all("Company", filters={"parent_company": company}, pluck="name")
+	if child_companies:
+		return [company, *child_companies]
+	return [company]
+
+
+def get_employees(filters, companies):
 	filters_for_employees = frappe._dict(deepcopy(filters) or {})
 	filters_for_employees["status"] = "Active"
 	filters_for_employees[filters.get("parameter").lower().replace(" ", "_")] = ["is", "set"]
 	filters_for_employees.pop("parameter")
+	if len(companies) > 1:
+		filters_for_employees["company"] = ["in", companies]
 	return frappe.get_list(
 		"Employee",
 		filters=filters_for_employees,
@@ -68,7 +78,7 @@ def get_parameters(filters):
 	return frappe.get_all(parameter, pluck="name")
 
 
-def get_chart_data(parameters, filters):
+def get_chart_data(parameters, filters, companies):
 	if not parameters:
 		parameters = []
 	datasets = []
@@ -77,21 +87,28 @@ def get_chart_data(parameters, filters):
 	employee = frappe.qb.DocType("Employee")
 	for parameter in parameters:
 		if parameter:
-			total_employee = (
+			query = (
 				frappe.qb.from_(employee)
 				.select(Count(employee.name).as_("count"))
-				.where(employee.company == filters.get("company"))
 				.where(employee.status == "Active")
 				.where(employee[parameter_field_name] == parameter)
 				.where(Criterion.all(build_qb_match_conditions("Employee")))
-			).run()
+			)
+			if len(companies) > 1:
+				query = query.where(employee.company.isin(companies))
+			else:
+				query = query.where(employee.company == companies[0])
+			total_employee = query.run()
 			if total_employee[0][0]:
 				label.append(parameter)
 			datasets.append(total_employee[0][0])
 
 	values = [value for value in datasets if value != 0]
 
-	total_employee = frappe.db.count("Employee", {"status": "Active", "company": filters.get("company")})
+	if len(companies) > 1:
+		total_employee = frappe.db.count("Employee", {"status": "Active", "company": ["in", companies]})
+	else:
+		total_employee = frappe.db.count("Employee", {"status": "Active", "company": companies[0]})
 	others = total_employee - sum(values)
 
 	label.append("Not Set")

--- a/hrms/hr/report/employee_analytics/employee_analytics.py
+++ b/hrms/hr/report/employee_analytics/employee_analytics.py
@@ -40,10 +40,16 @@ def get_columns():
 
 
 def get_companies(company):
-	child_companies = frappe.get_all("Company", filters={"parent_company": company}, pluck="name")
-	if child_companies:
-		return [company, *child_companies]
-	return [company]
+	company_list = [company]
+
+	if company and frappe.db.get_value("Company", company, "is_group"):
+		lft, rgt = frappe.db.get_value("Company", company, ["lft", "rgt"])
+		child_companies = frappe.db.get_list(
+			"Company", filters={"lft": [">", lft], "rgt": ["<", rgt]}, pluck="name"
+		)
+		company_list.extend(child_companies)
+
+	return company_list
 
 
 def get_employees(filters, companies):
@@ -51,8 +57,7 @@ def get_employees(filters, companies):
 	filters_for_employees["status"] = "Active"
 	filters_for_employees[filters.get("parameter").lower().replace(" ", "_")] = ["is", "set"]
 	filters_for_employees.pop("parameter")
-	if len(companies) > 1:
-		filters_for_employees["company"] = ["in", companies]
+	filters_for_employees["company"] = ["in", companies]
 	return frappe.get_list(
 		"Employee",
 		filters=filters_for_employees,
@@ -87,28 +92,21 @@ def get_chart_data(parameters, filters, companies):
 	employee = frappe.qb.DocType("Employee")
 	for parameter in parameters:
 		if parameter:
-			query = (
+			total_employee = (
 				frappe.qb.from_(employee)
 				.select(Count(employee.name).as_("count"))
+				.where(employee.company.isin(companies))
 				.where(employee.status == "Active")
 				.where(employee[parameter_field_name] == parameter)
 				.where(Criterion.all(build_qb_match_conditions("Employee")))
-			)
-			if len(companies) > 1:
-				query = query.where(employee.company.isin(companies))
-			else:
-				query = query.where(employee.company == companies[0])
-			total_employee = query.run()
+			).run()
 			if total_employee[0][0]:
 				label.append(parameter)
 			datasets.append(total_employee[0][0])
 
 	values = [value for value in datasets if value != 0]
 
-	if len(companies) > 1:
-		total_employee = frappe.db.count("Employee", {"status": "Active", "company": ["in", companies]})
-	else:
-		total_employee = frappe.db.count("Employee", {"status": "Active", "company": companies[0]})
+	total_employee = frappe.db.count("Employee", {"status": "Active", "company": ["in", companies]})
 	others = total_employee - sum(values)
 
 	label.append("Not Set")

--- a/hrms/hr/report/employee_analytics/test_employee_analytics.py
+++ b/hrms/hr/report/employee_analytics/test_employee_analytics.py
@@ -47,6 +47,32 @@ class TestEmployeeAnalytics(HRMSTestSuite):
 		chart_data = report[3]["data"]
 		test_data(self, values_to_assert, chart_data)
 
+	def test_group_company(self):
+		parent_company = create_company("_Test Group Company")
+		child_company_1 = create_company("_Test Child Company 1", parent_company=parent_company)
+		child_company_2 = create_company("_Test Child Company 2", parent_company=parent_company)
+
+		make_employee("test_group1@example.com", company=parent_company, branch="Test Branch 1")
+		make_employee("test_group2@example.com", company=child_company_1, branch="Test Branch 1")
+		make_employee("test_group3@example.com", company=child_company_2, branch="Test Branch 2")
+
+		filters = frappe._dict({"company": parent_company, "parameter": "Branch"})
+		report = execute(filters=filters)
+		employees_in_report = report[1]
+
+		self.assertEqual(len(employees_in_report), 3)
+
+		chart_data = report[3]["data"]
+		branch_1_idx = chart_data["labels"].index("Test Branch 1")
+		branch_2_idx = chart_data["labels"].index("Test Branch 2")
+		self.assertEqual(chart_data["datasets"][0]["values"][branch_1_idx], 2)
+		self.assertEqual(chart_data["datasets"][0]["values"][branch_2_idx], 1)
+
+		# selecting a child company should show only that company's data
+		filters_child = frappe._dict({"company": child_company_1, "parameter": "Branch"})
+		report_child = execute(filters=filters_child)
+		self.assertEqual(len(report_child[1]), 1)
+
 
 def test_data(self, values_to_assert, chart_data):
 	values = list(zip(chart_data["labels"], chart_data["datasets"][0]["values"], strict=False))
@@ -77,19 +103,19 @@ def get_employees_without_set_parameter(parameter, company):
 	return frappe.db.count("Employee", {parameter: ("is", "not set"), "company": company, "status": "Active"})
 
 
-def create_company(company_name):
+def create_company(company_name, parent_company=None):
 	if frappe.db.exists("Company", company_name):
 		company = frappe.get_doc("Company", company_name)
 	else:
-		company = frappe.get_doc(
-			{
-				"doctype": "Company",
-				"company_name": company_name,
-				"country": "India",
-				"default_currency": "INR",
-				"create_chart_of_accounts_based_on": "Standard Template",
-				"chart_of_accounts": "Standard",
-			}
-		)
-		company = company.save()
+		doc = {
+			"doctype": "Company",
+			"company_name": company_name,
+			"country": "India",
+			"default_currency": "INR",
+			"create_chart_of_accounts_based_on": "Standard Template",
+			"chart_of_accounts": "Standard",
+		}
+		if parent_company:
+			doc["parent_company"] = parent_company
+		company = frappe.get_doc(doc).save()
 	return company.name

--- a/hrms/hr/report/employee_analytics/test_employee_analytics.py
+++ b/hrms/hr/report/employee_analytics/test_employee_analytics.py
@@ -12,18 +12,18 @@ class TestEmployeeAnalytics(HRMSTestSuite):
 	def setUp(self):
 		create_branches()
 		create_employee_grade()
-		self.company = "_Test Company"
-		self.company_2 = create_company("_Test Company 2")
 
 	def test_branches(self):
-		make_employee("test_analytics1@example.com", company=self.company, branch="Test Branch 1")
-		make_employee("test_analytics2@example.com", company=self.company, branch="Test Branch 2")
-		make_employee("test_analytics3@example.com", company=self.company, branch="Test Branch 2")
-		make_employee("test_analytics4@Eexample.com", company=self.company_2)
+		# Use a standalone company so the is_group expansion does not pull in other test data
+		standalone_company = create_company("_Test Analytics Standalone Company")
 
-		employees_with_no_branch = get_employees_without_set_parameter("branch", self.company)
+		make_employee("test_analytics1@example.com", company=standalone_company, branch="Test Branch 1")
+		make_employee("test_analytics2@example.com", company=standalone_company, branch="Test Branch 2")
+		make_employee("test_analytics3@example.com", company=standalone_company, branch="Test Branch 2")
 
-		filters = frappe._dict({"company": self.company, "parameter": "Branch"})
+		employees_with_no_branch = get_employees_without_set_parameter("branch", standalone_company)
+
+		filters = frappe._dict({"company": standalone_company, "parameter": "Branch"})
 
 		report = execute(filters=filters)
 		employees_in_report = report[1]
@@ -35,13 +35,16 @@ class TestEmployeeAnalytics(HRMSTestSuite):
 		test_data(self, values_to_assert, chart_data)
 
 	def test_employee_grade(self):
-		make_employee("test_analytics1@example.com", company=self.company, grade="1")
-		make_employee("test_analytics2@example.com", company=self.company, grade="2")
-		make_employee("test_analytics3@example.com", company=self.company, grade="2")
+		# Use a standalone company so the is_group expansion does not pull in other test data
+		standalone_company = create_company("_Test Analytics Standalone Company")
 
-		employees_with_no_grade = get_employees_without_set_parameter("grade", self.company)
+		make_employee("test_analytics1@example.com", company=standalone_company, grade="1")
+		make_employee("test_analytics2@example.com", company=standalone_company, grade="2")
+		make_employee("test_analytics3@example.com", company=standalone_company, grade="2")
+
+		employees_with_no_grade = get_employees_without_set_parameter("grade", standalone_company)
 		values_to_assert = {"1": 1, "2": 2, "Not Set": employees_with_no_grade}
-		filters = frappe._dict({"company": self.company, "parameter": "Grade"})
+		filters = frappe._dict({"company": standalone_company, "parameter": "Grade"})
 		report = execute(filters=filters)
 
 		chart_data = report[3]["data"]
@@ -105,17 +108,17 @@ def get_employees_without_set_parameter(parameter, company):
 
 def create_company(company_name, parent_company=None):
 	if frappe.db.exists("Company", company_name):
-		company = frappe.get_doc("Company", company_name)
-	else:
-		doc = {
-			"doctype": "Company",
-			"company_name": company_name,
-			"country": "India",
-			"default_currency": "INR",
-			"create_chart_of_accounts_based_on": "Standard Template",
-			"chart_of_accounts": "Standard",
-		}
-		if parent_company:
-			doc["parent_company"] = parent_company
-		company = frappe.get_doc(doc).save()
-	return company.name
+		return company_name
+
+	doc = {
+		"doctype": "Company",
+		"company_name": company_name,
+		"country": "India",
+		"default_currency": "INR",
+		"create_chart_of_accounts_based_on": "Standard Template",
+		"chart_of_accounts": "Standard",
+	}
+	if parent_company:
+		doc["parent_company"] = parent_company
+
+	return frappe.get_doc(doc).save().name

--- a/hrms/hr/report/employee_analytics/test_employee_analytics.py
+++ b/hrms/hr/report/employee_analytics/test_employee_analytics.py
@@ -51,7 +51,7 @@ class TestEmployeeAnalytics(HRMSTestSuite):
 		test_data(self, values_to_assert, chart_data)
 
 	def test_group_company(self):
-		parent_company = create_company("_Test Group Company")
+		parent_company = create_company("_Test Group Company", is_group=1)
 		child_company_1 = create_company("_Test Child Company 1", parent_company=parent_company)
 		child_company_2 = create_company("_Test Child Company 2", parent_company=parent_company)
 
@@ -106,7 +106,7 @@ def get_employees_without_set_parameter(parameter, company):
 	return frappe.db.count("Employee", {parameter: ("is", "not set"), "company": company, "status": "Active"})
 
 
-def create_company(company_name, parent_company=None):
+def create_company(company_name, parent_company=None, is_group=0):
 	if frappe.db.exists("Company", company_name):
 		return company_name
 
@@ -117,6 +117,7 @@ def create_company(company_name, parent_company=None):
 		"default_currency": "INR",
 		"create_chart_of_accounts_based_on": "Standard Template",
 		"chart_of_accounts": "Standard",
+		"is_group": is_group,
 	}
 	if parent_company:
 		doc["parent_company"] = parent_company


### PR DESCRIPTION
## What changed

The Employee Analytics report now supports Group Companies.

When a company is set up as a parent with child companies, selecting the parent in the report shows combined data from all child companies. Selecting a child company still shows only that company's data.



https://github.com/user-attachments/assets/3c1dca94-1566-4659-8004-f5dd791a0b69





no-docs