### PR TITLE
feat: bulk download salary slips from the pwa

### DIFF
--- a/frontend/src/components/SalarySlipItem.vue
+++ b/frontend/src/components/SalarySlipItem.vue
@@ -23,14 +23,19 @@
 			<span v-if="doc?.net_pay" class="text-gray-700 font-normal rounded text-base">
 				{{ formatCurrency(doc.net_pay, doc.currency) }}
 			</span>
-			<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
+			<Checkbox
+				v-if="props.selectable"
+				class="pointer-events-none"
+				:modelValue="props.selected"
+			/>
+			<FeatherIcon v-else name="chevron-right" class="h-5 w-5 text-gray-500" />
 		</template>
 	</ListItem>
 </template>
 
 <script setup>
 import { computed, inject } from "vue"
-import { FeatherIcon } from "frappe-ui"
+import { Checkbox, FeatherIcon } from "frappe-ui"
 
 import ListItem from "@/components/ListItem.vue"
 import SalaryIcon from "@/components/icons/SalaryIcon.vue"
@@ -42,6 +47,14 @@ const dayjs = inject("$dayjs")
 const props = defineProps({
 	doc: {
 		type: Object,
+	},
+	selectable: {
+		type: Boolean,
+		default: false,
+	},
+	selected: {
+		type: Boolean,
+		default: false,
 	},
 })
 

--- a/frontend/src/utils/download.js
+++ b/frontend/src/utils/download.js
@@ -1,0 +1,63 @@
+// the PDF endpoints stream a file back instead of JSON, so they are called
+// with fetch directly rather than through a frappe-ui resource
+
+function getHeaders() {
+	const headers = { "X-Frappe-Site-Name": window.location.hostname }
+	if (window.csrf_token) {
+		headers["X-Frappe-CSRF-Token"] = window.csrf_token
+	}
+	return headers
+}
+
+async function getErrorMessage(response) {
+	try {
+		const data = await response.json()
+		const serverMessages = JSON.parse(data._server_messages || "[]")
+		if (serverMessages.length) {
+			return JSON.parse(serverMessages[0]).message.replace(/<[^>]*>/g, "")
+		}
+		return data.exception || response.statusText
+	} catch (error) {
+		return response.statusText
+	}
+}
+
+function saveBlob(blob, filename) {
+	const blobUrl = window.URL.createObjectURL(blob)
+	const link = document.createElement("a")
+	link.href = blobUrl
+	link.download = filename
+	link.click()
+
+	setTimeout(() => {
+		window.URL.revokeObjectURL(blobUrl)
+	}, 3000)
+}
+
+async function downloadFile(url, body, filename) {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: getHeaders(),
+		body: new URLSearchParams(body),
+	})
+
+	if (!response.ok) throw new Error(await getErrorMessage(response))
+
+	saveBlob(await response.blob(), filename)
+}
+
+export function downloadPDF(doctype, docname, filename) {
+	return downloadFile(
+		"/api/method/hrms.api._download_pdf",
+		{ doctype, docname },
+		filename || `${docname}.pdf`
+	)
+}
+
+export function downloadBulkPDF(doctype, docnames, filename) {
+	return downloadFile(
+		"/api/method/hrms.api._download_bulk_pdf",
+		{ doctype, docnames: JSON.stringify(docnames) },
+		filename || `${doctype.replace(/ /g, "-")}.pdf`
+	)
+}

--- a/frontend/src/views/salary_slip/Dashboard.vue
+++ b/frontend/src/views/salary_slip/Dashboard.vue
@@ -27,26 +27,60 @@
 				</div>
 
 				<div class="flex flex-col items-center mt-5 mb-7 w-full">
-					<div
-						v-if="documents.data?.length"
-						class="flex flex-col bg-white rounded mt-5 overflow-auto w-full"
-					>
-						<div
-							class="p-3.5 items-center justify-between border-b cursor-pointer"
-							v-for="link in documents.data"
-							:key="link.name"
-						>
-							<router-link
-								:to="{
-									name: 'SalarySlipDetailView',
-									params: { id: link.name },
-								}"
-								v-slot="{ navigate }"
-							>
-								<SalarySlipItem :doc="link" @click="navigate" />
-							</router-link>
+					<template v-if="documents.data?.length">
+						<div class="flex flex-row items-center justify-between w-full">
+							<span class="text-gray-600 text-sm font-medium leading-5">
+								{{ isSelecting ? __("{0} selected", [selectedSlips.length]) : "" }}
+							</span>
+							<div class="flex flex-row items-center gap-2">
+								<Button v-if="isSelecting" variant="ghost" @click="toggleSelectAll">
+									{{ areAllSelected ? __("Clear") : __("Select All") }}
+								</Button>
+								<Button variant="ghost" @click="toggleSelectionMode">
+									{{ isSelecting ? __("Cancel") : __("Select") }}
+								</Button>
+							</div>
 						</div>
