### PR TITLE
fix: add audit_trail_doctypes to hooks

### DIFF
--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -291,7 +291,7 @@ accounting_dimension_doctypes = [
 
 bank_reconciliation_doctypes = ["Expense Claim"]
 
-audit_trail_doctypes = ["Expense Claim", "Payroll Entry", "Salary Slip"]
+audit_trail_doctypes = ["Expense Claim", "Payroll Entry", "Salary Slip", "Leave Encashment", "Gratuity"]
 
 # Testing
 # -------

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -291,6 +291,8 @@ accounting_dimension_doctypes = [
 
 bank_reconciliation_doctypes = ["Expense Claim"]
 
+audit_trail_doctypes = ["Expense Claim", "Payroll Entry", "Salary Slip"]
+
 # Testing
 # -------
 


### PR DESCRIPTION
Adding `audit_trail_doctypes` allows other apps to have better customization over audit trail of `hrms` DocTypes.


### Original Issue
India Compliance app has a feature to globally `Enable Audit Trail` which creates `Property Setters` for multiple DocTypes  setting `track_changes` true . This should also work on DocTypes of other apps of frappe suite. But `hrms` never defines this hook.

### Solution
Add `audit_trail_doctypes` to other frappe apps, ensuring every other app can add customisation to enable audit trail.
