### PR TITLE
fix(hr): exclude cancelled Expense Claims in Vehicle Log make_expense_claim

### DIFF
--- a/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
@@ -267,6 +267,9 @@ class TestVehicleLog(HRMSTestSuite):
 		claim.cancel()
 		new_claim = make_expense_claim(v_log.name)
 		self.assertTrue(new_claim)
+		v_log.reload()
+		v_log.cancel()
+		v_log.delete()
 
 
 def get_vehicle(employee_id):

--- a/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
@@ -258,6 +258,16 @@ class TestVehicleLog(HRMSTestSuite):
 		expense_claim.reload()
 		self.assertEqual(expense_claim.docstatus, 2)
 
+	def test_make_expense_claim_allows_new_claim_after_cancellation(self):
+		v_log = make_vehicle_log()
+		claim_dict = make_expense_claim(v_log.name)
+		claim = frappe.get_doc(claim_dict)
+		claim.insert()
+		claim.submit()
+		claim.cancel()
+		new_claim = make_expense_claim(v_log.name)
+		self.assertTrue(new_claim)
+
 		vehicle_log.reload()
 		vehicle_log.cancel()
 		self.assertEqual(vehicle_log.docstatus, 2)

--- a/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
@@ -272,6 +272,16 @@ class TestVehicleLog(HRMSTestSuite):
 		vehicle_log.cancel()
 		self.assertEqual(vehicle_log.docstatus, 2)
 
+	def test_make_expense_claim_allows_new_claim_after_cancellation(self):
+		v_log = make_vehicle_log()
+		claim_dict = make_expense_claim(v_log.name)
+		claim = frappe.get_doc(claim_dict)
+		claim.insert()
+		claim.submit()
+		claim.cancel()
+		new_claim = make_expense_claim(v_log.name)
+		self.assertTrue(new_claim)
+
 
 def get_vehicle(employee_id):
 	license_plate = random_string(10).upper()

--- a/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/test_vehicle_log.py
@@ -259,21 +259,7 @@ class TestVehicleLog(HRMSTestSuite):
 		self.assertEqual(expense_claim.docstatus, 2)
 
 	def test_make_expense_claim_allows_new_claim_after_cancellation(self):
-		v_log = make_vehicle_log()
-		claim_dict = make_expense_claim(v_log.name)
-		claim = frappe.get_doc(claim_dict)
-		claim.insert()
-		claim.submit()
-		claim.cancel()
-		new_claim = make_expense_claim(v_log.name)
-		self.assertTrue(new_claim)
-
-		vehicle_log.reload()
-		vehicle_log.cancel()
-		self.assertEqual(vehicle_log.docstatus, 2)
-
-	def test_make_expense_claim_allows_new_claim_after_cancellation(self):
-		v_log = make_vehicle_log()
+		v_log = make_vehicle_log(self.license_plate, self.employee_id)
 		claim_dict = make_expense_claim(v_log.name)
 		claim = frappe.get_doc(claim_dict)
 		claim.insert()

--- a/hrms/hr/doctype/vehicle_log/vehicle_log.py
+++ b/hrms/hr/doctype/vehicle_log/vehicle_log.py
@@ -73,7 +73,7 @@ class VehicleLog(Document):
 def make_expense_claim(docname: str) -> dict:
 	frappe.has_permission("Vehicle Log", "read", docname, throw=True)
 
-	expense_claim = frappe.db.exists("Expense Claim", {"vehicle_log": docname})
+	expense_claim = frappe.db.exists("Expense Claim", {"vehicle_log": docname, "docstatus": ["!=", 2]})
 	if expense_claim:
 		frappe.throw(_("Expense Claim {0} already exists for the Vehicle Log").format(expense_claim))
 


### PR DESCRIPTION
### Summary of Changes
- Add  filter to  in  ().
- Previously, cancelled Expense Claims () matched , throwing an error and permanently blocking users from creating a valid new claim for a vehicle log.