### PR TITLE
fix(pwa): show draft leave applications as draft instead of approved

### DIFF
--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -421,7 +421,17 @@ const status = computed(() => {
 		if (stateField) return formModel.value[stateField]
 	}
 
-	return formModel.value.status || formModel.value.approval_status
+	const rawStatus = formModel.value.status || formModel.value.approval_status
+
+	if (
+		props.doctype === "Leave Application" &&
+		!formModel.value.docstatus &&
+		["Approved", "Rejected"].includes(rawStatus)
+	) {
+		return "Draft"
+	}
+
+	return rawStatus
 })
 
 watch(

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -425,7 +425,7 @@ const status = computed(() => {
 
 	if (
 		props.doctype === "Leave Application" &&
-		!formModel.value.docstatus &&
+		formModel.value.docstatus === 0 &&
 		["Approved", "Rejected"].includes(rawStatus)
 	) {
 		return "Draft"

--- a/frontend/src/components/FormattedField.vue
+++ b/frontend/src/components/FormattedField.vue
@@ -75,6 +75,7 @@ const colorMap = {
 	Approved: "green",
 	Rejected: "red",
 	Open: "orange",
+	Draft: "red",
 }
 
 const getCoordinates = (value) => {

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -47,12 +47,18 @@ const props = defineProps({
 })
 
 const status = computed(() => {
-	return props.workflowStateField ? props.doc[props.workflowStateField] : props.doc.status
+	const rawStatus = props.workflowStateField
+		? props.doc[props.workflowStateField]
+		: props.doc.status
+
+	if (!props.doc.docstatus && ["Approved", "Rejected"].includes(rawStatus)) return "Draft"
+	return rawStatus
 })
 
 const colorMap = {
 	Approved: "green",
 	Rejected: "red",
 	Open: "orange",
+	Draft: "red",
 }
 </script>

--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -51,7 +51,7 @@ const status = computed(() => {
 		? props.doc[props.workflowStateField]
 		: props.doc.status
 
-	if (!props.doc.docstatus && ["Approved", "Rejected"].includes(rawStatus)) return "Draft"
+	if (props.doc.docstatus === 0 && ["Approved", "Rejected"].includes(rawStatus)) return "Draft"
 	return rawStatus
 })
 

--- a/frontend/src/components/RequestActionSheet.vue
+++ b/frontend/src/components/RequestActionSheet.vue
@@ -271,6 +271,14 @@ const fieldsWithValues = computed(() => {
 			}
 			field.value =
 				document?.doc?.[field.fieldname] || props.modelValue[field.fieldname]
+
+			if (
+				field.fieldname === approvalField.value &&
+				document?.doc?.docstatus === 0 &&
+				["Approved", "Rejected"].includes(field.value)
+			) {
+				field.value = "Draft"
+			}
 		}
 
 		return field.value

--- a/frontend/src/views/leave/List.vue
+++ b/frontend/src/views/leave/List.vue
@@ -26,6 +26,7 @@ const LEAVE_FIELDS = [
 	"to_date",
 	"total_leave_days",
 	"status",
+	"docstatus",
 ]
 const STATUS_FILTER_OPTIONS = ["Open", "Approved", "Rejected"] // __("Open"), __("Approved"), __("Rejected")
 const FILTER_CONFIG = [

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -358,6 +358,7 @@ def get_leave_applications(
 		"employee_name",
 		"leave_type",
 		"status",
+		"docstatus",
 		"from_date",
 		"to_date",
 		"half_day",


### PR DESCRIPTION
## Summary
- The mobile app (PWA) was showing the raw `status` field for Leave Applications, so a draft (unsubmitted) record with `status` set to Approved or Rejected appeared as Approved in the app.
- The desk list view already handles this correctly by treating the status as Draft when the document has not been submitted (`docstatus` is 0). This change applies the same logic on the mobile app side, in the leave list item and the leave detail view.
- Also added `docstatus` to the fields returned by `get_leave_applications` so the mobile app has the data needed to make this check.

**Before:**
<img width="2424" height="2694" alt="image" src="https://github.com/user-attachments/assets/c8220d78-6804-4e07-9c78-49cbd9923b5e" />
<img width="756" height="1360" alt="image" src="https://github.com/user-attachments/assets/e575e181-c13e-4a41-b5cd-a729c097962f" />

**After:**
<img width="2874" height="2713" alt="image" src="https://github.com/user-attachments/assets/794fc02b-642a-4324-9fd6-571fe8eed181" />
<img width="742" height="1152" alt="image" src="https://github.com/user-attachments/assets/e509618c-cabf-4950-bc69-53b2ed58fc80" />
