### PR TITLE
fix(payroll): resolve every salary slip field in component formulas

### DIFF
--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -344,10 +344,10 @@ class SalaryStructureAssignment(Document):
 
 		data = get_component_eval_context(self.employee, self.as_dict())
 
-		# The SSA has no salary slip, so formulas referencing slip period fields (e.g.
-		# start_date) would raise NameError. Seed a full cycle -- the period containing
-		# from_date -- with no LWP/absence so proration-based formulas yield full-cycle
-		# values (payment_days == total_working_days, ratio 1).
+		# The SSA has no salary slip, so slip fields only carry their defaults here.
+		# Seed a full cycle -- the period containing from_date -- with no LWP/absence
+		# so proration-based formulas yield full-cycle values (payment_days ==
+		# total_working_days, ratio 1) rather than the zeroed defaults.
 		frequency = frappe.get_cached_value("Salary Structure", self.salary_structure, "payroll_frequency")
 		dates = get_start_end_dates(frequency, self.from_date, self.company)
 		period_days = date_diff(dates.end_date, dates.start_date) + 1

--- a/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
@@ -7,6 +7,7 @@ from frappe.utils import get_first_day, nowdate
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+from hrms.payroll.utils import get_salary_slip_eval_defaults
 from hrms.tests.utils import HRMSTestSuite
 
 
@@ -168,6 +169,55 @@ class TestSalaryStructureAssignment(HRMSTestSuite):
 
 		components = {r.salary_component: r.default_amount for r in ssa.get_evaluated_components().deductions}
 		self.assertEqual(components["SSA Test YTD Guard"], 50000)
+
+	def test_salary_slip_eval_defaults_cover_every_slip_field(self):
+		"""The seeded field set is derived from the Salary Slip meta, so it covers
+		fields outside the previously hard-coded list -- including custom fields,
+		which cannot be enumerated ahead of time."""
+		defaults = get_salary_slip_eval_defaults()
+		meta = frappe.get_meta("Salary Slip")
+
+		for field in meta.fields:
+			if field.fieldtype in ("Currency", "Float", "Int", "Percent", "Check"):
+				self.assertIn(field.fieldname, defaults)
+				self.assertEqual(defaults[field.fieldname], 0)
+
+		# layout and table fieldtypes hold no value and must stay out of the context
+		self.assertNotIn("earnings", defaults)
+		self.assertNotIn("deductions", defaults)
+
+	def test_get_evaluated_components_resolves_slip_fields_outside_hardcoded_set(self):
+		"""A formula may reference a slip field that the SSA pre-pass does not seed
+		explicitly and that is not one of the totals (here base_gross_pay). It must
+		resolve to its default instead of raising a NameError."""
+		emp = make_employee("ssa_unseeded_field@test.com", company="_Test Company")
+
+		formula = "base + base_gross_pay"
+		_make_component(
+			"SSA Test Unseeded Field", "SSATUF", "Earning", amount_based_on_formula=1, formula=formula
+		)
+		earnings = [
+			{
+				"salary_component": "SSA Test Unseeded Field",
+				"abbr": "SSATUF",
+				"amount_based_on_formula": 1,
+				"formula": formula,
+			},
+		]
+
+		make_salary_structure(
+			"SSA Test Unseeded Field Structure",
+			"Monthly",
+			employee=emp,
+			company="_Test Company",
+			base=50000,
+			earnings=earnings,
+			deductions=[],
+		)
+		ssa = frappe.get_last_doc("Salary Structure Assignment", filters={"employee": emp})
+
+		components = {r.salary_component: r.default_amount for r in ssa.get_evaluated_components().earnings}
+		self.assertEqual(components["SSA Test Unseeded Field"], 50000)
 
 	def test_do_not_include_in_total_earning_is_in_ctc_but_not_gross(self):
 		"""A 'Do Not Include in Total' earning is part of CTC but not payable - it

--- a/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
+++ b/hrms/payroll/doctype/salary_structure_assignment/test_salary_structure_assignment.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.model import numeric_fieldtypes
 from frappe.utils import get_first_day, nowdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
@@ -178,7 +179,7 @@ class TestSalaryStructureAssignment(HRMSTestSuite):
 		meta = frappe.get_meta("Salary Slip")
 
 		for field in meta.fields:
-			if field.fieldtype in ("Currency", "Float", "Int", "Percent", "Check"):
+			if field.fieldtype in numeric_fieldtypes:
 				self.assertIn(field.fieldname, defaults)
 				self.assertEqual(defaults[field.fieldname], 0)
 

--- a/hrms/payroll/utils.py
+++ b/hrms/payroll/utils.py
@@ -61,41 +61,52 @@ def get_component_abbr_map() -> dict:
 	return frappe.cache().get_value("salary_component_values", generator=_fetch_component_values)
 
 
-SALARY_SLIP_EVAL_DEFAULTS = {
-	"gross_pay": 0,
-	"net_pay": 0,
-	"total_deduction": 0,
-	"rounded_total": 0,
-	"total_working_hours": 0,
-	"hour_rate": 0,
-	"year_to_date": 0,
-	"month_to_date": 0,
-	"gross_year_to_date": 0,
-	"ctc": 0,
-	"total_earnings": 0,
-	"income_from_other_sources": 0,
-	"non_taxable_earnings": 0,
-	"deductions_before_tax_calculation": 0,
-	"tax_exemption_declaration": 0,
-	"standard_tax_exemption_amount": 0,
-	"annual_taxable_amount": 0,
-	"income_tax_deducted_till_date": 0,
-	"future_income_tax_deductions": 0,
-	"current_month_income_tax": 0,
-	"total_income_tax": 0,
+NUMERIC_FIELDTYPES = {"Currency", "Float", "Int", "Percent", "Check"}
+
+# Fieldtypes that hold no value of their own and must stay out of the formula context.
+NON_VALUE_FIELDTYPES = {
+	"Button",
+	"Column Break",
+	"Fold",
+	"Heading",
+	"HTML",
+	"Image",
+	"Section Break",
+	"Tab Break",
+	"Table",
+	"Table MultiSelect",
 }
+
+
+def get_salary_slip_eval_defaults() -> dict:
+	"""Zero/empty default for every Salary Slip field.
+
+	A formula may reference any Salary Slip field, including a custom one, but the
+	value is not always available when the formula is evaluated: the Salary Structure
+	Assignment pre-pass runs before a slip exists at all. Seeding a default keeps such
+	a formula evaluable instead of failing with a misleading NameError.
+
+	These are only defaults. The real value overrides them whenever there is one --
+	the salary slip overlays its own fields, and the assignment pre-pass seeds the
+	period fields it can derive.
+	"""
+	return {
+		field.fieldname: 0 if field.fieldtype in NUMERIC_FIELDTYPES else ""
+		for field in frappe.get_meta("Salary Slip").fields
+		if field.fieldname and field.fieldtype not in NON_VALUE_FIELDTYPES
+	}
 
 
 def get_component_eval_context(employee: str, ssa_as_dict: dict) -> frappe._dict:
 	"""Build the base evaluation context for salary component formulas.
 
