### PR TITLE
fix: prevent mutation/deletion of submitted Shift Assignments in insert_shift

### DIFF
--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -242,7 +242,7 @@ def insert_shift(
 		"shift_type": shift_type,
 		"status": status,
 		"shift_location": shift_location,
-		"docstatus": ["!=", 2],
+		"docstatus": 0,
 	}
 	prev_shift = frappe.db.exists(dict({"end_date": add_days(start_date, -1)}, **filters))
 	next_shift = (
@@ -255,7 +255,6 @@ def insert_shift(
 			frappe.has_permission("Shift Assignment", "write", next_shift, throw=True)
 			end_date = frappe.db.get_value("Shift Assignment", next_shift, "end_date")
 			frappe.has_permission("Shift Assignment", "delete", next_shift, throw=True)
-			frappe.db.set_value("Shift Assignment", next_shift, "docstatus", 2)
 			frappe.delete_doc("Shift Assignment", next_shift)
 		frappe.db.set_value("Shift Assignment", prev_shift, "end_date", end_date or None)
 

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -80,7 +80,6 @@ class TestRoster(HRMSTestSuite):
 		)
 		self.assertTrue(new_assignment)
 
-
 	def test_insert_shift_rejects_adjacent_submitted_shift(self):
 		"""Submitted Shift Assignments should not be mutated. A new Draft should be created."""
 		employee_name = f"_Test Roster Sub {frappe.generate_hash(length=8)}"
@@ -193,6 +192,8 @@ class TestRoster(HRMSTestSuite):
 			},
 		)
 		self.assertTrue(new_assignment)
+
+
 def create_employee(employee_name: str):
 	create_company()
 	if not frappe.db.exists("Gender", "Female"):

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -81,6 +81,118 @@ class TestRoster(HRMSTestSuite):
 		self.assertTrue(new_assignment)
 
 
+	def test_insert_shift_rejects_adjacent_submitted_shift(self):
+		"""Submitted Shift Assignments should not be mutated. A new Draft should be created."""
+		employee_name = f"_Test Roster Sub {frappe.generate_hash(length=8)}"
+		employee = create_employee(employee_name)
+		shift_type = create_shift_type(
+			f"_Test Sub Shift {frappe.generate_hash(length=8)}",
+			start_time="08:00:00",
+			end_time="17:00:00",
+			color="Blue",
+		)
+
+		original = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": employee.name,
+				"company": "_Test Company",
+				"shift_type": shift_type.name,
+				"start_date": "2026-07-01",
+				"end_date": "2026-07-10",
+				"status": "Active",
+			}
+		)
+		original.submit()
+		original_end_date = original.end_date
+
+		insert_shift(
+			employee=employee.name,
+			company="_Test Company",
+			shift_type=shift_type.name,
+			start_date="2026-07-11",
+			end_date="2026-07-20",
+			status="Active",
+		)
+
+		original.reload()
+		self.assertEqual(getdate(original.end_date), getdate(original_end_date))
+		self.assertEqual(original.docstatus, 1)
+
+		new_assignment = frappe.db.get_value(
+			"Shift Assignment",
+			{
+				"employee": employee.name,
+				"start_date": "2026-07-11",
+				"end_date": "2026-07-20",
+				"docstatus": 1,
+			},
+		)
+		self.assertTrue(new_assignment)
+
+	def test_insert_shift_rejects_merging_two_submitted_shifts(self):
+		"""When inserted between two submitted shifts, neither should be deleted/mutated. A new Draft should be created in between."""
+		employee_name = f"_Test Roster Merge {frappe.generate_hash(length=8)}"
+		employee = create_employee(employee_name)
+		shift_type = create_shift_type(
+			f"_Test Merge Shift {frappe.generate_hash(length=8)}",
+			start_time="08:00:00",
+			end_time="17:00:00",
+			color="Green",
+		)
+
+		left = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": employee.name,
+				"company": "_Test Company",
+				"shift_type": shift_type.name,
+				"start_date": "2026-07-01",
+				"end_date": "2026-07-10",
+				"status": "Active",
+			}
+		)
+		left.submit()
+		left_end_date = left.end_date
+
+		right = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": employee.name,
+				"company": "_Test Company",
+				"shift_type": shift_type.name,
+				"start_date": "2026-07-21",
+				"end_date": "2026-07-30",
+				"status": "Active",
+			}
+		)
+		right.submit()
+		right_start_date = right.start_date
+
+		insert_shift(
+			employee=employee.name,
+			company="_Test Company",
+			shift_type=shift_type.name,
+			start_date="2026-07-11",
+			end_date="2026-07-20",
+			status="Active",
+		)
+
+		left.reload()
+		right.reload()
+		self.assertEqual(getdate(left.end_date), getdate(left_end_date))
+		self.assertEqual(getdate(right.start_date), getdate(right_start_date))
+
+		new_assignment = frappe.db.get_value(
+			"Shift Assignment",
+			{
+				"employee": employee.name,
+				"start_date": "2026-07-11",
+				"end_date": "2026-07-20",
+				"docstatus": 1,
+			},
+		)
+		self.assertTrue(new_assignment)
 def create_employee(employee_name: str):
 	create_company()
 	if not frappe.db.exists("Gender", "Female"):
@@ -138,3 +250,4 @@ def create_shift_assignment(shift_type: str, employee: str, date: str):
 	)
 	shift_assignment.submit()
 	return shift_assignment
+

--- a/hrms/tests/test_roster.py
+++ b/hrms/tests/test_roster.py
@@ -251,4 +251,3 @@ def create_shift_assignment(shift_type: str, employee: str, date: str):
 	)
 	shift_assignment.submit()
 	return shift_assignment
-


### PR DESCRIPTION
insert_shift() in roster.py can match a Submitted (docstatus=1) adjacent Shift Assignment and either silently mutate its dates via db.set_value, or in the merge case, force docstatus=2 and delete_doc it directly -- bypassing on_cancel hooks entirely and orphaning any linked records (checkins, attendance). This is a state-machine gap independent of the permission checks already merged in #4740 and the cancelled-record filter in #4890 -- neither of those addressed Submitted-state documents specifically. Added an explicit docstatus == 0 guard before any mutation, so submitted/cancelled assignments must be properly cancelled first via the standard workflow.