### PR TITLE
fix(payroll): filter submitted records in get_payroll_entries_for_jv

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1756,6 +1756,7 @@ def get_payroll_entries_for_jv(
 	return (
 		frappe.qb.from_(PayrollEntry)
 		.select(PayrollEntry.name)
+		.where(PayrollEntry.docstatus == 1)
 		.where(PayrollEntry[searchfield].like("%%%s%%" % txt))
 		.where(PayrollEntry.name.notin(linked_entries))
 		.orderby(PayrollEntry.name)

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -236,6 +236,22 @@ class TestPayrollEntry(HRMSTestSuite):
 		self.assertEqual(get_end_date("2017-02-15", "monthly"), {"end_date": "2017-03-14"})
 		self.assertEqual(get_end_date("2017-02-15", "daily"), {"end_date": "2017-02-15"})
 
+	def test_get_payroll_entries_for_jv_filters_docstatus(self):
+		from hrms.payroll.doctype.payroll_entry.payroll_entry import get_payroll_entries_for_jv
+
+		draft_pe = frappe.new_doc("Payroll Entry")
+		draft_pe.company = "_Test Company"
+		draft_pe.currency = "INR"
+		draft_pe.payroll_frequency = "Monthly"
+		draft_pe.start_date = "2026-07-06"
+		draft_pe.end_date = "2026-07-31"
+		draft_pe.flags.ignore_mandatory = True
+		draft_pe.insert(ignore_permissions=True)
+
+		res = get_payroll_entries_for_jv("Payroll Entry", "%", "name", 0, 100, {})
+		entry_names = [d[0] for d in res]
+		self.assertNotIn(draft_pe.name, entry_names)
+
 	@if_lending_app_installed
 	@HRMSTestSuite.change_settings(
 		"Payroll Settings", {"process_payroll_accounting_entry_based_on_employee": 1}


### PR DESCRIPTION
### Summary of Changes

- **Filter Submitted Records**: Added `.where(PayrollEntry.docstatus == 1)` condition to the QueryBuilder query in `get_payroll_entries_for_jv()`.
- **Reason**: `Payroll Entry` is a submittable Doctype. Previously, Draft (`docstatus=0`) and Cancelled (`docstatus=2`) records were returned in Journal Entry selection dialogs. Adding `docstatus = 1` ensures only submitted payroll entries are available for linking in Journal Entries.
- **Unit Test**: Added `test_get_payroll_entries_for_jv_filters_docstatus` in `test_payroll_entry.py`.