### PR TITLE
test(payroll_entry): use relative dates for loan repayment value date…

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 import frappe
 from frappe.query_builder.functions import Coalesce, Sum
-from frappe.utils import add_days, add_months, cstr, date_diff, flt
+from frappe.utils import add_days, add_months, cstr, date_diff, flt, get_first_day, get_last_day
 
 import erpnext
 from erpnext.accounts.utils import get_fiscal_year, getdate, nowdate
@@ -886,6 +886,11 @@ class TestPayrollEntry(HRMSTestSuite):
 		frappe.db.delete("Loan")
 		applicant, branch, currency, payroll_payable_account = setup_lending()
 
+		payroll_start_date = get_first_day(getdate())
+		payroll_end_date = get_last_day(getdate())
+		loan_posting_date = get_first_day(add_months(getdate(), -1))
+		repayment_start_date = add_days(payroll_start_date, 4)
+
 		loan = create_loan(
 			applicant,
 			"Car Loan",
@@ -893,8 +898,8 @@ class TestPayrollEntry(HRMSTestSuite):
 			"Repay Over Number of Periods",
 			20,
 			applicant_type="Employee",
-			posting_date="2026-06-02",
-			repayment_start_date="2026-07-05",
+			posting_date=loan_posting_date,
+			repayment_start_date=repayment_start_date,
 		)
 		loan.repay_from_salary = 1
 		loan.submit()
@@ -902,15 +907,14 @@ class TestPayrollEntry(HRMSTestSuite):
 		make_loan_disbursement_entry(
 			loan.name,
 			loan.loan_amount,
-			disbursement_date="2026-06-02",
-			repayment_start_date="2026-07-05",
+			disbursement_date=loan_posting_date,
+			repayment_start_date=repayment_start_date,
 		)
 
-		# July 2026 payroll — end_date 2026-07-31 covers the 2026-07-05 demand
 		payroll_entry = make_payroll_entry(
 			company="_Test Company",
-			start_date="2026-07-01",
-			end_date="2026-07-31",
+			start_date=payroll_start_date,
+			end_date=payroll_end_date,
 			payable_account=payroll_payable_account,
 			currency=currency,
 			branch=branch,
@@ -929,7 +933,7 @@ class TestPayrollEntry(HRMSTestSuite):
 			"Loan Repayment", loan_repayment_name, ["value_date", "interest_payable"]
 		)
 
-		self.assertEqual(getdate(lr_value_date), getdate("2026-07-31"))
+		self.assertEqual(getdate(lr_value_date), payroll_end_date)
 		self.assertGreater(flt(lr_interest_payable), 0)
 
 	@HRMSTestSuite.change_settings(

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -886,9 +886,10 @@ class TestPayrollEntry(HRMSTestSuite):
 		frappe.db.delete("Loan")
 		applicant, branch, currency, payroll_payable_account = setup_lending()
 
-		payroll_start_date = get_first_day(getdate())
-		payroll_end_date = get_last_day(getdate())
-		loan_posting_date = get_first_day(add_months(getdate(), -1))
+		today = getdate()
+		payroll_start_date = get_first_day(today)
+		payroll_end_date = get_last_day(today)
+		loan_posting_date = get_first_day(add_months(today, -1))
 		repayment_start_date = add_days(payroll_start_date, 4)
 
 		loan = create_loan(


### PR DESCRIPTION
**Description:** test_loan_repayment_value_date_for_future_payroll fails on every CI run since 02-08-2026:
`TypeError: cannot unpack non-iterable NoneType object.`

The test hardcodes the payroll period as 01-07-2026 to 31-07-2026, but setup_lending() creates the salary structure assignment with a relative date, add_months(getdate(), -1).

Salary Slip looks for an assignment with from_date <= actual_start_date. Once the current date passed 01-08-2026, the assignment starts after the payroll period begins, so no salary slip is created, and the test errors while reading the loan repayment of a slip that does not exist.