### PR TITLE
fix(hr): resolve UnboundLocalError and filter cancelled docstatus in create_additional_salary

### DIFF
--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -112,13 +112,19 @@ def create_job_applicant(source_name: str, target_doc: str | Document | None = N
 @frappe.whitelist()
 def create_additional_salary(employee_referral: str) -> Document:
 	doc = frappe.get_doc("Employee Referral", employee_referral)
+	doc.check_permission("read")
 
-	if not frappe.db.exists("Additional Salary", {"ref_docname": doc.name}):
-		additional_salary = frappe.new_doc("Additional Salary")
-		additional_salary.employee = doc.referrer
-		additional_salary.company = frappe.db.get_value("Employee", doc.referrer, "company")
-		additional_salary.overwrite_salary_structure_amount = 0
-		additional_salary.ref_doctype = doc.doctype
-		additional_salary.ref_docname = doc.name
+	existing = frappe.db.get_value(
+		"Additional Salary", {"ref_docname": doc.name, "docstatus": ["!=", 2]}, "name"
+	)
+	if existing:
+		return frappe.get_doc("Additional Salary", existing)
+
+	additional_salary = frappe.new_doc("Additional Salary")
+	additional_salary.employee = doc.referrer
+	additional_salary.company = frappe.db.get_value("Employee", doc.referrer, "company")
+	additional_salary.overwrite_salary_structure_amount = 0
+	additional_salary.ref_doctype = doc.doctype
+	additional_salary.ref_docname = doc.name
 
 	return additional_salary

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -46,6 +46,10 @@ class TestEmployeeReferral(HRMSTestSuite):
 		add_sal = create_additional_salary(emp_ref.name)
 		self.assertEqual(add_sal.ref_docname, emp_ref.name)
 
+		# calling again when Additional Salary exists must not crash UnboundLocalError
+		add_sal_2 = create_additional_salary(emp_ref.name)
+		self.assertEqual(add_sal_2.ref_docname, emp_ref.name)
+
 	def test_status_on_discard(self):
 		refarral = create_employee_referral(do_not_submit=True)
 		refarral.discard()


### PR DESCRIPTION
### Summary of Changes
- Fix `UnboundLocalError` crash in `create_additional_salary` in `hrms/hr/doctype/employee_referral/employee_referral.py`.
- Previously, if an `Additional Salary` already existed, the method fell through without defining `additional_salary`, causing an immediate `UnboundLocalError` on return.
- Added `"docstatus": ["!=", 2]` filter so cancelled Additional Salaries do not block creating a new record.
- Added read permission check and updated unit tests.