### PR TITLE
fix(hr): enforce Appraisal read permission check in get_kras_for_employee

### DIFF
--- a/hrms/hr/doctype/appraisal/appraisal.py
+++ b/hrms/hr/doctype/appraisal/appraisal.py
@@ -369,9 +369,14 @@ def get_kras_for_employee(
 		{
 			"appraisal_cycle": filters.get("appraisal_cycle"),
 			"employee": filters.get("employee"),
+			"docstatus": ["!=", 2],
 		},
 		"name",
 	)
+	if appraisal:
+		frappe.has_permission("Appraisal", "read", appraisal, throw=True)
+	else:
+		return ()
 
 	return frappe.get_all(
 		"Appraisal KRA",

--- a/hrms/hr/doctype/appraisal/test_appraisal.py
+++ b/hrms/hr/doctype/appraisal/test_appraisal.py
@@ -329,7 +329,9 @@ class TestAppraisal(HRMSTestSuite):
 		self.assertEqual(summary, expected_data)
 
 	def test_get_kras_for_employee_permission_check(self):
+		cycle = create_appraisal_cycle(designation="Engineer")
+		cycle.create_appraisals()
 		self.addCleanup(frappe.set_user, "Administrator")
 		frappe.set_user("test@example.com")
 		with self.assertRaises(frappe.PermissionError):
-			get_kras_for_employee("Appraisal KRA", "", "kra", 0, 10, {"appraisal_cycle": "CYC-001", "employee": "EMP-001"})
+			get_kras_for_employee("Appraisal KRA", "", "kra", 0, 10, {"appraisal_cycle": cycle.name, "employee": self.employee1})

--- a/hrms/hr/doctype/appraisal/test_appraisal.py
+++ b/hrms/hr/doctype/appraisal/test_appraisal.py
@@ -327,3 +327,9 @@ class TestAppraisal(HRMSTestSuite):
 			"feedback_missing": 1,
 		}
 		self.assertEqual(summary, expected_data)
+
+	def test_get_kras_for_employee_permission_check(self):
+		self.addCleanup(frappe.set_user, "Administrator")
+		frappe.set_user("test@example.com")
+		with self.assertRaises(frappe.PermissionError):
+			get_kras_for_employee("Appraisal KRA", "", "kra", 0, 10, {"appraisal_cycle": "CYC-001", "employee": "EMP-001"})


### PR DESCRIPTION
### Summary of Changes
- Add  and  to  ().
- Previously,  fetched  entries without validating read permissions on the target  and matched cancelled appraisal records.