### PR TITLE
fix: format earned leave schedule dates

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.js
@@ -203,12 +203,14 @@ frappe.ui.form.on("Leave Allocation", {
 			frm.doc.name,
 		);
 		df.formatter = function (value, df, options, row) {
+			const formatted_date = frappe.form.formatters.Date(value, df, options, row);
+
 			if (row.attempted && row.failed) {
-				return `<span class="indicator red">${value}</span>`;
+				return `<span class="indicator red">${formatted_date}</span>`;
 			} else if (row.attempted && row.is_allocated) {
-				return `<span class="indicator green">${value}</span>`;
+				return `<span class="indicator green">${formatted_date}</span>`;
 			} else {
-				return value;
+				return formatted_date;
 			}
 		};
 		frm.refresh_field("earned_leave_schedule");


### PR DESCRIPTION

Fixes Earned Leave Schedule dates in Leave Allocation to respect the System Settings date format.
The schedule’s custom status formatter previously rendered the raw ISO date, bypassing Frappe’s standard Date formatter. It now formats the date first, then applies the existing red/green allocation status indicator.

Before:
<img width="438" height="449" alt="image" src="https://github.com/user-attachments/assets/d21e1c1e-14b8-4861-802b-43108db70fd7" />

After (matching my system settings):
<img width="475" height="438" alt="image" src="https://github.com/user-attachments/assets/d9489710-2024-4835-9cb8-549f575b41b6" />