### PR TITLE
fix(expense_claim): enforce advance currency and account type checks consistently across selection and save

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.js
+++ b/hrms/hr/doctype/expense_claim/expense_claim.js
@@ -598,15 +598,17 @@ frappe.ui.form.on("Expense Claim Advance", {
 						set_in_company_currency(frm, child, ["allocated_amount"]);
 						refresh_field("advances");
 					} else {
-						frm.doc.advances = [];
+						remove_invalid_advance_row(frm, cdt, cdn);
 						frappe.validated = false;
-						refresh_field("advances");
 						frappe.throw(
 							__("Selected employee advance is not of employee {0}", [
 								frm.doc.employee,
 							]),
 						);
 					}
+				},
+				error: function () {
+					remove_invalid_advance_row(frm, cdt, cdn);
 				},
 			});
 		}
@@ -659,4 +661,15 @@ async function set_in_company_currency(frm, doc, fields, exchange_rate = frm.doc
 			precision("base_" + f, doc),
 		);
 	});
+}
+
+function remove_invalid_advance_row(frm, cdt, cdn) {
+	const grid_row = frm.fields_dict.advances.grid.grid_rows_by_docname[cdn];
+	if (grid_row) {
+		grid_row.remove();
+	} else {
+		console.error("expense_claim: could not find grid row to remove for cdn", cdn);
+		frappe.model.set_value(cdt, cdn, "employee_advance", "");
+		refresh_field("advances");
+	}
 }

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -549,6 +549,8 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 			if self.employee != advance_employee:
 				frappe.throw(_("Selected employee advance is not of employee {}").format(self.employee))
 
