### PR TITLE
fix: support custom attendance calendars

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -289,7 +289,12 @@ class Attendance(Document):
 
 
 @frappe.whitelist()
-def get_events(start: date | str, end: date | str, filters: str | list | None = None) -> list[dict]:
+def get_events(
+	start: date | str,
+	end: date | str,
+	filters: str | list | None = None,
+	order_by: str | None = None,
+) -> list[dict]:
 	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
 	if not employee:
 		return []
@@ -301,12 +306,12 @@ def get_events(start: date | str, end: date | str, filters: str | list | None = 
 	if not filters:
 		filters = []
 	filters.append(["attendance_date", "between", [get_datetime(start).date(), get_datetime(end).date()]])
-	attendance_records = add_attendance(filters)
+	attendance_records = add_attendance(filters, order_by)
 	add_holidays(attendance_records, start, end, employee)
 	return attendance_records
 
 
-def add_attendance(filters):
+def add_attendance(filters, order_by=None):
 	attendance = frappe.get_list(
 		"Attendance",
 		fields=[
@@ -318,6 +323,7 @@ def add_attendance(filters):
 			"docstatus",
 		],
 		filters=filters,
+		order_by=order_by,
 	)
 	for record in attendance:
 		record["title"] = f"{record['employee_name']} : {record['status']}"

--- a/hrms/hr/doctype/attendance/attendance_calendar.js
+++ b/hrms/hr/doctype/attendance/attendance_calendar.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 frappe.views.calendar["Attendance"] = {
+	fields: ["status"],
+	apply_to_custom_calendar_views: true,
 	field_map: {
 		start: "attendance_date",
 		end: "attendance_date",
@@ -11,7 +13,7 @@ frappe.views.calendar["Attendance"] = {
 	},
 	get_css_class: function (data) {
 		if (data.doctype === "Holiday") return "default";
-		else if (data.doctype === "Attendance") {
+		else if (!data.doctype || data.doctype === "Attendance") {
 			if (data.status === "Absent" || data.status === "On Leave") {
 				return "danger";
 			}


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/41804
Changes:
 - Pass Attendance calendar sorting through to the Attendance query.
 - Make custom Attendance Calendar Views receive status and use Attendance status colours.
 
 Before Change:
 
<img width="2312" height="1794" alt="image" src="https://github.com/user-attachments/assets/05c17dd1-1cd8-49d0-9257-410a86cbb026" />

After Change:
<img width="2372" height="1970" alt="image" src="https://github.com/user-attachments/assets/99518a1b-0958-4578-852e-eefc564ad9f7" />
