### PR TITLE
fix(employee_leave_balance): resolve report error when no employee is selected and default filter to self

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -84,10 +84,11 @@ frappe.query_reports["Employee Leave Balance"] = {
 			},
 		});
 
-		const is_restricted_to_specific_employees = frappe.defaults.get_user_permissions()["Employee"];
+		const is_restricted_to_specific_employees =
+			frappe.defaults.get_user_permissions()["Employee"];
 		if (is_restricted_to_specific_employees) {
 			hrms.get_current_employee().then((employee) => {
-				if (employee) {
+				if (employee && !frappe.query_report.get_filter_value("employee")) {
 					frappe.query_report.set_filter_value("employee", employee);
 				}
 			});

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -83,5 +83,14 @@ frappe.query_reports["Employee Leave Balance"] = {
 				frappe.query_report.set_filter_value("to_date", data.message[0].to_date);
 			},
 		});
+
+		const is_restricted_to_specific_employees = frappe.defaults.get_user_permissions()["Employee"];
+		if (is_restricted_to_specific_employees) {
+			hrms.get_current_employee().then((employee) => {
+				if (employee) {
+					frappe.query_report.set_filter_value("employee", employee);
+				}
+			});
+		}
 	},
 };

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -145,24 +145,23 @@ def get_leave_types() -> list[str]:
 
 
 def get_employees(filters: Filters) -> list[dict]:
-	Employee = frappe.qb.DocType("Employee")
-	query = frappe.qb.from_(Employee).select(
-		Employee.name,
-		Employee.employee_name,
-		Employee.department,
-	)
+	conditions = {}
 
 	for field in ["company", "department"]:
 		if filters.get(field):
-			query = query.where(getattr(Employee, field) == filters.get(field))
+			conditions[field] = filters.get(field)
 
 	if filters.get("employee"):
-		query = query.where(Employee.name == filters.get("employee"))
+		conditions["name"] = filters.get("employee")
 
 	if filters.get("employee_status"):
-		query = query.where(Employee.status == filters.get("employee_status"))
+		conditions["status"] = filters.get("employee_status")
 
-	return query.run(as_dict=True)
+	return frappe.get_list(
+		"Employee",
+		filters=conditions,
+		fields=["name", "employee_name", "department"],
+	)
 
 
 def get_opening_balance(

--- a/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/test_employee_leave_balance.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe.permissions import add_user_permission
 from frappe.utils import add_days, add_months, flt, get_year_ending, get_year_start, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
@@ -14,7 +15,7 @@ from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
 	process_expired_allocation,
 )
 from hrms.hr.doctype.leave_type.test_leave_type import create_leave_type
-from hrms.hr.report.employee_leave_balance.employee_leave_balance import execute
+from hrms.hr.report.employee_leave_balance.employee_leave_balance import execute, get_employees
 from hrms.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
@@ -293,6 +294,16 @@ class TestEmployeeLeaveBalance(HRMSTestSuite):
 		)
 		report = execute(filters)
 		self.assertEqual(len(report[1]), 1)
+
+	def test_employee_permission_filter(self):
+		make_employee("test_emp_leave_balance_other@example.com", company="_Test Company")
+		add_user_permission("Employee", self.employee_id, "test_emp_leave_balance@example.com")
+
+		filters = frappe._dict({"from_date": self.year_start, "to_date": self.year_end})
+		with self.set_user("test_emp_leave_balance@example.com"):
+			employees = {emp.name for emp in get_employees(filters)}
+
+		self.assertEqual(employees, {self.employee_id})
 
 	def test_manually_expired_leaves(self):
 		leave_type = create_leave_type(leave_type_name="Compensatory off")


### PR DESCRIPTION
The **Employee Leave Balance** report errored out for users when the Employee filter was left blank, since it tried computing balances for every employee in the company instead of just the ones the current user can actually view. 

https://github.com/user-attachments/assets/974d75a4-cd17-4ac3-b737-c6a063403b8b

Fixed the underlying employee lookup and now default the filter to the logged-in user's own record when applicable, so the report now loads cleanly

https://github.com/user-attachments/assets/9b915b73-2301-45ea-bcb7-fd2fef4ef412

