### PR TITLE
fix: update no copy for attendance request in attendance

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.json
+++ b/hrms/hr/doctype/attendance/attendance.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-01-10 16:34:13",
@@ -162,6 +163,7 @@
    "fieldname": "attendance_request",
    "fieldtype": "Link",
    "label": "Attendance Request",
+   "no_copy": 1,
    "options": "Attendance Request",
    "read_only": 1
   },
@@ -259,7 +261,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-16 17:44:13.859387",
+ "modified": "2026-08-06 14:04:47.580547",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",


### PR DESCRIPTION
**Description:** Attendance created from an Attendance Request stores that request in the read-only attendance_request field. Using Duplicate on such a record copied the link along with everything else, and because the field is read-only it could not be cleared from the form. Changing the date and saving then produced a second Attendance record pointing at the same Attendance Request.

**Before:**

[Screencast from 2026-08-06 14-03-51.webm](https://github.com/user-attachments/assets/222b5e34-1339-4ea3-ae52-a19101db4868)

**After:**

[Screencast from 2026-08-06 14-05-03.webm](https://github.com/user-attachments/assets/ac570914-b1ec-46dd-9503-fb769af69a5e)
