### PR TITLE
Feature/employee credential emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ hrms/public/frontend
 hrms/www/hrms.html
 hrms/public/roster
 hrms/www/roster.html
+
+# Employee credential rotation scripts -- never commit real secrets/outputs
+scripts/employee_credentials/smtp_config.json
+scripts/employee_credentials/password_audit_DO_NOT_SHARE.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+    agent any
+    options { timeout(time: 15, unit: 'MINUTES') }
+    environment {
+        COMPOSE_FILE = '/opt/app/hrms/docker/docker-compose.yml'
+        PROJECT = 'docker'
+    }
+    stages {
+        stage('Checkout') {
+            steps { checkout scm }
+        }
+        stage('Redeploy dev stack') {
+            steps {
+                sh 'docker compose -f $COMPOSE_FILE -p $PROJECT down'
+                sh 'docker compose -f $COMPOSE_FILE -p $PROJECT up -d --build'
+            }
+        }
+        stage('Health check') {
+            steps {
+                sh '''
+                  for i in $(seq 1 20); do
+                    if curl -sf http://localhost:8000 > /dev/null; then
+                      echo "hrms is up"; exit 0
+                    fi
+                    sleep 15
+                  done
+                  echo "hrms did not become healthy in time"; exit 1
+                '''
+            }
+        }
+    }
+}

--- a/scripts/employee_credentials/1_configure_sendgrid.py
+++ b/scripts/employee_credentials/1_configure_sendgrid.py
@@ -1,0 +1,45 @@
+import frappe
+import json
+
+SITE_NAME = 'hrms.localhost'  # change to the real site name on the target machine
+CONFIG_PATH = 'smtp_config.json'  # keep this file next to the script, never commit it
+
+frappe.init(site=SITE_NAME)
+frappe.connect()
+frappe.flags.mute_emails = True
+
+with open(CONFIG_PATH) as f:
+	cfg = json.load(f)
+
+RESULT = {}
+
+existing_name = frappe.db.get_value("Email Account", {"email_id": cfg["email_id"]}, "name")
+if existing_name:
+	acc = frappe.get_doc("Email Account", existing_name)
+else:
+	acc = frappe.new_doc("Email Account")
+	acc.email_id = cfg["email_id"]
+	acc.email_account_name = "Clustox HRMS Outgoing (SendGrid)"
+
+acc.enable_outgoing = 1
+acc.smtp_server = cfg["smtp_server"]
+acc.smtp_port = cfg["smtp_port"]
+acc.use_tls = 1
+acc.auth_method = "Basic"
+acc.login_id_is_different = 1
+acc.login_id = cfg["login_id"]
+acc.password = cfg["password"]
+acc.default_outgoing = 1
+acc.always_use_account_email_id_as_sender = 1
+acc.save(ignore_permissions=True)
+frappe.db.commit()
+
+RESULT["email_account"] = acc.name
+RESULT["enable_outgoing"] = acc.enable_outgoing
+RESULT["default_outgoing"] = acc.default_outgoing
+RESULT["smtp_server"] = acc.smtp_server
+RESULT["smtp_port"] = acc.smtp_port
+
+print("SMTP_CONFIG_RESULT_START")
+print(json.dumps(RESULT, indent=2, default=str))
+print("SMTP_CONFIG_RESULT_END")

