### PR TITLE
fix: use get_component_totals in set_totals for consistent net pay calculation

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2038,13 +2038,8 @@ class SalarySlip(TransactionBase):
 		if self.salary_slip_based_on_timesheet == 1:
 			self.calculate_total_for_salary_slip_based_on_timesheet()
 		else:
-			self.total_deduction = 0.0
-			if hasattr(self, "earnings"):
-				for earning in self.earnings:
-					self.gross_pay += flt(earning.amount, earning.precision("amount"))
-			if hasattr(self, "deductions"):
-				for deduction in self.deductions:
-					self.total_deduction += flt(deduction.amount, deduction.precision("amount"))
+			self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
+			self.total_deduction = self.get_component_totals("deductions")
 			self.net_pay = (
 				flt(self.gross_pay) - flt(self.total_deduction) - flt(self.get("total_loan_repayment"))
 			)


### PR DESCRIPTION
## Problem

`set_totals()` is triggered from the client on every amount edit in the Salary Slip form. It computes `net_pay` by looping raw row amounts — no payment-days pro-ration applied.

`set_net_pay()`, called during `validate()`, uses `get_component_totals()` which correctly applies payment-day pro-ration per component.

For employees joining mid-month, `total_in_words` displayed on the form while editing is computed from an unprorated `net_pay`, while the value saved after `validate()` uses the prorated figure.

## Root Cause

`set_totals()` was using a raw loop over `self.earnings` / `self.deductions` instead of `get_component_totals()`, diverging from `set_net_pay()`.

## Fix

Replaced the raw loop with `get_component_totals()` calls, consistent with `set_net_pay()`:

```python
self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
self.total_deduction = self.get_component_totals("deductions")
```

## Changes
- `salary_slip.py`: replaced raw loop in `set_totals()` with `get_component_totals()` calls

## Testing
- Tested on v15 with mid-month joining employee
- `total_in_words` on form now matches value saved after validate