### PR TITLE
fix(expense_claim): skip reference field patch if payment_entry column is missing

### DIFF
--- a/hrms/patches/v16_0/set_reference_fields_in_expense_claim_advance.py
+++ b/hrms/patches/v16_0/set_reference_fields_in_expense_claim_advance.py
@@ -3,6 +3,9 @@ from frappe.query_builder.functions import IfNull
 
 
 def execute():
+	if not frappe.db.has_column("Expense Claim Advance", "payment_entry"):
+		return
+
 	ExpenseClaimAdvance = frappe.qb.DocType("Expense Claim Advance")
 
 	(


### PR DESCRIPTION

- `payment_entry` existed only on an intermediate v16 schema of **Expense Claim Advance**. Sites that skipped that window fail migrate with `Unknown column 'payment_entry'`.
- Skip the backfill when the column is absent. Sites that still have it continue to copy values into _Reference Name_ / _Reference Type_.

## Test plan
- [x] Run migrate on a site that never had `payment_entry` on **Expense Claim Advance**; the patch should succeed without error.
- [ ] Run migrate on a site that still has the `payment_entry` column; rows with a payment entry and empty `reference_name` should be backfilled as "Payment Entry".

> no-docs