### PR TITLE
fix(api): validate non-guest user in mark_all_notifications_as_read

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -118,6 +118,8 @@ def get_unread_notifications_count() -> int:
 
 @frappe.whitelist()
 def mark_all_notifications_as_read() -> None:
+	if frappe.session.user == "Guest":
+		return
 	frappe.db.set_value(
 		"PWA Notification",
 		{"to_user": frappe.session.user, "read": 0},

--- a/hrms/tests/test_utils.py
+++ b/hrms/tests/test_utils.py
@@ -157,3 +157,9 @@ def create_job_applicant(**args):
 
 def get_email_by_subject(subject: str) -> str | None:
 	return frappe.db.exists("Email Queue", {"message": ("like", f"%{subject}%")})
+
+
+def test_mark_all_notifications_as_read_guest_check():
+	from hrms.api import mark_all_notifications_as_read
+	frappe.set_user("Guest")
+	mark_all_notifications_as_read()


### PR DESCRIPTION
### Summary of Changes
- Add  check to  in .
- Previously, unauthenticated Guest sessions triggered batch DB updates attempting to set notification read status for the Guest user.