### PR TITLE
fix: skip expire_allocation for already-cancelled Leave Allocations

### DIFF
--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -227,6 +227,9 @@ def expire_allocation(allocation: str | Document | frappe._dict, expiry_date: da
 		allocation = json.loads(allocation)
 		allocation = frappe.get_doc("Leave Allocation", allocation["name"])
 
+	if getattr(allocation, "docstatus", 0) == 2:
+		return
+
 	frappe.has_permission("Leave Allocation", "write", allocation.name, throw=True)
 
 	leaves = get_remaining_leaves(allocation)


### PR DESCRIPTION
expire_allocation() in leave_ledger_entry.py set expired=1 and created ledger entries for a Leave Allocation without checking if it was already cancelled (docstatus == 2). Added an early-return guard.