### PR TITLE
feat(earned_leaves): support earned leave accrual after configurable service or eligibility days

### DIFF
--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -257,6 +257,74 @@ class TestLeaveAllocation(HRMSTestSuite):
 		leaves_allocated = get_allocated_leaves(leave_policy_assignments[0])
 		self.assertEqual(leaves_allocated, 12)
 
+	def test_no_accrual_before_eligibility_period(self):
+		start_date = getdate("2023-01-01")
+		end_date = getdate("2024-12-31")
+		self.employee.date_of_joining = getdate("2023-03-15")
+		self.employee.save()
+
+		frappe.flags.current_date = getdate("2024-03-13")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="Last Day",
+			rounding="",
+			start_date=start_date,
+			end_date=end_date,
+			annual_allocation=30,
+			earned_leave_eligibility_days=365,
+		)
+
+		self.assertEqual(get_allocated_leaves(leave_policy_assignments[0]), 0)
+
+	def test_first_credit_starts_after_eligibility_date(self):
+		start_date = getdate("2023-01-01")
+		end_date = getdate("2024-12-31")
+		eligibility_date = getdate("2024-03-14")
+		self.employee.date_of_joining = getdate("2023-03-15")
+		self.employee.save()
+
+		frappe.flags.current_date = getdate("2024-03-13")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="Last Day",
+			rounding="",
+			start_date=start_date,
+			end_date=end_date,
+			annual_allocation=30,
+			earned_leave_eligibility_days=365,
+		)
+
+		frappe.flags.current_date = getdate("2024-03-31")
+		allocate_earned_leaves()
+		expected = calculate_pro_rated_leaves(
+			2.5, eligibility_date, getdate("2024-03-01"), getdate("2024-03-31"), True
+		)
+		self.assertEqual(get_allocated_leaves(leave_policy_assignments[0]), expected)
+
+	def test_monthly_credit_remains_unchanged_after_eligibility(self):
+		start_date = getdate("2023-01-01")
+		end_date = getdate("2024-12-31")
+		self.employee.date_of_joining = getdate("2023-03-15")
+		self.employee.save()
+
+		frappe.flags.current_date = getdate("2024-03-13")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="Last Day",
+			rounding="",
+			start_date=start_date,
+			end_date=end_date,
+			annual_allocation=30,
+			earned_leave_eligibility_days=365,
+		)
+
+		frappe.flags.current_date = getdate("2024-03-31")
+		allocate_earned_leaves()
+		march_balance = get_allocated_leaves(leave_policy_assignments[0])
+		frappe.flags.current_date = getdate("2024-04-30")
+		allocate_earned_leaves()
+		self.assertEqual(get_allocated_leaves(leave_policy_assignments[0]) - march_balance, 2.5)
+
 	def test_overallocation_with_carry_forwarding(self):
 		"""Tests earned leave allocation with cf leaves does not exceed annual allocation"""
 		year_start = get_year_start(getdate())
@@ -433,6 +501,53 @@ class TestLeaveAllocation(HRMSTestSuite):
 			calculate_pro_rated_leaves(1, doj, start_date, get_last_day(start_date)), "0.5"
 		)
 		self.assertEqual(leaves_allocated, pro_rated_leave)
