### PR TITLE
feat: add on-duty legend in the montly attendance sheet report

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -156,7 +156,7 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 				if (value == "HD/P") value = "<span style='color:#914EE3'>" + value + "</span>";
 				else if (value == "HD/A")
 					value = "<span style='color:orange'>" + value + "</span>";
-				else if (value == "P" || value == "WFH")
+				else if (value == "P" || value == "WFH" || value == "OD")
 					value = "<span style='color:green'>" + value + "</span>";
 				else if (value == "A") value = "<span style='color:red'>" + value + "</span>";
 				else if (value == "L") value = "<span style='color:#318AD8'>" + value + "</span>";

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -30,6 +30,7 @@ status_map = {
 	"Half Day/Other Half Absent": "HD/A",
 	"Half Day/Other Half Present": "HD/P",
 	"Work From Home": "WFH",
+	"On Duty": "OD",
 	"On Leave": "L",
 	"Holiday": "H",
 	"Weekly Off": "WO",
@@ -88,6 +89,7 @@ def get_message() -> str:
 		"red",
 		"orange",
 		"#914EE3",
+		"green",
 		"green",
 		"#3187D8",
 		"#878787",
@@ -319,6 +321,7 @@ def get_attendance_map(filters: Filters) -> dict:
 def get_attendance_records(filters: Filters) -> list[dict]:
 	Attendance = frappe.qb.DocType("Attendance")
 	Employee = frappe.qb.DocType("Employee")
+	AttendanceRequest = frappe.qb.DocType("Attendance Request")
 	attendance_date_condition = get_date_condition(Attendance.attendance_date, filters)
 	status = (
 		frappe.qb.terms.Case()
@@ -330,10 +333,18 @@ def get_attendance_records(filters: Filters) -> list[dict]:
 			((Attendance.status == "Half Day") & (Attendance.half_day_status == "Absent")),
 			"Half Day/Other Half Absent",
 		)
+		# "On Duty" is not an attendance status, it is only available as an
+		# attendance request reason that marks the employee as present
+		.when(
+			((Attendance.status == "Present") & (AttendanceRequest.reason == "On Duty")),
+			"On Duty",
+		)
 		.else_(Attendance.status)
 	)
 	query = (
 		frappe.qb.from_(Attendance)
+		.left_join(AttendanceRequest)
+		.on(Attendance.attendance_request == AttendanceRequest.name)
 		.select(
 			Attendance.employee,
 			Attendance.attendance_date,
@@ -776,7 +787,7 @@ def get_chart_data(attendance_map: dict, filters: Filters) -> dict:
 					break
 				elif attendance_on_day == "Absent":
 					total_absent_on_day += 1
-				elif attendance_on_day in ["Present", "Work From Home"]:
+				elif attendance_on_day in ["Present", "Work From Home", "On Duty"]:
 					total_present_on_day += 1
 				elif attendance_on_day == "Half Day":
 					total_present_on_day += 0.5

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -6,6 +6,7 @@ from frappe.utils import add_days, get_year_ending, get_year_start, getdate
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
+from hrms.hr.doctype.attendance_request.test_attendance_request import create_attendance_request
 from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
 	assign_holiday_list,
 	create_holiday_list_assignment,
@@ -117,6 +118,40 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 			== row_without_shift[date_key(add_days(previous_month_first, 2))]
 			== "L"
 		)
+
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_on_duty_in_detailed_view(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		# attendance marked via an "On Duty" attendance request
+		create_attendance_request(
+			employee=self.employee,
+			from_date=previous_month_first,
+			to_date=previous_month_first,
+			reason="On Duty",
+			include_holidays=1,
+		)
+		# plain present attendance, not linked to any attendance request
+		mark_attendance(self.employee, previous_month_first + relativedelta(days=1), "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		row = report[1][0]
+		self.assertEqual(row[date_key(previous_month_first)], "OD")  # on duty on the 1st day of the month
+		self.assertEqual(row[date_key(add_days(previous_month_first, 1))], "P")  # present on the 2nd day
+
+		# on duty should still be counted as present in the chart
+		present = report[3]["data"]["datasets"][1]["values"]
+		self.assertEqual(present[0], 1)
+		self.assertEqual(present[1], 1)
 
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_single_shift_with_leaves_in_detailed_view(self):


### PR DESCRIPTION
Closes: #971 

**Description:** Attendance marked through an Attendance Request with reason On Duty was indistinguishable from regular attendance in the Monthly Attendance Sheet — it showed up as P, same as a normal present day.

This adds a dedicated OD legend so those days are visible at a glance.

On Duty is not an Attendance status (the DocType only has Present/Absent/On Leave/Half Day/Work From Home) — it exists only as an Attendance Request reason, and submitting one creates a Present record linked via attendance_request. The report now resolves it through that link.


**Before:**

<img width="1920" height="1011" alt="image" src="https://github.com/user-attachments/assets/1b50b29e-1ab9-4a48-adca-47571c9a0b3e" />

**After:**

<img width="1919" height="1009" alt="image" src="https://github.com/user-attachments/assets/153367d0-50db-4b3d-be20-de745b74310d" />


**Backport needed for v15, v16**