### PR TITLE
fix: use get_component_totals in set_totals for consistent net pay calculation

### DIFF
--- a/hrms/__init__.py
+++ b/hrms/__init__.py
@@ -1,6 +1,6 @@
 import frappe
 
-__version__ = "15.63.2"
+__version__ = "15.63.3"
 
 
 def refetch_resource(cache_key: str | list, user=None):

--- a/hrms/__init__.py
+++ b/hrms/__init__.py
@@ -1,6 +1,6 @@
 import frappe
 
-__version__ = "15.63.1"
+__version__ = "15.63.2"
 
 
 def refetch_resource(cache_key: str | list, user=None):

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2038,13 +2038,8 @@ class SalarySlip(TransactionBase):
 		if self.salary_slip_based_on_timesheet == 1:
 			self.calculate_total_for_salary_slip_based_on_timesheet()
 		else:
-			self.total_deduction = 0.0
-			if hasattr(self, "earnings"):
-				for earning in self.earnings:
-					self.gross_pay += flt(earning.amount, earning.precision("amount"))
-			if hasattr(self, "deductions"):
-				for deduction in self.deductions:
-					self.total_deduction += flt(deduction.amount, deduction.precision("amount"))
+			self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
+			self.total_deduction = self.get_component_totals("deductions")
 			self.net_pay = (
 				flt(self.gross_pay) - flt(self.total_deduction) - flt(self.get("total_loan_repayment"))
 			)

--- a/hrms/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/test_salary_slip.py
@@ -3229,3 +3229,33 @@ def clear_cache():
 		TAX_COMPONENTS_BY_COMPANY,
 	]:
 		frappe.cache().delete_value(key)
+
+	def test_set_totals_consistent_with_set_net_pay_for_partial_payment_days(self):
+		from datetime import timedelta
+
+		from frappe.utils import get_first_day, nowdate
+
+		employee = make_employee(
+			"test_partial_days@example.com",
+			date_of_joining=get_first_day(nowdate()) + timedelta(days=14),
+		)
+		salary_structure = make_salary_structure(
+			"Test Structure Partial Days",
+			"Monthly",
+			employee=employee,
+			include_payment_days_based_components=True,
+		)
+
+		ss = make_salary_slip(salary_structure.name, employee=employee)
+		ss.insert()
+
+		ss.calculate_net_pay()
+		expected_net_pay = flt(ss.net_pay, ss.precision("net_pay"))
+		expected_words = ss.total_in_words
+
+		ss.reload()
+		ss.set_totals()
+
+		self.assertEqual(flt(ss.net_pay, ss.precision("net_pay")), expected_net_pay)
+		self.assertEqual(ss.total_in_words, expected_words)
+


### PR DESCRIPTION
## Problem

`set_totals()` is triggered from the client on every amount edit in the Salary Slip form. It computes `net_pay` by looping raw row amounts — no payment-days pro-ration applied.

`set_net_pay()`, called during `validate()`, uses `get_component_totals()` which correctly applies payment-day pro-ration per component.

For employees joining mid-month, `total_in_words` displayed on the form while editing is computed from an unprorated `net_pay`, while the value saved after `validate()` uses the prorated figure.

## Root Cause

`set_totals()` was using a raw loop over `self.earnings` / `self.deductions` instead of `get_component_totals()`, diverging from `set_net_pay()`.

## Fix

```python
self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
self.total_deduction = self.get_component_totals("deductions")
```

## Changes
- `salary_slip.py`: replaced raw loop in `set_totals()` with `get_component_totals()` calls

## Testing
- Tested on v15 with mid-month joining employee
- `total_in_words` on form now matches value saved after validate