### PR TITLE
fix: correct salary slip naming when created via data import

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -150,8 +150,11 @@ class SalarySlip(TransactionBase):
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.default_series = f"Sal Slip/{self.employee}/.#####"
 		self.whitelisted_globals = COMPONENT_EVAL_GLOBALS.copy()
+
+	@property
+	def default_series(self):
+		return f"Sal Slip/{self.employee}/.#####"
 
 	def autoname(self):
 		if not self.has_custom_naming_series:


### PR DESCRIPTION
## What's the problem?

When a Salary Slip is created via Data Import, the name comes out wrong — for example `Sal Slip/None/00001` instead of `Sal Slip/HR-EMP-00010/00001`.

## Why does it happen?

`default_series` was set as an instance variable in `__init__` using `self.employee`. At that point, Frappe hasn't set any field values yet, so `self.employee` is `None`.

## Fix

Changed `default_series` from an instance variable to a `@property`. It now reads `self.employee` lazily — at the time `autoname()` actually calls it, the employee field is already set.

## Test

1. Create a Data Import for Salary Slip with an employee and period.
2. Run the import.
3. Verify the generated name follows the pattern `Sal Slip/<employee>/<number>`.

Before:

https://github.com/user-attachments/assets/a71f6194-0abd-439c-9977-db2529d3cbe5

After:

https://github.com/user-attachments/assets/603acc71-983f-4012-b1cd-3a59e8fa9faa



no-docs