+			validate_employee_advance_currency_and_account(self, d.employee_advance)
+
 			self.round_floats_in(d)
 			if d.allocated_amount and flt(d.allocated_amount) > flt(
 				flt(d.unclaimed_amount) - flt(d.return_amount), precision
@@ -675,6 +677,36 @@ def get_expense_claim_account(expense_claim_type: str, company: str) -> dict:
 	return {"account": account}
 
 
+def validate_employee_advance_currency_and_account(expense_claim: Document, employee_advance: str) -> None:
+	advance_details = frappe.db.get_value(
+		"Employee Advance",
+		{"name": employee_advance, "employee": expense_claim.employee},
+		["currency", "advance_account"],
+		as_dict=True,
+	)
+	if not advance_details:
+		return
+
+	if expense_claim.currency and advance_details.currency != expense_claim.currency:
+		frappe.throw(
+			_(
+				"Employee Advance {0} is in currency {1} and can only be claimed in an Expense Claim of the same currency. This Expense Claim is in {2}."
+			).format(
+				frappe.bold(employee_advance),
+				frappe.bold(advance_details.currency),
+				frappe.bold(expense_claim.currency),
+			)
+		)
+
+	account_type = frappe.db.get_value("Account", advance_details.advance_account, "account_type")
+	if account_type != "Receivable":
+		frappe.throw(
+			_(
+				"Employee Advance {0} is linked to account {1}, which is not of type Receivable, so it cannot be claimed against an Expense Claim. Please correct the account type or contact your administrator."
+			).format(frappe.bold(employee_advance), frappe.bold(advance_details.advance_account))
+		)
+
+
 @frappe.whitelist()
 def get_advances(expense_claim: str | dict | Document, advance_id: str | None = None):
 	import json
@@ -704,12 +736,12 @@ def get_advances(expense_claim: str | dict | Document, advance_id: str | None = 
 			& (advance.paid_amount > 0)
 			& (advance.status.notin(["Claimed", "Returned", "Partly Claimed and Returned"]))
 		)
+		# advance can only be adjusted in its own currency
+		if expense_claim_doc.currency:
+			query = query.where(advance.currency == expense_claim_doc.currency)
 	else:
 		query = query.where((advance.name == advance_id) & (advance.employee == expense_claim_doc.employee))
-
-	# advance can only be adjusted in its own currency
-	if expense_claim_doc.currency:
-		query = query.where(advance.currency == expense_claim_doc.currency)
+		validate_employee_advance_currency_and_account(expense_claim_doc, advance_id)
 
 	advances = query.run(as_dict=True)
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -545,11 +545,16 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		precision = self.precision("total_advance_amount")
 
 		for d in self.get("advances"):
-			advance_employee = frappe.db.get_value("Employee Advance", d.employee_advance, "employee")
-			if self.employee != advance_employee:
+			advance_details = frappe.db.get_value(
+				"Employee Advance",
+				d.employee_advance,
+				["employee", "currency", "advance_account", "paid_amount"],
+				as_dict=True,
+			)
+			if not advance_details or self.employee != advance_details.employee:
 				frappe.throw(_("Selected employee advance is not of employee {}").format(self.employee))
 
-			validate_employee_advance_currency_and_account(self, d.employee_advance)
+			validate_employee_advance_currency_and_account(self, d.employee_advance, advance_details)
 
 			self.round_floats_in(d)
 			if d.allocated_amount and flt(d.allocated_amount) > flt(
@@ -677,13 +682,16 @@ def get_expense_claim_account(expense_claim_type: str, company: str) -> dict:
 	return {"account": account}
 
 
-def validate_employee_advance_currency_and_account(expense_claim: Document, employee_advance: str) -> None:
-	advance_details = frappe.db.get_value(
-		"Employee Advance",
-		{"name": employee_advance, "employee": expense_claim.employee},
-		["currency", "advance_account", "paid_amount"],
-		as_dict=True,
-	)
+def validate_employee_advance_currency_and_account(
+	expense_claim: Document, employee_advance: str, advance_details: dict | None = None
+) -> None:
+	if advance_details is None:
+		advance_details = frappe.db.get_value(
+			"Employee Advance",
+			{"name": employee_advance, "employee": expense_claim.employee},
+			["currency", "advance_account", "paid_amount"],
+			as_dict=True,
+		)
 	if not advance_details:
 		return
 

--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -681,7 +681,7 @@ def validate_employee_advance_currency_and_account(expense_claim: Document, empl
 	advance_details = frappe.db.get_value(
 		"Employee Advance",
 		{"name": employee_advance, "employee": expense_claim.employee},
-		["currency", "advance_account"],
+		["currency", "advance_account", "paid_amount"],
 		as_dict=True,
 	)
 	if not advance_details:
@@ -698,12 +698,45 @@ def validate_employee_advance_currency_and_account(expense_claim: Document, empl
 			)
 		)
 
+	paid_amount = flt(advance_details.paid_amount)
+	redo_payment_msg = _(
+		"Cancel the Payment Entry made against it, correct the advance account to be of type Receivable, and create a new Payment Entry."
+	)
+
 	account_type = frappe.db.get_value("Account", advance_details.advance_account, "account_type")
 	if account_type != "Receivable":
+		if paid_amount:
+			frappe.throw(
+				_(
+					"Employee Advance {0} is linked to account {1}, which is not of type Receivable. {2}"
+				).format(
+					frappe.bold(employee_advance),
+					frappe.bold(advance_details.advance_account),
+					redo_payment_msg,
+				)
+			)
 		frappe.throw(
 			_(
-				"Employee Advance {0} is linked to account {1}, which is not of type Receivable, so it cannot be claimed against an Expense Claim. Please correct the account type or contact your administrator."
+				"Employee Advance {0} is linked to account {1}, which is not of type Receivable. Please correct the account type before making a payment against it."
 			).format(frappe.bold(employee_advance), frappe.bold(advance_details.advance_account))
+		)
+
+	# the account may have been switched back to Receivable after the payment was made
+	# while it was Payable, that entry is still recorded with a negative amount
+	if paid_amount and not frappe.db.exists(
+		"Advance Payment Ledger Entry",
+		{
+			"against_voucher_type": "Employee Advance",
+			"against_voucher_no": employee_advance,
+			"event": "Submit",
+			"delinked": 0,
+			"amount": (">", 0),
+		},
+	):
+		frappe.throw(
+			_(
+				"Employee Advance {0}'s payment does not match its Receivable account. This can happen if the account's type was changed after the payment was made. {1}"
+			).format(frappe.bold(employee_advance), redo_payment_msg)
 		)
 
 

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -272,6 +272,82 @@ class TestExpenseClaim(HRMSTestSuite):
 		self.assertEqual(advance_row.unclaimed_amount, 1000)
 		self.assertEqual(advance_row.allocated_amount, 1000)
 
+	def test_advance_with_non_receivable_account(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
+		frappe.db.delete("Employee Advance")
+
+		payable_advance_account = create_account(
+			account_name="Payable Employee Advance",
+			parent_account="Accounts Payable - _TC",
+			company="_Test Company",
+			account_currency=get_company_currency("_Test Company"),
+			account_type="Payable",
+		)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+		)
+
+		# validate_advance_account_type normally blocks a Payable account; ignored here to
+		# simulate one whose type was reclassified after the advance was already submitted
+		advance = make_employee_advance(
+			claim.employee, args={"advance_account": payable_advance_account}, do_not_submit=True
+		)
+		advance.flags.ignore_validate = True
+		advance.insert()
+		advance.submit()
+		make_payment_entry(advance)
+
+		self.assertRaises(frappe.ValidationError, get_advances, claim, advance.name)
+
+	def test_validate_advances_blocks_non_receivable_advance(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
+		frappe.db.delete("Employee Advance")
+
+		payable_advance_account = create_account(
+			account_name="Payable Employee Advance 2",
+			parent_account="Accounts Payable - _TC",
+			company="_Test Company",
+			account_currency=get_company_currency("_Test Company"),
+			account_type="Payable",
+		)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+		)
+
+		advance = make_employee_advance(
+			claim.employee, args={"advance_account": payable_advance_account}, do_not_submit=True
+		)
+		advance.flags.ignore_validate = True
+		advance.insert()
+		advance.submit()
+		make_payment_entry(advance)
+
+		# simulates a row added without going through get_advances(), e.g. a direct API call
+		claim.append(
+			"advances",
+			{
+				"employee_advance": advance.name,
+				"advance_account": payable_advance_account,
+				"advance_paid": 1000,
+				"unclaimed_amount": 1000,
+				"allocated_amount": 1000,
+			},
+		)
+
+		self.assertRaises(frappe.ValidationError, claim.save)
+
 	def test_advance_amount_allocation_against_claim_with_taxes(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			get_advances_for_claim,
@@ -826,9 +902,10 @@ class TestExpenseClaim(HRMSTestSuite):
 			do_not_submit=True,
 		)
 
-		# mismatched-currency advance is excluded from both the bulk and explicit fetch
+		# mismatched-currency advance is excluded from the bulk fetch
 		self.assertEqual(get_advances(claim), [])
-		self.assertEqual(get_advances(claim, advance.name), [])
+		# explicit fetch raises a currency-specific error
+		self.assertRaises(frappe.ValidationError, get_advances, claim, advance.name)
 
 	def test_multicurrency_claim(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -293,8 +293,8 @@ class TestExpenseClaim(HRMSTestSuite):
 			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
 		)
 
-		# validate_advance_account_type normally blocks a Payable account; ignored here to
-		# simulate one whose type was reclassified after the advance was already submitted
+		# bypasses validate_advance_account_type, simulating an account that was
+		# set to Payable after the advance was submitted
 		advance = make_employee_advance(
 			claim.employee, args={"advance_account": payable_advance_account}, do_not_submit=True
 		)
@@ -302,6 +302,41 @@ class TestExpenseClaim(HRMSTestSuite):
 		advance.insert()
 		advance.submit()
 		make_payment_entry(advance)
+
+		self.assertRaises(frappe.ValidationError, get_advances, claim, advance.name)
+
+	def test_advance_blocked_after_account_reverted_to_receivable(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
+		frappe.db.delete("Employee Advance")
+
+		payable_advance_account = create_account(
+			account_name="Payable Employee Advance 3",
+			parent_account="Accounts Payable - _TC",
+			company="_Test Company",
+			account_currency=get_company_currency("_Test Company"),
+			account_type="Payable",
+		)
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+		)
+
+		advance = make_employee_advance(
+			claim.employee, args={"advance_account": payable_advance_account}, do_not_submit=True
+		)
+		advance.flags.ignore_validate = True
+		advance.insert()
+		advance.submit()
+		make_payment_entry(advance)
+
+		# account corrected back to Receivable without cancelling and redoing the payment
+		# the existing ledger entry is still recorded as a negative amount
+		frappe.db.set_value("Account", payable_advance_account, "account_type", "Receivable")
 
 		self.assertRaises(frappe.ValidationError, get_advances, claim, advance.name)
 
@@ -334,7 +369,6 @@ class TestExpenseClaim(HRMSTestSuite):
 		advance.submit()
 		make_payment_entry(advance)
 
-		# simulates a row added without going through get_advances(), e.g. a direct API call
 		claim.append(
 			"advances",
 			{


### PR DESCRIPTION
### Reason
Selecting a valid Employee Advance in an Expense Claim sometimes threw "Selected employee advance is not of employee X", even though it genuinely belonged to that employee. The real cause was one of:
- A **currency mismatch** between the advance and the Expense Claim.
- A **non-Receivable** advance account.

The error never said so, and nothing enforced this at save time, only during interactive selection.

https://github.com/user-attachments/assets/7c39f66c-e5e8-49e8-b621-b947d963e904


### Changes Done
- Show the **real reason** when an advance can't be claimed: currency mismatch or a non-Receivable account, instead of the generic employee mismatch message.
- Detect the case where the account was corrected back to Receivable but the existing payment is still recorded under the old Payable, and **guide the user to cancel the Payment Entry and redo it**.
- Enforce the same checks at save time too, not just during interactive selection.
- Fix the row in the **Advances table** to properly clear on an invalid selection instead of leaving stale data behind.

https://github.com/user-attachments/assets/d63256d6-0ceb-40c0-9b55-9e42788c102c

