### PR TITLE
feat: filter system users in department approver tables

### DIFF
--- a/hrms/public/js/erpnext/department.js
+++ b/hrms/public/js/erpnext/department.js
@@ -11,5 +11,15 @@ frappe.ui.form.on("Department", {
 				},
 			};
 		});
+
+		["leave_approvers", "expense_approvers", "shift_request_approver"].forEach((table) => {
+			frm.set_query("approver", table, function () {
+				return {
+					filters: {
+						user_type: "System User",
+					},
+				};
+			});
+		});
 	},
 });


### PR DESCRIPTION
## What changed
Added a set_query filter on the Approver field in all three Department Approver
child tables (Leave Approvers, Expense Approvers, Shift Request Approver) to
show only System Users in the dropdown.

## Why
Website Users should not be selectable as approvers in the Department form.
Only System Users can act as approvers.

## How to test
1. Open any Department record.
2. Go to the Leave Approvers / Expense Approvers / Shift Request Approver table.
3. Click the Approver field and search — only System Users should appear.

Before:

https://github.com/user-attachments/assets/fe7eca0b-6520-4d3f-85e5-ca4e865df96f

After:

https://github.com/user-attachments/assets/b87d101e-0fe4-47ed-8da0-d3824e85e55b


no-docs