### PR TITLE
fix: handle empty component tables in salary slip eval

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -1386,7 +1386,7 @@ class SalarySlip(TransactionBase):
 		default_data = data.copy()
 
 		for key in COMPONENT_PARENTFIELDS:
-			for d in self.get(key):
+			for d in self.get(key) or []:
 				default_data[d.abbr] = d.default_amount or 0
 				data[d.abbr] = d.amount or 0
 


### PR DESCRIPTION
**Description:** Prevents Salary Slip creation from failing when component child tables are empty during formula evaluation.

The salary slip eval context now safely handles empty `earnings`, `deductions`, or `employer_contributions` tables by treating them as empty lists.


**Before:**

[Screencast from 2026-08-28 13-00-47.webm](https://github.com/user-attachments/assets/73e23193-1da9-4324-beb3-eeec67ec3092)


**After:**

[Screencast from 2026-08-28 13-03-44.webm](https://github.com/user-attachments/assets/497f7035-273f-422b-b298-981edbeaec7f)