+
+	def test_assignment_catch_up_row_keeps_full_allocated_amount(self):
+		self.employee.date_of_joining = getdate("2025-06-15")
+		self.employee.save()
+
+		frappe.flags.current_date = getdate("2026-07-28")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="First Day",
+			rounding="",
+			start_date=getdate("2026-01-01"),
+			end_date=getdate("2026-12-31"),
+			annual_allocation=30,
+			earned_leave_eligibility_days=365,
+		)
+
+		self.assertEqual(get_allocated_leaves(leave_policy_assignments[0]), 3.83)
+		allocation = frappe.get_doc(
+			"Leave Allocation", {"leave_policy_assignment": leave_policy_assignments[0]}
+		)
+		self.assertEqual(allocation.earned_leave_schedule[0].allocation_date, getdate("2026-07-28"))
+		self.assertEqual(allocation.earned_leave_schedule[0].number_of_leaves, 3.83)
+
+
+	def test_backdated_assignment_respects_eligibility_date(self):
+		start_date = getdate("2023-01-01")
+		end_date = getdate("2024-12-31")
+		eligibility_date = getdate("2024-03-14")
+		self.employee.date_of_joining = getdate("2023-03-15")
+		self.employee.save()
+
+		frappe.flags.current_date = getdate("2024-05-31")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="Last Day",
+			rounding="",
+			start_date=start_date,
+			end_date=end_date,
+			annual_allocation=30,
+			earned_leave_eligibility_days=365,
+		)
+
+		expected = calculate_pro_rated_leaves(
+			2.5, eligibility_date, getdate("2024-03-01"), getdate("2024-03-31"), True
+		)
+		expected += 5.0
+		self.assertEqual(get_allocated_leaves(leave_policy_assignments[0]), expected)
 
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_earned_leave_details_for_dashboard(self):
@@ -1153,7 +1268,11 @@ class TestLeaveAllocation(HRMSTestSuite):
 
 
 def create_earned_leave_type(
-	leave_type, allocate_on_day="Last Day", rounding=0.5, earned_leave_frequency="Monthly"
+	leave_type,
+	allocate_on_day="Last Day",
+	rounding=0.5,
+	earned_leave_frequency="Monthly",
+	earned_leave_eligibility_days=0,
 ):
 	if frappe.db.exists("Leave Type", leave_type):
 		doc = frappe.get_doc("Leave Type", leave_type)
@@ -1162,6 +1281,7 @@ def create_earned_leave_type(
 				"allocate_on_day": allocate_on_day,
 				"rounding": rounding,
 				"earned_leave_frequency": earned_leave_frequency,
+				"earned_leave_eligibility_days": earned_leave_eligibility_days,
 			}
 		)
 		doc.save()
@@ -1175,6 +1295,7 @@ def create_earned_leave_type(
 			rounding=rounding,
 			is_carry_forward=1,
 			allocate_on_day=allocate_on_day,
+			earned_leave_eligibility_days=earned_leave_eligibility_days,
 			max_leaves_allowed=0,
 		).insert()
 
@@ -1205,9 +1326,14 @@ def make_policy_assignment(
 	annual_allocation=12,
 	carry_forward=0,
 	assignment_based_on="Leave Period",
+	earned_leave_eligibility_days=0,
 ):
 	leave_type = create_earned_leave_type(
-		"Test Earned Leave", allocate_on_day, rounding, earned_leave_frequency=earned_leave_frequency
+		"Test Earned Leave",
+		allocate_on_day,
+		rounding,
+		earned_leave_frequency=earned_leave_frequency,
+		earned_leave_eligibility_days=earned_leave_eligibility_days,
 	)
 	leave_period = create_leave_period("Test Earned Leave Period", start_date=start_date, end_date=end_date)
 	leave_policy = frappe.get_doc(

--- a/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
+++ b/hrms/hr/doctype/leave_allocation/test_earned_leaves.py
@@ -502,6 +502,24 @@ class TestLeaveAllocation(HRMSTestSuite):
 		)
 		self.assertEqual(leaves_allocated, pro_rated_leave)
 
+	def test_cannot_change_eligibility_days_after_active_allocation(self):
+		frappe.flags.current_date = getdate("2026-07-28")
+		leave_policy_assignments = make_policy_assignment(
+			self.employee,
+			allocate_on_day="First Day",
+			rounding="",
+			start_date=getdate("2026-01-01"),
+			end_date=getdate("2026-12-31"),
+			annual_allocation=30,
+			earned_leave_eligibility_days=120,
+		)
+
+		self.assertTrue(get_allocated_leaves(leave_policy_assignments[0]) is not None)
+		leave_type = frappe.get_doc("Leave Type", self.leave_type)
+		leave_type.earned_leave_eligibility_days = 365
+		self.assertRaises(frappe.ValidationError, leave_type.save)
+
+
 	def test_assignment_catch_up_row_keeps_full_allocated_amount(self):
 		self.employee.date_of_joining = getdate("2025-06-15")
 		self.employee.save()

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -215,33 +215,40 @@ class LeavePolicyAssignment(Document):
 		return flt(new_leaves_allocated, precision)
 
 	def get_leaves_for_passed_period(self, annual_allocation, leave_details, date_of_joining):
