### PR TITLE
feat(expense_claim): add partially paid status

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.json
+++ b/hrms/hr/doctype/expense_claim/expense_claim.json
@@ -283,7 +283,7 @@
    "in_list_view": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nPaid\nUnpaid\nRejected\nSubmitted\nCancelled",
+   "options": "Draft\nPaid\nPartially Paid\nUnpaid\nRejected\nSubmitted\nCancelled",
    "print_hide": 1,
    "read_only": 1
   },
@@ -623,6 +623,10 @@
   {
    "color": "Green",
    "title": "Paid"
+  },
+  {
+   "color": "Blue",
+   "title": "Partially Paid"
   },
   {
    "color": "Yellow",

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -81,7 +81,7 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		posting_date: DF.Date
 		project: DF.Link | None
 		remark: DF.SmallText | None
-		status: DF.Literal["Draft", "Paid", "Unpaid", "Rejected", "Submitted", "Cancelled"]
+		status: DF.Literal["Draft", "Paid", "Partially Paid", "Unpaid", "Rejected", "Submitted", "Cancelled"]
 		task: DF.Link | None
 		taxes: DF.Table[ExpenseTaxesandCharges]
 		total_advance_amount: DF.Currency
@@ -141,7 +141,10 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 				):
 					status = "Paid"
 				elif flt(self.total_sanctioned_amount) > 0:
-					status = "Unpaid"
+					if flt(self.total_amount_reimbursed, precision) > 0:
+						status = "Partially Paid"
+					else:
+						status = "Unpaid"
 			elif self.approval_status == "Rejected":
 				status = "Rejected"
 

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -549,6 +549,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 5000)
 		self.assertEqual(expense_claim.total_amount_reimbursed, 500)
+		self.assertEqual(expense_claim.status, "Partially Paid")
 
 		# Payment entry 2: paying 2000
 		pe2 = make_claim_payment_entry(expense_claim, 2000)
@@ -559,6 +560,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 3000)
 		self.assertEqual(expense_claim.total_amount_reimbursed, 2500)
+		self.assertEqual(expense_claim.status, "Partially Paid")
 
 		# Payment entry 3: paying 3000
 		pe3 = make_claim_payment_entry(expense_claim, 3000)
@@ -569,6 +571,7 @@ class TestExpenseClaim(HRMSTestSuite):
 		outstanding_amount = get_outstanding_amount_for_claim(expense_claim)
 		self.assertEqual(outstanding_amount, 0)
 		self.assertEqual(expense_claim.total_amount_reimbursed, 5500)
+		self.assertEqual(expense_claim.status, "Paid")
 
 	def test_expense_claim_against_delivery_trip(self):
 		from erpnext.stock.doctype.delivery_trip.test_delivery_trip import (

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -49,3 +49,4 @@ hrms.patches.v16_0.add_default_hr_role_permissions #2026-05-28
 hrms.patches.v16_0.set_reference_fields_in_expense_claim_advance
 hrms.patches.v16_0.update_partially_paid_employee_advance_status
 hrms.patches.v16_0.delete_upload_attendance_doctype #2026-07-16
+hrms.patches.v16_0.update_partially_paid_expense_claim_status

--- a/hrms/patches/v16_0/update_partially_paid_expense_claim_status.py
+++ b/hrms/patches/v16_0/update_partially_paid_expense_claim_status.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc("hr", "doctype", "expense_claim")
+
+	claim = frappe.qb.DocType("Expense Claim")
+	(
+		frappe.qb.update(claim)
+		.set(claim.status, "Partially Paid")
+		.where(
+			(claim.docstatus == 1)
+			& (claim.total_amount_reimbursed > 0)
+			& (claim.total_amount_reimbursed < claim.grand_total)
+			& (claim.status == "Unpaid")
+		)
+	).run()


### PR DESCRIPTION
**Description:** An Expense Claim shows "Unpaid" even after it is partly reimbursed, so there is no way to tell a fully outstanding claim from a partly settled one. This adds a "Partially Paid" status, set when total_amount_reimbursed is greater than 0 but less than grand_total, along with a patch to backfill existing claims.


Closes: #4566 

**Before:**

[Screencast from 2026-08-07 12-35-22.webm](https://github.com/user-attachments/assets/fe53ba83-fcc7-45ff-abfb-9af896b72b7a)


**After:**

[Screencast from 2026-08-07 12-29-15.webm](https://github.com/user-attachments/assets/924b68f9-f2fe-4bd6-ae36-0a4a8ac3ffe3)


`no-docs`
