### PR TITLE
feat: add button to close/reopen job opening

### DIFF
--- a/hrms/hr/doctype/job_opening/job_opening.js
+++ b/hrms/hr/doctype/job_opening/job_opening.js
@@ -11,6 +11,20 @@ frappe.ui.form.on("Job Opening", {
 			};
 		});
 	},
+	refresh: function (frm) {
+		frm.trigger("add_status_toggle_button");
+	},
+	add_status_toggle_button: function (frm) {
+		if (frm.is_new()) return;
+
+		const is_open = frm.doc.status === "Open";
+		const label = is_open ? __("Close Job Opening") : __("Reopen Job Opening");
+
+		frm.add_custom_button(label, () => {
+			frm.set_value("status", is_open ? "Closed" : "Open");
+			frm.save();
+		});
+	},
 	designation: function (frm) {
 		if (frm.doc.designation) {
 			frm.set_value("job_title", frm.doc.designation);

--- a/hrms/hr/doctype/job_opening/job_opening.json
+++ b/hrms/hr/doctype/job_opening/job_opening.json
@@ -66,6 +66,7 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "hidden": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
@@ -284,7 +285,7 @@
  "idx": 1,
  "is_published_field": "publish",
  "links": [],
- "modified": "2026-07-20 18:22:48.627602",
+ "modified": "2026-08-10 12:10:00.000000",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Opening",


### PR DESCRIPTION
 Instead of having to update status field manually.
 
 The status field is hidden in form view. The status is now changed though action buttons.

### Before


https://github.com/user-attachments/assets/a49f6776-045f-4da1-8e52-623c0964c4be



### After

https://github.com/user-attachments/assets/8710283a-4383-42e8-a8dc-fd1d297d9167


docs: https://docs.frappe.io/hr/job-opening