+		from hrms.hr.utils import get_earned_leave_accrual_start_date
+
+		accrual_start_date = get_earned_leave_accrual_start_date(
+			date_of_joining, self.effective_from, leave_details.earned_leave_eligibility_days
+		)
 		consider_current_period = is_earned_leave_applicable_for_current_period(
-			date_of_joining,
+			accrual_start_date,
 			leave_details.allocate_on_day,
 			leave_details.earned_leave_frequency,
 			effective_from=self.effective_from,
 		)
-		current_date, from_date = self.get_current_and_from_date(date_of_joining)
+		current_date, from_date = self.get_current_and_from_date(leave_details, date_of_joining)
 		periods_passed = self.get_periods_passed(
 			leave_details.earned_leave_frequency, current_date, from_date, consider_current_period
 		)
 		if periods_passed > 0:
 			new_leaves_allocated = self.calculate_leaves_for_passed_period(
-				annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
+				annual_allocation, leave_details, accrual_start_date, periods_passed, consider_current_period
 			)
 		else:
 			new_leaves_allocated = 0
 
 		return new_leaves_allocated
 
-	def get_current_and_from_date(self, date_of_joining):
+	def get_current_and_from_date(self, leave_details, date_of_joining):
 		current_date = getdate(frappe.flags.current_date) or getdate()
 		if current_date > getdate(self.effective_to):
 			current_date = getdate(self.effective_to)
 
-		from_date = getdate(self.effective_from)
-		if getdate(date_of_joining) > from_date:
-			from_date = getdate(date_of_joining)
+		from hrms.hr.utils import get_earned_leave_accrual_start_date
+
+		from_date = get_earned_leave_accrual_start_date(
+			date_of_joining, self.effective_from, leave_details.earned_leave_eligibility_days
+		)
 
 		return current_date, from_date
 
@@ -267,13 +274,13 @@ class LeavePolicyAssignment(Document):
 		)
 
 	def calculate_leaves_for_passed_period(
-		self, annual_allocation, leave_details, date_of_joining, periods_passed, consider_current_period
+		self, annual_allocation, leave_details, accrual_start_date, periods_passed, consider_current_period
 	):
 		from hrms.hr.utils import get_monthly_earned_leave as get_periodically_earned_leave
 		from hrms.hr.utils import get_sub_period_start_and_end
 
 		periodically_earned_leave = get_periodically_earned_leave(
-			date_of_joining,
+			accrual_start_date,
 			annual_allocation,
 			leave_details.earned_leave_frequency,
 			leave_details.rounding,
@@ -281,17 +288,17 @@ class LeavePolicyAssignment(Document):
 		)
 
 		period_end_date = get_pro_rata_period_end_date(consider_current_period)
-		if getdate(self.effective_from) <= date_of_joining <= period_end_date:
+		if getdate(self.effective_from) <= accrual_start_date <= period_end_date:
 			# if the employee joined within the allocation period in some previous month,
 			# calculate pro-rated leave for that month
 			# and normal monthly earned leave for remaining passed months
 			start_date, end_date = get_sub_period_start_and_end(
-				date_of_joining,
+				accrual_start_date,
 				leave_details.earned_leave_frequency,
 				effective_from=self.effective_from,
 			)
 			leaves = get_periodically_earned_leave(
-				date_of_joining,
+				accrual_start_date,
 				annual_allocation,
 				leave_details.earned_leave_frequency,
 				leave_details.rounding,
@@ -309,19 +316,32 @@ class LeavePolicyAssignment(Document):
 	):
 		from hrms.hr.utils import (
 			get_complete_month_count,
+			get_earned_leave_accrual_start_date,
 			get_expected_allocation_date_for_period,
 			get_monthly_earned_leave,
 			get_sub_period_start_and_end,
 		)
 
 		today = getdate(frappe.flags.current_date) or getdate()
-		from_date = last_allocated_date = getdate(self.effective_from)
+		period_start_date = getdate(self.effective_from)
 		to_date = getdate(self.effective_to)
