### PR TITLE
fix: error message in html to text

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.json
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.json
@@ -252,7 +252,7 @@
   {
    "depends_on": "eval:doc.status=='Failed';",
    "fieldname": "error_message",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "label": "Error Message",
    "no_copy": 1,
    "read_only": 1
@@ -340,7 +340,7 @@
    "link_fieldname": "payroll_entry"
   }
  ],
- "modified": "2025-08-25 20:05:37.733324",
+ "modified": "2026-07-28 20:19:41.847412",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Entry",

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -55,7 +55,7 @@ class PayrollEntry(Document):
 		designation: DF.Link | None
 		employees: DF.Table[PayrollEmployeeDetail]
 		end_date: DF.Date
-		error_message: DF.SmallText | None
+		error_message: DF.TextEditor | None
 		exchange_rate: DF.Float
 		grade: DF.Link | None
 		number_of_employees: DF.Int


### PR DESCRIPTION
fixes #5012 
Before fix:
<img width="1917" height="798" alt="image" src="https://github.com/user-attachments/assets/9049c616-5473-46e9-962f-4aa47ba0435d" />

After fix:
<img width="1917" height="766" alt="image" src="https://github.com/user-attachments/assets/ed57b077-b2eb-4b38-8fdb-76d97e1046e6" />
