### PR TITLE
fix(salary_slip): count a half day holiday as half a working day

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -64,6 +64,9 @@ LEAVE_TYPE_MAP = "leave_type_map"
 SALARY_COMPONENT_VALUES = "salary_component_values"
 TAX_COMPONENTS_BY_COMPANY = "tax_components_by_company"
 
+# fraction of a working day contributed by a holiday marked as half day
+HALF_DAY_HOLIDAY_FRACTION = 0.5
+
 
 class SalarySlip(TransactionBase):
 	# begin: auto-generated types
@@ -578,12 +581,20 @@ class SalarySlip(TransactionBase):
 			return
 
 		holidays = self.get_holidays_for_employee(self.start_date, self.end_date)
+		# holidays marked as half day are half a working day, so they are only excluded by half
+		# when holidays are included in total working days, they are counted in full like any other holiday
+		half_day_holidays = (
+			[]
+			if cint(payroll_settings.include_holidays_in_total_working_days)
+			else self.get_half_day_holidays_for_employee(self.start_date, self.end_date)
+		)
+		full_day_holidays = [date for date in holidays if date not in half_day_holidays]
 		working_days_list = [add_days(getdate(self.start_date), days=day) for day in range(0, working_days)]
 
 		if not cint(payroll_settings.include_holidays_in_total_working_days):
-			working_days_list = [i for i in working_days_list if i not in holidays]
+			working_days_list = [i for i in working_days_list if i not in full_day_holidays]
 
-			working_days -= len(holidays)
+			working_days -= len(full_day_holidays) + HALF_DAY_HOLIDAY_FRACTION * len(half_day_holidays)
 			if working_days < 0:
 				frappe.throw(_("There are more holidays than working days this month."))
 
@@ -592,12 +603,15 @@ class SalarySlip(TransactionBase):
 
 		if payroll_settings.payroll_based_on == "Attendance":
 			actual_lwp, absent = self.calculate_lwp_ppl_and_absent_days_based_on_attendance(
-				holidays, daily_wages_fraction_for_half_day, consider_marked_attendance_on_holidays
+				full_day_holidays,
+				half_day_holidays,
+				daily_wages_fraction_for_half_day,
+				consider_marked_attendance_on_holidays,
 			)
 			self.absent_days = absent
 		else:
 			actual_lwp = self.calculate_lwp_or_ppl_based_on_leave_application(
-				holidays, working_days_list, daily_wages_fraction_for_half_day
+				full_day_holidays, half_day_holidays, working_days_list, daily_wages_fraction_for_half_day
 			)
 
 		if not lwp:
@@ -625,7 +639,9 @@ class SalarySlip(TransactionBase):
 			if payroll_settings.payroll_based_on == "Attendance":
 				if consider_unmarked_attendance_as == "Absent":
 					unmarked_days = self.get_unmarked_days(
-						payroll_settings.include_holidays_in_total_working_days, holidays
+						payroll_settings.include_holidays_in_total_working_days,
+						full_day_holidays,
+						half_day_holidays,
 					)
 					self.absent_days += unmarked_days  # will be treated as absent
 					self.payment_days -= unmarked_days
@@ -643,13 +659,18 @@ class SalarySlip(TransactionBase):
 				self.payment_days += lwp_days_corrected
 
 	def get_unmarked_days(
-		self, include_holidays_in_total_working_days: bool, holidays: list | None = None
+		self,
+		include_holidays_in_total_working_days: bool,
+		holidays: list | None = None,
+		half_day_holidays: list | None = None,
 	) -> float:
 		"""Calculates the number of unmarked days for an employee within a date range"""
 		unmarked_days = (
 			self.total_working_days
-			- self._get_days_outside_period(include_holidays_in_total_working_days, holidays)
-			- self._get_marked_attendance_days(holidays)
+			- self._get_days_outside_period(
+				include_holidays_in_total_working_days, holidays, half_day_holidays
+			)
+			- self._get_marked_attendance_days(holidays, half_day_holidays)
 		)
 
 		if include_holidays_in_total_working_days and holidays:
@@ -676,9 +697,13 @@ class SalarySlip(TransactionBase):
 		return query.run()[0][0]
 
 	def _get_days_outside_period(
-		self, include_holidays_in_total_working_days: bool, holidays: list | None = None
+		self,
+		include_holidays_in_total_working_days: bool,
+		holidays: list | None = None,
+		half_day_holidays: list | None = None,
 	):
 		"""Returns days before DOJ or after relieving date"""
+		half_day_holidays = half_day_holidays or []
 
 		def _get_days(start_date, end_date):
 			no_of_days = date_diff(end_date, start_date) + 1
