### PR TITLE
fix: update employee permission filters in payroll entry

### DIFF
--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1461,16 +1461,30 @@ def set_filter_conditions(query, filters, qb_object):
 
 def set_match_conditions(query, qb_object):
 	match_conditions = get_match_cond("Employee", as_condition=False)
+	employee_permission_fields = get_employee_permission_fields()
 
 	for cond in match_conditions:
 		if isinstance(cond, dict):
 			for key, value in cond.items():
+				fieldname = employee_permission_fields.get(key)
+				if not fieldname:
+					continue
+
 				if isinstance(value, list):
-					query = query.where(qb_object[key].isin(value))
+					query = query.where(qb_object[fieldname].isin(value))
 				else:
-					query = query.where(qb_object[key] == value)
+					query = query.where(qb_object[fieldname] == value)
 
 	return query
+
+
+def get_employee_permission_fields():
+	permission_fields = {"Employee": "name"}
+	for df in frappe.get_meta("Employee").get_link_fields():
+		if not df.get("ignore_user_permissions"):
+			permission_fields[df.options] = df.fieldname
+
+	return permission_fields
 
 
 def remove_payrolled_employees(emp_list, start_date, end_date):

--- a/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from unittest.mock import patch
+
 from dateutil.relativedelta import relativedelta
 
 import frappe
@@ -18,6 +20,7 @@ from hrms.payroll.doctype.payroll_entry.payroll_entry import (
 	PayrollEntry,
 	get_end_date,
 	get_start_end_dates,
+	set_match_conditions,
 )
 from hrms.payroll.doctype.salary_component.test_salary_component import create_salary_component
 from hrms.payroll.doctype.salary_slip.salary_slip_loan_utils import if_lending_app_installed
@@ -1184,6 +1187,22 @@ class TestPayrollEntry(HRMSTestSuite):
 		payroll_entry.discard()
 		payroll_entry.reload()
 		self.assertEqual(payroll_entry.status, "Cancelled")
+
+	def test_set_match_conditions_maps_permission_doctype_to_employee_field(self):
+		employee = frappe.qb.DocType("Employee")
+		query = frappe.qb.from_(employee).select(employee.name)
+
+		with patch(
+			"hrms.payroll.doctype.payroll_entry.payroll_entry.get_match_cond",
+			return_value=[{"Employee Grade": ["A"], "Unknown Doctype": ["Ignored"]}],
+		):
+			query = set_match_conditions(query, employee)
+
+		query_sql = query.get_sql()
+		self.assertIn("grade", query_sql)
+		self.assertIn("'A'", query_sql)
+		self.assertNotIn("Employee Grade", query_sql)
+		self.assertNotIn("Unknown Doctype", query_sql)
 
 
 def get_payroll_entry(**args):


### PR DESCRIPTION
**Description:** Update Payroll Entry employee filtering when user permissions are defined against linked Employee fields such as Employee Grade.

Closes: #5028 

**Before:**

[Screencast from 2026-08-28 20-35-28.webm](https://github.com/user-attachments/assets/aa444658-522f-4937-9f7d-5ba158d9a0a2)


**After:** 

[Screencast from 2026-08-28 20-34-23.webm](https://github.com/user-attachments/assets/d7ecfb85-b8d5-4a46-b98d-eab66e8ab72e)
