### PR TITLE
fix(pwa): add scope and ID to webmanifest to avoid conflicts

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -27,6 +27,8 @@ export default defineConfig({
 				name: "Frappe HR",
 				short_name: "Frappe HR",
 				start_url: "/hrms",
+				scope: "/hrms",
+				id: "/hrms",
 				description: "Everyday HR & Payroll operations at your fingertips",
 				theme_color: "#ffffff",
 				icons: [


### PR DESCRIPTION
Scope and ID is required to avoid Android devices assuming the invalid scope to be site-wide ("/"). 