### PR TITLE
fix: show Holiday List Assignment in Holiday List connections

### DIFF
--- a/hrms/overrides/dashboard_overrides.py
+++ b/hrms/overrides/dashboard_overrides.py
@@ -89,6 +89,16 @@ def get_dashboard_for_employee(data):
 def get_dashboard_for_holiday_list(data):
 	data["non_standard_fieldnames"].update({"Leave Period": "optional_holiday_list"})
 
+	for section in data["transactions"]:
+		items = section.get("items", [])
+		removed = False
+		for doctype in ("Employee", "Company"):
+			if doctype in items:
+				items.remove(doctype)
+				removed = True
+		if removed:
+			items.append("Holiday List Assignment")
+
 	data["transactions"].append({"items": ["Leave Period", "Shift Type"]})
 
 	return data


### PR DESCRIPTION
The Holiday List connections section showed Employee and Company using a direct link field that HRMS does not use. This gave wrong counts.

In HRMS version 16, holiday lists are assigned via Holiday List Assignment for both employees and companies. This fix replaces Employee and Company with Holiday List Assignment in the connections section so the count is accurate.

Before:
<img width="2880" height="1368" alt="image" src="https://github.com/user-attachments/assets/e183d2d8-7a0e-448e-915e-86de0b434317" />

After:

<img width="2880" height="1368" alt="image" src="https://github.com/user-attachments/assets/6c8d05d7-4636-4155-9e79-97e6ee3d6b86" />

no-docs