### PR TITLE
feat: prevent attendance on future dates

### DIFF
--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -81,6 +81,7 @@ class Attendance(Document):
 		validate_status(self.status, ["Present", "Absent", "On Leave", "Half Day", "Work From Home"])
 		validate_active_employee(self.employee)
 		self.validate_attendance_date()
+		self.validate_future_date()
 		self.validate_duplicate_record()
 		self.validate_overlapping_shift_attendance()
 		self.validate_employee_status()
@@ -100,6 +101,13 @@ class Attendance(Document):
 					frappe.bold(format_date(date_of_joining)),
 				)
 			)
+
+	def validate_future_date(self):
+		if frappe.db.get_single_value("HR Settings", "allow_future_date_attendance"):
+			return
+
+		if getdate(self.attendance_date) > getdate() and self.status != "On Leave":
+			frappe.throw(_("Attendance cannot be marked for a future date."))
 
 	def validate_duplicate_record(self):
 		duplicate = self.get_duplicate_attendance_record()

--- a/hrms/hr/doctype/attendance/test_attendance.py
+++ b/hrms/hr/doctype/attendance/test_attendance.py
@@ -326,5 +326,60 @@ class TestAttendance(HRMSTestSuite):
 		attendance_records = frappe.get_all("Attendance", {"employee": employee2})
 		self.assertEqual(len(attendance_records), 1)
 
+	def test_future_date_attendance_restricted(self):
+		employee = make_employee("test_future_date_attendance@example.com", company="_Test Company")
+		future_date = add_days(nowdate(), 5)
+
+		frappe.db.set_single_value("HR Settings", "allow_future_date_attendance", 0)
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": future_date,
+				"status": "Present",
+				"company": "_Test Company",
+			}
+		)
+		self.assertRaises(frappe.ValidationError, attendance.insert)
+
+	def test_future_date_attendance_allowed_on_leave(self):
+		employee = make_employee("test_future_date_attendance_on_leave@example.com", company="_Test Company")
+		future_date = add_days(nowdate(), 5)
+
+		frappe.db.set_single_value("HR Settings", "allow_future_date_attendance", 0)
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": future_date,
+				"status": "On Leave",
+				"company": "_Test Company",
+			}
+		)
+		attendance.insert()
+		self.assertEqual(getdate(attendance.attendance_date), getdate(future_date))
+
+	def test_future_date_attendance_allowed_when_setting_enabled(self):
+		employee = make_employee(
+			"test_future_date_attendance_setting_enabled@example.com", company="_Test Company"
+		)
+		future_date = add_days(nowdate(), 5)
+
+		frappe.db.set_single_value("HR Settings", "allow_future_date_attendance", 1)
+
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": future_date,
+				"status": "Present",
+				"company": "_Test Company",
+			}
+		)
+		attendance.insert()
+		self.assertEqual(getdate(attendance.attendance_date), getdate(future_date))
+
 	def tearDown(self):
 		frappe.db.rollback()

--- a/hrms/hr/doctype/hr_settings/hr_settings.json
+++ b/hrms/hr/doctype/hr_settings/hr_settings.json
@@ -44,6 +44,7 @@
   "attendance_settings_section",
   "allow_employee_checkin_from_mobile_app",
   "allow_geolocation_tracking",
+  "allow_future_date_attendance",
   "tenure_tab",
   "employee_exit_settings_section",
   "exit_questionnaire_web_form",
@@ -295,6 +296,12 @@
    "label": "Allow Geolocation Tracking"
   },
   {
+   "default": "1",
+   "fieldname": "allow_future_date_attendance",
+   "fieldtype": "Check",
+   "label": "Allow Future Date Attendance"
+  },
+  {
    "fieldname": "attendance_settings_section",
    "fieldtype": "Section Break",
    "label": "Attendance Settings"
@@ -381,7 +388,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-06 13:01:43.187327",
+ "modified": "2026-08-22 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/hrms/hr/doctype/hr_settings/hr_settings.py
+++ b/hrms/hr/doctype/hr_settings/hr_settings.py
@@ -21,6 +21,7 @@ class HRSettings(Document):
 		from frappe.types import DF
 
 		allow_employee_checkin_from_mobile_app: DF.Check
+		allow_future_date_attendance: DF.Check
 		allow_geolocation_tracking: DF.Check
 		allow_multiple_shift_assignments: DF.Check
 		auto_leave_encashment: DF.Check


### PR DESCRIPTION
## What this does

Adds a new setting **Allow Future Date Attendance** in HR Settings. When turned off, users cannot create an Attendance record for a future date unless the status is On Leave. The default value is set to 1.

This fixes #5125.

## Test plan

- [ ] Turn off the new setting in HR Settings
- [ ] Try to save Attendance for a future date with status Present -> should show an error
- [ ] Try to save Attendance for a future date with status On Leave -> should save fine
- [ ] Turn on the setting and try again -> should save fine for any status



https://github.com/user-attachments/assets/0c12ee99-efc2-45fe-8028-9d69dd4059b5



no-docs