### PR TITLE
feat: quick check in/out button on employee checkin doctype

### DIFF
--- a/hrms/hr/doctype/employee_checkin/employee_checkin.json
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.json
@@ -184,6 +184,7 @@
    "options": "Overtime Type"
   }
  ],
+ "in_create": 1,
  "links": [],
  "modified": "2025-07-09 10:47:34.591144",
  "modified_by": "Administrator",

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -28,6 +28,12 @@ frappe.listview_settings["Employee Checkin"] = {
 	before_render: function () {
 		refresh_checkin_state(cur_list);
 	},
+	primary_action: function () {
+		const listview = cur_list;
+		if (listview?.checkin_employee) {
+			start_checkin(listview, listview.next_checkin || get_next_checkin());
+		}
+	},
 };
 
 function get_next_checkin(last_log_type) {
@@ -56,6 +62,26 @@ async function setup_checkin_action(listview) {
 			},
 			next.icon,
 		);
+	};
+
+	const default_no_result_message = listview.get_no_result_message.bind(listview);
+	listview.get_no_result_message = () => {
+		if (listview.filter_area?.get()?.length) {
+			return default_no_result_message();
+		}
+
+		return frappe.ui.empty_state.html({
+			icon: "clock",
+			title: __("No check-ins yet"),
+			description: __("Check in to create your first log."),
+			actions: [
+				{
+					label: __("Check In"),
+					icon: "circle-arrow-right",
+					css_class: "btn-new-doc",
+				},
+			],
+		});
 	};
 
 	await refresh_checkin_state(listview);

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -114,14 +114,30 @@ async function start_checkin(listview, next) {
 	}
 
 	let coordinates;
