### PR TITLE
feat(job_applicant): copy applicant data when creating an Employee

### DIFF
--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -85,6 +85,16 @@ frappe.ui.form.on("Job Applicant", {
 		}
 
 		if (!frm.doc.__islocal && frm.doc.status == "Accepted") {
+			if (frm.doc.__onload && frm.doc.__onload.employee) {
+				frm.add_custom_button(__("Show Employee"), function () {
+					frappe.set_route("Form", "Employee", frm.doc.__onload.employee);
+				});
+			} else {
+				frm.add_custom_button(__("Create Employee"), function () {
+					frm.make_methods.Employee();
+				});
+			}
+
 			if (frm.doc.__onload && frm.doc.__onload.job_offer) {
 				$('[data-doctype="Employee Onboarding"]').find("button").show();
 				$('[data-doctype="Job Offer"]').find("button").hide();

--- a/hrms/hr/doctype/job_applicant/job_applicant.js
+++ b/hrms/hr/doctype/job_applicant/job_applicant.js
@@ -7,6 +7,16 @@
 cur_frm.email_field = "email_id";
 
 frappe.ui.form.on("Job Applicant", {
+	setup: function (frm) {
+		frm.make_methods = {
+			Employee: () =>
+				frappe.model.open_mapped_doc({
+					method: "hrms.hr.doctype.job_applicant.job_applicant.make_employee",
+					frm: frm,
+				}),
+		};
+	},
+
 	refresh: function (frm) {
 		frm.set_query("job_title", function () {
 			return {

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -9,6 +9,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import flt, validate_email_address
 
@@ -105,6 +106,50 @@ class JobApplicant(Document):
 
 
 KANBAN_COLUMNS = ["Open", "Replied", "Shortlisted", "Accepted"]
+
+
+@frappe.whitelist()
+def make_employee(source_name: str, target_doc: str | Document | None = None) -> Document:
+	def set_missing_values(source, target):
+		target.employee_name = source.applicant_name
+
+		if not source.job_title:
+			return
+
+		job_opening = frappe.db.get_value(
+			"Job Opening",
+			source.job_title,
+			["company", "department", "employment_type"],
+			as_dict=True,
+		)
+		if not job_opening:
+			return
+
+		if job_opening.company:
+			target.company = job_opening.company
+		if job_opening.department:
+			target.department = job_opening.department
+		if job_opening.employment_type:
+			target.employment_type = job_opening.employment_type
+
+	return get_mapped_doc(
+		"Job Applicant",
+		source_name,
+		{
+			"Job Applicant": {
+				"doctype": "Employee",
+				"field_map": {
+					"applicant_name": "first_name",
+					"email_id": "personal_email",
+					"phone_number": "cell_number",
+					"currency": "salary_currency",
+				},
+				"field_no_map": ["status"],
+			}
+		},
+		target_doc,
+		set_missing_values,
+	)
 
 
 @frappe.whitelist()

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -54,6 +54,9 @@ class JobApplicant(Document):
 		if job_offer:
 			self.get("__onload").job_offer = job_offer[0].name
 
+		employee = frappe.db.get_value("Employee", {"job_applicant": self.name}, "name") or ""
+		self.set_onload("employee", employee)
+
 	def autoname(self):
 		self.name = self.email_id
 

--- a/hrms/hr/doctype/job_applicant/test_job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/test_job_applicant.py
@@ -6,7 +6,9 @@ from frappe.utils import nowdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
+from hrms.hr.doctype.job_applicant.job_applicant import make_employee as map_applicant_to_employee
 from hrms.hr.doctype.job_offer.test_job_offer import create_job_offer
+from hrms.hr.doctype.job_opening.test_job_opening import get_job_opening
 from hrms.tests.test_utils import create_job_applicant
 from hrms.tests.utils import HRMSTestSuite
 
@@ -52,3 +54,40 @@ class TestJobApplicant(HRMSTestSuite):
 		self.assertEqual(applicant.status, "Accepted")
 		job_offer.reload()
 		self.assertEqual(job_offer.status, "Accepted")
+
+	def test_make_employee(self):
+		opening = get_job_opening(
+			job_title="Mapped Applicant Role",
+			designation="Software Developer",
+			company="_Test Company",
+			department="_Test Department - _TC",
+		)
+		if opening.is_new():
+			opening.insert()
+
+		applicant = frappe.get_doc(
+			{
+				"doctype": "Job Applicant",
+				"applicant_name": "Jane Mapped",
+				"email_id": "jane.mapped@example.com",
+				"phone_number": "1234567890",
+				"designation": "Software Developer",
+				"job_title": opening.name,
+				"currency": "INR",
+				"status": "Accepted",
+			}
+		).insert()
+
+		employee = map_applicant_to_employee(applicant.name)
+
+		self.assertEqual(employee.doctype, "Employee")
+		self.assertEqual(employee.job_applicant, applicant.name)
+		self.assertEqual(employee.first_name, "Jane Mapped")
+		self.assertEqual(employee.employee_name, "Jane Mapped")
+		self.assertEqual(employee.personal_email, "jane.mapped@example.com")
+		self.assertEqual(employee.cell_number, "1234567890")
+		self.assertEqual(employee.designation, "Software Developer")
+		self.assertEqual(employee.salary_currency, "INR")
+		self.assertEqual(employee.status, "Active")
+		self.assertEqual(employee.company, "_Test Company")
+		self.assertEqual(employee.department, "_Test Department - _TC")

--- a/hrms/hr/doctype/job_applicant/test_job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/test_job_applicant.py
@@ -61,9 +61,7 @@ class TestJobApplicant(HRMSTestSuite):
 			designation="Software Developer",
 			company="_Test Company",
 			department="_Test Department - _TC",
-		)
-		if opening.is_new():
-			opening.insert()
+		).insert()
 
 		applicant = frappe.get_doc(
 			{


### PR DESCRIPTION
- Creating an **Employee** from a **Job Applicant** (Dashboard/Connections) now uses `get_mapped_doc` instead of opening a blank form.
- Copies name, email, phone, designation, salary currency, and the applicant link; pulls company, department, and employment type from the linked **Job Opening** when present.

> no-docs