### PR TITLE
fix(hr): exclude cancelled Job Offers in JobApplicant.onload

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -49,9 +49,9 @@ class JobApplicant(Document):
 	# end: auto-generated types
 
 	def onload(self):
-		job_offer = frappe.get_all("Job Offer", filters={"job_applicant": self.name})
+		job_offer = frappe.get_all("Job Offer", filters={"job_applicant": self.name, "docstatus": ["!=", 2]})
 		if job_offer:
-			self.get("__onload").job_offer = job_offer[0].name
+			self.set_onload("job_offer", job_offer[0].name)
 
 	def autoname(self):
 		self.name = self.email_id

--- a/hrms/hr/doctype/job_applicant/test_job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/test_job_applicant.py
@@ -12,6 +12,24 @@ from hrms.tests.utils import HRMSTestSuite
 
 
 class TestJobApplicant(HRMSTestSuite):
+	def test_onload_filters_out_cancelled_job_offer(self):
+		applicant = create_job_applicant()
+		job_offer = create_job_offer(job_applicant=applicant.name)
+		job_offer.submit()
+		job_offer.cancel()
+
+		applicant.onload()
+		onload = applicant.get("__onload") or {}
+		self.assertNotIn("job_offer", onload)
+
+		# positive case: active job offer should be loaded
+		active_job_offer = create_job_offer(job_applicant=applicant.name)
+		active_job_offer.submit()
+
+		applicant.onload()
+		onload = applicant.get("__onload") or {}
+		self.assertEqual(onload.get("job_offer"), active_job_offer.name)
+
 	def test_job_applicant_naming(self):
 		applicant = frappe.get_doc(
 			{


### PR DESCRIPTION
### Summary of Changes
- Add `"docstatus": ["!=", 2]` filter to `frappe.get_all("Job Offer", ...)` in `JobApplicant.onload` (`hrms/hr/doctype/job_applicant/job_applicant.py`).
- Previously, `onload` fetched cancelled `Job Offer` records (`docstatus = 2`), populating `__onload.job_offer` with dead/cancelled offer links in the UI.
- Added unit test `test_onload_filters_out_cancelled_job_offer` in `test_job_applicant.py`.