+	let failure;
 	frappe.dom.freeze(__("Fetching your geolocation") + "...");
 	try {
 		coordinates = await hrms.get_current_position();
 		await frappe.require(["leaflet.bundle.js", "leaflet.bundle.css"]);
 	} catch (error) {
-		return;
+		failure = error || {};
 	} finally {
 		frappe.dom.unfreeze();
+	}
+
+	if (failure) {
+		return frappe.msgprint({
+			message: hrms.get_geolocation_error_message(failure),
+			title: __("Geolocation Error"),
+			indicator: "red",
+			primary_action: {
+				label: __("Retry"),
+				action: () => {
+					frappe.hide_msgprint(true);
+					start_checkin(listview, next);
+				},
+			},
+		});
 	}
 
 	confirm_checkin_location(listview, next, time, coordinates);

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -38,8 +38,18 @@ frappe.listview_settings["Employee Checkin"] = {
 
 function get_next_checkin(last_log_type) {
 	return last_log_type === "IN"
-		? { log_type: "OUT", label: __("Check Out"), icon: "circle-arrow-left" }
-		: { log_type: "IN", label: __("Check In"), icon: "circle-arrow-right" };
+		? {
+				log_type: "OUT",
+				label: __("Check Out"),
+				working_label: __("Checking Out..."),
+				icon: "circle-arrow-left",
+		  }
+		: {
+				log_type: "IN",
+				label: __("Check In"),
+				working_label: __("Checking In..."),
+				icon: "circle-arrow-right",
+		  };
 }
 
 async function setup_checkin_action(listview) {
@@ -47,6 +57,10 @@ async function setup_checkin_action(listview) {
 	if (!employee) return;
 
 	listview.checkin_employee = employee;
+	listview.track_geolocation = await frappe.db.get_single_value(
+		"HR Settings",
+		"allow_geolocation_tracking",
+	);
 	listview.set_primary_action = () => {
 		const next = listview.next_checkin;
 		if (!next) return;
@@ -58,9 +72,11 @@ async function setup_checkin_action(listview) {
 		listview.page.set_primary_action(
 			next.label,
 			() => {
-				start_checkin(listview, next);
+				const checkin = start_checkin(listview, next);
+				return listview.track_geolocation ? undefined : checkin;
 			},
 			next.icon,
+			next.working_label,
 		);
 	};
 
@@ -105,11 +121,7 @@ async function refresh_checkin_state(listview) {
 async function start_checkin(listview, next) {
 	const time = frappe.datetime.now_datetime();
 
-	const track_geolocation = await frappe.db.get_single_value(
-		"HR Settings",
-		"allow_geolocation_tracking",
-	);
-	if (!track_geolocation) {
+	if (!listview.track_geolocation) {
 		return submit_checkin(listview, next, time);
 	}
 
@@ -194,9 +206,10 @@ function confirm_checkin_location(listview, next, time, coordinates) {
 			},
 		],
 		primary_action_label: __("Confirm {0}", [next.label]),
-		primary_action: () => {
-			dialog.hide();
-			submit_checkin(listview, next, time, coordinates);
+		primary_action_loading_label: next.working_label,
+		primary_action: async () => {
+			const checkin = await submit_checkin(listview, next, time, coordinates);
+			if (checkin) dialog.hide();
 		},
 	});
 
@@ -205,28 +218,35 @@ function confirm_checkin_location(listview, next, time, coordinates) {
 }
 
 async function submit_checkin(listview, next, time, coordinates) {
-	let checkin;
+	if (listview.checkin_in_progress) return;
+	listview.checkin_in_progress = true;
+
 	try {
-		checkin = await frappe.db.insert({
+		const checkin = await frappe.db.insert({
 			doctype: "Employee Checkin",
 			employee: listview.checkin_employee.name,
 			log_type: next.log_type,
 			time: time,
 			...(coordinates || {}),
 		});
+
+		frappe.show_alert({
+			message: checkin.offshift
+				? __(
+						"{0} recorded outside shift hours. It will not be considered for attendance.",
+						[next.label],
+				  )
+				: __("{0} successful", [next.label]),
+			indicator: checkin.offshift ? "orange" : "green",
+		});
+
+		await refresh_checkin_state(listview);
+		await listview.refresh();
+
+		return checkin;
 	} catch (error) {
 		return;
+	} finally {
+		listview.checkin_in_progress = false;
 	}
-
-	frappe.show_alert({
-		message: checkin.offshift
-			? __("{0} recorded outside shift hours. It will not be considered for attendance.", [
-					next.label,
-			  ])
-			: __("{0} successful", [next.label]),
-		indicator: checkin.offshift ? "orange" : "green",
-	});
-
-	await refresh_checkin_state(listview);
-	await listview.refresh();
 }

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -16,5 +16,175 @@ frappe.listview_settings["Employee Checkin"] = {
 				},
 			});
 		});
+
+		if (frappe.perm.has_perm("Employee Checkin", 0, "create")) {
+			listview.page.add_inner_button(__("Add Checkin for Another Employee"), () =>
+				frappe.new_doc("Employee Checkin"),
+			);
+		}
+
+		setup_checkin_action(listview);
+	},
+	before_render: function () {
+		refresh_checkin_state(cur_list);
 	},
 };
+
+function get_next_checkin(last_log_type) {
+	return last_log_type === "IN"
+		? { log_type: "OUT", label: __("Check Out"), icon: "circle-arrow-left" }
+		: { log_type: "IN", label: __("Check In"), icon: "circle-arrow-right" };
+}
+
+async function setup_checkin_action(listview) {
+	const employee = await frappe.xcall("hrms.api.get_current_employee_info");
+	if (!employee) return;
+
+	listview.checkin_employee = employee;
+	listview.set_primary_action = () => {
+		const next = listview.next_checkin;
+		if (!next) return;
+
+		const button = listview.page.btn_primary;
+		if (listview.painted_checkin === next.log_type && !button.hasClass("hide")) return;
+		listview.painted_checkin = next.log_type;
+
+		listview.page.set_primary_action(
+			next.label,
+			() => {
+				start_checkin(listview, next);
+			},
+			next.icon,
+		);
+	};
+
+	await refresh_checkin_state(listview);
+}
+
+async function refresh_checkin_state(listview) {
+	const employee = listview?.checkin_employee;
+	if (!employee) return;
+
+	const [last_log] = await frappe.db.get_list("Employee Checkin", {
+		filters: { employee: employee.name },
+		fields: ["log_type"],
+		order_by: "time desc",
+		limit: 1,
+	});
+
+	listview.next_checkin = get_next_checkin(last_log?.log_type);
+	listview.set_primary_action();
+}
+
+async function start_checkin(listview, next) {
+	const time = frappe.datetime.now_datetime();
+
+	const track_geolocation = await frappe.db.get_single_value(
+		"HR Settings",
+		"allow_geolocation_tracking",
+	);
+	if (!track_geolocation) {
+		return submit_checkin(listview, next, time);
+	}
+
+	let coordinates;
+	frappe.dom.freeze(__("Fetching your geolocation") + "...");
+	try {
+		coordinates = await hrms.get_current_position();
+		await frappe.require(["leaflet.bundle.js", "leaflet.bundle.css"]);
+	} catch (error) {
+		return;
+	} finally {
+		frappe.dom.unfreeze();
+	}
+
+	confirm_checkin_location(listview, next, time, coordinates);
+}
+
+function confirm_checkin_location(listview, next, time, coordinates) {
+	const geojson = JSON.stringify({
+		type: "FeatureCollection",
+		features: [
+			{
+				type: "Feature",
+				properties: {},
+				geometry: {
+					type: "Point",
+					coordinates: [coordinates.longitude, coordinates.latitude],
+				},
+			},
+		],
+	});
+
+	const dialog = new frappe.ui.Dialog({
+		title: next.label,
+		fields: [
+			{
+				fieldname: "time",
+				label: __("Time"),
+				fieldtype: "Datetime",
+				read_only: 1,
+				default: time,
+			},
+			{ fieldtype: "Section Break", hide_border: 1 },
+			{
+				fieldname: "latitude",
+				label: __("Latitude"),
+				fieldtype: "Float",
+				precision: "7",
+				read_only: 1,
+				default: coordinates.latitude,
+			},
+			{ fieldtype: "Column Break" },
+			{
+				fieldname: "longitude",
+				label: __("Longitude"),
+				fieldtype: "Float",
+				precision: "7",
+				read_only: 1,
+				default: coordinates.longitude,
+			},
+			{ fieldtype: "Section Break", hide_border: 1 },
+			{
+				fieldname: "geolocation",
+				fieldtype: "Geolocation",
+				default: geojson,
+			},
+		],
+		primary_action_label: __("Confirm {0}", [next.label]),
+		primary_action: () => {
+			dialog.hide();
+			submit_checkin(listview, next, time, coordinates);
+		},
+	});
+
+	dialog.fields_dict.geolocation.disabled = 1;
+	dialog.show();
+}
+
+async function submit_checkin(listview, next, time, coordinates) {
+	let checkin;
+	try {
+		checkin = await frappe.db.insert({
+			doctype: "Employee Checkin",
+			employee: listview.checkin_employee.name,
+			log_type: next.log_type,
+			time: time,
+			...(coordinates || {}),
+		});
+	} catch (error) {
+		return;
+	}
+
+	frappe.show_alert({
+		message: checkin.offshift
+			? __("{0} recorded outside shift hours. It will not be considered for attendance.", [
+					next.label,
+			  ])
+			: __("{0} successful", [next.label]),
+		indicator: checkin.offshift ? "orange" : "green",
+	});
+
+	await refresh_checkin_state(listview);
+	await listview.refresh();
+}

--- a/hrms/public/js/utils/index.js
+++ b/hrms/public/js/utils/index.js
@@ -179,43 +179,57 @@ $.extend(hrms, {
 		});
 	},
 
