### PR TITLE
fix(salary_slip): fix incorrect ctc in salary component formula

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1362,10 +1362,13 @@ class SalarySlip(TransactionBase):
 
 		data = get_component_eval_context(self.employee, self._salary_structure_assignment)
 		# Overlay salary-slip fields (payment_days, gross_pay, start_date, …) last, so the
-		# actual period context wins. Note: this means on a name collision a Salary Slip
-		# field takes precedence over an Employee field (employee is layered earlier in
-		# get_component_eval_context); no current formula relies on the reverse.
-		data.update(self.as_dict())
+		# actual period context wins on a name collision with an Employee field (e.g. a saved
+		# payslip keeps its own department/branch snapshot, not the employee's current one).
+		slip_data = self.as_dict()
+		# Exception: ctc is computed later by compute_ctc(), so it's still 0/unset here
+		# drop it instead of overwriting the real value from Employee/SSA.
+		slip_data.pop("ctc", None)
+		data.update(slip_data)
 
 		# shallow copy to store default amounts (without payment-days proration) for tax calculation
 		default_data = data.copy()

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1899,6 +1899,37 @@ class TestSalarySlip(HRMSTestSuite):
 
 				self.assertEqual(earning.default_amount, 19000)
 
+	def test_ctc_in_statistical_component_formula(self):
+		from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+			create_salary_structure_assignment,
+		)
+
+		emp = make_employee(
+			"test_ctc_statistical_component@salary.com",
+			company="_Test Company",
+			ctc=15000,
+		)
+
+		salary_structure_doc = make_salary_structure_for_statistical_component(
+			"_Test Company", sc_formula="ctc"
+		)
+
+		create_salary_structure_assignment(
+			employee=emp,
+			salary_structure=salary_structure_doc.name,
+			company="_Test Company",
+			currency="INR",
+			base=40000,
+		)
+
+		salary_slip = make_salary_slip(salary_structure_doc.name, employee=emp, posting_date=nowdate())
+
+		for earning in salary_slip.earnings:
+			if earning.salary_component == "Leave Travel Allowance":
+				# SC (statistical) = ctc = 15000
+				# LTA = base - SC = 40000 - 15000 = 25000
+				self.assertEqual(earning.amount, 25000)
+
 	def test_variable_tax_component(self):
 		from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
@@ -3041,7 +3072,7 @@ def create_additional_salary_for_income_tax(employee, payroll_period, company):
 	add_sal.submit()
 
 
-def make_salary_structure_for_statistical_component(company):
+def make_salary_structure_for_statistical_component(company, sc_formula="base - BSC - HRAC"):
 	earnings = [
 		{
 			"salary_component": "Basic Component",
@@ -3055,7 +3086,7 @@ def make_salary_structure_for_statistical_component(company):
 			"salary_component": "Statistical Component",
 			"abbr": "SC",
 			"type": "Earning",
-			"formula": "base - BSC - HRAC",
+			"formula": sc_formula,
 			"statistical_component": 1,
 			"amount_based_on_formula": 1,
 			"depends_on_payment_days": 0,


### PR DESCRIPTION
### Reason
When a Salary Component is marked as **Statistical Component** and its formula uses **ctc**, it evaluates to 0 instead of the employee's actual ctc, even though the exact same formula works fine on a normal (non-statistical) component. 
Since other formulas sometimes build on top of that statistical component (like HRA depending on Gross), they end up wrong too.
￼￼
<img width="1834" height="734" alt="image" src="https://github.com/user-attachments/assets/b1d35524-fb09-47c9-bddb-b1765aeb3e9e" />

<img width="2486" height="1528" alt="image" src="https://github.com/user-attachments/assets/bfeca7a1-e395-41ab-987b-d2f172b64fc6" />


### Changes done
- Fixed how **ctc** is looked up while formulas are being evaluated, so it always picks up the employee's real ctc value instead of an internal placeholder that hadn't been calculated yet at that point.
<img width="2386" height="1394" alt="image" src="https://github.com/user-attachments/assets/69384881-a478-4f7c-aece-7ea585691bb1" />
