### PR TITLE
fix: filter employees by company in Employee Leave Balance report

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -22,6 +22,9 @@ frappe.query_reports["Employee Leave Balance"] = {
 			options: "Company",
 			reqd: 1,
 			default: frappe.defaults.get_user_default("Company"),
+			on_change: () => {
+				frappe.query_report.set_filter_value("employee", "");
+			},
 		},
 		{
 			fieldname: "department",

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -34,6 +34,13 @@ frappe.query_reports["Employee Leave Balance"] = {
 			label: __("Employee"),
 			fieldtype: "Link",
 			options: "Employee",
+			get_query: () => {
+				return {
+					filters: {
+						company: frappe.query_report.get_filter_value("company"),
+					},
+				};
+			},
 		},
 		{
 			fieldname: "employee_status",


### PR DESCRIPTION
## Why
Without this, a user could pick an employee from a different company while a company filter was set, and the report would return no data without any error.

## How
Same approach used by the Account filter in the General Ledger report.

## What 
The Employee filter now displays only employees belonging to the selected Company.

<img width="1436" height="678" alt="image" src="https://github.com/user-attachments/assets/b92f7040-ad22-466b-a7c0-357197b8188d" />


no-docs