### PR TITLE
fix: show Preview Salary Slip option in draft Salary Structure Assign…

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -906,6 +906,14 @@ class SalarySlip(TransactionBase):
 			as_dict=True,
 		)
 
+		if not self._salary_structure_assignment and getattr(self, "_preview_ssa_name", None):
+			self._salary_structure_assignment = frappe.db.get_value(
+				"Salary Structure Assignment",
+				self._preview_ssa_name,
+				"*",
+				as_dict=True,
+			)
+
 		if not self._salary_structure_assignment:
 			frappe.throw(
 				_(
@@ -1139,6 +1147,12 @@ class SalarySlip(TransactionBase):
 		salary_slip = frappe.copy_doc(self)
 		# consider full payment days for future period
 		salary_slip.payment_days = salary_slip.total_working_days
+		if getattr(self, "_preview_ssa_name", None):
+			salary_slip._preview_ssa_name = self._preview_ssa_name
+		if getattr(self, "_ssa_doc", None):
+			salary_slip._ssa_doc = self._ssa_doc
+		if getattr(self, "_salary_structure_assignment", None):
+			salary_slip._salary_structure_assignment = self._salary_structure_assignment
 		salary_slip.calculate_net_pay(skip_tax_breakup_computation=True)
 
 		future_period_non_taxable_earnings = 0

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -372,6 +372,7 @@ def make_salary_slip(
 	print_format: str | None = None,
 	for_preview: int = 0,
 	lwp_days_corrected: float | None = None,
+	salary_structure_assignment: str | None = None,
 ) -> str | Document:
 	if employee:
 		frappe.has_permission("Employee", "read", employee, throw=True)
@@ -385,6 +386,7 @@ def make_salary_slip(
 		print_format=print_format,
 		for_preview=for_preview,
 		lwp_days_corrected=lwp_days_corrected,
+		salary_structure_assignment=salary_structure_assignment,
 	)
 
 
@@ -398,12 +400,19 @@ def _make_salary_slip(
 	for_preview: int = 0,
 	lwp_days_corrected: float | None = None,
 	ignore_permissions: bool = False,
+	salary_structure_assignment: str | None = None,
 ) -> str | Document:
 	def postprocess(source, target):
 		if employee:
 			target.employee = employee
 			if posting_date:
 				target.posting_date = posting_date
+
+		if salary_structure_assignment:
+			ssa_doc = frappe.get_doc("Salary Structure Assignment", salary_structure_assignment)
+			target._preview_ssa_name = salary_structure_assignment
+			target._salary_structure_assignment = ssa_doc.as_dict()
+			target._ssa_doc = ssa_doc
 
 		target.run_method(
 			"process_salary_structure", for_preview=for_preview, lwp_days_corrected=lwp_days_corrected

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -409,6 +409,9 @@ def _make_salary_slip(
 				target.posting_date = posting_date
 
 		if salary_structure_assignment:
+			frappe.has_permission(
+				"Salary Structure Assignment", "read", salary_structure_assignment, throw=True
+			)
 			ssa_doc = frappe.get_doc("Salary Structure Assignment", salary_structure_assignment)
 			if ssa_doc.employee != target.employee or ssa_doc.salary_structure != target.salary_structure:
 				frappe.throw(

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -410,6 +410,12 @@ def _make_salary_slip(
 
 		if salary_structure_assignment:
 			ssa_doc = frappe.get_doc("Salary Structure Assignment", salary_structure_assignment)
+			if ssa_doc.employee != target.employee or ssa_doc.salary_structure != target.salary_structure:
+				frappe.throw(
+					_(
+						"Salary Structure Assignment does not match the requested employee or salary structure."
+					)
+				)
 			target._preview_ssa_name = salary_structure_assignment
 			target._salary_structure_assignment = ssa_doc.as_dict()
 			target._ssa_doc = ssa_doc

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -55,6 +55,16 @@ frappe.ui.form.on("Salary Structure Assignment", {
 	refresh: function (frm) {
 		frm.trigger("toggle_opening_balances_section");
 
+		if (frm.doc.docstatus === 0 && !frm.is_new()) {
+			frm.add_custom_button(
+				__("Preview Salary Slip"),
+				function () {
+					frm.trigger("preview_salary_slip");
+				},
+				__("Actions"),
+			);
+		}
+
 		if (frm.doc.docstatus != 1) return;
 
 		frm.add_custom_button(
@@ -140,16 +150,20 @@ frappe.ui.form.on("Salary Structure Assignment", {
 				const print_format = r.salary_slip_based_on_timesheet
 					? "Salary Slip based on Timesheet"
 					: "Salary Slip Standard";
+				const args = {
+					source_name: frm.doc.salary_structure,
+					employee: frm.doc.employee,
+					posting_date: frm.doc.from_date,
+					as_print: 1,
+					print_format: print_format,
+					for_preview: 1,
+				};
+				if (frm.doc.docstatus === 0) {
+					args.salary_structure_assignment = frm.doc.name;
+				}
 				frappe.call({
 					method: "hrms.payroll.doctype.salary_structure.salary_structure.make_salary_slip",
-					args: {
-						source_name: frm.doc.salary_structure,
-						employee: frm.doc.employee,
-						posting_date: frm.doc.from_date,
-						as_print: 1,
-						print_format: print_format,
-						for_preview: 1,
-					},
+					args: args,
 					callback: function (r) {
 						const new_window = window.open();
 						new_window.document.write(r.message);


### PR DESCRIPTION
## Summary

- The **Preview Salary Slip** button now appears in the **Actions** menu as soon as a Salary Structure Assignment is saved in Draft status.
- The preview uses the values from the draft document directly, without needing a submitted record.
- The existing behavior after submission remains unchanged.

## Changes

- `salary_structure_assignment.js`: Add the Preview button for saved draft documents using `!frm.is_new()` check. Pass the draft SSA name to the API when previewing from draft.
- `salary_structure.py`: Accept an optional `salary_structure_assignment` param in `make_salary_slip` and use it to load the SSA doc directly (supports draft), bypassing the submitted-only DB lookup.
- `salary_slip.py`: Fall back to draft SSA lookup via `_preview_ssa_name` when no submitted assignment is found. Propagate preview context to copied salary slip docs used in tax breakup calculations.

## Test Plan

- [ ] Create a Salary Structure Assignment and save it (do not submit).
- [ ] Verify **Actions > Preview Salary Slip** appears in Draft.
- [ ] Click it and confirm the salary slip preview opens correctly.
- [ ] Submit the document and verify the preview option still works.
- [ ] Verify new (unsaved) documents do not show the preview button.


https://github.com/user-attachments/assets/4c310841-a6b8-4254-85d1-cd87e16b482d


no-docs