### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/docs_checker.yml
+++ b/.github/workflows/docs_checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: 'Clone repo'
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.10`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.10` (using `3.10` where a concrete pin is needed).

- `.github/workflows/docs_checker.yml`
  - `python-version: 3.8` → `python-version: 3.10`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.10`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
