### PR TITLE
fix(monthly_attendance_sheet): incorrect present/absent/leave count for half-day attendance in summarized view

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -12,7 +12,7 @@ from pypika.terms import Criterion
 import frappe
 from frappe import _
 from frappe.query_builder import Case
-from frappe.query_builder.functions import Count, Extract, Sum
+from frappe.query_builder.functions import Coalesce, Count, Extract, Sum
 from frappe.utils import add_days, cint, cstr, formatdate, getdate
 from frappe.utils.nestedset import get_descendants_of
 
@@ -573,9 +573,11 @@ def get_attendance_status_for_summarized_view(
 			total_unmarked_days += 1
 
 	return {
-		"total_present": summary.total_present + summary.total_half_days,
-		"total_leaves": summary.total_leaves + summary.total_half_days,
-		"total_absent": summary.total_absent,
+		"total_present": summary.total_present
+		+ summary.total_half_day_present
+		+ summary.total_half_day_worked,
+		"total_leaves": summary.total_leaves + summary.total_half_day_leave,
+		"total_absent": summary.total_absent + summary.total_half_day_absent,
 		"total_holidays": total_holidays,
 		"unmarked_days": total_unmarked_days,
 	}
@@ -597,8 +599,39 @@ def get_attendance_summary_and_days(employee: str, filters: Filters) -> tuple[di
 	leave_case = frappe.qb.terms.Case().when(Attendance.status == "On Leave", 1).else_(0)
 	sum_leave = Sum(leave_case).as_("total_leaves")
 
-	half_day_case = frappe.qb.terms.Case().when(Attendance.status == "Half Day", 0.5).else_(0)
-	sum_half_day = Sum(half_day_case).as_("total_half_days")
+	leave_application_condition = Coalesce(Attendance.leave_application, "") != ""
+
+	# the leave portion of a Half Day only counts as leave when an approved Leave Application
+	# backs it; otherwise it reflects hours actually worked and counts as present
+	half_day_leave_case = (
+		frappe.qb.terms.Case()
+		.when(((Attendance.status == "Half Day") & leave_application_condition), 0.5)
+		.else_(0)
+	)
+	sum_half_day_leave = Sum(half_day_leave_case).as_("total_half_day_leave")
+
+	half_day_worked_case = (
+		frappe.qb.terms.Case()
+		.when(((Attendance.status == "Half Day") & leave_application_condition), 0)
+		.when(Attendance.status == "Half Day", 0.5)
+		.else_(0)
+	)
+	sum_half_day_worked = Sum(half_day_worked_case).as_("total_half_day_worked")
+
+	half_day_absent_case = (
+		frappe.qb.terms.Case()
+		.when(((Attendance.status == "Half Day") & (Attendance.half_day_status == "Absent")), 0.5)
+		.else_(0)
+	)
+	sum_half_day_absent = Sum(half_day_absent_case).as_("total_half_day_absent")
+
+	half_day_present_case = (
+		frappe.qb.terms.Case()
+		.when(((Attendance.status == "Half Day") & (Attendance.half_day_status == "Absent")), 0)
+		.when(Attendance.status == "Half Day", 0.5)
+		.else_(0)
+	)
+	sum_half_day_present = Sum(half_day_present_case).as_("total_half_day_present")
 
 	attendance_date_condition = get_date_condition(Attendance.attendance_date, filters)
 
@@ -608,7 +641,10 @@ def get_attendance_summary_and_days(employee: str, filters: Filters) -> tuple[di
 			sum_present,
 			sum_absent,
 			sum_leave,
-			sum_half_day,
+			sum_half_day_leave,
+			sum_half_day_worked,
+			sum_half_day_present,
+			sum_half_day_absent,
 		)
 		.where(
 			(Attendance.docstatus == 1)

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -225,6 +225,51 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertEqual(row["total_early_exits"], 1)
 
 	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_summarized_view_with_leave_backed_half_day(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		mark_attendance(self.employee, previous_month_first, "Absent")
+		mark_attendance(self.employee, previous_month_first + relativedelta(days=1), "Present")
+
+		year_start = getdate(get_year_start(previous_month_first))
+		year_end = getdate(get_year_ending(previous_month_first))
+		try:
+			make_allocation_record(employee=self.employee, from_date=year_start, to_date=year_end)
+		except OverlapError:
+			pass
+
+		leave_backed_day = previous_month_first + relativedelta(days=5)
+		make_leave_application(
+			self.employee,
+			leave_backed_day,
+			leave_backed_day,
+			"_Test Leave Type",
+			half_day=True,
+			half_day_date=leave_backed_day,
+		)
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"summarized_view": 1,
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+
+		row = report[1][0]
+		self.assertEqual(row["employee"], self.employee)
+
+		# 1 present + half day worked 0.5 (leave-backed)
+		self.assertEqual(row["total_present"], 1.5)
+		# 1 absent, half day doesn't count as absent (leave-backed)
+		self.assertEqual(row["total_absent"], 1)
+		# half day leave 0.5 (leave-backed)
+		self.assertEqual(row["total_leaves"], 0.5)
+
+	@assign_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_attendance_with_group_by_filter(self):
 		previous_month_first = get_first_day_for_prev_month()
 

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -213,12 +213,12 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		row = report[1][0]
 		self.assertEqual(row["employee"], self.employee)
 
-		# 4 present + half day absent 0.5
+		# 4 present + half day worked 0.5 (not leave-backed)
 		self.assertEqual(row["total_present"], 4.5)
-		# 1 present
-		self.assertEqual(row["total_absent"], 1)
-		# leave days + half day leave 0.5
-		self.assertEqual(row["total_leaves"], leave_application.total_leave_days + 0.5)
+		# 1 absent + half day absent 0.5 (not leave-backed, defaults to absent)
+		self.assertEqual(row["total_absent"], 1.5)
+		# leave days only, half day isn't leave-backed
+		self.assertEqual(row["total_leaves"], leave_application.total_leave_days)
 
 		self.assertEqual(row["_test_leave_type"], leave_application.total_leave_days)
 		self.assertEqual(row["total_late_entries"], 1)
@@ -477,12 +477,12 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		row = report[1][0]
 		self.assertEqual(row["employee"], self.employee)
 
-		# 4 present + half day absent 0.5
+		# 4 present + half day worked 0.5 (not leave-backed)
 		self.assertEqual(row["total_present"], 4.5)
-		# 1 present
-		self.assertEqual(row["total_absent"], 1)
-		# leave days + half day leave 0.5
-		self.assertEqual(row["total_leaves"], leave_application.total_leave_days + 0.5)
+		# 1 absent + half day absent 0.5 (not leave-backed, defaults to absent)
+		self.assertEqual(row["total_absent"], 1.5)
+		# leave days only, half day isn't leave-backed
+		self.assertEqual(row["total_leaves"], leave_application.total_leave_days)
 
 		self.assertEqual(row["_test_leave_type"], leave_application.total_leave_days)
 		self.assertEqual(row["total_late_entries"], 1)


### PR DESCRIPTION
### Reason
- **Monthly Attendance Sheet's** summarized view always counted a Half Day's **other half** as Present, ignoring the **Status for Other Half** field. So an employee marked absent for that half day never showed up under Total Absent.
- Every Half Day was counted as 0.5 leave, even when there was no actual Leave Application behind it. So half-days auto-marked by shift processing (employee just worked fewer hours, no leave taken) were wrongly shown as leave instead of present.

<img width="1880" height="964" alt="image" src="https://github.com/user-attachments/assets/b29813e9-d17c-4b3c-9e6a-a83921d2e173" />


<img width="2392" height="1160" alt="image" src="https://github.com/user-attachments/assets/58e73d13-f37d-4fd2-8799-845f41516bc3" />


### Changes done
- Split the half-day aggregation in the report query: the **other half** is now routed to **Present/Absent** based on the **attendance's half-day status**, and the leave portion only counts toward Total Leaves when a Leave Application actually backs it. otherwise it counts as Present.
- Updated the existing report tests to match the corrected Present/Absent/Leave totals
 
<img width="2396" height="1172" alt="image" src="https://github.com/user-attachments/assets/dd8bfc27-b2fd-4f18-aed9-4a47b2cfeb22" />
