### PR TITLE
fix: display correct leave application status

### DIFF
--- a/frontend/src/components/LeaveRequestItem.vue
+++ b/frontend/src/components/LeaveRequestItem.vue
@@ -47,7 +47,12 @@ const props = defineProps({
 })
 
 const status = computed(() => {
-	return props.workflowStateField ? props.doc[props.workflowStateField] : props.doc.status
+	if (props.doc.docstatus === 0) return "Draft"
+	if (props.doc.docstatus === 2) return "Cancelled"
+
+	return props.workflowStateField
+		? props.doc[props.workflowStateField]
+		: props.doc.status
 })
 
 const colorMap = {


### PR DESCRIPTION
Fixes an issue where a Draft Leave Application was shown as Approved in the PWA.

Now, Draft Leave Applications are shown as Draft.