-	fetch_geolocation: async (frm) => {
-		if (!navigator.geolocation) {
-			frappe.msgprint({
-				message: __("Geolocation is not supported by your current browser"),
-				title: __("Geolocation Error"),
-				indicator: "red",
-			});
-			hide_field(["geolocation"]);
-			return;
-		}
-
-		frappe.dom.freeze(__("Fetching your geolocation") + "...");
-
-		navigator.geolocation.getCurrentPosition(
-			async (position) => {
-				frappe.run_serially([
-					() => frm.set_value("latitude", position.coords.latitude),
-					() => frm.set_value("longitude", position.coords.longitude),
-					() => frm.call("set_geolocation"),
-					() => frappe.dom.unfreeze(),
-				]);
-			},
-
-			(error) => {
-				frappe.dom.unfreeze();
-
-				let msg = __("Unable to retrieve your location") + "<br><br>";
-				if (error) {
-					msg += __("ERROR({0}): {1}", [error.code, error.message]);
-				}
+	get_current_position: () => {
+		return new Promise((resolve, reject) => {
+			if (!navigator.geolocation) {
 				frappe.msgprint({
-					message: msg,
+					message: __("Geolocation is not supported by your current browser"),
 					title: __("Geolocation Error"),
 					indicator: "red",
 				});
-			},
-		);
+				reject({ unsupported: true });
+				return;
+			}
+
+			navigator.geolocation.getCurrentPosition(
+				(position) =>
+					resolve({
+						latitude: position.coords.latitude,
+						longitude: position.coords.longitude,
+					}),
+
+				(error) => {
+					let msg = __("Unable to retrieve your location") + "<br><br>";
+					if (error) {
+						msg += __("ERROR({0}): {1}", [error.code, error.message]);
+					}
+					frappe.msgprint({
+						message: msg,
+						title: __("Geolocation Error"),
+						indicator: "red",
+					});
+					reject(error);
+				},
+				{ timeout: 10000 },
+			);
+		});
+	},
+
+	fetch_geolocation: async (frm) => {
+		frappe.dom.freeze(__("Fetching your geolocation") + "...");
+
+		try {
+			const { latitude, longitude } = await hrms.get_current_position();
+			await frappe.run_serially([
+				() => frm.set_value("latitude", latitude),
+				() => frm.set_value("longitude", longitude),
+				() => frm.call("set_geolocation"),
+			]);
+		} catch (error) {
+			if (error?.unsupported) hide_field(["geolocation"]);
+		} finally {
+			frappe.dom.unfreeze();
+		}
 	},
 
 	get_doctype_fields_for_autocompletion: (doctype) => {

--- a/hrms/public/js/utils/index.js
+++ b/hrms/public/js/utils/index.js
@@ -182,11 +182,6 @@ $.extend(hrms, {
 	get_current_position: () => {
 		return new Promise((resolve, reject) => {
 			if (!navigator.geolocation) {
-				frappe.msgprint({
-					message: __("Geolocation is not supported by your current browser"),
-					title: __("Geolocation Error"),
-					indicator: "red",
-				});
 				reject({ unsupported: true });
 				return;
 			}
@@ -198,21 +193,30 @@ $.extend(hrms, {
 						longitude: position.coords.longitude,
 					}),
 
-				(error) => {
-					let msg = __("Unable to retrieve your location") + "<br><br>";
-					if (error) {
-						msg += __("ERROR({0}): {1}", [error.code, error.message]);
-					}
-					frappe.msgprint({
-						message: msg,
-						title: __("Geolocation Error"),
-						indicator: "red",
-					});
-					reject(error);
-				},
+				(error) => reject(error),
 				{ timeout: 10000 },
 			);
 		});
+	},
+
+	get_geolocation_error_message: (error) => {
+		if (error?.unsupported) {
+			return __("Geolocation is not supported by your current browser");
+		}
+
+		if (error?.code === 1) {
+			return __(
+				"User denied location prompt. Please allow access to your location in your browser settings and try again.",
+			);
+		}
+
+		if (error) {
+			return __("ERROR({0}): {1}", [
+				error.code,
+				frappe.utils.escape_html(error.message || ""),
+			]);
+		}
+		return __("An unknown error occurred while fetching your geolocation");
 	},
 
 	fetch_geolocation: async (frm) => {
@@ -227,6 +231,11 @@ $.extend(hrms, {
 			]);
 		} catch (error) {
 			if (error?.unsupported) hide_field(["geolocation"]);
+			frappe.msgprint({
+				message: hrms.get_geolocation_error_message(error),
+				title: __("Geolocation Error"),
+				indicator: "red",
+			});
 		} finally {
 			frappe.dom.unfreeze();
 		}


### PR DESCRIPTION
Show quick check in/out button on employee checkin list view. Confirm dialog is skipped if geolocation is turned off. User can add checkins for another employee using the form as usual.

#### Quick checkin for session employee and regular form to add for other employees

https://github.com/user-attachments/assets/ce725cff-0c65-40a4-a2ed-a9c47417526b


#### Checkin with geolocation enabled and error message dialog

https://github.com/user-attachments/assets/c8f5d1cc-b9af-4785-8901-9d183c3e8dd2



`no-docs`