--- a/scripts/employee_credentials/2_rotate_and_email_passwords.py
+++ b/scripts/employee_credentials/2_rotate_and_email_passwords.py
@@ -1,0 +1,178 @@
+"""
+Generates a fresh unique 20-character alphanumeric password for every
+Employee-linked User on this site, sets it on their account, and emails it
+to them.
+
+Scope: dynamically queries the database for every Employee record that is
+(a) Active and (b) linked to an enabled User -- NOT a hardcoded list. This
+is intentional so it automatically covers however many users actually exist
+on a given site (local test data vs. dev vs. live), instead of drifting out
+of date. It will touch every matching account it finds, including ones that
+already have a real password set -- review COUNT_ONLY output before ever
+flipping SEND_EMAILS.
+
+SEND_EMAILS:
+  False -> sets real passwords (works anywhere), but only PREVIEWS each
+           email's content instead of sending (safe on machines where the
+           configured SMTP/SendGrid key doesn't authenticate).
+  True  -> does the same, but actually sends via frappe.sendmail(), which
+           uses the default Outgoing Email Account already configured
+           (SendGrid). Only flip this on a machine where that account
+           actually authenticates (currently: the GPU machine).
+
+COUNT_ONLY:
+  True  -> does nothing except print who WOULD be affected (no password
+           changes, no emails). Run this first on any new environment.
+
+Run from frappe-bench/sites:
+  env/bin/python /path/to/rotate_and_email_passwords.py
+"""
+
+import frappe
+import json
+import secrets
+import string
+
+COUNT_ONLY = True   # run this first on a new environment -- touches nothing
+SEND_EMAILS = False  # flip to True only on the machine where SMTP auth works
+SITE_NAME = 'hrms.localhost'  # change to the real site name on the target machine
+SITE_URL = "http://localhost:8000"  # change to the real login URL on the target machine
+
+# Accounts to never touch even if they match the query below.
+EXCLUDE_EMAILS = {"Administrator", "Guest"}
+
+frappe.init(site=SITE_NAME)
+frappe.connect()
+ALPHABET = string.ascii_letters + string.digits
+
+
+def get_target_users():
+	"""Every enabled User linked to an Active Employee, on this site, right now."""
+	rows = frappe.db.sql(
+		"""
+		SELECT e.user_id, e.employee_name, e.employee_number
+		FROM `tabEmployee` e
+		INNER JOIN `tabUser` u ON u.name = e.user_id
+		WHERE e.status = 'Active'
+		  AND e.user_id IS NOT NULL AND e.user_id != ''
+		  AND u.enabled = 1
+		ORDER BY e.employee_number
+		""",
+		as_dict=True,
+	)
+	return [r for r in rows if r.user_id not in EXCLUDE_EMAILS]
+
+
+def gen_password(length=20, used=None):
+	used = used or set()
+	while True:
+		pwd = ''.join(secrets.choice(ALPHABET) for _ in range(length))
+		if pwd not in used:
+			return pwd
+
+
+def build_email(full_name, email, password):
+	subject = "Your Clustox HRMS login"
+	text = (
+		f"Hi {full_name},\n\n"
+		f"Your Clustox HRMS account is ready.\n\n"
+		f"Login: {SITE_URL}\n"
+		f"Email: {email}\n"
+		f"Password: {password}\n\n"
+		f"Please change your password after logging in for the first time.\n"
+	)
+	html = f"""
+	<div style="font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto;">
+		<p>Hi {full_name},</p>
+		<p>Your Clustox HRMS account is ready.</p>
+		<p>
+			<strong>Login:</strong> <a href="{SITE_URL}">{SITE_URL}</a><br>
+			<strong>Email:</strong> {email}<br>
+			<strong>Password:</strong> <code>{password}</code>
+		</p>
+		<p>Please change your password after logging in for the first time.</p>
+	</div>
+	"""
+	return subject, text, html
+
+
+targets = get_target_users()
+
+if COUNT_ONLY:
+	print("COUNT_ONLY_RESULT_START")
+	print(json.dumps({
+		"count": len(targets),
+		"users": [{"email": t.user_id, "name": t.employee_name, "code": t.employee_number} for t in targets],
+	}, indent=2))
+	print("COUNT_ONLY_RESULT_END")
+	raise SystemExit(0)
+
+# --- Phase 1: generate every password up front, then hard-verify uniqueness
+# across the WHOLE batch before touching a single account. If this ever
+# fails, nothing has been changed and nothing has been sent yet.
+used_passwords = set()
+password_by_email = {}
+for t in targets:
+	pwd = gen_password(20, used_passwords)
+	used_passwords.add(pwd)
+	password_by_email[t.user_id] = pwd
+
+all_pwds = list(password_by_email.values())
+assert len(all_pwds) == len(set(all_pwds)), (
+	"Password uniqueness check failed -- aborting before any account was touched."
+)
+assert all(len(p) == 20 for p in all_pwds), "Password length check failed -- aborting."
+print(f"UNIQUENESS_CHECK_PASSED: {len(all_pwds)} passwords, all unique, all 20 characters.")
+
+# --- Phase 2: apply. Each password was already generated + verified above,
+# so this loop only sets/sends -- it never generates a password itself.
+results = []
+audit = []  # kept local only, never printed
+
+for t in targets:
+	email = t.user_id
+	pwd = password_by_email[email]
+	record = {"email": email, "employee": t.employee_number}
+	try:
+		user = frappe.get_doc("User", email)
+		full_name = user.full_name or t.employee_name or email
+
+		user.new_password = pwd
+		user.send_welcome_email = 0
+		user.save(ignore_permissions=True)
+		record["password_set"] = True
+
+		subject, text, html = build_email(full_name, email, pwd)
+		audit.append({"email": email, "password": pwd})
+
+		if SEND_EMAILS:
+			frappe.sendmail(recipients=[email], subject=subject, message=html, now=True)
+			record["status"] = "SENT"
+		else:
+			record["status"] = "DRY_RUN_PREVIEW"
+			record["preview_subject"] = subject
+			record["preview_text"] = text
+
+		results.append(record)
+	except Exception as e:
+		record["status"] = "ERROR"
+		record["error"] = str(e)
+		results.append(record)
+
+frappe.db.commit()
+
+# Audit file kept local for our own recovery only -- never printed to logs/chat.
+# Delete this file once you've confirmed all emails arrived correctly.
+with open('password_audit_DO_NOT_SHARE.json', 'w') as f:
+	json.dump(audit, f, indent=2)
+
+# Printed summary intentionally omits password values.
+summary = [{k: v for k, v in r.items() if k not in ("preview_text",)} for r in results]
+print("ROTATE_RESULT_START")
+print(json.dumps(summary, indent=2))
+print("ROTATE_RESULT_END")
+
+if not SEND_EMAILS and results:
+	print("SAMPLE_EMAIL_PREVIEW_START")
+	print(results[0].get("preview_text", "(no preview available)"))
+	print("SAMPLE_EMAIL_PREVIEW_END")