@@ -690,7 +715,9 @@ class SalarySlip(TransactionBase):
 				end_date = getdate(end_date)
 				for day in range(no_of_days):
 					date = add_days(end_date, -day)
-					if date not in holidays:
+					if date in half_day_holidays:
+						days += HALF_DAY_HOLIDAY_FRACTION
+					elif date not in holidays:
 						days += 1
 				return days
 
@@ -714,7 +741,9 @@ class SalarySlip(TransactionBase):
 
 		return no_of_holidays
 
-	def _get_marked_attendance_days(self, holidays: list | None = None) -> float:
+	def _get_marked_attendance_days(
+		self, holidays: list | None = None, half_day_holidays: list | None = None
+	) -> float:
 		Attendance = frappe.qb.DocType("Attendance")
 		query = (
 			frappe.qb.from_(Attendance)
@@ -728,7 +757,16 @@ class SalarySlip(TransactionBase):
 		if holidays:
 			query = query.where(Attendance.attendance_date.notin(holidays))
 
-		return query.run()[0][0]
+		marked_days = query.run()[0][0]
+
+		if half_day_holidays:
+			# attendance marked on a half day holiday accounts for half a working day
+			marked_days -= (
+				HALF_DAY_HOLIDAY_FRACTION
+				* (query.where(Attendance.attendance_date.isin(half_day_holidays)).run()[0][0])
+			)
+
+		return marked_days
 
 	def get_payment_days(self, include_holidays_in_total_working_days):
 		if self.joining_date and self.joining_date > getdate(self.end_date):
@@ -748,7 +786,11 @@ class SalarySlip(TransactionBase):
 
 		if not cint(include_holidays_in_total_working_days):
 			holidays = self.get_holidays_for_employee(self.actual_start_date, self.actual_end_date)
-			payment_days -= len(holidays)
+			half_day_holidays = self.get_half_day_holidays_for_employee(
+				self.actual_start_date, self.actual_end_date
+			)
+			# half day holidays are working days for half the day, so only half of them is deducted
+			payment_days -= len(holidays) - HALF_DAY_HOLIDAY_FRACTION * len(half_day_holidays)
 
 		return payment_days
 
@@ -763,8 +805,20 @@ class SalarySlip(TransactionBase):
 
 		return holiday_dates
 
+	def get_half_day_holidays_for_employee(self, start_date, end_date):
+		"""Returns holidays marked as half day, they count as half a working day"""
+		holiday_list = get_holiday_list_for_employee(self.employee)
+		key = f"half_day:{holiday_list}:{start_date}:{end_date}"
+		holiday_dates = frappe.cache().hget(HOLIDAYS_BETWEEN_DATES, key)
+
+		if holiday_dates is None:
+			holiday_dates = get_holiday_dates_between(holiday_list, start_date, end_date, only_half_days=True)
+			frappe.cache().hset(HOLIDAYS_BETWEEN_DATES, key, holiday_dates)
+
+		return holiday_dates
+
 	def calculate_lwp_or_ppl_based_on_leave_application(
-		self, holidays, working_days_list, daily_wages_fraction_for_half_day
+		self, holidays, half_day_holidays, working_days_list, daily_wages_fraction_for_half_day
 	):
 		lwp = 0
 		leaves = get_lwp_or_ppl_for_date_range(
@@ -798,6 +852,10 @@ class SalarySlip(TransactionBase):
 				equivalent_lwp_count *= (
 					(1 - fraction_of_daily_salary_per_leave) if fraction_of_daily_salary_per_leave else 1
 				)
+
+			if not leave.include_holiday and getdate(d) in half_day_holidays:
+				# only half of the day was a working day, so only half of it can be unpaid
+				equivalent_lwp_count *= HALF_DAY_HOLIDAY_FRACTION
 
 			lwp += equivalent_lwp_count
 
@@ -838,7 +896,11 @@ class SalarySlip(TransactionBase):
 		return attendance_details
 
 	def calculate_lwp_ppl_and_absent_days_based_on_attendance(
-		self, holidays, daily_wages_fraction_for_half_day, consider_marked_attendance_on_holidays
+		self,
+		holidays,
+		half_day_holidays,
+		daily_wages_fraction_for_half_day,
+		consider_marked_attendance_on_holidays,
 	):
 		lwp = 0
 		absent = 0
@@ -870,6 +932,9 @@ class SalarySlip(TransactionBase):
 					"fraction_of_daily_salary_per_leave"
 				]
 
+			# only half of the day was a working day, so only half of it can be unpaid
+			day_fraction = HALF_DAY_HOLIDAY_FRACTION if getdate(d.attendance_date) in half_day_holidays else 1
+
 			if d.status == "Half Day" and d.leave_type and d.leave_type in leave_type_map.keys():
 				equivalent_lwp = 1 - daily_wages_fraction_for_half_day
 
@@ -877,7 +942,7 @@ class SalarySlip(TransactionBase):
 					equivalent_lwp *= (
 						fraction_of_daily_salary_per_leave if fraction_of_daily_salary_per_leave else 1
 					)
-				lwp += equivalent_lwp
+				lwp += equivalent_lwp * day_fraction
 
 			elif d.status == "On Leave" and d.leave_type and d.leave_type in leave_type_map.keys():
 				equivalent_lwp = 1
@@ -885,10 +950,10 @@ class SalarySlip(TransactionBase):
 					equivalent_lwp *= (
 						fraction_of_daily_salary_per_leave if fraction_of_daily_salary_per_leave else 1
 					)
-				lwp += equivalent_lwp
+				lwp += equivalent_lwp * day_fraction
 
 			elif d.status == "Absent":
-				absent += 1
+				absent += day_fraction
 
 		return lwp, absent
 

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -46,7 +46,7 @@ from hrms.payroll.doctype.salary_slip.salary_slip import (
 	make_salary_slip_from_timesheet,
 )
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
-from hrms.tests.test_utils import get_email_by_subject, get_first_sunday
+from hrms.tests.test_utils import add_date_to_holiday_list, get_email_by_subject, get_first_sunday
 from hrms.tests.utils import HRMSTestSuite
 
 
@@ -671,6 +671,95 @@ class TestSalarySlip(HRMSTestSuite):
 		self.assertEqual(ss.earnings[0].default_amount, 50000)
 		self.assertEqual(ss.earnings[1].amount, 3000)
 		self.assertEqual(ss.gross_pay, 78000)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"include_holidays_in_total_working_days": 0, "payroll_based_on": "Leave"}
