### PR TITLE
chore(frontend): remove unused frappe-ui submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "frappe-ui"]
-	path = frappe-ui
-	url = https://github.com/frappe/frappe-ui

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/frappe/hrms/issues"
   },
-  "aworkspaces": ["frontend", "roster", "frappe-ui"],
+  "aworkspaces": ["frontend", "roster"],
   "scripts": {
     "postinstall": "yarn install-pwa-deps && yarn install-roster-deps",
     "install-pwa-deps": "cd frontend && yarn install --check-files",


### PR DESCRIPTION
## What changed

- Removed the unused `frappe-ui` Git submodule and `.gitmodules`.
- Removed the stale `frappe-ui` entry from the root `aworkspaces` list.

## Why

The HRMS PWA and Roster frontend already install `frappe-ui` independently through their respective `package.json` and lockfiles. Neither the build scripts nor CI use the submodule.

Keeping the submodule therefore introduced an additional, misleading `frappe-ui` version reference without affecting either frontend build.

## Impact

This simplifies repository setup and avoids confusion about which `frappe-ui` version is actually used. Frontend dependency versions and runtime behavior remain unchanged.

## Documentation

No documentation changes are required because this only removes unused repository configuration.