### PR TITLE
fix: None type error on updating Salary Component where type "Employer Contribution"

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -164,6 +164,8 @@ class SalaryComponent(Document):
 		if not structures:
 			structures = self.get_structures_to_be_updated()
 
+		table_fieldname = frappe.scrub(self.type) + "s"
+
 		for structure in structures:
 			frappe.has_permission("Salary Structure", "write", structure, throw=True)
 			salary_structure = frappe.get_doc("Salary Structure", structure)
@@ -173,9 +175,13 @@ class SalaryComponent(Document):
 			salary_structure._doc_before_save = copy.deepcopy(salary_structure)
 
 			salary_detail_row = next(
-				(d for d in salary_structure.get(f"{self.type.lower()}s") if d.salary_component == self.name),
+				(d for d in salary_structure.get(table_fieldname) if d.salary_component == self.name),
 				None,
 			)
+
+			if not salary_detail_row:
+				continue
+
 			if is_formula_related:
 				value = value if self.amount_based_on_formula else None
 				salary_detail_row.set("amount_based_on_formula", self.amount_based_on_formula)


### PR DESCRIPTION
`no-docs`

<img width="1837" height="705" alt="image" src="https://github.com/user-attachments/assets/2e785a3a-2e29-4321-b645-cd679862e901" />

Resolves #5004 