+	)
+	def test_salary_slip_with_half_day_holiday(self):
+		"""Tests that a holiday marked as half day is counted as half a working day"""
+		no_of_days = get_no_of_days()
+		emp_id, _half_day_holiday = setup_employee_with_half_day_holiday(
+			"Test Half Day Holiday List", "test_half_day_holiday@salary.com"
+		)
+
+		ss = make_employee_salary_slip(emp_id, "Monthly", "Test Salary Slip With Half Day Holiday")
+
+		# weekly offs are excluded in full, the half day holiday is excluded by half only
+		expected_working_days = no_of_days[0] - no_of_days[1] - 0.5
+		self.assertEqual(ss.total_working_days, expected_working_days)
+		self.assertEqual(ss.payment_days, expected_working_days)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings", {"include_holidays_in_total_working_days": 0, "payroll_based_on": "Leave"}
+	)
+	def test_lwp_on_half_day_holiday(self):
+		"""Tests that leave without pay on a half day holiday is unpaid for half the day only"""
+		no_of_days = get_no_of_days()
+		emp_id, half_day_holiday = setup_employee_with_half_day_holiday(
+			"Test LWP Half Day Holiday List", "test_lwp_on_half_day_holiday@salary.com"
+		)
+		frappe.db.set_value("Leave Type", "Leave Without Pay", "include_holiday", 0)
+
+		# leave on the half day holiday and on the working day after it
+		make_leave_application(emp_id, half_day_holiday, add_days(half_day_holiday, 1), "Leave Without Pay")
+
+		ss = make_employee_salary_slip(emp_id, "Monthly", "Test LWP On Half Day Holiday")
+
+		# 0.5 for the half day holiday + 1 for the full working day
+		expected_working_days = no_of_days[0] - no_of_days[1] - 0.5
+		self.assertEqual(ss.leave_without_pay, 1.5)
+		self.assertEqual(ss.total_working_days, expected_working_days)
+		self.assertEqual(ss.payment_days, expected_working_days - 1.5)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings",
+		{
+			"include_holidays_in_total_working_days": 0,
+			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Present",
+		},
+	)
+	def test_absent_on_half_day_holiday(self):
+		"""Tests that being absent on a half day holiday deducts half a day"""
+		no_of_days = get_no_of_days()
+		emp_id, half_day_holiday = setup_employee_with_half_day_holiday(
+			"Test Absent Half Day Holiday List", "test_absent_on_half_day_holiday@salary.com"
+		)
+
+		mark_attendance(emp_id, half_day_holiday, "Absent", ignore_validate=True)
+
+		ss = make_employee_salary_slip(emp_id, "Monthly", "Test Absent On Half Day Holiday")
+
+		expected_working_days = no_of_days[0] - no_of_days[1] - 0.5
+		self.assertEqual(ss.absent_days, 0.5)
+		self.assertEqual(ss.total_working_days, expected_working_days)
+		self.assertEqual(ss.payment_days, expected_working_days - 0.5)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings",
+		{
+			"include_holidays_in_total_working_days": 0,
+			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Absent",
+		},
+	)
+	def test_marked_attendance_on_half_day_holiday_with_unmarked_days_as_absent(self):
+		"""Tests that attendance marked on a half day holiday accounts for half a working day"""
+		no_of_days = get_no_of_days()
+		emp_id, half_day_holiday = setup_employee_with_half_day_holiday(
+			"Test Marked Half Day Holiday List", "test_marked_on_half_day_holiday@salary.com"
+		)
+
+		# only the half day holiday is marked, every other working day stays unmarked
+		mark_attendance(emp_id, half_day_holiday, "Present", ignore_validate=True)
+
+		ss = make_employee_salary_slip(emp_id, "Monthly", "Test Marked Attendance On Half Day Holiday")
+
+		# the half day holiday is the only day worked, and it is worth half a day
+		expected_working_days = no_of_days[0] - no_of_days[1] - 0.5
+		self.assertEqual(ss.total_working_days, expected_working_days)
+		self.assertEqual(ss.absent_days, expected_working_days - 0.5)
+		self.assertEqual(ss.payment_days, 0.5)
 
 	@HRMSTestSuite.change_settings(
 		"Payroll Settings",
@@ -2773,6 +2862,31 @@ def make_payroll_period(company=None):
 
 		if not payroll_period:
 			create_payroll_period(company=company, name=company_based_payroll_period[company])
+
+
+def setup_employee_with_half_day_holiday(list_name: str, employee_email: str) -> tuple[str, str]:
+	"""Creates a holiday list with weekly offs and one half day holiday, assigned to a new employee.
+
+	Returns the employee and the half day holiday date."""
+	from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+		create_holiday_list_assignment,
+	)
+
+	holiday_list = make_holiday_list(list_name)
+	# the day after the first weekly off, so that it does not fall on one
+	half_day_holiday = add_days(get_first_sunday(holiday_list), 1)
+	add_date_to_holiday_list(half_day_holiday, holiday_list, is_half_day=1)
+
+	emp_id = make_employee(
+		employee_email,
+		relieving_date=None,
+		status="Active",
+		company="_Test Company",
+		holiday_list=holiday_list,
+	)
+	create_holiday_list_assignment("Employee", emp_id, holiday_list)
+
+	return emp_id, half_day_holiday
 
 
 def make_holiday_list(

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -12,6 +12,7 @@ def get_holiday_dates_between(
 	skip_weekly_offs: bool = False,
 	as_dict: bool = False,
 	select_weekly_off: bool = False,
+	only_half_days: bool = False,
 ) -> list:
 	Holiday = frappe.qb.DocType("Holiday")
 	query = frappe.qb.from_(Holiday).select(Holiday.holiday_date)
@@ -25,6 +26,9 @@ def get_holiday_dates_between(
 
 	if skip_weekly_offs:
 		query = query.where(Holiday.weekly_off == 0)
+
+	if only_half_days:
+		query = query.where(Holiday.is_half_day == 1)
 
 	if as_dict:
 		return query.run(as_dict=True)


### PR DESCRIPTION
**Description:** A holiday marked as **Is Half Day** is deducted from payroll in full. A company with a full day off on Sunday and a half day off on Saturday loses 5 whole days in August 2026 instead of 2.5, so the salary slip shows 21 total
working days where it should show 23.5. That inflates the per-day rate used for leave without pay and absent deductions, and skews pro rata pay for employees joining or leaving mid-month.

Leave without pay or absence on such a day is also ignored completely, even though half of it is a working day.

**Steps to reproduce:**
1. Payroll Settings: *Payroll Based On* = `Leave`, uncheck *Include Holidays in Total Working Days`.
2. Create a Holiday List for 01-01-2026 to 31-12-2026:
   - *Weekly Off* = `Sunday`, **Is Half Day** unchecked, click *Get Weekly Off Dates*
   - tick **Is Half Day**, *Weekly Off* = `Saturday`, click *Get Weekly Off Dates*
   - August now has 5 Sundays as full holidays and 5 Saturdays as half-day holidays
3. Assign the new holiday list 
4. Assign a monthly Salary Structure with a payment days based component, base 30000.
5. Create a Salary Slip for 01-08-2026 to 31-08-2026 and check **Total Working Days**.


**Before:**

[Screencast from 2026-08-03 18-43-22.webm](https://github.com/user-attachments/assets/705913c4-36f3-49ad-97ef-2acaa3d41293)


**After:**

[Screencast from 2026-08-03 18-37-47.webm](https://github.com/user-attachments/assets/24d706cc-3bd3-458d-8b45-b8b50f0ad46a)


**Backport needed for v-15, v-16**