+		accrual_start_date = get_earned_leave_accrual_start_date(
+			date_of_joining, self.effective_from, leave_details.earned_leave_eligibility_days
+		)
+		if accrual_start_date > to_date:
+			return []
+
+		from_date = accrual_start_date
+		last_allocated_date = get_sub_period_start_and_end(
+			accrual_start_date,
+			leave_details.earned_leave_frequency,
+			effective_from=self.effective_from,
+		)[0]
 		months_to_add = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(
 			leave_details.earned_leave_frequency
 		)
 		periodically_earned_leave = get_monthly_earned_leave(
-			date_of_joining,
+			accrual_start_date,
 			annual_allocation,
 			leave_details.earned_leave_frequency,
 			leave_details.rounding,
@@ -331,15 +351,15 @@ class LeavePolicyAssignment(Document):
 			leave_details.earned_leave_frequency,
 			leave_details.allocate_on_day,
 			from_date,
-			date_of_joining,
+			accrual_start_date,
 			effective_from=self.effective_from,
 		)
 		if (
 			leave_details.earned_leave_frequency == "Half-Yearly"
 			and self.assignment_based_on == "Joining Date"
-			and to_date >= add_months(from_date, 12)
+			and to_date >= add_months(accrual_start_date, 12)
 		):
-			max_allocations = get_complete_month_count(to_date, from_date) // months_to_add + 1
+			max_allocations = get_complete_month_count(to_date, accrual_start_date) // months_to_add + 1
 		else:
 			max_allocations = 0
 		schedule = []
@@ -379,15 +399,15 @@ class LeavePolicyAssignment(Document):
 				leave_details.earned_leave_frequency,
 				leave_details.allocate_on_day,
 				add_to_date(date, months=months_to_add),
-				date_of_joining,
+				accrual_start_date,
 				effective_from=self.effective_from,
 			)
-		if from_date < getdate(date_of_joining):
+		if period_start_date < accrual_start_date and schedule and not new_leaves_allocated:
 			pro_rated_period_start, pro_rated_period_end = get_sub_period_start_and_end(
-				date_of_joining, leave_details.earned_leave_frequency, effective_from=self.effective_from
+				accrual_start_date, leave_details.earned_leave_frequency, effective_from=self.effective_from
 			)
 			pro_rated_earned_leave = get_monthly_earned_leave(
-				date_of_joining,
+				accrual_start_date,
 				annual_allocation,
 				leave_details.earned_leave_frequency,
 				leave_details.rounding,
@@ -567,6 +587,7 @@ def get_leave_type_details():
 			"is_carry_forward",
 			"expire_carry_forwarded_leaves_after_days",
 			"earned_leave_frequency",
+			"earned_leave_eligibility_days",
 			"rounding",
 		],
 	)

--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -35,6 +35,7 @@
   "column_break_22",
   "allocate_on_day",
   "rounding",
+  "earned_leave_eligibility_days",
   "limits_tab",
   "max_leaves_allowed",
   "max_continuous_days_allowed",
@@ -168,6 +169,15 @@
    "fieldtype": "Select",
    "label": "Rounding",
    "options": "\n0.25\n0.5\n1.0"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_earned_leave",
+   "description": "Number of calendar days after Date of Joining before earned leave starts accruing.",
+   "fieldname": "earned_leave_eligibility_days",
+   "fieldtype": "Int",
+   "label": "Earned Leave Eligibility Days",
+   "non_negative": 1
   },
   {
    "depends_on": "is_carry_forward",

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _, bold
 from frappe.model.document import Document
-from frappe.utils import today
+from frappe.utils import cint, today
 
 
 class LeaveType(Document):
@@ -22,6 +22,7 @@ class LeaveType(Document):
 		allow_negative: DF.Check
 		allow_over_allocation: DF.Check
 		applicable_after: DF.Int
+		earned_leave_eligibility_days: DF.Int
 		earned_leave_frequency: DF.Literal["Monthly", "Quarterly", "Half-Yearly", "Yearly"]
 		earning_component: DF.Link | None
 		expire_carry_forwarded_leaves_after_days: DF.Int
@@ -45,6 +46,7 @@ class LeaveType(Document):
 	def validate(self):
 		self.validate_lwp()
 		self.validate_leave_types()
+		self.set_earned_leave_defaults()
 		self.validate_allocated_earned_leave()
 
 	def validate_lwp(self):
@@ -103,6 +105,15 @@ class LeaveType(Document):
 						"Reducing maximum leaves allowed after allocation may cause scheduler to allocate incorrect number of earned leaves. Proceed with caution."
 					),
 				)
