### PR TITLE
fix(hr): enforce write permission check in send_exit_questionnaire

### DIFF
--- a/hrms/hr/doctype/exit_interview/exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/exit_interview.py
@@ -101,6 +101,7 @@ def send_exit_questionnaire(interviews: str | list) -> None:
 
 	for exit_interview in interviews:
 		interview = frappe.get_doc("Exit Interview", exit_interview.get("name"))
+		interview.check_permission("write")
 		if interview.get("questionnaire_email_sent"):
 			continue
 

--- a/hrms/hr/doctype/exit_interview/test_exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/test_exit_interview.py
@@ -85,6 +85,13 @@ class TestExitInterview(HRMSTestSuite):
 		interview.reload()
 		self.assertEqual(interview.status, "Cancelled")
 
+	def test_send_exit_questionnaire_permission_check(self):
+		exit_interview = create_exit_interview()
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("test@example.com")
+		with self.assertRaises(frappe.PermissionError):
+			send_exit_questionnaire([exit_interview.name])
+
 
 def create_exit_interview(employee, save=True):
 	interviewer = create_user("test_exit_interviewer@example.com")

--- a/hrms/hr/doctype/exit_interview/test_exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/test_exit_interview.py
@@ -86,7 +86,9 @@ class TestExitInterview(HRMSTestSuite):
 		self.assertEqual(interview.status, "Cancelled")
 
 	def test_send_exit_questionnaire_permission_check(self):
-		exit_interview = create_exit_interview()
+		employee = make_employee("test_exit_perm@example.com", company="_Test Company")
+		frappe.db.set_value("Employee", employee, "relieving_date", getdate())
+		exit_interview = create_exit_interview(employee)
 		self.addCleanup(frappe.set_user, "Administrator")
 		frappe.set_user("test@example.com")
 		with self.assertRaises(frappe.PermissionError):


### PR DESCRIPTION
### Summary of Changes
- Add  inside  ().
- Previously,  triggered email questionnaires and updated  without verifying write permissions.