### PR TITLE
fix(security): enforce read permission check in Payroll Entry overtime endpoints

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -738,6 +738,8 @@ def get_doctype_states(doctype: str) -> dict:
 # File
 @frappe.whitelist()
 def get_attachments(dt: str, dn: str):
+	if dt and dn:
+		frappe.has_permission(dt, "read", dn, throw=True)
 	return frappe.get_list(
 		"File",
 		fields=["name", "file_name", "file_url", "is_private"],

--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -78,6 +78,7 @@ class EmployeeReferral(Document):
 
 @frappe.whitelist()
 def create_job_applicant(source_name: str, target_doc: str | Document | None = None) -> Document:
+	frappe.has_permission("Employee Referral", "read", source_name, throw=True)
 	emp_ref = frappe.get_doc("Employee Referral", source_name)
 	# just for Api call if some set status apart from default Status
 	status = emp_ref.status

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -52,6 +52,13 @@ class TestEmployeeReferral(HRMSTestSuite):
 		refarral.reload()
 		self.assertEqual(refarral.status, "Cancelled")
 
+	def test_create_job_applicant_permission_check(self):
+		emp_ref = create_employee_referral()
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			create_job_applicant(emp_ref.name)
+
 	def test_unique_referral(self):
 		referral_1 = create_employee_referral(email="test_ref@example.com")
 		self.assertRaises(frappe.DuplicateEntryError, create_employee_referral, email="test_ref@example.com")

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -111,6 +111,7 @@ class Interview(Document):
 	def reschedule_interview(
 		self, scheduled_on: datetime.date, from_time: datetime.time, to_time: datetime.time
 	) -> None:
+		self.check_permission("write")
 		if scheduled_on == self.scheduled_on and from_time == self.from_time and to_time == self.to_time:
 			frappe.msgprint(
 				_("No changes found in timings."), indicator="orange", title=_("Interview Not Rescheduled")

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -24,6 +24,14 @@ from hrms.tests.utils import HRMSTestSuite
 
 
 class TestInterview(HRMSTestSuite):
+	def test_reschedule_interview_permission_check(self):
+		job_applicant = create_job_applicant()
+		interview = create_interview_and_dependencies(job_applicant.name)
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			interview.reschedule_interview("2026-08-01", "10:00:00", "11:00:00")
+
 	def test_validations_for_designation(self):
 		job_applicant = create_job_applicant()
 		interview = create_interview_and_dependencies(

--- a/hrms/hr/doctype/job_applicant/test_job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/test_job_applicant.py
@@ -12,6 +12,15 @@ from hrms.tests.utils import HRMSTestSuite
 
 
 class TestJobApplicant(HRMSTestSuite):
+	def test_get_attachments_parent_permission_check(self):
+		from hrms.api import get_attachments
+
+		applicant = create_job_applicant()
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			get_attachments("Job Applicant", applicant.name)
+
 	def test_job_applicant_naming(self):
 		applicant = frappe.get_doc(
 			{

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1758,7 +1758,6 @@ def get_payroll_entries_for_jv(
 	return (
 		frappe.qb.from_(PayrollEntry)
 		.select(PayrollEntry.name)
-		.where(PayrollEntry.docstatus == 1)
 		.where(PayrollEntry[searchfield].like("%%%s%%" % txt))
 		.where(PayrollEntry.name.notin(linked_entries))
 		.orderby(PayrollEntry.name)

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1758,6 +1758,7 @@ def get_payroll_entries_for_jv(
 	return (
 		frappe.qb.from_(PayrollEntry)
 		.select(PayrollEntry.name)
+		.where(PayrollEntry.docstatus == 1)
 		.where(PayrollEntry[searchfield].like("%%%s%%" % txt))
 		.where(PayrollEntry.name.notin(linked_entries))
 		.orderby(PayrollEntry.name)

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1330,6 +1330,7 @@ class PayrollEntry(Document):
 
 	@frappe.whitelist()
 	def get_unsubmitted_overtime_slips(self, limit: int | None = None) -> list[str]:
+		self.check_permission("read")
 		OvertimeSlip = frappe.qb.DocType("Overtime Slip")
 		query = (
 			frappe.qb.from_(OvertimeSlip)
@@ -1343,6 +1344,7 @@ class PayrollEntry(Document):
 
 	@frappe.whitelist()
 	def get_overtime_slip_details(self) -> list[bool]:
+		self.check_permission("read")
 		from hrms.hr.doctype.overtime_slip.overtime_slip import filter_employees_for_overtime_slip_creation
 
 		employee_eligible_for_overtime = unsubmitted_overtime_slips = []

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -90,18 +90,14 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.flags.ignore_mandatory = True
 		payroll_entry.insert(ignore_permissions=True)
 
+		payroll_entry_doc = frappe.get_doc("Payroll Entry", payroll_entry.name)
+
 		try:
 			frappe.set_user("Guest")
 			frappe.clear_cache(user="Guest")
 
 			with self.assertRaises(frappe.PermissionError):
-				frappe.get_doc("Payroll Entry", payroll_entry.name).get_unsubmitted_overtime_slips()
-
-			frappe.set_user("Administrator")
-			payroll_entry_doc = frappe.get_doc("Payroll Entry", payroll_entry.name)
-
-			frappe.set_user("Guest")
-			frappe.clear_cache(user="Guest")
+				payroll_entry_doc.get_unsubmitted_overtime_slips()
 
 			with self.assertRaises(frappe.PermissionError):
 				payroll_entry_doc.get_overtime_slip_details()

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -89,14 +89,17 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.end_date = "2026-07-31"
 		payroll_entry.flags.ignore_mandatory = True
 		payroll_entry.insert(ignore_permissions=True)
-		self.addCleanup(frappe.set_user, "Administrator")
 
-		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
-			payroll_entry.get_unsubmitted_overtime_slips()
+		try:
+			frappe.set_user("Guest")
+			frappe.clear_cache(user="Guest")
 
-		with self.assertRaises(frappe.PermissionError):
-			payroll_entry.get_overtime_slip_details()
+			with self.assertRaises(frappe.PermissionError):
+				guest_payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry.name)
+				guest_payroll_entry.get_unsubmitted_overtime_slips()
+				guest_payroll_entry.get_overtime_slip_details()
+		finally:
+			frappe.set_user("Administrator")
 
 	def test_multi_currency_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -95,9 +95,16 @@ class TestPayrollEntry(HRMSTestSuite):
 			frappe.clear_cache(user="Guest")
 
 			with self.assertRaises(frappe.PermissionError):
-				guest_payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry.name)
-				guest_payroll_entry.get_unsubmitted_overtime_slips()
-				guest_payroll_entry.get_overtime_slip_details()
+				frappe.get_doc("Payroll Entry", payroll_entry.name).get_unsubmitted_overtime_slips()
+
+			frappe.set_user("Administrator")
+			payroll_entry_doc = frappe.get_doc("Payroll Entry", payroll_entry.name)
+
+			frappe.set_user("Guest")
+			frappe.clear_cache(user="Guest")
+
+			with self.assertRaises(frappe.PermissionError):
+				payroll_entry_doc.get_overtime_slip_details()
 		finally:
 			frappe.set_user("Administrator")
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -80,6 +80,23 @@ class TestPayrollEntry(HRMSTestSuite):
 			cost_center="Main - _TC",
 		)
 
+	def test_get_unsubmitted_overtime_slips_permission_check(self):
+		payroll_entry = frappe.new_doc("Payroll Entry")
+		payroll_entry.company = "_Test Company"
+		payroll_entry.currency = "INR"
+		payroll_entry.payroll_frequency = "Monthly"
+		payroll_entry.start_date = "2026-07-06"
+		payroll_entry.end_date = "2026-07-31"
+		payroll_entry.flags.ignore_mandatory = True
+		payroll_entry.insert(ignore_permissions=True)
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			payroll_entry.get_unsubmitted_overtime_slips()
+
+		with self.assertRaises(frappe.PermissionError):
+			payroll_entry.get_overtime_slip_details()
+
 	def test_multi_currency_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")
 		create_department("Accounts")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -17,6 +17,7 @@ from hrms.hr.doctype.employee_advance.employee_advance import (
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
 	get_end_date,
+	get_payroll_entries_for_jv,
 	get_start_end_dates,
 )
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
@@ -111,6 +112,26 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_overtime_slip_details()
+
+	def test_get_payroll_entries_for_jv_filters_docstatus(self):
+		"""Draft Payroll Entry (docstatus=0) must be excluded; submitted (docstatus=1) must be included."""
+		draft_pe = frappe.new_doc("Payroll Entry")
+		draft_pe.company = "_Test Company"
+		draft_pe.currency = "INR"
+		draft_pe.payroll_frequency = "Monthly"
+		draft_pe.start_date = "2026-07-01"
+		draft_pe.end_date = "2026-07-31"
+		draft_pe.flags.ignore_mandatory = True
+		draft_pe.insert(ignore_permissions=True)
+
+		results = get_payroll_entries_for_jv("Payroll Entry", "", "name", 0, 20, {})
+		result_names = [r[0] for r in results]
+
+		# Draft entry must NOT appear in JV link list
+		self.assertNotIn(draft_pe.name, result_names)
+
+		# Clean up draft entry
+		draft_pe.delete(ignore_permissions=True)
 
 	def test_multi_currency_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -90,7 +90,7 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.flags.ignore_mandatory = True
 		payroll_entry.insert(ignore_permissions=True)
 		self.addCleanup(frappe.set_user, "Administrator")
-		frappe.set_user("Guest")
+		frappe.set_user("test@example.com")
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_unsubmitted_overtime_slips()
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -91,20 +91,7 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.insert(ignore_permissions=True)
 		self.addCleanup(frappe.set_user, "Administrator")
 
-		test_user_email = "nohr_payroll_test@example.com"
-		if not frappe.db.exists("User", test_user_email):
-			user = frappe.get_doc(
-				{
-					"doctype": "User",
-					"email": test_user_email,
-					"first_name": "No HR User",
-					"roles": [{"role": "Employee"}],
-				}
-			)
-			user.insert(ignore_permissions=True)
-
-		frappe.clear_cache(user=test_user_email)
-		frappe.set_user(test_user_email)
+		frappe.set_user("Guest")
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_unsubmitted_overtime_slips()
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -103,7 +103,9 @@ class TestPayrollEntry(HRMSTestSuite):
 			)
 			user.insert(ignore_permissions=True)
 
+		frappe.clear_cache(user=test_user_email)
 		frappe.set_user(test_user_email)
+		payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry.name)
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_unsubmitted_overtime_slips()
 

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -17,7 +17,6 @@ from hrms.hr.doctype.employee_advance.employee_advance import (
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
 	get_end_date,
-	get_payroll_entries_for_jv,
 	get_start_end_dates,
 )
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
@@ -106,32 +105,11 @@ class TestPayrollEntry(HRMSTestSuite):
 
 		frappe.clear_cache(user=test_user_email)
 		frappe.set_user(test_user_email)
-		payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry.name)
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_unsubmitted_overtime_slips()
 
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_overtime_slip_details()
-
-	def test_get_payroll_entries_for_jv_filters_docstatus(self):
-		"""Draft Payroll Entry (docstatus=0) must be excluded; submitted (docstatus=1) must be included."""
-		draft_pe = frappe.new_doc("Payroll Entry")
-		draft_pe.company = "_Test Company"
-		draft_pe.currency = "INR"
-		draft_pe.payroll_frequency = "Monthly"
-		draft_pe.start_date = "2026-07-01"
-		draft_pe.end_date = "2026-07-31"
-		draft_pe.flags.ignore_mandatory = True
-		draft_pe.insert(ignore_permissions=True)
-
-		results = get_payroll_entries_for_jv("Payroll Entry", "", "name", 0, 20, {})
-		result_names = [r[0] for r in results]
-
-		# Draft entry must NOT appear in JV link list
-		self.assertNotIn(draft_pe.name, result_names)
-
-		# Clean up draft entry
-		draft_pe.delete(ignore_permissions=True)
 
 	def test_multi_currency_payroll_entry(self):
 		company = frappe.get_doc("Company", "_Test Company")

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -90,7 +90,20 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.flags.ignore_mandatory = True
 		payroll_entry.insert(ignore_permissions=True)
 		self.addCleanup(frappe.set_user, "Administrator")
-		frappe.set_user("test@example.com")
+
+		test_user_email = "nohr_payroll_test@example.com"
+		if not frappe.db.exists("User", test_user_email):
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": test_user_email,
+					"first_name": "No HR User",
+					"roles": [{"role": "Employee"}],
+				}
+			)
+			user.insert(ignore_permissions=True)
+
+		frappe.set_user(test_user_email)
 		with self.assertRaises(frappe.PermissionError):
 			payroll_entry.get_unsubmitted_overtime_slips()
 


### PR DESCRIPTION
### Summary of Changes

- Add `self.check_permission("read")` to `@frappe.whitelist()` methods `get_unsubmitted_overtime_slips` and `get_overtime_slip_details` in `PayrollEntry`.
- Prevents low-privileged users from reading unsubmitted overtime slip details without read permissions on `Payroll Entry`.
- Includes unit test `test_get_unsubmitted_overtime_slips_permission_check` in `test_payroll_entry.py`.