-	Merges component abbreviation defaults, Salary Structure Assignment fields
-	(base, variable, ...) and employee fields so that formulas can reference any
-	of them by name.
+	Merges component abbreviation defaults, Salary Slip field defaults, Salary
+	Structure Assignment fields (base, variable, ...) and employee fields so that
+	formulas can reference any of them by name.
 	"""
 	data = frappe._dict()
 	data.update(get_component_abbr_map())
-	data.update(SALARY_SLIP_EVAL_DEFAULTS)
+	data.update(get_salary_slip_eval_defaults())
 	data.update(ssa_as_dict)
 	data.update(frappe.get_cached_doc("Employee", employee).as_dict())
 	return data

--- a/hrms/payroll/utils.py
+++ b/hrms/payroll/utils.py
@@ -3,6 +3,7 @@ from datetime import date
 
 import frappe
 from frappe import _
+from frappe.model import no_value_fields, numeric_fieldtypes
 from frappe.utils import ceil, floor, get_first_day, get_last_day, get_link_to_form, getdate, rounded
 
 
@@ -61,23 +62,6 @@ def get_component_abbr_map() -> dict:
 	return frappe.cache().get_value("salary_component_values", generator=_fetch_component_values)
 
 
-NUMERIC_FIELDTYPES = {"Currency", "Float", "Int", "Percent", "Check"}
-
-# Fieldtypes that hold no value of their own and must stay out of the formula context.
-NON_VALUE_FIELDTYPES = {
-	"Button",
-	"Column Break",
-	"Fold",
-	"Heading",
-	"HTML",
-	"Image",
-	"Section Break",
-	"Tab Break",
-	"Table",
-	"Table MultiSelect",
-}
-
-
 def get_salary_slip_eval_defaults() -> dict:
 	"""Zero/empty default for every Salary Slip field.
 