--- a/scripts/employee_credentials/README.md
+++ b/scripts/employee_credentials/README.md
@@ -1,0 +1,67 @@
+# Employee credential rotation & delivery
+
+Two one-off admin scripts, run directly against a Frappe HR site's Python
+environment (not a Frappe app / not installed via `bench get-app`).
+
+## What they do
+
+1. **`1_configure_sendgrid.py`** — sets up the site's default Outgoing Email
+   Account using the shared Clustox SendGrid relay.
+2. **`2_rotate_and_email_passwords.py`** — for every **Active** Employee with
+   an **enabled**, linked User account, generates a fresh unique 20-character
+   alphanumeric password, sets it on the account, and emails it to them.
+
+Both were built and verified against a local test site. The SendGrid key in
+use only authenticates from specific machines (currently: the GPU machine) —
+if `1_configure_sendgrid.py` fails to save with an authentication error,
+that's expected anywhere else.
+
+## Before running anywhere
+
+1. Copy `smtp_config.example.json` to `smtp_config.json` **next to these
+   scripts** and fill in the real API key. This file is gitignored — it
+   must never be committed.
+2. In both scripts, update `SITE_NAME` to the target site's real name, and
+   in `2_rotate_and_email_passwords.py` also update `SITE_URL` to the
+   real login URL.
+
+## Run order
+
+```
+env/bin/python 1_configure_sendgrid.py
+```
+Sets up the Email Account. Only succeeds where the SendGrid key authenticates.
+
+```
+env/bin/python 2_rotate_and_email_passwords.py   # with COUNT_ONLY = True
+```
+Touches nothing. Prints exactly who would be affected — **read this list
+before proceeding**, especially on an environment with more users than it
+was last tested against.
+
+```
+env/bin/python 2_rotate_and_email_passwords.py   # COUNT_ONLY = False, SEND_EMAILS = False
+```
+Sets real passwords, previews email content, sends nothing. Safe dry run
+against the real dataset.
+
+```
+env/bin/python 2_rotate_and_email_passwords.py   # SEND_EMAILS = True
+```
+The real send.
+
+After confirming all emails arrived correctly, delete the generated
+`password_audit_DO_NOT_SHARE.json` (gitignored, but don't leave it sitting
+around regardless) — it's the only place the real passwords briefly exist
+outside each recipient's own inbox.
+
+## Guarantees baked into the password generation
+
+- Every password is exactly 20 characters, alphanumeric, generated with
+  Python's `secrets` module (cryptographically secure).
+- Uniqueness across the whole batch is generated and **hard-verified before
+  any account is touched** — if that check ever failed, the script aborts
+  before setting or sending anything.
+- User discovery is dynamic (queries `Employee` joined to `User` at runtime)
+  rather than a hardcoded list, so it scales correctly to however many
+  people actually exist on the target site.