-					</div>
+
+						<div class="flex flex-col bg-white rounded mt-3 overflow-auto w-full">
+							<div
+								class="p-3.5 items-center justify-between border-b cursor-pointer"
+								v-for="link in documents.data"
+								:key="link.name"
+							>
+								<div v-if="isSelecting" @click="toggleSelection(link.name)">
+									<SalarySlipItem
+										:doc="link"
+										selectable
+										:selected="selectedSlips.includes(link.name)"
+									/>
+								</div>
+								<router-link
+									v-else
+									:to="{
+										name: 'SalarySlipDetailView',
+										params: { id: link.name },
+									}"
+									v-slot="{ navigate }"
+								>
+									<SalarySlipItem :doc="link" @click="navigate" />
+								</router-link>
+							</div>
+						</div>
+
+						<div v-if="isSelecting" class="sticky bottom-4 w-full mt-5">
+							<ErrorMessage :message="downloadError" class="mb-2" />
+							<Button
+								class="w-full rounded py-5 text-base disabled:bg-gray-700 disabled:text-white"
+								variant="solid"
+								:loading="isDownloading"
+								:disabled="!selectedSlips.length"
+								@click="downloadSelected"
+							>
+								{{ downloadLabel }}
+							</Button>
+						</div>
+					</template>
 					<EmptyState :message="__('No salary slips found')" v-else />
 				</div>
 			</div>
