### PR TITLE
fix(hr): cancel linked Additional Salary on Overtime Slip cancellation

### DIFF
--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -57,6 +57,23 @@ class OvertimeSlip(Document):
 	def on_submit(self):
 		self.process_overtime_slip()
 
+	def on_cancel(self):
+		self.unlink_and_cancel_additional_salary()
+
+	def unlink_and_cancel_additional_salary(self):
+		additional_salaries = frappe.get_all(
+			"Additional Salary",
+			filters={
+				"ref_doctype": "Overtime Slip",
+				"ref_docname": self.name,
+				"docstatus": 1,
+			},
+			pluck="name",
+		)
+		for name in additional_salaries:
+			doc = frappe.get_doc("Additional Salary", name)
+			doc.cancel()
+
 	def validate_overlap(self):
 		overtime_slips = frappe.db.get_all(
 			"Overtime Slip",

--- a/hrms/hr/doctype/overtime_slip/test_overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/test_overtime_slip.py
@@ -62,6 +62,33 @@ class TestOvertimeSlip(HRMSTestSuite):
 		)
 		self.assertEqual(flt(expected_overtime_amount, 2), actual_overtime_amount)
 
+	def test_overtime_slip_cancel_cancels_additional_salary(self):
+		employee = make_employee("test_overtime_cancel@example.com", company="_Test Company")
+		make_salary_structure(
+			"Test Overtime Salary Slip", "Monthly", employee=employee, company="_Test Company"
+		)
+		_, overtime_slip, _ = setup_overtime(employee)
+
+		# Confirm Additional Salary was created and submitted
+		additional_salaries = frappe.get_all(
+			"Additional Salary",
+			filters={"ref_doctype": "Overtime Slip", "ref_docname": overtime_slip.name},
+			pluck="docstatus",
+		)
+		self.assertIn(1, additional_salaries)
+
+		# Cancel Overtime Slip
+		overtime_slip.cancel()
+
+		# Verify linked Additional Salary is cancelled (docstatus=2)
+		cancelled_salaries = frappe.get_all(
+			"Additional Salary",
+			filters={"ref_doctype": "Overtime Slip", "ref_docname": overtime_slip.name},
+			pluck="docstatus",
+		)
+		self.assertTrue(cancelled_salaries)
+		self.assertTrue(all(ds == 2 for ds in cancelled_salaries))
+
 	def test_overtime_calculation_for_fixed_hourly_rate(self):
 		employee = make_employee("test_overtime_slip_fixed@example.com", company="_Test Company")
 		make_salary_structure(


### PR DESCRIPTION
### Summary of Changes

- Implement `on_cancel(self)` hook in `OvertimeSlip` controller to find and cancel linked `Additional Salary` records (`ref_doctype="Overtime Slip"`, `ref_docname=self.name`).
- Prevents cancelled overtime slips from leaving active submitted `Additional Salary` records in payroll processing.
- Includes unit test `test_overtime_slip_cancel_cancels_additional_salary` in `test_overtime_slip.py`.