--- a/scripts/employee_credentials/smtp_config.example.json
+++ b/scripts/employee_credentials/smtp_config.example.json
@@ -1,0 +1,7 @@
+{
+  "email_id": "noreply@frappe.theclustox.com",
+  "smtp_server": "smtp.sendgrid.net",
+  "smtp_port": 587,
+  "login_id": "apikey",
+  "password": "REPLACE_WITH_REAL_SENDGRID_API_KEY"
+}


### PR DESCRIPTION
**Add employee credential rotation & email delivery scripts**
What this does
Adds two standalone admin scripts under scripts/employee_credentials/ for managing HRMS employee login credentials:

1.  1_configure_sendgrid.py — configures the site's default Outgoing Email Account using the shared Clustox SendGrid relay (smtp.sendgrid.net, sender noreply@frappe.theclustox.com).
2.  2_rotate_and_email_passwords.py — for every Active Employee with an enabled, linked User account, generates a fresh unique 20-character alphanumeric password, sets it, and emails it to them with their login details.

**Why**
It gives us a repeatable, auditable way to issue unique per-user passwords by email instead of manual or shared-password distribution — and to re-run safely whenever new employees are added, without editing any code.

**Key design points**
Dynamic user discovery — queries Employee joined to User at runtime rather than a hardcoded list, so it scales correctly to however many employees actually exist on a given site.
Password uniqueness hard-verified before any account is touched — the full batch of passwords is generated and checked (len(all) == len(set(all))) up front; if that assertion ever failed, the script aborts before setting or sending anything.
Three safety gates, meant to be used in order on any environment:
COUNT_ONLY=True — touches nothing, just prints who would be affected (review this list before proceeding)
SEND_EMAILS=False — sets real passwords, previews email content, sends nothing
SEND_EMAILS=True — the real send
Real SMTP credentials are never committed — smtp_config.json is gitignored, with smtp_config.example.json provided as a template. The generated password audit file is also gitignored.
Full setup/run instructions in scripts/employee_credentials/README.md.

**Testing**
Verified end-to-end against a local test instance:

✅ Password generation, uniqueness, and length checks pass
✅ Passwords correctly applied to User accounts (confirmed via live login)
✅ Dynamic user query correctly scopes to Active/enabled employees only
✅ Email content builds correctly
Not verified here: actual SendGrid delivery — this key currently only authenticates from the GPU machine, so running 1_configure_sendgrid.py there is the first real test of the send path, and should happen before SEND_EMAILS=True is ever flipped on real accounts