### PR TITLE
fix(hr): enforce write permission check in reschedule_interview

### DIFF
--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -111,6 +111,7 @@ class Interview(Document):
 	def reschedule_interview(
 		self, scheduled_on: datetime.date, from_time: datetime.time, to_time: datetime.time
 	) -> None:
+		self.check_permission("write")
 		if scheduled_on == self.scheduled_on and from_time == self.from_time and to_time == self.to_time:
 			frappe.msgprint(
 				_("No changes found in timings."), indicator="orange", title=_("Interview Not Rescheduled")

--- a/hrms/hr/doctype/interview/test_interview.py
+++ b/hrms/hr/doctype/interview/test_interview.py
@@ -24,6 +24,14 @@ from hrms.tests.utils import HRMSTestSuite
 
 
 class TestInterview(HRMSTestSuite):
+	def test_reschedule_interview_permission_check(self):
+		job_applicant = create_job_applicant()
+		interview = create_interview_and_dependencies(job_applicant.name)
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			interview.reschedule_interview("2026-08-01", "10:00:00", "11:00:00")
+
 	def test_validations_for_designation(self):
 		job_applicant = create_job_applicant()
 		interview = create_interview_and_dependencies(


### PR DESCRIPTION
### Summary of Changes
- Add `self.check_permission("write")` to whitelisted endpoint `reschedule_interview` in `Interview` (`hrms/hr/doctype/interview/interview.py`).
- Previously, `reschedule_interview` called `self.db_set(...)` directly without verifying write permissions, allowing unauthorized users to modify interview schedules.
- Added unit test `test_reschedule_interview_permission_check` in `test_interview.py`.