### PR TITLE
fix: handle zero payment days in payroll correction

### DIFF
--- a/hrms/payroll/doctype/payroll_correction/payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/payroll_correction.py
@@ -203,6 +203,17 @@ class PayrollCorrection(Document):
 			else:
 				total_working_days = salary_slip.get("total_working_days", 1)
 
+			if not total_working_days:
+				frappe.throw(
+					_(
+						"Cannot calculate payroll correction for salary component {0} because salary slip {1} has zero {2}."
+					).format(
+						frappe.bold(component),
+						frappe.bold(salary_slip.name),
+						_("payment days") if component_data.get("accrual_component") else _("working days"),
+					)
+				)
+
 			per_day_amount = flt(component_data["default_amount"] / total_working_days)
 			arrear_amount = flt(per_day_amount * self.days_to_reverse)
 

--- a/hrms/payroll/doctype/payroll_correction/test_payroll_correction.py
+++ b/hrms/payroll/doctype/payroll_correction/test_payroll_correction.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 import calendar
+from unittest.mock import patch
 
 import frappe
+from frappe import ValidationError
 from frappe.utils import add_days, flt
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
@@ -103,3 +105,38 @@ class TestPayrollCorrection(HRMSTestSuite):
 				},
 			)
 		)
+
+	def test_payroll_correction_with_zero_payment_days(self):
+		payroll_correction_doc = frappe.get_doc(
+			{
+				"doctype": "Payroll Correction",
+				"employee": "EMP-0001",
+				"payroll_period": "Test Payroll Period",
+				"payroll_date": "2025-02-01",
+				"company": "_Test Company",
+				"days_to_reverse": 1,
+				"month_for_lwp_reversal": "January",
+				"salary_slip_reference": "SAL-SLIP-ZERO-PAYMENT-DAYS",
+			}
+		)
+
+		salary_slip = frappe._dict(
+			{
+				"name": "SAL-SLIP-ZERO-PAYMENT-DAYS",
+				"payment_days": 0,
+				"total_working_days": 30,
+				"earnings": [],
+				"deductions": [],
+				"accrued_benefits": [
+					frappe._dict({"salary_component": "Mediclaim Allowance", "amount": 2000})
+				],
+			}
+		)
+		salary_slip.precision = lambda fieldname: 2
+
+		with (
+			patch("frappe.get_doc", return_value=salary_slip),
+			patch("frappe.db.get_list", return_value=["Mediclaim Allowance"]),
+			self.assertRaisesRegex(ValidationError, "zero payment days"),
+		):
+			payroll_correction_doc.populate_breakup_table()


### PR DESCRIPTION
**Description:** Prevents Payroll Correction from raising a `ZeroDivisionError` when reversing LWP for a salary slip where the full period is Leave Without Pay and `payment_days` is `0`.

Instead of dividing by zero while calculating accrued benefit arrears, Payroll Correction now shows a clear validation message when the salary slip has zero payment days or working days.

Closes: #5147 


**Before:**

[Screencast from 2026-08-28 12-40-36.webm](https://github.com/user-attachments/assets/22387f44-e859-429e-ab35-bbe73ac6b96f)


**After:**

[Screencast from 2026-08-28 12-31-43.webm](https://github.com/user-attachments/assets/a84a5897-9e3d-4517-91f6-c1d7a3184cce)
