### PR TITLE
fix: update system date format for password in salary slip

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import datetime
+
 import frappe
 from frappe import _, msgprint
 from frappe.model.document import Document
@@ -16,6 +18,7 @@ from frappe.utils import (
 	date_diff,
 	floor,
 	flt,
+	format_datetime,
 	formatdate,
 	get_first_day,
 	get_last_day,
@@ -2531,9 +2534,43 @@ def unlink_ref_doc_from_salary_slip(doc, method=None):
 			frappe.db.set_value("Salary Slip", ss_doc.name, "journal_entry", "")
 
 
+class SystemFormattedDate(datetime.date):
+	"""Date that renders in the system date format when interpolated into a password policy.
+
+	Subclasses `date` so that policies relying on the underlying object, like
+	`{date_of_birth.year}` or `{date_of_birth:%d%m%Y}`, keep working.
+	"""
+
+	def __str__(self):
+		return formatdate(datetime.date(self.year, self.month, self.day))
+
+
+class SystemFormattedDatetime(datetime.datetime):
+	"""Datetime counterpart of `SystemFormattedDate`."""
+
+	def __str__(self):
+		return format_datetime(
+			datetime.datetime(
+				self.year, self.month, self.day, self.hour, self.minute, self.second, self.microsecond
+			)
+		)
+
+
+def format_dates_in_system_format(value):
+	# datetime is a subclass of date, so it has to be checked first
+	if isinstance(value, datetime.datetime):
+		return SystemFormattedDatetime(
+			value.year, value.month, value.day, value.hour, value.minute, value.second, value.microsecond
+		)
+	if isinstance(value, datetime.date):
+		return SystemFormattedDate(value.year, value.month, value.day)
+	return value
+
+
 def generate_password_for_pdf(policy_template, employee):
 	employee = frappe.get_cached_doc("Employee", employee)
-	return policy_template.format(**employee.as_dict())
+	values = {key: format_dates_in_system_format(value) for key, value in employee.as_dict().items()}
+	return policy_template.format(**values)
 
 
 def get_salary_component_data(component):

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -43,6 +43,7 @@ from hrms.payroll.doctype.salary_slip.salary_slip import (
 	TAX_COMPONENTS_BY_COMPANY,
 	SalarySlip,
 	_safe_eval,
+	generate_password_for_pdf,
 	make_salary_slip_from_timesheet,
 )
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
@@ -921,6 +922,19 @@ class TestSalarySlip(HRMSTestSuite):
 		ss.submit()
 
 		self.assertIsNotNone(get_email_by_subject("Test Salary Slip Email Template"))
+
+	@HRMSTestSuite.change_settings("System Settings", {"date_format": "dd-mm-yyyy"})
+	def test_pdf_password_uses_system_date_format(self):
+		emp_id = make_employee("test_pdf_password@salary.com", company="_Test Company")
+
+		# the format is cached per request, reset it so that the changed setting is picked up
+		frappe.local.user_date_format = None
+		self.addCleanup(setattr, frappe.local, "user_date_format", None)
+
+		self.assertEqual(generate_password_for_pdf("{date_of_birth}", emp_id), "08-05-1990")
+		# the value is still a date, so attribute access and format specs keep working
+		self.assertEqual(generate_password_for_pdf("SAL-{date_of_birth.year}", emp_id), "SAL-1990")
+		self.assertEqual(generate_password_for_pdf("{date_of_birth:%d%m%Y}", emp_id), "08051990")
 
 	def test_payroll_frequency(self):
 		fiscal_year = get_fiscal_year(nowdate(), company="_Test Company")[0]


### PR DESCRIPTION
Closes: #1941 

**Description:** The password policy in Payroll Settings substitutes Employee fields into a template, e.g. SAL-{first_name}-{date_of_birth}. Date fields were interpolated as raw datetime.date objects, which always stringify as ISO, so the password contained 1990-05-08 regardless of the date format configured in System Settings.
An employee whose system is set to dd-mm-yyyy is told the password is their date of birth, tries 08-05-1990, and cannot open the salary slip PDF.