### PR TITLE
fix: use public scrub API in unpaid expense report

### DIFF
--- a/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
+++ b/hrms/hr/report/unpaid_expense_claim/unpaid_expense_claim.py
@@ -4,9 +4,8 @@
 from collections import OrderedDict
 
 import frappe
-from frappe import _
+from frappe import _, scrub
 from frappe.query_builder.functions import Sum
-from frappe.utils import scrub
 
 
 def execute(filters=None):


### PR DESCRIPTION
## Summary

- replace the unavailable `frappe.utils.scrub` import with the stable `frappe.scrub` API
- prevent the Unpaid Expense Claim report import failure on Frappe v16

Closes #5103

## Verification

- pre-commit checks passed
- imported the report successfully against Frappe v16.31.0

no-docs