### PR TITLE
fix: mark absent for overlapping shift assignments in auto attendance

### DIFF
--- a/hrms/hr/doctype/shift_assignment/shift_assignment.py
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment.py
@@ -299,8 +299,8 @@ def get_shift_type_timing(shift_types):
 	return shift_timing_map
 
 
-def get_shift_for_time(shifts: list[dict], for_timestamp: datetime) -> dict:
-	"""Returns shift with details for given timestamp"""
+def get_valid_shifts_for_time(shifts: list[dict], for_timestamp: datetime) -> list[dict]:
+	"""Returns all shifts active at the given timestamp, sorted with overlapping timings adjusted"""
 	valid_shifts = []
 
 	for assignment in shifts:
@@ -316,7 +316,12 @@ def get_shift_for_time(shifts: list[dict], for_timestamp: datetime) -> dict:
 	valid_shifts.sort(key=lambda x: x["actual_start"])
 	_adjust_overlapping_shifts(valid_shifts)
 
-	return get_exact_shift(valid_shifts, for_timestamp)
+	return valid_shifts
+
+
+def get_shift_for_time(shifts: list[dict], for_timestamp: datetime) -> dict:
+	"""Returns shift with details for given timestamp"""
+	return get_exact_shift(get_valid_shifts_for_time(shifts, for_timestamp), for_timestamp)
 
 
 def _is_shift_outside_assignment_period(shift_details: dict, assignment: dict) -> bool:

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -28,7 +28,12 @@ from hrms.hr.doctype.employee_checkin.employee_checkin import (
 	calculate_working_hours,
 	mark_attendance_and_link_log,
 )
-from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift, get_shift_details
+from hrms.hr.doctype.shift_assignment.shift_assignment import (
+	get_employee_shift,
+	get_shift_details,
+	get_shifts_for_date,
+	get_valid_shifts_for_time,
+)
 from hrms.utils import get_date_range
 from hrms.utils.holiday_list import get_holiday_dates_between
 
@@ -365,7 +370,12 @@ class ShiftType(Document):
 
 		# check if shift is found for 1 day before the last sync of checkin
 		# absentees are auto-marked 1 day after the shift to wait for any manual attendance records
-		prev_shift = get_employee_shift(employee, last_shift_time - timedelta(days=1), True, "reverse")
+		ref_time = last_shift_time - timedelta(days=1)
+		prev_shift = get_employee_shift(employee, ref_time, True, "reverse")
+		if prev_shift and prev_shift.shift_type.name != self.name:
+			# an overlapping assignment may have won resolution; prefer this shift if also scheduled then
+			prev_shift = self.get_scheduled_shift_at(employee, ref_time) or prev_shift
+
 		if prev_shift and prev_shift.shift_type.name == self.name:
 			end_date = (
 				min(prev_shift.start_datetime.date(), relieving_date)
@@ -376,6 +386,11 @@ class ShiftType(Document):
 			# no shift found
 			return None, None
 		return start_date, end_date
+
+	def get_scheduled_shift_at(self, employee: str, for_timestamp: datetime) -> dict | None:
+		"""Return this shift's details if it is validly scheduled for the employee at the given timestamp"""
+		shifts = get_valid_shifts_for_time(get_shifts_for_date(employee, for_timestamp), for_timestamp)
+		return next((shift for shift in shifts if shift.shift_type.name == self.name), None)
 
 	def get_marked_attendance_dates_between(self, employee: str, start_date: str, end_date: str) -> list[str]:
 		Attendance = frappe.qb.DocType("Attendance")

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -663,6 +663,47 @@ class TestShiftType(HRMSTestSuite):
 		attendance = frappe.db.get_value("Attendance", {"employee": employee}, "status")
 		self.assertIsNone(attendance)
 
+	@HRMSTestSuite.change_settings("HR Settings", {"allow_multiple_shift_assignments": 1})
+	def test_mark_absent_with_multiple_overlapping_shift_assignments(self):
+		"""Tests absent is marked for each shift when actual timings of multiple assignments overlap"""
+		employee = make_employee("test_employee_multishift@example.com", company="_Test Company")
+		today = getdate()
+		start_date = add_days(today, -5)
+		absent_date = add_days(today, -3)
+		last_sync = datetime.combine(today, get_time("06:00:00"))
+
+		# actual windows overlap (day: 05:00-23:00, night: 20:01-08:59) but raw timings don't
+		day_shift = setup_shift_type(
+			shift_type="Test Overlap Day",
+			start_time="06:00:00",
+			end_time="22:00:00",
+			process_attendance_after=start_date,
+			last_sync_of_checkin=last_sync,
+		)
+		night_shift = setup_shift_type(
+			shift_type="Test Overlap Night",
+			start_time="22:01:00",
+			end_time="05:59:00",
+			begin_check_in_before_shift_start_time=120,
+			allow_check_out_after_shift_end_time=180,
+			process_attendance_after=start_date,
+			last_sync_of_checkin=last_sync,
+		)
+
+		make_shift_assignment(day_shift.name, employee, start_date)
+		make_shift_assignment(night_shift.name, employee, start_date)
+
+		day_shift.process_auto_attendance()
+		night_shift.process_auto_attendance()
+
+		for shift in (day_shift, night_shift):
+			status = frappe.db.get_value(
+				"Attendance",
+				{"employee": employee, "shift": shift.name, "attendance_date": absent_date},
+				"status",
+			)
+			self.assertEqual(status, "Absent", msg=f"Absent not marked for {shift.name}")
+
 	def test_get_start_and_end_dates(self):
 		date = getdate()
 


### PR DESCRIPTION
Fixes auto attendance not marking Absent when an employee has multiple shift assignments with overlapping actual timings and no default shift.

https://support.frappe.io/helpdesk/tickets/76030?view=VIEW-HD+Ticket-70178