### PR TITLE
fix: allow single-day leave allocation

### DIFF
--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -210,7 +210,7 @@ class LeaveAllocation(Document):
 			)
 
 	def validate_period(self):
-		if date_diff(self.to_date, self.from_date) <= 0:
+		if date_diff(self.to_date, self.from_date) < 0:
 			frappe.throw(_("To date cannot be before from date"))
 
 	def validate_lwp(self):

--- a/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -62,6 +62,24 @@ class TestLeaveAllocation(HRMSTestSuite):
 		# invalid period
 		self.assertRaises(frappe.ValidationError, doc.save)
 
+	def test_single_day_allocation(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Leave Allocation",
+				"__islocal": 1,
+				"employee": self.employee.name,
+				"employee_name": self.employee.employee_name,
+				"leave_type": "_Test Leave Type",
+				"from_date": getdate("2015-09-1"),
+				"to_date": getdate("2015-09-1"),
+				"new_leaves_allocated": 1,
+			}
+		)
+
+		# from_date and to_date on the same day should be allowed
+		doc.save()
+		self.assertEqual(doc.from_date, doc.to_date)
+
 	def test_validation_for_over_allocation(self):
 		leave_type = create_leave_type(leave_type_name="Test Over Allocation", is_carry_forward=1)
 


### PR DESCRIPTION
## Problem
`validate_period` used `date_diff(self.to_date, self.from_date) <= 0`, which incorrectly
rejected single-day allocations (from_date == to_date, diff = 0) with
"To date cannot be before from date".

## Use case
HR often needs to grant leave for a single specific day — e.g., compensatory
off (comp-off) credited for working on a holiday/weekend, where from_date and
to_date are the same date. Previously this was blocked by validation even
though the range wasn't actually inverted.

## Fix
Changed the check to `< 0` so only to_date before from_date is rejected; same-day
allocations are now allowed.

## Test
Added a test creating a Leave Allocation with from_date == to_date and asserting it saves.

Before:

[HRMS_before.webm](https://github.com/user-attachments/assets/5f449435-64e6-4fc9-a6c8-3c9679487124)

After:

[HRMS_after.webm](https://github.com/user-attachments/assets/84b18950-262a-4f9b-91e3-a884feeebf09)

Backport Needed : v15,v16