### PR TITLE
fix(pwa): load translations from the endpoint frappe v17 exposes

### DIFF
--- a/frontend/src/plugins/translationsPlugin.js
+++ b/frontend/src/plugins/translationsPlugin.js
@@ -14,14 +14,15 @@ function makeTranslationFunction() {
 			return;
 		}
 
-		const url = new URL("/api/method/frappe.translate.load_all_translations", location.origin);
+		const url = new URL("/api/method/frappe.translate.get_boot_translations", location.origin);
 		url.searchParams.append("lang", window.frappe?.boot?.lang ?? navigator.language);
-		url.searchParams.append("hash", window.frappe?.boot?.translations_hash || window._version_number || Math.random()); // for cache busting
-		// url.searchParams.append("app", "hrms");
+		url.searchParams.append("hash", window.frappe?.boot?.translations_version || window._version_number || Math.random()); // for cache busting
 
 		try {
 			const response = await fetch(url);
-			messages = await response.json() || {}
+			const data = await response.json();
+			// whitelisted methods wrap their return value in `message`
+			messages = data?.message ?? data ?? {}
 		} catch (error) {
 			console.error("Failed to fetch translations:", error)
 		}


### PR DESCRIPTION
## Problem

The PWA fetches `frappe.translate.load_all_translations`, which no longer exists in frappe v17:

```
{"exception":"frappe.exceptions.ValidationError: ... module 'frappe.translate' has no attribute 'load_all_translations'"}
```

The request throws, the `catch` in `translationsPlugin.js` swallows it, and `messages` stays `{}` — so the PWA renders untranslated English regardless of what the user or the site is set to. The desk at `/desk` is translated; `/hrms` is not.

### To reproduce

1. Set a site and a user to any non-English language.
2. Open `/hrms`.
3. Everything renders in English. The console shows `Failed to fetch translations:`.

## Fix

v17 exposes `frappe.translate.get_boot_translations` instead. Two follow-on details:

- It is whitelisted, so the payload arrives under `message` — unwrapped here.
- The cache-busting token now reads `boot.translations_version`, the key the server actually sends. `boot.translations_hash` was always `undefined`, so it silently fell through to `Math.random()` and defeated the HTTP cache on every load. The endpoint is decorated with `@http_cache(max_age=31536000)`, and the payload is ~2.4 MB, so this was re-downloading it on every page load.

## Verified

Against a site running in Lao: the home screen, quick links, bottom tabs and request statuses all render translated. The response is a single cached fetch instead of one per load.

Before:

```
Leaves · Expense Claims · Salary Slips · Check In
```

After:

```
ການລາພັກ · ການເບີກຄ່າໃຊ້ຈ່າຍ · ໃບແຈ້ງເງິນເດືອນ · ລົງເວລາເຂົ້າ
```
