### PR TITLE
Add status filter in Monthly Attendance Sheet

### DIFF
--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -112,6 +112,13 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			options: "Branch",
 		},
 		{
+			fieldname: "status",
+			label: __("Status"),
+			fieldtype: "Select",
+			options: ["", "Active", "Inactive", "Suspended", "Left"],
+			default: "Active",
+		},
+		{
 			fieldname: "group_by",
 			label: __("Group By"),
 			fieldtype: "Select",

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -84,6 +84,13 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			},
 		},
 		{
+			fieldname: "status",
+			label: __("Status"),
+			fieldtype: "Select",
+			options: ["", "Active", "Inactive", "Suspended", "Left"],
+			default: "Active",
+		},
+		{
 			fieldname: "company",
 			label: __("Company"),
 			fieldtype: "Link",
@@ -110,12 +117,6 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			label: __("Branch"),
 			fieldtype: "Link",
 			options: "Branch",
-		},
-		{
-			fieldname: "status",
-			label: __("Status"),
-			fieldtype: "Select",
-			options: ["", "Active", "Inactive", "Suspended", "Left"],
 		},
 		{
 			fieldname: "group_by",

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -116,7 +116,6 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 			label: __("Status"),
 			fieldtype: "Select",
 			options: ["", "Active", "Inactive", "Suspended", "Left"],
-			default: "Active",
 		},
 		{
 			fieldname: "group_by",

--- a/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.py
@@ -350,12 +350,14 @@ def get_attendance_records(filters: Filters) -> list[dict]:
 	if filters.employee:
 		query = query.where(Attendance.employee == filters.employee)
 
-	if filters.department or filters.branch:
+	if filters.department or filters.branch or filters.status:
 		query = query.join(Employee).on(Attendance.employee == Employee.name)
 		if filters.department and filters.department != "All Departments":
 			query = query.where(Employee.department == filters.department)
 		if filters.branch:
 			query = query.where(Employee.branch == filters.branch)
+		if filters.status:
+			query = query.where(Employee.status == filters.status)
 
 	query = query.orderby(Attendance.employee, Attendance.attendance_date)
 
@@ -400,6 +402,8 @@ def get_employee_related_details(filters: Filters) -> tuple[dict, list]:
 		query = query.where(Employee.department == filters.department)
 	if filters.branch:
 		query = query.where(Employee.branch == filters.branch)
+	if filters.status:
+		query = query.where(Employee.status == filters.status)
 
 	group_by = filters.group_by
 	if group_by:

--- a/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
+++ b/hrms/hr/report/monthly_attendance_sheet/test_monthly_attendance_sheet.py
@@ -635,6 +635,48 @@ class TestMonthlyAttendanceSheet(HRMSTestSuite):
 		self.assertIn(emp_dept1, employees_in_report)
 		self.assertNotIn(emp_dept2, employees_in_report)
 
+	def test_attendance_with_status_filter(self):
+		previous_month_first = get_first_day_for_prev_month()
+
+		active_employee = make_employee("emp_active@example.com", company=self.company)
+		left_employee = make_employee("emp_left@example.com", company=self.company)
+		frappe.db.set_value("Employee", left_employee, "status", "Left")
+
+		mark_attendance(active_employee, previous_month_first, "Present")
+		mark_attendance(left_employee, previous_month_first, "Present")
+
+		filters = frappe._dict(
+			{
+				"month": previous_month_first.month,
+				"year": previous_month_first.year,
+				"company": self.company,
+				"status": "Active",
+				"filter_based_on": self.filter_based_on,
+			}
+		)
+		report = execute(filters=filters)
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only the active employee should appear
+		self.assertIn(active_employee, employees_in_report)
+		self.assertNotIn(left_employee, employees_in_report)
+
+		filters.status = "Left"
+		report = execute(filters=filters)
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# only the left employee should appear
+		self.assertIn(left_employee, employees_in_report)
+		self.assertNotIn(active_employee, employees_in_report)
+
+		filters.status = ""
+		report = execute(filters=filters)
+		employees_in_report = [row.get("employee") for row in report[1] if row.get("employee")]
+
+		# both employees should appear when status filter is blank
+		self.assertIn(active_employee, employees_in_report)
+		self.assertIn(left_employee, employees_in_report)
+
 	def test_attendance_with_branch_filter(self):
 		previous_month_first = get_first_day_for_prev_month()
 


### PR DESCRIPTION
## Summary
Added a Status filter to the Monthly Attendance Sheet report, placed right after the Employee filter. You can filter the report by employee status: Active, Inactive, Suspended, or Left. The default value is Active.

Fixes #5102

## Test plan
- Open Monthly Attendance Sheet report
- Check the Status filter shows up next to Employee, with Active as default
- Change status to Left and check only left employees show up
- Change status to blank and check all employees show up
- Added test `test_attendance_with_status_filter` covering Active, Left, and blank status values

## Screenshot / Video

https://github.com/user-attachments/assets/6a17503c-8867-4627-b07d-2b84199496e2

