### PR TITLE
fix: PostgreSQL compatibility — explicit numeric comparisons

### DIFF
--- a/hrms/patches/post_install/update_employee_advance_status.py
+++ b/hrms/patches/post_install/update_employee_advance_status.py
@@ -10,7 +10,8 @@ def execute():
 		.set(advance.status, "Returned")
 		.where(
 			(advance.docstatus == 1)
-			& ((advance.return_amount) & (advance.paid_amount == advance.return_amount))
+			& (advance.return_amount > 0)
+			& (advance.paid_amount == advance.return_amount)
 			& (advance.status == "Paid")
 		)
 	).run()
@@ -20,10 +21,9 @@ def execute():
 		.set(advance.status, "Partly Claimed and Returned")
 		.where(
 			(advance.docstatus == 1)
-			& (
-				(advance.claimed_amount & advance.return_amount)
-				& (advance.paid_amount == (advance.return_amount + advance.claimed_amount))
-			)
+			& (advance.claimed_amount > 0)
+			& (advance.return_amount > 0)
+			& (advance.paid_amount == (advance.return_amount + advance.claimed_amount))
 			& (advance.status == "Paid")
 		)
 	).run()


### PR DESCRIPTION
Fix PostgreSQL error during Frappe v17 (develop) setup with PostgreSQL backend:

### `update_employee_advance_status.py` — bare numeric fields in WHERE

The post-install patch used bare `return_amount` and `claimed_amount` (Currency fields, stored as `numeric`) in boolean context:

```python
.where((advance.return_amount) & (advance.paid_amount == advance.return_amount))
```

PostgreSQL rejects numeric types in boolean context with:

```
argument of AND must be type boolean, not type numeric
```

**Fix:** Changed bare numeric references to explicit `> 0` comparisons:

```python
.where((advance.return_amount > 0) & (advance.paid_amount == advance.return_amount))
```

Semantically equivalent — both return_amount and claimed_amount are non-negative currency values. Backwards-compatible with MariaDB.