### PR TITLE
fix(payroll): remove duplicate links

### DIFF
--- a/hrms/payroll/workspace/payroll/payroll.json
+++ b/hrms/payroll/workspace/payroll/payroll.json
@@ -4,10 +4,6 @@
   {
    "chart_name": "Outgoing Salary",
    "label": "Outgoing Salary"
-  },
-  {
-   "chart_name": "Outgoing Salary",
-   "label": "Outgoing Salary"
   }
  ],
  "content": "[{\"id\":\"sN-N90hh44\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Outgoing Salary\",\"col\":12}},{\"id\":\"ORKhwX-uqw\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"gGURwviUAZ\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Transactions &amp; Reports</b></span>\",\"col\":12}},{\"id\":\"m7ibJXxzpl\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"U-jv2v4nCv\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll\",\"col\":4}},{\"id\":\"LG69O3ku4y\",\"type\":\"card\",\"data\":{\"card_name\":\"Incentives\",\"col\":4}},{\"id\":\"kOuItimoNm\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting\",\"col\":4}},{\"id\":\"UJqBhPqNZd\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting Reports\",\"col\":4}},{\"id\":\"eNZuk6i-jy\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll Reports\",\"col\":4}},{\"id\":\"ll91Zs2cbx\",\"type\":\"card\",\"data\":{\"card_name\":\"Deduction Reports\",\"col\":4}}]",
@@ -33,37 +29,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Masters",
-   "link_count": 4,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Salary Component",
    "link_count": 0,
    "link_to": "Salary Component",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Salary Component",
-   "link_count": 0,
-   "link_to": "Salary Component",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Salary Structure",
-   "link_count": 0,
-   "link_to": "Salary Structure",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -91,26 +59,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Income Tax Slab",
-   "link_count": 0,
-   "link_to": "Income Tax Slab",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Payroll Period",
-   "link_count": 0,
-   "link_to": "Payroll Period",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Payroll Period",
    "link_count": 0,
    "link_to": "Payroll Period",
@@ -129,37 +77,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Incentives",
-   "link_count": 3,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Additional Salary",
    "link_count": 0,
    "link_to": "Additional Salary",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Additional Salary",
-   "link_count": 0,
-   "link_to": "Additional Salary",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Employee Incentive",
-   "link_count": 0,
-   "link_to": "Employee Incentive",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -187,24 +107,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Retention Bonus",
-   "link_count": 0,
-   "link_to": "Retention Bonus",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Payroll Reports",
-   "link_count": 5,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Payroll Reports",
    "link_count": 5,
    "onboard": 0,
@@ -216,26 +118,6 @@
    "label": "Salary Register",
    "link_count": 0,
    "link_to": "Salary Register",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Salary Register",
-   "link_count": 0,
-   "link_to": "Salary Register",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Bank Remittance",
-   "link_count": 0,
-   "link_to": "Bank Remittance",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -263,39 +145,9 @@
   {
    "hidden": 0,
    "is_query_report": 1,
-   "label": "Salary Payments Based On Payment Mode",
-   "link_count": 0,
-   "link_to": "Salary Payments Based On Payment Mode",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
    "label": "Salary Payments via ECS",
    "link_count": 0,
    "link_to": "Salary Payments via ECS",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Salary Payments via ECS",
-   "link_count": 0,
-   "link_to": "Salary Payments via ECS",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Income Tax Computation",
-   "link_count": 0,
-   "link_to": "Income Tax Computation",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -320,38 +172,10 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
-   "label": "Deduction Reports",
-   "link_count": 3,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
    "is_query_report": 1,
    "label": "Provident Fund Deductions",
    "link_count": 0,
    "link_to": "Provident Fund Deductions",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Provident Fund Deductions",
-   "link_count": 0,
-   "link_to": "Provident Fund Deductions",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Professional Tax Deductions",
-   "link_count": 0,
-   "link_to": "Professional Tax Deductions",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -378,24 +202,6 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 1,
-   "label": "Income Tax Deductions",
-   "link_count": 0,
-   "link_to": "Income Tax Deductions",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Accounting",
-   "link_count": 7,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
    "is_query_report": 0,
    "label": "Accounting",
    "link_count": 7,
@@ -408,26 +214,6 @@
    "label": "Chart of Accounts",
    "link_count": 0,
    "link_to": "Account",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Chart of Accounts",
-   "link_count": 0,
-   "link_to": "Account",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Chart of Cost Centers",
-   "link_count": 0,
-   "link_to": "Cost Center",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -455,39 +241,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Payment Entry",
-   "link_count": 0,
-   "link_to": "Payment Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Journal Entry",
    "link_count": 0,
    "link_to": "Journal Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Journal Entry",
-   "link_count": 0,
-   "link_to": "Journal Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Accounts Settings",
-   "link_count": 0,
-   "link_to": "Accounts Settings",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -515,26 +271,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Accounting Dimension",
-   "link_count": 0,
-   "link_to": "Accounting Dimension",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Currency",
-   "link_count": 0,
-   "link_to": "Currency",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Currency",
    "link_count": 0,
    "link_to": "Currency",
@@ -552,38 +288,10 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
-   "label": "Accounting Reports",
-   "link_count": 3,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
    "is_query_report": 1,
    "label": "General Ledger",
    "link_count": 0,
    "link_to": "General Ledger",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "General Ledger",
-   "link_count": 0,
-   "link_to": "General Ledger",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Accounts Payable",
-   "link_count": 0,
-   "link_to": "Accounts Payable",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -610,25 +318,6 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 1,
-   "label": "Accounts Receivable",
-   "link_count": 0,
-   "link_to": "Accounts Receivable",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Payroll",
-   "link_count": 5,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
    "is_query_report": 0,
    "label": "Payroll",
    "link_count": 5,
@@ -642,26 +331,6 @@
    "label": "Salary Structure Assignment",
    "link_count": 0,
    "link_to": "Salary Structure Assignment",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Salary Structure Assignment",
-   "link_count": 0,
-   "link_to": "Salary Structure Assignment",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Bulk Salary Structure Assignment",
-   "link_count": 0,
-   "link_to": "Bulk Salary Structure Assignment",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -689,39 +358,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Salary Slip",
-   "link_count": 0,
-   "link_to": "Salary Slip",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Payroll Entry",
    "link_count": 0,
    "link_to": "Payroll Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Payroll Entry",
-   "link_count": 0,
-   "link_to": "Payroll Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Salary Withholding",
-   "link_count": 0,
-   "link_to": "Salary Withholding",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -737,7 +376,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-03 01:05:50.395061",
+ "modified": "2026-08-11 15:13:53.803768",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll",


### PR DESCRIPTION
**Description:**  In the Payroll workspace every link is shown twice, payroll.json has 74 link rows that are 37 unique entries stored twice, and the Outgoing Salary chart is duplicated the same way (regression from c618f559a). Deduplicated links and charts the remainder matches the pre-regression file at 9c91aaa32 exactly.

**Before:**

<img width="1797" height="912" alt="image" src="https://github.com/user-attachments/assets/a6aa1608-a370-4f26-9829-8a323576e292" />


**After:**

<img width="1912" height="916" alt="image" src="https://github.com/user-attachments/assets/6d5f26e3-a410-40c7-910a-66fe3bd9d42e" />
