### PR TITLE
fix: release withheld salaries unreachable

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -456,7 +456,24 @@ let make_bank_entry = function (frm, for_withheld_salaries = 0) {
 				dn: frm.doc.name,
 				args: { for_withheld_salaries: for_withheld_salaries },
 			},
-			callback: function () {
+			callback: function (r) {
+				// the server returns nothing when no salary qualifies for payment,
+				// so don't route to an empty Journal Entry list without explanation
+				if (!r.message) {
+					frappe.msgprint({
+						title: __("No Bank Entry Created"),
+						message: for_withheld_salaries
+							? __(
+									"There are no withheld salaries pending release for this Payroll Entry.",
+							  )
+							: __(
+									"There are no salaries pending payment for this Payroll Entry. Withheld salaries have to be paid using the Release Withheld Salaries button.",
+							  ),
+						indicator: "orange",
+					});
+					return;
+				}
+
 				frappe.set_route("List", "Journal Entry", {
 					"Journal Entry Account.reference_name": frm.doc.name,
 				});

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.js
@@ -180,13 +180,20 @@ frappe.ui.form.on("Payroll Entry", {
 
 	add_bank_entry_button: function (frm) {
 		frm.call("has_bank_entries").then((r) => {
-			if (!r.message.has_bank_entries) {
+			const { has_bank_entries, has_withheld_salaries, has_unwithheld_salaries } = r.message;
+
+			if (!has_bank_entries && has_unwithheld_salaries) {
 				frm.add_custom_button(__("Make Bank Entry"), function () {
 					make_bank_entry(frm);
 				}).addClass("btn-primary");
-			} else if (!r.message.has_bank_entries_for_withheld_salaries) {
+			}
+
+			// releasing normally waits for the regular bank entry, but when every employee
+			// is withheld there is no regular entry to wait for and the release would
+			// otherwise be unreachable, leaving the salaries stranded
+			if (has_withheld_salaries && (has_bank_entries || !has_unwithheld_salaries)) {
 				frm.add_custom_button(__("Release Withheld Salaries"), function () {
-					make_bank_entry(frm, (for_withheld_salaries = 1));
+					make_bank_entry(frm, 1);
 				}).addClass("btn-primary");
 			}
 		});

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -945,11 +945,12 @@ class PayrollEntry(Document):
 			)
 		).run(as_dict=True)
 
+		withheld_flags = [bool(employee.is_salary_withheld) for employee in self.employees]
+
 		return {
 			"has_bank_entries": bool(bank_entries),
-			"has_bank_entries_for_withheld_salaries": not any(
-				employee.is_salary_withheld for employee in self.employees
-			),
+			"has_withheld_salaries": any(withheld_flags),
+			"has_unwithheld_salaries": any(not flag for flag in withheld_flags),
 		}
 
 	@frappe.whitelist()

--- a/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py
+++ b/hrms/payroll/doctype/salary_withholding/test_salary_withholding.py
@@ -111,6 +111,29 @@ class TestSalaryWithholding(HRMSTestSuite):
 		payroll_employee = self._get_payroll_employee_row(payroll_entry)
 		self.assertEqual(payroll_employee.is_salary_withheld, 1)
 
+	def test_release_withheld_salaries_when_every_employee_is_withheld(self):
+		# a payroll entry where every employee is withheld has no regular bank entry
+		# to make, so the release path has to stay reachable on its own
+		create_salary_withholding(self.employee1, MONTH_1_START, 1).submit()
+		create_salary_withholding(self.employee2, MONTH_1_START, 1).submit()
+
+		payroll_entry = self._make_payroll_entry()
+
+		flags = payroll_entry.has_bank_entries()
+		self.assertFalse(flags["has_bank_entries"])
+		self.assertTrue(flags["has_withheld_salaries"])
+		self.assertFalse(flags["has_unwithheld_salaries"])
+
+		# nothing is payable outside the withholding
+		self.assertIsNone(payroll_entry.make_bank_entry())
+
+		bank_entry = payroll_entry.make_bank_entry(for_withheld_salaries=1)
+		self.assertIsNotNone(bank_entry)
+		self._submit_bank_entry(bank_entry)
+
+		for employee in (self.employee1, self.employee2):
+			self.assertEqual(get_salary_slip_details(payroll_entry.name, employee).status, "Submitted")
+
 	def _make_payroll_entry(self, date: str | None = None):
 		dates = get_start_end_dates("Monthly", date or MONTH_1_START)
 


### PR DESCRIPTION
**Description:** When every employee in a Payroll Entry has an active Salary Withholding, the withheld salaries can never be paid:

- Make Bank Entry creates nothing (all slips are Withheld, so they are filtered out), but still redirects to an empty Journal Entry list with no message.
- Release Withheld Salaries never appears, so there is no way to pay the withheld salaries.