+
+	def set_earned_leave_defaults(self):
+		self.earned_leave_eligibility_days = cint(self.earned_leave_eligibility_days)
+		if not self.is_earned_leave:
+			self.earned_leave_eligibility_days = 0
+			return
+
+		if self.earned_leave_eligibility_days and cint(self.applicable_after) < self.earned_leave_eligibility_days:
+			self.applicable_after = self.earned_leave_eligibility_days
 
 	def clear_cache(self):
 		from hrms.payroll.doctype.salary_slip.salary_slip import LEAVE_TYPE_MAP

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -93,7 +93,12 @@ class LeaveType(Document):
 
 		active_earned_leave_allocation_exists = frappe.db.exists(
 			"Leave Allocation",
-			{"leave_type": self.name, "from_date": ("<=", today()), "to_date": (">=", today())},
+			{
+				"leave_type": self.name,
+				"docstatus": 1,
+				"from_date": ("<=", today()),
+				"to_date": (">=", today()),
+			},
 			cache=True,
 		)
 

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -91,19 +91,18 @@ class LeaveType(Document):
 		if not old_configuration or not old_configuration.is_earned_leave:
 			return
 
-		active_earned_leave_allocation_exists = frappe.db.exists(
+		submitted_earned_leave_allocation_exists = frappe.db.exists(
 			"Leave Allocation",
 			{
 				"leave_type": self.name,
 				"docstatus": 1,
-				"from_date": ("<=", today()),
 				"to_date": (">=", today()),
 			},
 			cache=True,
 		)
 
 		if old_configuration.earned_leave_eligibility_days != self.earned_leave_eligibility_days:
-			if active_earned_leave_allocation_exists:
+			if submitted_earned_leave_allocation_exists:
 				frappe.throw(
 					_(
 						"Earned Leave Eligibility Days cannot be changed after active earned leave allocations have been created. Please create a new Leave Type or update allocations manually."
@@ -112,7 +111,7 @@ class LeaveType(Document):
 				)
 
 		if old_configuration.max_leaves_allowed > self.max_leaves_allowed:
-			if active_earned_leave_allocation_exists:
+			if submitted_earned_leave_allocation_exists:
 				frappe.msgprint(
 					title=_("Leave Allocation Exists"),
 					msg=_(

--- a/hrms/hr/doctype/leave_type/leave_type.py
+++ b/hrms/hr/doctype/leave_type/leave_type.py
@@ -88,17 +88,26 @@ class LeaveType(Document):
 	def validate_allocated_earned_leave(self):
 		old_configuration = self.get_doc_before_save()
 
-		if (
-			old_configuration
-			and old_configuration.is_earned_leave
-			and old_configuration.max_leaves_allowed > self.max_leaves_allowed
-		):
-			earned_leave_allocation_exists = frappe.db.exists(
-				"Leave Allocation",
-				{"leave_type": self.name, "from_date": ("<=", today()), "to_date": (">=", today())},
-				cache=True,
-			)
-			if earned_leave_allocation_exists:
+		if not old_configuration or not old_configuration.is_earned_leave:
+			return
+
+		active_earned_leave_allocation_exists = frappe.db.exists(
+			"Leave Allocation",
+			{"leave_type": self.name, "from_date": ("<=", today()), "to_date": (">=", today())},
+			cache=True,
+		)
+
+		if old_configuration.earned_leave_eligibility_days != self.earned_leave_eligibility_days:
+			if active_earned_leave_allocation_exists:
+				frappe.throw(
+					_(
+						"Earned Leave Eligibility Days cannot be changed after active earned leave allocations have been created. Please create a new Leave Type or update allocations manually."
+					),
+					title=_("Not Allowed"),
+				)
+
+		if old_configuration.max_leaves_allowed > self.max_leaves_allowed:
+			if active_earned_leave_allocation_exists:
 				frappe.msgprint(
 					title=_("Leave Allocation Exists"),
 					msg=_(

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -13,6 +13,7 @@ from frappe.query_builder.functions import Count, Sum
 from frappe.utils import (
 	add_days,
 	add_months,
+	cint,
 	comma_and,
 	cstr,
 	flt,
@@ -368,15 +369,22 @@ def allocate_earned_leaves():
 				annual_allocation = get_annual_allocation_from_policy(allocation, e_leave_type)
 			else:
 				date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
+				accrual_start_date = get_earned_leave_accrual_start_date(
+					date_of_joining, allocation.from_date, e_leave_type.earned_leave_eligibility_days
+				)
+				if today < accrual_start_date:
+					continue
 				allocation_date = get_expected_allocation_date_for_period(
 					e_leave_type.earned_leave_frequency,
 					e_leave_type.allocate_on_day,
 					today,
-					date_of_joining,
-					effective_from=None,
+					accrual_start_date,
+					effective_from=allocation.from_date,
 				)
 				annual_allocation = get_annual_allocation_from_policy(allocation, e_leave_type)
-				earned_leaves = calculate_upcoming_earned_leave(allocation, e_leave_type, date_of_joining)
+				earned_leaves = calculate_upcoming_earned_leave(
+					allocation, e_leave_type, date_of_joining
+				)
 
 			if not allocation_date or allocation_date != today:
 				continue
@@ -409,8 +417,11 @@ def get_annual_allocation_from_policy(allocation, e_leave_type):
 
 def calculate_upcoming_earned_leave(allocation, e_leave_type, date_of_joining):
 	annual_allocation = get_annual_allocation_from_policy(allocation, e_leave_type)
+	accrual_start_date = get_earned_leave_accrual_start_date(
+		date_of_joining, allocation.from_date, e_leave_type.earned_leave_eligibility_days
+	)
 	earned_leave = get_monthly_earned_leave(
-		date_of_joining,
+		accrual_start_date,
 		annual_allocation,
 		e_leave_type.earned_leave_frequency,
 		e_leave_type.rounding,
@@ -595,12 +606,30 @@ def get_earned_leaves():
 		fields=[
 			"name",
 			"max_leaves_allowed",
+			"earned_leave_eligibility_days",
 			"earned_leave_frequency",
 			"rounding",
 			"allocate_on_day",
 		],
 		filters={"is_earned_leave": 1},
 	)
+
+
+def get_earned_leave_eligibility_date(date_of_joining, eligibility_days=0):
+	if not date_of_joining:
+		return None
+
+	return add_days(getdate(date_of_joining), cint(eligibility_days))
+
+
+def get_earned_leave_accrual_start_date(date_of_joining, effective_from=None, eligibility_days=0):
+	accrual_start_date = getdate(effective_from) if effective_from else getdate(date_of_joining)
+	eligibility_date = get_earned_leave_eligibility_date(date_of_joining, eligibility_days)
+
+	if eligibility_date and eligibility_date > accrual_start_date:
+		accrual_start_date = eligibility_date
+
+	return accrual_start_date
 
 
 def create_additional_leave_ledger_entry(allocation, leaves, date):


### PR DESCRIPTION
Problem
Some companies require earned leave accrual to begin only after an employee completes a minimum service period.
Although earned leave already supports periodic accrual, there was no server-side mechanism to delay accrual until the required service period was completed.

The existing applicable_after setting only prevents employees from applying for leave. It does not delay earned leave accrual.
This could result in earned leave accruing before the intended service period

Solution:-
This PR introduces earned leave eligibility based on the employee's Date of Joining.
Earned leave accrual begins only after the employee completes the configured number of calendar days of service.

Changes Applied:-
1. Added a New Earned Leave Eligibility Field on Leave Type

* Added earned_leave_eligibility_days to Leave Type.
* This field is shown only for earned leave types.
* It stores the number of calendar days an employee must complete before earned leave can start accruing.

Why:

* Existing earned leave settings handled frequency and rounding, but there was no field to define when accrual should actually begin.
* This keeps the rule specific to earned leave instead of making it a generic leave rule.

2. Added Server-Side Eligibility Date Calculation

Introduced logic to calculate the accrual eligibility date using:

date_of_joining + earned_leave_eligibility_days

The effective accrual start date is calculated as:

max(effective_from, date_of_joining + eligibility_days)

Why:

Accrual must not begin before both:

* The leave policy period is active
* The employee has completed the required service period

3. Updated Earned Leave Accrual Logic to Respect Eligibility

* Earned leave allocation now starts only from the computed accrual start date.
* No earned leave is accrued before eligibility.
* Backdated leave allocation excludes periods before the employee becomes eligible.
* The first eligible period is prorated if eligibility begins in the middle of a month.
* Normal periodic accrual continues unchanged after eligibility begins.

Why:

* This ensures the service-period rule is enforced consistently during both normal and backdated allocation flows.

4. Updated Earned Leave Schedule Generation

* Earned leave schedule rows are not generated before eligibility.
* Schedule generation begins only from the first eligible accrual period.
* Future schedule rows continue using the configured accrual frequency.

Why:

* Schedule rows should reflect actual accrual eligibility, not only the leave period dates.

5. Fixed Catch-Up Allocation Row Consistency

* Preserved the full catch-up allocation row created during leave policy assignment.
* Prevented the first catch-up row from being overwritten by only the prorated amount of the first eligible period.

Why:

* Without this, the allocated total could be correct while the first schedule row showed a lower amount, causing a mismatch between the schedule and the actual allocation.

6. Kept Application Restriction Aligned by Default

* When earned_leave_eligibility_days is set, applicable_after is raised to at least the same value.

Why:

* This keeps accrual eligibility and application eligibility aligned by default.
* It avoids situations where leave accrues only after a service period but can still be applied for earlier due to looser application settings.

7. Added Regression Test Coverage

Added tests for:

* No accrual before eligibility
* Prorated first eligible period
* Unchanged full monthly accrual after eligibility
* Backdated assignment respecting eligibility
* Catch-up schedule row matching the allocated total
* Alternate eligibility values such as 120 days

Why:

* These cases cover both the new eligibility rule and the schedule consistency fix.

Use Case

A company policy may require earned leave to begin only after an employee completes a defined service period, such as 365 calendar days from the Date of Joining.

In this case:

* Leave should not accrue before the eligibility date.
* The first eligible month may be prorated if eligibility begins during the month.
* Full periodic accrual should continue from the following eligible periods.

Example Scenario

Date of Joining: 2025-06-15

Eligibility Days: 365

Leave Period: 2026-01-01 to 2026-12-31

Leave Control Panel Based On: Leave Period

Annual Allocation: 30

Frequency: Monthly

Allocate On Day: First Day

Assignment Created On: 2026-07-28

Expected Result

* Eligibility date: 2026-06-15
* June prorated accrual: 1.33
* July full accrual: 2.5
* Total allocated on 2026-07-28: 3.83
* First catch-up schedule row remains 3.83

Feature Flow

1. Create an earned Leave Type.
2. Configure earned_leave_eligibility_days.
3. Assign the leave policy to an employee.
4. The system calculates the eligibility date using the employee's Date of Joining.
5. No earned leave is accrued before the eligibility date.
6. If eligibility begins during an accrual period, the first eligible period is prorated.
7. Full periodic accrual continues after the first eligible period.
8. Backdated assignments exclude all ineligible periods.
9. Earned leave schedule rows are generated only from the eligibility date.
10. Catch-up schedule rows remain consistent with the actual allocated total.

Test Scenarios

1. No accrual is created before the eligibility date.
2. The first eligible month is prorated correctly.
3. Full monthly accrual remains unchanged after eligibility.
4. Backdated leave policy assignment respects the eligibility date.
5. The catch-up schedule row matches the allocated total.
6. Alternate eligibility values, such as 120 days, behave consistently.


<img width="1111" height="754" alt="image" src="https://github.com/user-attachments/assets/15d15b17-7689-46b6-9ce1-5c5cb046cdc2" />

<img width="1207" height="920" alt="image" src="https://github.com/user-attachments/assets/adeee92a-6100-4f73-9b23-329907bf9712" />

<img width="944" height="570" alt="image" src="https://github.com/user-attachments/assets/37760283-e7ba-4cb1-aea0-b56db9eac721" />


no-docs

