### PR TITLE
fix(leave_application): enforce mandatory leave approver and sync leave approver name

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -122,6 +122,8 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			self.validate_optional_leave()
 		self.validate_applicable_after()
 		self.validate_for_self_approval()
+		self.validate_leave_approver()
+		self.set_leave_approver_name()
 
 	def on_update(self):
 		if self.status == "Open" and self.docstatus < 1:
@@ -909,6 +911,20 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			if leaves:
 				args.update(dict(from_date=start_date, to_date=self.to_date, leaves=leaves * -1))
 				create_leave_ledger_entry(self, args, submit)
+
+	def validate_leave_approver(self):
+		if (
+			self.docstatus != 2
+			and not self.leave_approver
+			and frappe.db.get_single_value("HR Settings", "leave_approver_mandatory_in_leave_application")
+		):
+			frappe.throw(_("Leave Approver is mandatory"))
+
+	def set_leave_approver_name(self):
+		if not self.leave_approver:
+			self.leave_approver_name = None
+		elif not self.leave_approver_name or self.has_value_changed("leave_approver"):
+			self.leave_approver_name = get_fullname(self.leave_approver)
 
 	def validate_for_self_approval(self):
 		self_leave_approval_not_allowed = frappe.db.get_single_value(

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -50,7 +50,6 @@ from hrms.tests.utils import HRMSTestSuite
 class TestLeaveApplication(HRMSTestSuite):
 	def setUp(self):
 		frappe.set_user("Administrator")
-		frappe.db.set_single_value("HR Settings", "leave_approver_mandatory_in_leave_application", 0)
 		employee = get_employee()
 		self.leave_application = frappe.get_value(
 			"Leave Application",

--- a/hrms/hr/doctype/leave_application/test_leave_application.py
+++ b/hrms/hr/doctype/leave_application/test_leave_application.py
@@ -50,6 +50,7 @@ from hrms.tests.utils import HRMSTestSuite
 class TestLeaveApplication(HRMSTestSuite):
 	def setUp(self):
 		frappe.set_user("Administrator")
+		frappe.db.set_single_value("HR Settings", "leave_approver_mandatory_in_leave_application", 0)
 		employee = get_employee()
 		self.leave_application = frappe.get_value(
 			"Leave Application",
@@ -909,6 +910,26 @@ class TestLeaveApplication(HRMSTestSuite):
 		employee.reload()
 		employee.leave_approver = ""
 		employee.save()
+
+	def test_leave_approver_mandatory(self):
+		frappe.db.set_single_value("HR Settings", "leave_approver_mandatory_in_leave_application", 1)
+
+		employee = get_employee()
+		application = frappe.get_doc(
+			doctype="Leave Application",
+			employee=employee.name,
+			leave_type="_Test Leave Type",
+			from_date="2014-06-01",
+			to_date="2014-06-02",
+			posting_date="2014-05-30",
+			description="_Test Reason",
+			company="_Test Company",
+		)
+		self.assertRaises(frappe.ValidationError, application.insert)
+
+		application.leave_approver = "test@example.com"
+		application.insert()
+		self.assertEqual(application.leave_approver_name, frappe.utils.get_fullname("test@example.com"))
 
 	def test_self_leave_approval_allowed(self):
 		frappe.db.set_single_value("HR Settings", "prevent_self_leave_approval", 0)

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -49,3 +49,4 @@ hrms.patches.v16_0.add_default_hr_role_permissions #2026-05-28
 hrms.patches.v16_0.set_reference_fields_in_expense_claim_advance
 hrms.patches.v16_0.update_partially_paid_employee_advance_status
 hrms.patches.v16_0.delete_upload_attendance_doctype #2026-07-16
+hrms.patches.v16_0.set_leave_approver_name_in_leave_application #2026-08-05

--- a/hrms/patches/v16_0/set_leave_approver_name_in_leave_application.py
+++ b/hrms/patches/v16_0/set_leave_approver_name_in_leave_application.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.utils import get_fullname
+
+
+def execute():
+	leave_applications = frappe.get_all(
+		"Leave Application",
+		filters={
+			"leave_approver": ("is", "set"),
+			"leave_approver_name": ("in", (None, "")),
+		},
+		fields=["name", "leave_approver"],
+	)
+
+	if not leave_applications:
+		return
+
+	updates = {
+		entry.name: {"leave_approver_name": get_fullname(entry.leave_approver)}
+		for entry in leave_applications
+	}
+	frappe.db.bulk_update("Leave Application", updates, update_modified=False)

--- a/hrms/tests/utils.py
+++ b/hrms/tests/utils.py
@@ -227,6 +227,7 @@ class BootStrapTestData:
 				"leave_type": "_Test Leave Type",
 				"posting_date": "2013-01-02",
 				"to_date": "2013-05-05",
+				"leave_approver": "Administrator",
 			},
 			{
 				"company": "_Test Company",
@@ -237,6 +238,7 @@ class BootStrapTestData:
 				"leave_type": "_Test Leave Type",
 				"posting_date": "2013-01-02",
 				"to_date": "2013-05-05",
+				"leave_approver": "Administrator",
 			},
 			{
 				"company": "_Test Company",
@@ -247,6 +249,7 @@ class BootStrapTestData:
 				"leave_type": "_Test Leave Type LWP",
 				"posting_date": "2013-01-02",
 				"to_date": "2013-01-15",
+				"leave_approver": "Administrator",
 			},
 		]
 		self.make_records(["employee", "from_date"], records)

--- a/hrms/tests/utils.py
+++ b/hrms/tests/utils.py
@@ -26,6 +26,7 @@ class BootStrapTestData:
 		self.make_salary_components()
 		self.update_email_account_settings()
 		self.update_system_settings()
+		self.update_hr_settings()
 		# TODO: clean up
 		if frappe.db.get_value("Holiday List Assignment", {"assigned_to": "_Test Company"}, "docstatus") == 0:
 			frappe.get_doc("Holiday List Assignment", {"assigned_to": "_Test Company"}).submit()
@@ -341,6 +342,9 @@ class BootStrapTestData:
 		system_settings = frappe.get_doc("System Settings")
 		system_settings.country = "India"
 		system_settings.save()
+
+	def update_hr_settings(self):
+		frappe.db.set_single_value("HR Settings", "leave_approver_mandatory_in_leave_application", 0)
 
 	def make_records(self, key, records):
 		doctype = records[0].get("doctype")


### PR DESCRIPTION
Leave Approver was only required and named on the client side, so it could end up blank or unnamed depending on how the application was created. Now both are set and enforced server-side, with a patch to backfill existing records.