@@ -89,11 +73,14 @@ def get_salary_slip_eval_defaults() -> dict:
 	These are only defaults. The real value overrides them whenever there is one --
 	the salary slip overlays its own fields, and the assignment pre-pass seeds the
 	period fields it can derive.
+
+	The fieldtype sets come from the framework rather than a local list, so a
+	fieldtype added upstream is classified without another edit here.
 	"""
 	return {
-		field.fieldname: 0 if field.fieldtype in NUMERIC_FIELDTYPES else ""
+		field.fieldname: 0 if field.fieldtype in numeric_fieldtypes else ""
 		for field in frappe.get_meta("Salary Slip").fields
-		if field.fieldname and field.fieldtype not in NON_VALUE_FIELDTYPES
+		if field.fieldname and field.fieldtype not in no_value_fields
 	}
 
 


### PR DESCRIPTION
Fixes #5057. Also reported as #5141.

A salary component formula may reference any Salary Slip field, but the evaluation
context seeded only 21 hard-coded totals. Referencing any other slip field fails at
salary slip creation with:

```
Error while evaluating the Salary Structure <name> at row N.
Error: name 'custom_worked_hours' is not defined
Hint: This error can be due to missing or deleted field.
```

The hint is misleading — the field exists, and so does its column.

## Details

`SALARY_SLIP_EVAL_DEFAULTS` in `hrms/payroll/utils.py` listed 21 fieldnames, all
totals. It became load-bearing when component evaluation moved to a pre-pass on the
Salary Structure Assignment, which runs before any slip exists — so the pre-pass had
to hand-seed seven more fields (`start_date`, `end_date`, `payment_days`,
`total_working_days`, `leave_without_pay`, `absent_days`, `unmarked_days`) for
exactly this reason. Its comment named the hazard but only for the fields it needed.

That leaves two incomplete lists and 34 of the doctype's own value-bearing fields
uncovered. It is not only custom fields: `base_gross_pay`, `exchange_rate`,
`base_net_pay` and the loan fields this app installs itself
(`total_principal_amount`, via `get_salary_slip_loan_fields`) all raise the same
NameError today.

The intended contract is already written down in this repo, in
`test_get_evaluated_components_resolves_salary_slip_fields`:

> SSA evaluation has no slip, so it must mirror a full-cycle preview slip's field
> set; otherwise the formula raises a NameError on the missing slip field.

A literal list cannot mirror a field set that includes custom fields.

## Change

Replace the literal with `get_salary_slip_eval_defaults()`, which derives the
defaults from `frappe.get_meta("Salary Slip")`: `0` for numeric fieldtypes, `""`
otherwise, skipping layout and table fieldtypes. `frappe.get_meta` is already cached
and invalidated on custom field changes, so no separate cache is introduced.

The SSA pre-pass keeps seeding the period values — those are needed for correct
full-cycle proration, not just to avoid a NameError — and its comment is updated to
say so.

## Compatibility

The derived map is a strict superset of the previous literal: all 21 fieldnames are
real Salary Slip fields of type Currency or Float, so each still defaults to `0`.
Precedence in `get_component_eval_context` is untouched — assignment fields, then
employee fields, override these defaults, as do the pre-pass period values and the
slip's own `as_dict()` overlay. So a formula that resolved before resolves to the
same value; only formulas that previously raised now evaluate.

## Verification

- New `test_get_evaluated_components_resolves_slip_fields_outside_hardcoded_set`
  covers a slip field outside both lists (`base_gross_pay`), which is the case that
  fails on `develop`.
- New `test_salary_slip_eval_defaults_cover_every_slip_field` asserts every numeric
  slip field is seeded and that table fieldtypes are excluded, so the coverage
  cannot silently regress to a literal list again.
- Verified offline against the real doctype metadata: 64 fields seeded vs 21; all 21
  previous entries preserved as `0`; layout and table fieldtypes excluded; the
  reported `custom_worked_hours * 100` evaluates; and assignment, employee, and
  explicit period values still win over the defaults.
- `ruff check` and `ruff format --check` clean on all three files.

I could not run the integration suite locally (no bench), so the two new tests have
not been executed — happy to adjust if CI disagrees.

One note: #5105 also edits `get_component_eval_context`, one line below this change.
It touches the employee lookup rather than the defaults, so there is no overlap in
intent, but whichever lands second will need a trivial rebase.
