### PR TITLE
Fix: Move filters variable inside callback in full_and_final_statement.js

### DIFF
--- a/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
+++ b/hrms/hr/doctype/full_and_final_statement/full_and_final_statement.js
@@ -25,9 +25,8 @@ frappe.ui.form.on("Full and Final Statement", {
 			};
 		});
 
-		let filters = {};
-
 		frm.set_query("reference_document", type, function (doc, cdt, cdn) {
+			let filters = {};
 			let fnf_doc = frappe.get_doc(cdt, cdn);
 
 			frappe.model.with_doctype(fnf_doc.reference_document_type, function () {


### PR DESCRIPTION
# Fix: Move filters variable inside callback in full_and_final_statement.js

## Summary

The filters variable in the reference_document query callback was declared outside the callback, causing it to persist across multiple calls and apply incorrect filters. Moving the variable inside the callback ensures each call gets a fresh filters object.

Fixes #4960

## Changes

- Moved the `let filters = {};` declaration inside the callback function for the reference_document query in full_and_final_statement.js.

## Testing

- Verified the JavaScript syntax is correct using `node -c`.
- Reviewed the code to ensure no other similar issues exist.
- Since the change is localized and does not affect the server-side logic, manual testing of the Leave Encashment and Expense Claim flows in the Full and Final Statement form would be required to confirm the fix, but we rely on the sandbox environment for safety.

---
### AI disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
