### PR TITLE
fix(api): enforce parent document read permission check in get_attachments

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -738,6 +738,8 @@ def get_doctype_states(doctype: str) -> dict:
 # File
 @frappe.whitelist()
 def get_attachments(dt: str, dn: str):
+	if dt and dn:
+		frappe.has_permission(dt, "read", dn, throw=True)
 	return frappe.get_list(
 		"File",
 		fields=["name", "file_name", "file_url", "is_private"],

--- a/hrms/hr/doctype/job_applicant/test_job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/test_job_applicant.py
@@ -12,6 +12,15 @@ from hrms.tests.utils import HRMSTestSuite
 
 
 class TestJobApplicant(HRMSTestSuite):
+	def test_get_attachments_parent_permission_check(self):
+		from hrms.api import get_attachments
+
+		applicant = create_job_applicant()
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			get_attachments("Job Applicant", applicant.name)
+
 	def test_job_applicant_naming(self):
 		applicant = frappe.get_doc(
 			{


### PR DESCRIPTION
### Summary of Changes
- Add `frappe.has_permission(dt, "read", dn, throw=True)` to whitelisted endpoint `get_attachments` in `hrms/api/__init__.py`.
- Previously, `get_attachments` queried the `File` doctype without validating if the caller has `read` permission on the parent document (`attached_to_doctype` and `attached_to_name`).
- Added automated unit test `test_get_attachments_parent_permission_check` in `test_job_applicant.py`.