### PR TITLE
fix(job_applicant): set indicator colors on kanban columns

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -105,7 +105,7 @@ class JobApplicant(Document):
 
 
 KANBAN_COLUMNS = [
-	{"column_name": "Open",},
+	{"column_name": "Open"},
 	{"column_name": "Replied", "indicator": "Orange"},
 	{"column_name": "Shortlisted", "indicator": "Blue"},
 	{"column_name": "Accepted", "indicator": "Green"},
@@ -128,7 +128,10 @@ def create_kanban_board(board_name: str) -> dict:
 	board.show_labels = 1
 
 	for col in KANBAN_COLUMNS:
-		board.append("columns", {"column_name": col["column_name"], "indicator": col.get("indicator", ""), "status": "Active"})
+		board.append(
+			"columns",
+			{"column_name": col["column_name"], "indicator": col.get("indicator", ""), "status": "Active"},
+		)
 
 	board.insert(ignore_permissions=True)
 	return board.as_dict()

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -104,7 +104,12 @@ class JobApplicant(Document):
 			emp_ref.db_set("status", self.status)
 
 
-KANBAN_COLUMNS = ["Open", "Replied", "Shortlisted", "Accepted"]
+KANBAN_COLUMNS = [
+	{"column_name": "Open",},
+	{"column_name": "Replied", "indicator": "Orange"},
+	{"column_name": "Shortlisted", "indicator": "Blue"},
+	{"column_name": "Accepted", "indicator": "Green"},
+]
 
 
 @frappe.whitelist()
@@ -122,8 +127,8 @@ def create_kanban_board(board_name: str) -> dict:
 	board.fields = json.dumps(["designation", "applicant_rating"])
 	board.show_labels = 1
 
-	for column_name in KANBAN_COLUMNS:
-		board.append("columns", {"column_name": column_name, "status": "Active"})
+	for col in KANBAN_COLUMNS:
+		board.append("columns", {"column_name": col["column_name"], "indicator": col.get("indicator", ""), "status": "Active"})
 
 	board.insert(ignore_permissions=True)
 	return board.as_dict()

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -50,3 +50,4 @@ hrms.patches.v16_0.set_reference_fields_in_expense_claim_advance
 hrms.patches.v16_0.update_partially_paid_employee_advance_status
 hrms.patches.v16_0.delete_upload_attendance_doctype #2026-07-16
 hrms.patches.v16_0.set_leave_approver_name_in_leave_application #2026-08-05
+hrms.patches.v16_0.set_job_applicant_kanban_column_indicators #2026-08-12

--- a/hrms/patches/v16_0/set_job_applicant_kanban_column_indicators.py
+++ b/hrms/patches/v16_0/set_job_applicant_kanban_column_indicators.py
@@ -1,0 +1,21 @@
+import frappe
+
+INDICATOR_MAP = {
+	"Replied": "Orange",
+	"Shortlisted": "Blue",
+	"Accepted": "Green",
+}
+
+
+def execute():
+	columns = frappe.get_all(
+		"Kanban Board Column",
+		filters={"parent": "Hiring Pipeline", "parenttype": "Kanban Board"},
+		fields=["name", "column_name"],
+	)
+
+	if not columns:
+		return
+
+	updates = {col.name: {"indicator": INDICATOR_MAP.get(col.column_name, "")} for col in columns}
+	frappe.db.bulk_update("Kanban Board Column", updates, update_modified=False)

--- a/hrms/patches/v16_0/set_job_applicant_kanban_column_indicators.py
+++ b/hrms/patches/v16_0/set_job_applicant_kanban_column_indicators.py
@@ -10,12 +10,16 @@ INDICATOR_MAP = {
 def execute():
 	columns = frappe.get_all(
 		"Kanban Board Column",
-		filters={"parent": "Hiring Pipeline", "parenttype": "Kanban Board"},
+		filters={
+			"parent": "Hiring Pipeline",
+			"parenttype": "Kanban Board",
+			"column_name": ("in", list(INDICATOR_MAP.keys())),
+		},
 		fields=["name", "column_name"],
 	)
 
 	if not columns:
 		return
 
-	updates = {col.name: {"indicator": INDICATOR_MAP.get(col.column_name, "")} for col in columns}
+	updates = {col.name: {"indicator": INDICATOR_MAP[col.column_name]} for col in columns}
 	frappe.db.bulk_update("Kanban Board Column", updates, update_modified=False)


### PR DESCRIPTION
### Reason
Previously, the indicator color was applied as a background fill on the entire kanban column. However, indicator colors were not being set on Job Applicant kanban columns when a new board was created, leaving the dots colorless.
<img width="3024" height="1564" alt="image" src="https://github.com/user-attachments/assets/5839a934-343f-4329-80e8-79bfcd548477" />


### Changes Done

- Indicator colors are now set per column when a new board is created.
- A patch backfills the indicator colors on existing boards.
<img width="2880" height="1586" alt="image" src="https://github.com/user-attachments/assets/f3523aeb-02eb-4d2c-9b15-27f15ae7dca4" />

Depends on: https://github.com/frappe/frappe/pull/41807