### PR TITLE
feat: add Contract link in Employee Connections section

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -58,12 +58,14 @@ def get_dashboard_for_employee(data):
 				"items": ["Training Event", "Training Result", "Training Feedback", "Employee Skill Map"],
 			},
 			{"label": _("Evaluation"), "items": ["Appraisal"]},
+			{"label": _("Contract"), "items": ["Contract"]},
 		]
 	)
 
 	data["non_standard_fieldnames"].update(
 		{
 			"Bank Account": "party",
+			"Contract": "party_name",
 			"Employee Grievance": "raised_by",
 			"Holiday List Assignment": "assigned_to",
 		}
@@ -72,6 +74,7 @@ def get_dashboard_for_employee(data):
 	if not data.get("dynamic_links"):
 		data["dynamic_links"] = {}
 	data["dynamic_links"]["assigned_to"] = ["Employee", "applicable_for"]
+	data["dynamic_links"]["party_name"] = ["Employee", "party_type"]
 	data.update(
 		{
 			"heatmap": True,


### PR DESCRIPTION
Closes #[1648](https://github.com/frappe/hrms/issues/1648)

## What changed

Added `Contract` to the Employee connections dashboard. Employees can now
see and create linked Contracts directly from the Employee form.

## How it works

The CRM `Contract` doctype already supports `party_type = Employee`. The
change wires this into the Employee dashboard by:
- Adding a `Contract` section to the connections list
- Mapping `Contract` to its `party_name` field (non-standard fieldname)
- Adding a `party_name` dynamic link so Frappe filters by `party_type = Employee`

no-docs
