### PR TITLE
feat: quick action menu for assigning important masters to the employee

### DIFF
--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.json
@@ -46,12 +46,14 @@
    "reqd": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "assignment_based_on",
    "fieldtype": "Select",
    "label": "Assignment based on",
    "options": "\nLeave Period\nJoining Date"
   },
   {
+   "allow_in_quick_entry": 1,
    "depends_on": "eval:doc.assignment_based_on == \"Leave Period\"",
    "fieldname": "leave_period",
    "fieldtype": "Link",
@@ -97,6 +99,7 @@
   },
   {
    "default": "0",
+   "allow_in_quick_entry": 1,
    "fieldname": "carry_forward",
    "fieldtype": "Check",
    "label": "Add unused leaves from previous allocations"

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -156,6 +156,21 @@ def get_timeline_data(doctype: str, name: str) -> dict:
 
 
 @frappe.whitelist()
+def get_assignable_masters(company: str) -> dict[str, bool]:
+	"""Return whether a submitted master exists for each gated Employee assignment action"""
+	masters = {
+		"Leave Policy": {"docstatus": 1},
+		"Salary Structure": {"docstatus": 1, "is_active": "Yes", "company": company},
+		"Shift Schedule": {"docstatus": 1},
+	}
+
+	return {
+		doctype: bool(frappe.get_list(doctype, filters=filters, limit=1, pluck="name"))
+		for doctype, filters in masters.items()
+	}
+
+
+@frappe.whitelist()
 def get_retirement_date(date_of_birth: str | None = None):
 	if date_of_birth:
 		try:

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -1,6 +1,98 @@
 // Copyright (c) 2016, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
+const assignable_masters = {};
+
+function get_assignment_actions() {
+	return [
+		{
+			label: __("Holiday List"),
+			doctype: "Holiday List Assignment",
+			prefill: (frm) => ({
+				applicable_for: "Employee",
+				assigned_to: frm.doc.name,
+				employee_name: frm.doc.employee_name,
+				employee_company: frm.doc.company,
+			}),
+		},
+		{
+			label: __("Leave Policy"),
+			doctype: "Leave Policy Assignment",
+			master: "Leave Policy",
+			prefill: (frm) => ({ employee: frm.doc.name }),
+			queries: { leave_policy: { docstatus: 1 } },
+		},
+		{
+			label: __("Salary Structure"),
+			doctype: "Salary Structure Assignment",
+			master: "Salary Structure",
+			redirect: true,
+		},
+		{
+			label: __("Shift"),
+			doctype: "Shift Assignment",
+			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
+		},
+		{
+			label: __("Shift Schedule"),
+			doctype: "Shift Schedule Assignment",
+			master: "Shift Schedule",
+			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
+		},
+	];
+}
+
+function get_assignable_masters(company) {
+	if (!assignable_masters[company]) {
+		assignable_masters[company] = frappe
+			.xcall("hrms.overrides.employee_master.get_assignable_masters", { company })
+			.catch(() => {
+				delete assignable_masters[company];
+				return {};
+			});
+	}
+
+	return assignable_masters[company];
+}
+
+function open_assignment(frm, action) {
+	if (action.redirect) {
+		return frappe.new_doc(action.doctype, {
+			employee: frm.doc.name,
+			company: frm.doc.company,
+		});
+	}
+
+	frappe.model.with_doctype(action.doctype, () => {
+		const doc = Object.assign(
+			frappe.model.get_new_doc(action.doctype, null, null, true),
+			action.prefill(frm),
+		);
+
+		frappe.ui.form.make_quick_entry(
+			action.doctype,
+			(created_doc) => notify_assignment_created(action, created_doc),
+			(dialog) => setup_dialog(dialog, action),
+			doc,
+			true,
+		);
+	});
+}
+
+function setup_dialog(dialog, action) {
+	for (const [fieldname, filters] of Object.entries(action.queries || {}))
+		dialog.set_query(fieldname, () => ({ filters }));
+
+	dialog.add_custom_action(__("Edit Full Form"), () => dialog.open_doc(false));
+}
+
+function notify_assignment_created(action, doc) {
+	frappe.show_alert({
+		message: __("Created {0}", [frappe.utils.get_form_link(action.doctype, doc.name, true)]),
+		indicator: "green",
+	});
+}
+
 frappe.ui.form.on("Employee", {
 	refresh: function (frm) {
 		frm.set_query("payroll_cost_center", function () {
@@ -32,6 +124,21 @@ frappe.ui.form.on("Employee", {
 		frappe.db.get_single_value("HR Settings", "emp_created_by").then((value) => {
 			frm.toggle_display("naming_series", value === "Naming Series");
 		});
+
+		frm.trigger("add_assignment_actions");
+	},
+
+	add_assignment_actions: async function (frm) {
+		if (frm.is_new() || frm.doc.status !== "Active") return;
+
+		const available_masters = await get_assignable_masters(frm.doc.company);
+
+		for (const action of get_assignment_actions()) {
+			if (action.master && !available_masters[action.master]) continue;
+			if (!frappe.model.can_create(action.doctype)) continue;
+
+			frm.add_custom_button(action.label, () => open_assignment(frm, action), __("Assign"));
+		}
 	},
 
 	date_of_birth(frm) {

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -8,17 +8,24 @@ function get_assignment_actions() {
 		{
 			label: __("Holiday List"),
 			doctype: "Holiday List Assignment",
+			master_field: "holiday_list",
 			prefill: (frm) => ({
 				applicable_for: "Employee",
 				assigned_to: frm.doc.name,
 				employee_name: frm.doc.employee_name,
 				employee_company: frm.doc.company,
 			}),
+			hide: ["naming_series"],
+			on_change: {
+				holiday_list: sync_holiday_list_range,
+				from_date: flag_start_date_outside_range,
+			},
 		},
 		{
 			label: __("Leave Policy"),
 			doctype: "Leave Policy Assignment",
 			master: "Leave Policy",
+			master_field: "leave_policy",
 			prefill: (frm) => ({ employee: frm.doc.name }),
 			queries: { leave_policy: { docstatus: 1 } },
 		},
@@ -31,12 +38,14 @@ function get_assignment_actions() {
 		{
 			label: __("Shift"),
 			doctype: "Shift Assignment",
+			master_field: "shift_type",
 			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
 		},
 		{
 			label: __("Shift Schedule"),
 			doctype: "Shift Schedule Assignment",
 			master: "Shift Schedule",
+			master_field: "shift_schedule",
 			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
 		},
 	];
@@ -83,12 +92,92 @@ function setup_dialog(dialog, action) {
 	for (const [fieldname, filters] of Object.entries(action.queries || {}))
 		dialog.set_query(fieldname, () => ({ filters }));
 
+	for (const fieldname of action.hide || []) {
+		const control = dialog.fields_dict[fieldname];
+		if (!control) continue;
+
+		control.df = { ...control.df, hidden: 1 };
+		control.refresh();
+	}
+
+	for (const [fieldname, handler] of Object.entries(action.on_change || {})) {
+		const control = dialog.fields_dict[fieldname];
+		if (!control) continue;
+
+		control.df = { ...control.df, onchange: () => handler(dialog) };
+	}
+
 	dialog.add_custom_action(__("Edit Full Form"), () => dialog.open_doc(false));
+	keep_dialog_open_for_submit(dialog);
+}
+
+function keep_dialog_open_for_submit(dialog) {
+	dialog.set_primary_action(__("Save"), () => {
+		if (dialog.working || !dialog.get_values()) return;
+
+		dialog.working = true;
+		dialog.insert().finally(() => (dialog.working = false));
+	});
+}
+
+function set_field_hint(dialog, fieldname, title) {
+	dialog.modal_body.find(".assignment-hint").remove();
+	if (!title) return;
+
+	frappe.ui
+		.alert({ title, theme: "blue", css_class: "assignment-hint" })
+		.insertAfter(dialog.fields_dict[fieldname].$wrapper);
+}
+
+async function sync_holiday_list_range(dialog) {
+	const holiday_list = dialog.get_value("holiday_list");
+	dialog.holiday_list_range = null;
+
+	if (holiday_list) {
+		const response = await frappe.db.get_value("Holiday List", holiday_list, [
+			"from_date",
+			"to_date",
+		]);
+		dialog.holiday_list_range = response.message?.from_date ? response.message : null;
+	}
+
+	const range_start = dialog.holiday_list_range?.from_date;
+	if (range_start && !dialog.get_value("from_date"))
+		await dialog.set_value("from_date", range_start);
+
+	flag_start_date_outside_range(dialog);
+}
+
+function flag_start_date_outside_range(dialog) {
+	const range = dialog.holiday_list_range;
+	const from_date = dialog.get_value("from_date");
+	if (!range || !from_date) return set_field_hint(dialog, "from_date", null);
+
+	const outside =
+		frappe.datetime.get_diff(from_date, range.from_date) < 0 ||
+		frappe.datetime.get_diff(from_date, range.to_date) > 0;
+
+	set_field_hint(
+		dialog,
+		"from_date",
+		outside &&
+			__("Assignment must start between {0} and {1}", [
+				frappe.datetime.str_to_user(range.from_date),
+				frappe.datetime.str_to_user(range.to_date),
+			]),
+	);
 }
 
 function notify_assignment_created(action, doc) {
+	frappe.quick_entry?.hide();
+
+	const master_doctype = frappe.meta.get_docfield(action.doctype, action.master_field).options;
+
 	frappe.show_alert({
-		message: __("Created {0}", [frappe.utils.get_form_link(action.doctype, doc.name, true)]),
+		message: __("{0} was assigned {1}", [
+			__(master_doctype),
+			frappe.utils.get_form_link(action.doctype, doc.name, true),
+		]),
 		indicator: "green",
 	});
 }

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -53,8 +53,8 @@ function get_assignment_actions() {
 			label: __("Shift Schedule"),
 			doctype: "Shift Schedule Assignment",
 			master: "Shift Schedule",
-			master_field: "shift_schedule",
 			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
+			redirect: true,
 		},
 	];
 }

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -222,7 +222,11 @@ frappe.ui.form.on("Employee", {
 			if (action.master && !available_masters[action.master]) continue;
 			if (!frappe.model.can_create(action.doctype)) continue;
 
-			frm.add_custom_button(action.label, () => open_assignment(frm, action), __("Assign"));
+			frm.add_custom_button(
+				action.label,
+				() => open_assignment(frm, action),
+				__("Create Assignments"),
+			);
 		}
 	},
 

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -27,7 +27,14 @@ function get_assignment_actions() {
 			master: "Leave Policy",
 			master_field: "leave_policy",
 			prefill: (frm) => ({ employee: frm.doc.name }),
-			queries: { leave_policy: { docstatus: 1 } },
+			queries: (frm) => ({
+				leave_policy: { docstatus: 1 },
+				leave_period: { is_active: 1, company: frm.doc.company },
+			}),
+			on_change: {
+				assignment_based_on: set_leave_effective_dates,
+				leave_period: set_leave_effective_dates,
+			},
 		},
 		{
 			label: __("Salary Structure"),
@@ -77,15 +84,15 @@ function open_assignment(frm, action) {
 		frappe.ui.form.make_quick_entry(
 			action.doctype,
 			(created_doc) => notify_assignment_created(action, created_doc),
-			(dialog) => setup_dialog(dialog, action),
+			(dialog) => setup_dialog(dialog, action, frm),
 			doc,
 			true,
 		);
 	});
 }
 
-function setup_dialog(dialog, action) {
-	for (const [fieldname, filters] of Object.entries(action.queries || {}))
+function setup_dialog(dialog, action, frm) {
+	for (const [fieldname, filters] of Object.entries(action.queries?.(frm) || {}))
 		dialog.set_query(fieldname, () => ({ filters }));
 
 	for (const fieldname of action.hide || []) {
@@ -100,7 +107,7 @@ function setup_dialog(dialog, action) {
 		const control = dialog.fields_dict[fieldname];
 		if (!control) continue;
 
-		control.df = { ...control.df, onchange: () => handler(dialog) };
+		control.df = { ...control.df, onchange: () => handler(dialog, frm) };
 	}
 
 	dialog.add_custom_action(__("Edit Full Form"), () => dialog.open_doc(false));
@@ -142,6 +149,37 @@ async function sync_holiday_list_range(dialog) {
 		await dialog.set_value("from_date", range_start);
 
 	flag_start_date_outside_range(dialog);
+}
+
+async function set_leave_effective_dates(dialog, frm) {
+	const assignment_based_on = dialog.get_value("assignment_based_on");
+
+	if (!assignment_based_on) {
+		await dialog.set_value("effective_from", "");
+		await dialog.set_value("effective_to", "");
+		return;
+	}
+
+	if (assignment_based_on === "Joining Date") {
+		await dialog.set_value("effective_from", frm.doc.date_of_joining);
+		await dialog.set_value(
+			"effective_to",
+			frappe.datetime.add_months(frm.doc.date_of_joining, 12),
+		);
+		return;
+	}
+
+	const leave_period = dialog.get_value("leave_period");
+	if (!leave_period) return;
+
+	const response = await frappe.db.get_value("Leave Period", leave_period, [
+		"from_date",
+		"to_date",
+	]);
+	if (!response.message) return;
+
+	await dialog.set_value("effective_from", response.message.from_date);
+	await dialog.set_value("effective_to", response.message.to_date);
 }
 
 function flag_start_date_outside_range(dialog) {

--- a/hrms/public/js/erpnext/employee.js
+++ b/hrms/public/js/erpnext/employee.js
@@ -33,13 +33,14 @@ function get_assignment_actions() {
 			label: __("Salary Structure"),
 			doctype: "Salary Structure Assignment",
 			master: "Salary Structure",
+			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
 			redirect: true,
 		},
 		{
 			label: __("Shift"),
 			doctype: "Shift Assignment",
-			master_field: "shift_type",
 			prefill: (frm) => ({ employee: frm.doc.name, company: frm.doc.company }),
+			redirect: true,
 		},
 		{
 			label: __("Shift Schedule"),
@@ -65,12 +66,7 @@ function get_assignable_masters(company) {
 }
 
 function open_assignment(frm, action) {
-	if (action.redirect) {
-		return frappe.new_doc(action.doctype, {
-			employee: frm.doc.name,
-			company: frm.doc.company,
-		});
-	}
+	if (action.redirect) return frappe.new_doc(action.doctype, action.prefill(frm));
 
 	frappe.model.with_doctype(action.doctype, () => {
 		const doc = Object.assign(


### PR DESCRIPTION
### Create Assignments menu
 (other suggestions for the label are welcome :shrug:)
<img width="1610" height="417" alt="image" src="https://github.com/user-attachments/assets/551de3ee-3519-478a-ae33-29a095ed15bd" />

There are 5 menu items, sorted by importance
1. Holiday List
2. Leave Policy
3. Salary structure
4. Shift
5. Shift Schedule

These options appear if even one document of the dependent masters exist. The idea is to help make the important assignment quickly for new employee onboardings, ideally without having to move away from employee in question. This may not be very helpful for new users setting their system up for the first time.


### Holiday list assignment form

The straightforward forms like holiday list assignment open up in dialog boxes

https://github.com/user-attachments/assets/d35dbd72-17f7-48b1-b6b4-f0b0aa08a0f5

### Leave policy assignment

A little bigger than holiday list assignment but still makes sense to put in a dialog

https://github.com/user-attachments/assets/9a1b02f4-75e1-4e9e-bdf9-5fdedfa4aa6b


### Salary Structure and Shift and Shift Schedule

The others that have little more configuration options like salary structure and shift open in their own forms

https://github.com/user-attachments/assets/0fe05f91-811f-4e28-b4ea-d5b989e510e4


`no-docs`