### PR TITLE
fix(payroll): enforce read permission check in fetch_salary_slip_details

### DIFF
--- a/hrms/payroll/doctype/payroll_correction/payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/payroll_correction.py
@@ -85,6 +85,7 @@ class PayrollCorrection(Document):
 
 	@frappe.whitelist()
 	def fetch_salary_slip_details(self) -> dict[str, list] | None:
+		self.check_permission("read")
 		# Fetch salary slip details with LWP for the employee in the payroll period
 		if not (self.employee and self.payroll_period and self.company):
 			return {"months": [], "slip_details": []}

--- a/hrms/payroll/doctype/payroll_correction/test_payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/test_payroll_correction.py
@@ -103,3 +103,10 @@ class TestPayrollCorrection(HRMSTestSuite):
 				},
 			)
 		)
+
+	def test_fetch_salary_slip_details_permission_check(self):
+		pc = frappe.new_doc("Payroll Correction")
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("test@example.com")
+		with self.assertRaises(frappe.PermissionError):
+			pc.fetch_salary_slip_details()


### PR DESCRIPTION
### Summary of Changes
- Add  to whitelisted method  in  ().
- Previously,  returned salary slip names, working days, and start dates for an employee without checking read permissions.