### PR TITLE
fix: default exchange_rate to 1.0 when it is 0.0 or None in Expense Claim advances

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -374,9 +374,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		total_advance_exchange_gain_loss = 0
 		for advance in self.advances:
 			if advance.base_allocated_amount and self.base_total_advance_amount:
-				allocated_amount_in_adv_exchange_rate = flt(advance.allocated_amount) * flt(
-					advance.exchange_rate
-				)
+				advance_exchange_rate = flt(advance.exchange_rate) or 1.0
+				allocated_amount_in_adv_exchange_rate = flt(advance.allocated_amount) * advance_exchange_rate
 				per_advance_gain_loss += flt(
 					(advance.base_allocated_amount - allocated_amount_in_adv_exchange_rate),
 					self.precision("total_exchange_gain_loss"),
@@ -396,6 +395,9 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			dr_or_cr = "credit" if self.total_exchange_gain_loss > 0 else "debit"
 			reverse_dr_or_cr = "debit" if dr_or_cr == "credit" else "credit"
 
+			cost_center = self.cost_center or (self.expenses[0].cost_center if self.expenses else None)
+			project = self.project or (self.expenses[0].project if self.expenses else None)
+
 			je = create_gain_loss_journal(
 				company=self.company,
 				posting_date=today(),
@@ -412,8 +414,9 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				ref2_dt=self.doctype,
 				ref2_dn=self.name,
 				ref2_detail_no=1,
-				cost_center=self.cost_center,
+				cost_center=cost_center,
 				dimensions={},
+				project=project,
 			)
 			frappe.msgprint(
 				_("All Exchange Gain/Loss amount of {0} has been booked through {1}").format(
@@ -754,7 +757,7 @@ def get_expense_claim_advances(expense_claim, employee_advance):
 				"unclaimed_amount": unclaimed_amount,
 				"allocated_amount": allocated_amount,
 				"return_amount": return_amount,
-				"exchange_rate": advance["exchange_rate"],
+				"exchange_rate": flt(advance["exchange_rate"]) or 1.0,
 				"reference_type": advance["voucher_type"],
 				"reference_name": advance["voucher_no"],
 			},

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -1101,6 +1101,55 @@ class TestExpenseClaim(HRMSTestSuite):
 		self.assertEqual(advance.status, "Paid")
 		self.assertEqual(advance.claimed_amount, 0)
 
+	def test_expense_claim_advance_zero_or_none_exchange_rate(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			get_advances_for_claim,
+			make_employee_advance,
+			manual_journal_entry_for_advance,
+		)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account,
+			1000,
+			1000,
+			"_Test Company",
+			"Travel Expenses - _TC",
+			do_not_submit=True,
+		)
+
+		advance = make_employee_advance(claim.employee)
+		je = manual_journal_entry_for_advance(advance)
+		je.submit()
+
+		# Case 1: Test with exchange_rate = 0.0
+		claim = get_advances_for_claim(claim, advance.name)
+		self.assertEqual(len(claim.advances), 1)
+		claim.advances[0].exchange_rate = 0.0
+
+		claim.save()
+		claim.submit()
+		self.assertEqual(flt(claim.total_exchange_gain_loss), 0.0)
+		claim.cancel()
+
+		# Case 2: Test with exchange_rate = None
+		claim = make_expense_claim(
+			payable_account,
+			1000,
+			1000,
+			"_Test Company",
+			"Travel Expenses - _TC",
+			do_not_submit=True,
+		)
+		claim = get_advances_for_claim(claim, advance.name)
+		self.assertEqual(len(claim.advances), 1)
+		claim.advances[0].exchange_rate = None
+
+		claim.save()
+		claim.submit()
+		self.assertEqual(flt(claim.total_exchange_gain_loss), 0.0)
+		claim.cancel()
+
 
 def get_payable_account(company):
 	return frappe.get_cached_value("Company", company, "default_payable_account")


### PR DESCRIPTION
Ensure that when the exchange rate is not set (is 0.0 or None) for an Employee Advance, it defaults to 1.0. This prevents the system from calculating an incorrect exchange gain/loss difference and incorrectly attempting to create a Journal Entry.
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Page-format-for-ERPNext-docs

- Contribution Guide => https://github.com/frappe/erpnext/wiki/Contribution-Guidelines

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
