### PR TITLE
fix: fetch boarding holidays once instead of one query per day

### DIFF
--- a/hrms/controllers/employee_boarding_controller.py
+++ b/hrms/controllers/employee_boarding_controller.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from datetime import date
+
 import frappe
 from frappe import _
 from frappe.desk.form import assign_to
 from frappe.model.document import Document
-from frappe.utils import add_days, flt, unique
+from frappe.utils import add_days, flt, getdate, unique
 
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
-from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
 
 
 class EmployeeBoardingController(Document):
@@ -50,13 +51,13 @@ class EmployeeBoardingController(Document):
 
 	def create_task_and_notify_user(self):
 		# create the task for the given project and assign to the concerned person
-		holiday_list = self.get_holiday_list()
+		holidays = self.get_upcoming_holidays(self.get_holiday_list())
 
 		for activity in self.activities:
 			if activity.task:
 				continue
 
-			dates = self.get_task_dates(activity, holiday_list)
+			dates = self.get_task_dates(activity, holidays)
 
 			task = frappe.get_doc(
 				{
@@ -111,21 +112,44 @@ class EmployeeBoardingController(Document):
 				else:
 					return self.holiday_list
 
-	def get_task_dates(self, activity, holiday_list):
+	def get_upcoming_holidays(self, holiday_list: str | None) -> set[date]:
+		"""
+		Full-day holidays on or after the boarding start date, fetched in one go so that
+		shifting task dates past holidays does not query the Holiday table per day.
+		"""
+		if not holiday_list:
+			return set()
+
+		Holiday = frappe.qb.DocType("Holiday")
+		holidays = (
+			frappe.qb.from_(Holiday)
+			.select(Holiday.holiday_date)
+			.where(
+				(Holiday.parent == holiday_list)
+				& (Holiday.is_half_day == 0)
+				& (Holiday.holiday_date >= getdate(self.boarding_begins_on))
+			)
+			.run(pluck=True)
+		)
+
+		return {getdate(holiday) for holiday in holidays}
+
+	def get_task_dates(self, activity, holidays):
 		start_date = end_date = None
 
 		if activity.begin_on is not None:
 			start_date = add_days(self.boarding_begins_on, activity.begin_on)
-			start_date = self.update_if_holiday(start_date, holiday_list)
+			start_date = self.update_if_holiday(start_date, holidays)
 
 			if activity.duration is not None:
 				end_date = add_days(self.boarding_begins_on, activity.begin_on + activity.duration)
-				end_date = self.update_if_holiday(end_date, holiday_list)
+				end_date = self.update_if_holiday(end_date, holidays)
 
 		return [start_date, end_date]
 
-	def update_if_holiday(self, date, holiday_list):
-		while is_holiday(holiday_list, date):
+	def update_if_holiday(self, date, holidays):
+		date = getdate(date)
+		while date in holidays:
 			date = add_days(date, 1)
 		return date
 

--- a/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from datetime import date
+
 import frappe
 from frappe.utils import add_days, getdate
 
@@ -59,6 +61,32 @@ class TestEmployeeOnboarding(HRMSTestSuite):
 		employee.insert()
 		self.assertEqual(employee.employee_name, "Test Engineer")
 
+	def test_task_dates_skip_holidays(self):
+		boarding_begins_on = getdate()
+		onboarding = create_employee_onboarding(
+			boarding_begins_on=boarding_begins_on,
+			holidays=[
+				{"holiday_date": add_days(boarding_begins_on, 1), "description": "Test Holiday"},
+				{"holiday_date": add_days(boarding_begins_on, 2), "description": "Test Holiday"},
+				# half days are working days, so dates should not be pushed past them
+				{
+					"holiday_date": add_days(boarding_begins_on, 3),
+					"description": "Test Half Day Holiday",
+					"is_half_day": 1,
+				},
+			],
+		)
+
+		# first activity begins on day 0 and ends on day 1, which falls in the holiday block
+		start_date, end_date = get_task_dates(onboarding.activities[0].task)
+		self.assertEqual(start_date, boarding_begins_on)
+		self.assertEqual(end_date, add_days(boarding_begins_on, 3))
+
+		# second activity begins on day 1 and ends on day 2, both in the holiday block
+		start_date, end_date = get_task_dates(onboarding.activities[1].task)
+		self.assertEqual(start_date, add_days(boarding_begins_on, 3))
+		self.assertEqual(end_date, add_days(boarding_begins_on, 3))
+
 	def test_mark_onboarding_as_completed(self):
 		onboarding = create_employee_onboarding()
 
@@ -103,19 +131,24 @@ def get_job_offer(applicant_name):
 	return job_offer
 
 
-def create_employee_onboarding():
+def create_employee_onboarding(holidays: list | None = None, boarding_begins_on: date | str | None = None):
 	applicant = get_job_applicant()
 	job_offer = get_job_offer(applicant.name)
 
-	holiday_list = make_holiday_list("_Test Employee Boarding")
+	boarding_begins_on = getdate(boarding_begins_on)
+	holiday_list = make_holiday_list(
+		"_Test Employee Boarding", from_date=boarding_begins_on, to_date=add_days(boarding_begins_on, 30)
+	)
 	holiday_list = frappe.get_doc("Holiday List", holiday_list)
 	holiday_list.holidays = []
+	for holiday in holidays or []:
+		holiday_list.append("holidays", holiday)
 	holiday_list.save()
 
 	onboarding = frappe.new_doc("Employee Onboarding")
 	onboarding.job_applicant = applicant.name
 	onboarding.job_offer = job_offer.name
-	onboarding.date_of_joining = onboarding.boarding_begins_on = getdate()
+	onboarding.date_of_joining = onboarding.boarding_begins_on = boarding_begins_on
 	onboarding.company = "_Test Company"
 	onboarding.holiday_list = holiday_list.name
 	onboarding.designation = "Engineer"

--- a/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/test_employee_onboarding.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import date
 
 import frappe
@@ -87,6 +89,26 @@ class TestEmployeeOnboarding(HRMSTestSuite):
 		self.assertEqual(start_date, add_days(boarding_begins_on, 3))
 		self.assertEqual(end_date, add_days(boarding_begins_on, 3))
 
+	def test_holidays_are_fetched_in_a_single_query(self):
+		boarding_begins_on = getdate()
+		onboarding = create_employee_onboarding(
+			boarding_begins_on=boarding_begins_on,
+			holidays=[
+				{"holiday_date": add_days(boarding_begins_on, day), "description": "Test Holiday"}
+				for day in range(1, 8)
+			],
+		)
+		holiday_list = onboarding.get_holiday_list()
+
+		# dates walk over a week of holidays, but the holidays are read only once
+		with count_queries() as queries:
+			holidays = onboarding.get_upcoming_holidays(holiday_list)
+			for activity in onboarding.activities:
+				onboarding.get_task_dates(activity, holidays)
+
+		holiday_queries = [query for query in queries if "`tabHoliday`" in query]
+		self.assertEqual(len(holiday_queries), 1, msg="\n\n".join(holiday_queries))
+
 	def test_mark_onboarding_as_completed(self):
 		onboarding = create_employee_onboarding()
 
@@ -106,6 +128,23 @@ class TestEmployeeOnboarding(HRMSTestSuite):
 		self.assertEqual(project.status, "Completed")
 		for task_status in frappe.get_all("Task", dict(project=project.name), pluck="status"):
 			self.assertEqual(task_status, "Completed")
+
+
+@contextmanager
+def count_queries() -> Iterator[list[str]]:
+	"""Collect the queries fired inside the block, so N+1s can be asserted against."""
+	queries = []
+	original_sql = frappe.db.__class__.sql
+
+	def counting_sql(self, query, *args, **kwargs):
+		queries.append(str(query))
+		return original_sql(self, query, *args, **kwargs)
+
+	frappe.db.__class__.sql = counting_sql
+	try:
+		yield queries
+	finally:
+		frappe.db.__class__.sql = original_sql
 
 
 def get_job_applicant():


### PR DESCRIPTION
**Issue:**

- Submitting an Employee Onboarding or Employee Separation creates one task per activity, and each task's dates are pushed forward until they land on a working day. That check asks the database "is this a holiday?" one day at a time, and it runs twice for every activity. A template with many activities landing on a long holiday block fires hundreds of tiny queries on a single submit.

**Description:**

- Read the holidays once, up front, and reuse them for every activity instead of asking per day.

- Dates come out the same. Half days still count as working days, as before. Only the number of queries changes: many, down to one.

**Backport needed for V15 and V16**