### PR TITLE
feat: per-leave type notice period and backdated limits

### DIFF
--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -121,6 +121,7 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		if frappe.db.get_value("Leave Type", self.leave_type, "is_optional_leave"):
 			self.validate_optional_leave()
 		self.validate_applicable_after()
+		self.validate_notice_period()
 		self.validate_for_self_approval()
 		self.validate_leave_approver()
 		self.set_leave_approver_name()
@@ -184,6 +185,52 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		employee_user = frappe.db.get_value("Employee", self.employee, "user_id", cache=True)
 		hrms.refetch_resource("hrms:my_leaves", employee_user)
 		hrms.refetch_resource("hrms:team_leaves")
+
+	def validate_notice_period(self):
+		if not self.leave_type or not self.from_date:
+			return
+
+		leave_type = frappe.get_cached_doc("Leave Type", self.leave_type)
+
+		if leave_type.role_allowed_to_override_notice_period:
+			if leave_type.role_allowed_to_override_notice_period in frappe.get_roles(frappe.session.user):
+				return
+
+		today = getdate(nowdate())
+		from_date = getdate(self.from_date)
+		diff_days = date_diff(from_date, today)
+
+		if leave_type.min_advance_notice_days > 0:
+			if leave_type.notice_period_basis == "Working Days":
+				holidays = get_holiday_dates_for_employee(self.employee, today, from_date)
+				actual_diff_days = diff_days - len(holidays)
+			else:
+				actual_diff_days = diff_days
+
+			if actual_diff_days < leave_type.min_advance_notice_days:
+				earliest_date = add_days(today, leave_type.min_advance_notice_days)
+				frappe.throw(
+					_(
+						"{0} must be applied at least {1} days in advance. The earliest start date you can select is {2}."
+					).format(
+						frappe.bold(self.leave_type),
+						leave_type.min_advance_notice_days,
+						frappe.bold(formatdate(earliest_date)),
+					)
+				)
+
+		if leave_type.max_advance_booking_days > 0:
+			if diff_days > leave_type.max_advance_booking_days:
+				latest_date = add_days(today, leave_type.max_advance_booking_days)
+				frappe.throw(
+					_(
+						"{0} cannot be applied more than {1} days in advance. The latest start date you can select is {2}."
+					).format(
+						frappe.bold(self.leave_type),
+						leave_type.max_advance_booking_days,
+						frappe.bold(formatdate(latest_date)),
+					)
+				)
 
 	def validate_applicable_after(self):
 		if self.leave_type:
@@ -269,6 +316,19 @@ class LeaveApplication(Document, PWANotificationsMixin):
 		return allocation_based_on_from_date, allocation_based_on_to_date
 
 	def validate_back_dated_application(self):
+		if self.from_date >= getdate(nowdate()):
+			return
+
+		leave_type = frappe.get_cached_doc("Leave Type", self.leave_type)
+		if leave_type.backdated_application_limit_days > 0:
+			if abs(date_diff(getdate(self.from_date), getdate(nowdate()))) > leave_type.backdated_application_limit_days:
+				frappe.throw(
+					_("{0} cannot be backdated more than {1} days.").format(
+						frappe.bold(self.leave_type), leave_type.backdated_application_limit_days
+					)
+				)
+			return
+
 		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
 		future_allocation = (
 			frappe.qb.from_(LeaveAllocation)

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -327,8 +327,6 @@ class LeaveApplication(Document, PWANotificationsMixin):
 						frappe.bold(self.leave_type), leave_type.backdated_application_limit_days
 					)
 				)
-			return
-
 		LeaveAllocation = frappe.qb.DocType("Leave Allocation")
 		future_allocation = (
 			frappe.qb.from_(LeaveAllocation)

--- a/hrms/hr/doctype/leave_type/leave_type.json
+++ b/hrms/hr/doctype/leave_type/leave_type.json
@@ -65,6 +65,41 @@
    "label": "Allow Leave Application After (Calendar Days)"
   },
   {
+   "default": "0",
+   "description": "Application is rejected if From Date is fewer than N days after the application date. 0 = same-day allowed.",
+   "fieldname": "min_advance_notice_days",
+   "fieldtype": "Int",
+   "label": "Minimum Notice Required Before Leave (Days)"
+  },
+  {
+   "default": "Calendar Days",
+   "depends_on": "eval:doc.min_advance_notice_days > 0",
+   "fieldname": "notice_period_basis",
+   "fieldtype": "Select",
+   "label": "Notice Period Basis",
+   "options": "Calendar Days\nWorking Days"
+  },
+  {
+   "default": "0",
+   "description": "Application is rejected if From Date is more than N days in the future. 0 = no limit.",
+   "fieldname": "max_advance_booking_days",
+   "fieldtype": "Int",
+   "label": "Maximum Days Leave Can Be Applied in Advance"
+  },
+  {
+   "default": "0",
+   "description": "Per-type version of the global restriction. 0 = fall back to HR Settings.",
+   "fieldname": "backdated_application_limit_days",
+   "fieldtype": "Int",
+   "label": "Allow Backdated Application Within (Days)"
+  },
+  {
+   "fieldname": "role_allowed_to_override_notice_period",
+   "fieldtype": "Link",
+   "label": "Role Allowed to Override Notice Period",
+   "options": "Role"
+  },
+  {
    "fieldname": "max_continuous_days_allowed",
    "fieldtype": "Int",
    "in_list_view": 1,


### PR DESCRIPTION
Closes #5036

### Description of the Change
Currently, Frappe HR only supports a global restriction for backdated leaves and has no native way to enforce advance notice periods based on the specific type of leave (e.g., sick leave requires 0 days, while annual leave requires 15 days). 

This PR solves this by introducing per-leave-type constraints. It adds the following limit fields to the **Leave Type** DocType:
* `min_advance_notice_days`: Minimum days required before the leave start date.
* `notice_period_basis`: Option to calculate the notice period using Calendar Days or Working Days.
* `max_advance_booking_days`: Prevents booking leaves too far into the future.
* `backdated_application_limit_days`: Overrides the global HR settings for backdated applications on a per-type basis.
* `role_allowed_to_override_notice_period`: Allows specific administrative roles to bypass these constraints.

### Implementation Details
* Added the new fields to `leave_type.json`.
* Implemented all business logic and validations server-side in `leave_application.py`.
* Added `validate_notice_period` to handle the forward-looking constraints.
* Updated `validate_backdated_application` to respect the local limit over the global HR setting.