### PR TITLE
fix(hr): resolve AttributeError in update_job_applicant_status exception handling

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -226,17 +226,17 @@ def update_job_applicant_status(status: str, job_applicant: str):
 		if not job_applicant:
 			frappe.throw(_("Please specify the job applicant to be updated."))
 
-		job_applicant = frappe.get_doc("Job Applicant", job_applicant)
-		job_applicant.status = status
-		job_applicant.save()
+		doc = frappe.get_doc("Job Applicant", job_applicant)
+		doc.status = status
+		doc.save()
 
 		frappe.msgprint(
-			_("Updated the Job Applicant status to {0}").format(job_applicant.status),
+			_("Updated the Job Applicant status to {0}").format(doc.status),
 			alert=True,
 			indicator="green",
 		)
 	except Exception:
-		job_applicant.log_error("Failed to update Job Applicant status")
+		frappe.log_error("Failed to update Job Applicant status")
 		frappe.msgprint(
 			_("Failed to update the Job Applicant status"),
 			alert=True,

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -206,6 +206,18 @@ class TestInterview(HRMSTestSuite):
 
 		self.assertEqual(interview.status, "Cancelled")
 
+	def test_update_job_applicant_status_invalid_input(self):
+		# Ensure passing empty or non-existent job applicant string does not raise AttributeError
+		try:
+			update_job_applicant_status("Accepted", "")
+		except AttributeError:
+			self.fail("update_job_applicant_status raised AttributeError on empty job applicant string")
+
+		try:
+			update_job_applicant_status("Accepted", "NON_EXISTENT_JOB_APPLICANT")
+		except AttributeError:
+			self.fail("update_job_applicant_status raised AttributeError on invalid job applicant ID")
+
 
 def create_interview_and_dependencies(
 	job_applicant,


### PR DESCRIPTION
### Summary of Changes

- **Fix Variable Shadowing**: In `update_job_applicant_status()`, the Document instance is assigned to a separate variable `doc` instead of overriding the string parameter `job_applicant`.
- **Safe Exception Logging**: Replaced `job_applicant.log_error()` with `frappe.log_error()` in the `except Exception:` block. Previously, if `job_applicant` was empty (`""`) or an invalid string, calling `job_applicant.log_error()` raised an `AttributeError: 'str' object has no attribute 'log_error'`, returning an HTTP 500 server error on the whitelisted API endpoint.
- **Unit Test**: Added `test_update_job_applicant_status_invalid_input` in `test_interview.py` asserting graceful handling of invalid or empty job applicant strings.