### PR TITLE
fix(hr): enforce Employee Referral read permission check in create_job_applicant

### DIFF
--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -78,6 +78,7 @@ class EmployeeReferral(Document):
 
 @frappe.whitelist()
 def create_job_applicant(source_name: str, target_doc: str | Document | None = None) -> Document:
+	frappe.has_permission("Employee Referral", "read", source_name, throw=True)
 	emp_ref = frappe.get_doc("Employee Referral", source_name)
 	# just for Api call if some set status apart from default Status
 	status = emp_ref.status

--- a/hrms/hr/doctype/employee_referral/test_employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/test_employee_referral.py
@@ -52,6 +52,13 @@ class TestEmployeeReferral(HRMSTestSuite):
 		refarral.reload()
 		self.assertEqual(refarral.status, "Cancelled")
 
+	def test_create_job_applicant_permission_check(self):
+		emp_ref = create_employee_referral()
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			create_job_applicant(emp_ref.name)
+
 	def test_unique_referral(self):
 		referral_1 = create_employee_referral(email="test_ref@example.com")
 		self.assertRaises(frappe.DuplicateEntryError, create_employee_referral, email="test_ref@example.com")


### PR DESCRIPTION
### Summary of Changes
- Add `frappe.has_permission("Employee Referral", "read", source_name, throw=True)` to whitelisted endpoint `create_job_applicant` in `hrms/hr/doctype/employee_referral/employee_referral.py`.
- Previously, `create_job_applicant` loaded `Employee Referral` documents without validating if the caller has `read` permission on the referral record.
- Added unit test `test_create_job_applicant_permission_check` in `test_employee_referral.py`.