### PR TITLE
fix(monthly_attendance_sheet): fix holiday count for date ranges spanning months

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -563,7 +563,7 @@ def get_attendance_status_for_summarized_view(
 
 	for d in total_days:
 		d = getdate(d)
-		if d.day in attendance_days or (joined_in_current_period and d < joined_date):
+		if d in attendance_days or (joined_in_current_period and d < joined_date):
 			continue
 
 		status = get_holiday_status(d, holidays)
@@ -620,7 +620,7 @@ def get_attendance_summary_and_days(employee: str, filters: Filters) -> tuple[di
 
 	days = (
 		frappe.qb.from_(Attendance)
-		.select(Extract("day", Attendance.attendance_date).as_("day_of_month"))
+		.select(Attendance.attendance_date)
 		.distinct()
 		.where(
 			(Attendance.docstatus == 1)

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -488,6 +488,45 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(row["total_late_entries"], 1)
 		self.assertEqual(row["total_early_exits"], 1)
 
+	def test_summarised_view_with_date_range_across_month_boundary(self):
+		"""
+		Total Holidays must count a holiday even if an earlier date
+		in a different month shares its day-of-month.
+		"""
+		previous_month_first = get_first_day_for_prev_month()
+		year_start = getdate(get_year_start(previous_month_first))
+
+		start_date = previous_month_first.replace(day=5)
+		end_date = start_date + relativedelta(months=1)  # same day-of-month, next month
+		year_end = getdate(get_year_ending(end_date))
+
+		hl = make_holiday_list(
+			"Test Cross Month HL", from_date=year_start, to_date=year_end, add_weekly_offs=False
+		)
+		add_holiday_to_list(hl, end_date)  # holiday only on the later, colliding day-of-month
+
+		frappe.db.delete("Holiday List Assignment", {"assigned_to": self.employee})
+		create_holiday_list_assignment("Employee", self.employee, hl, from_date=year_start)
+
+		# attendance on the earlier date sharing the same day-of-month as the holiday
+		mark_attendance(self.employee, start_date, "Present")
+
+		filters = frappe._dict(
+			{
+				"filter_based_on": "Date Range",
+				"start_date": start_date,
+				"end_date": end_date,
+				"company": self.company,
+				"summarized_view": 1,
+			}
+		)
+		report = execute(filters=filters)
+		row = report[1][0]
+
+		# end_date's holiday must still be counted despite start_date (same day-of-month, different month)
+		# already having an attendance record
+		self.assertEqual(row["total_holidays"], 1)
+
 	def test_detailed_view_with_date_range_filter(self):
 		today = getdate()
 		mark_attendance(self.employee, today, "Absent", "Day Shift")


### PR DESCRIPTION
### Reason
- The report **Monthly Attendance Sheet** shows fewer holidays than it should when the Date Range spans a month boundary and a day-of-month number repeats across both months (e.g. 15-01-2026 → 20-02-2026, where **"15" falls in both January and February**).
- The check for "does this date already have attendance" only looked at the day-of-month number, not the full date, so an attendance record on 15-01-2026 caused 15-02-2026 (a real Sunday holiday) to get skipped from the count by mistake.
<img width="2390" height="1256" alt="image" src="https://github.com/user-attachments/assets/0b5e7297-dbb2-4806-ac87-ae1d75165cec" />


### Changes Done
- Compare full dates instead of just the day-of-month when checking for existing attendance, so dates in different months are no longer treated as the same.
<img width="2394" height="1236" alt="image" src="https://github.com/user-attachments/assets/c1ead04c-634a-47b2-a5ec-60a16cab7c83" />