@@ -56,16 +90,22 @@
 
 <script setup>
 import { inject, ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
-import { Autocomplete, createListResource } from "frappe-ui"
+import { Autocomplete, ErrorMessage, createListResource } from "frappe-ui"
 
 import BaseLayout from "@/components/BaseLayout.vue"
 import EmptyState from "@/components/EmptyState.vue"
 import SalarySlipItem from "@/components/SalarySlipItem.vue"
 
+import { downloadBulkPDF } from "@/utils/download"
 import { formatCurrency } from "@/utils/formatters"
 
 let selectedPeriod = ref({})
 let periodsByName = ref({})
+
+const isSelecting = ref(false)
+const selectedSlips = ref([])
+const isDownloading = ref(false)
+const downloadError = ref("")
 
 const employee = inject("$employee")
 const dayjs = inject("$dayjs")
@@ -114,6 +154,62 @@ const documents = createListResource({
 
 const lastSalarySlip = computed(() => documents.data?.[0])
 
+const areAllSelected = computed(
+	() => selectedSlips.value.length === documents.data?.length
+)
+
+const downloadLabel = computed(() => {
+	const count = selectedSlips.value.length
+	if (!count) return __("Download Salary Slips")
+	if (count === 1) return __("Download Salary Slip")
+	return __("Download {0} Salary Slips", [count])
+})
+
+function toggleSelectionMode() {
+	isSelecting.value = !isSelecting.value
+	resetSelection()
+}
+
+function resetSelection() {
+	selectedSlips.value = []
+	downloadError.value = ""
+}
+
+function toggleSelection(name) {
+	const index = selectedSlips.value.indexOf(name)
+	if (index === -1) selectedSlips.value.push(name)
+	else selectedSlips.value.splice(index, 1)
+
+	downloadError.value = ""
+}
+
+function toggleSelectAll() {
+	if (areAllSelected.value) selectedSlips.value = []
+	else selectedSlips.value = documents.data.map((slip) => slip.name)
+
+	downloadError.value = ""
+}
+
+async function downloadSelected() {
+	isDownloading.value = true
+	downloadError.value = ""
+
+	const period = selectedPeriod.value?.value?.replace(/\s/g, "-")
+
+	try {
+		await downloadBulkPDF(
+			"Salary Slip",
+			selectedSlips.value,
+			`Salary-Slips-${period}.pdf`
+		)
+		toggleSelectionMode()
+	} catch (error) {
+		downloadError.value = __("Failed to download PDF: {0}", [error.message])
+	} finally {
+		isDownloading.value = false
+	}
+}
+
 function getPeriodLabel(period) {
 	return `${dayjs(period?.start_date).format("MMM YYYY")} - ${dayjs(
 		period?.end_date
@@ -123,6 +219,8 @@ function getPeriodLabel(period) {
 watch(
 	() => selectedPeriod.value,
 	(value) => {
+		resetSelection()
+
 		let period = periodsByName.value[value?.value]
 		documents.filters.start_date = [
 			"between",
@@ -135,6 +233,7 @@ watch(
 onMounted(() => {
 	socket.on("hrms:update_salary_slips", (data) => {
 		if (data.employee === employee.data.name) {
+			resetSelection()
 			documents.reload()
 		}
 	})

--- a/frontend/src/views/salary_slip/Detail.vue
+++ b/frontend/src/views/salary_slip/Detail.vue
@@ -54,6 +54,7 @@ import FormView from "@/components/FormView.vue"
 import SalaryDetailTable from "@/components/SalaryDetailTable.vue"
 
 import { getCompanyCurrency } from "@/data/currencies"
+import { downloadPDF as downloadDocumentPDF } from "@/utils/download"
 
 const props = defineProps({
 	id: {
@@ -124,45 +125,16 @@ function getFilteredFields(fields) {
 	return fields.filter((field) => !excludeFields.includes(field.fieldname))
 }
 
-function downloadPDF() {
-	const salarySlipName = salarySlip.value.name
+async function downloadPDF() {
 	loading.value = true
+	downloadError.value = ""
 
-	let headers = { "X-Frappe-Site-Name": window.location.hostname }
-	if (window.csrf_token) {
-		headers["X-Frappe-CSRF-Token"] = window.csrf_token
+	try {
+		await downloadDocumentPDF("Salary Slip", salarySlip.value.name)
+	} catch (error) {
+		downloadError.value = `Failed to download PDF: ${error.message}`
+	} finally {
+		loading.value = false
 	}
-
-	fetch("/api/method/hrms.api._download_pdf", {
-		method: "POST",
-		headers,
-		body: new URLSearchParams({doctype: "Salary Slip" ,docname: salarySlipName }),
-		responseType: "blob",
-	})
-		.then((response) => {
-			if (response.ok) {
-				return response.blob()
-			} else {
-				downloadError.value = "Failed to download PDF"
-			}
-		})
-		.then((blob) => {
-			if (!blob) return
-			const blobUrl = window.URL.createObjectURL(blob)
-			const link = document.createElement("a")
-			link.href = blobUrl
-			link.download = `${salarySlipName}.pdf`
-			link.click()
-
-			setTimeout(() => {
-				window.URL.revokeObjectURL(blobUrl)
-			}, 3000)
-		})
-		.catch((error) => {
-			downloadError.value = `Failed to download PDF: ${error.message}`
-		})
-		.finally(() => {
-			loading.value = false
-		})
 }
 </script>

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -26,6 +26,9 @@ SUPPORTED_FIELD_TYPES = [
 	"Currency",
 ]
 
+# PDFs are merged synchronously, so cap the request size to keep it within the request timeout
+MAX_BULK_PDF_DOCS = 24
+
 
 @frappe.whitelist()
 def get_current_user_info() -> dict:
@@ -816,6 +819,49 @@ def _download_pdf(doctype: str, docname: str) -> str:
 	content_type = frappe.local.response.type
 
 	return f"data:{content_type};base64," + base64content.decode("utf-8")
+
+
+@frappe.whitelist()
+def _download_bulk_pdf(doctype: str, docnames: str | list[str]) -> None:
+	"""Merge the print formats of the given documents into a single PDF and stream it back"""
+	from io import BytesIO
+
+	from pypdf import PdfWriter
+
+	from frappe.www.printview import validate_print_permission
+
+	docnames = frappe.parse_json(docnames)
+	if not docnames:
+		frappe.throw(_("Please select at least one document to download"))
+
+	if len(docnames) > MAX_BULK_PDF_DOCS:
+		frappe.throw(
+			_("Cannot download more than {0} documents at a time").format(MAX_BULK_PDF_DOCS),
+			title=_("Too Many Documents"),
+		)
+
+	default_print_format = frappe.get_meta(doctype).default_print_format or "Standard"
+	pdf_writer = PdfWriter()
+
+	# frappe's download_multi_pdf swallows per document errors and can return an empty PDF,
+	# so the documents are merged here to surface failures instead
+	for docname in docnames:
+		doc = frappe.get_doc(doctype, docname)
+		validate_print_permission(doc)
+
+		try:
+			pdf_writer = frappe.get_print(
+				doctype, docname, default_print_format, doc=doc, as_pdf=True, output=pdf_writer
+			)
+		except Exception as e:
+			frappe.throw(_("Failed to download PDF for {0}: {1}").format(docname, str(e)))
+
+	with BytesIO() as merged_pdf:
+		pdf_writer.write(merged_pdf)
+
+		frappe.local.response.filename = "{doctype}.pdf".format(doctype=doctype.replace(" ", "-"))
+		frappe.local.response.filecontent = merged_pdf.getvalue()
+		frappe.local.response.type = "pdf"
 
 
 # Workflow


### PR DESCRIPTION
**Description:** Currently salary slips in the PWA can only be downloaded one at a time, by opening each slip and hitting "Download PDF". This adds multiselect so an employee can pick several slips from the list and get them as a single PDF.

`no-docs`

[Screencast from 2026-08-10 19-29-05.webm](https://github.com/user-attachments/assets/0b034ebe-d9bf-4016-a3f3-d80131005001)
