### PR TITLE
fix: use server time for employee checkin

### DIFF
--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -212,6 +212,7 @@ function handleModalDismiss() {
 
 const submitLog = (logType) => {
 	const actionLabel = logType === "IN" ? __("Check-in") : __("Check-out")
+	stopLiveClock()
 
 	checkins.insert.submit(
 		{
@@ -221,16 +222,20 @@ const submitLog = (logType) => {
 			longitude: longitude.value,
 		},
 		{
-			onSuccess() {
+			onSuccess(data) {
 				isModalOpen.value = false
-				stopLiveClock()
+				const recordedTime = data?.time ? dayjs(data.time).format("hh:mm:ss a") : null
+
 				toast({
 					title: __("Success"),
-					text: __("{0} successful!", [actionLabel]),
+					text: recordedTime
+						? __("{0} recorded at {1}", [actionLabel, recordedTime])
+						: __("{0} successful!", [actionLabel]),
 					icon: "check-circle",
 					position: "bottom-center",
 					iconClasses: "text-green-500",
 				})
+				checkins.reload() // ensure lastLog reflects the just-created record immediately
 			},
 			onError(error) {
 				let messages = error.messages || []

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -29,7 +29,7 @@
 		</template>
 
 		<div v-else class="font-medium text-sm text-gray-500 mt-1.5">
-			{{ dayjs().format("ddd, D MMMM, YYYY") }}
+			{{ serverNow ? dayjs(serverNow).format("ddd, D MMMM, YYYY") : "" }}
 		</div>
 	</div>
 
@@ -43,10 +43,10 @@
 		<div class="h-120 w-full flex flex-col items-center justify-center gap-5 p-4 mb-5">
 			<div class="flex flex-col gap-1.5 mt-2 items-center justify-center">
 				<div class="font-bold text-xl">
-					{{ dayjs(checkinTimestamp).format("hh:mm:ss a") }}
+					{{ checkinTimestamp ? dayjs(checkinTimestamp).format("hh:mm:ss a") : "" }}
 				</div>
 				<div class="font-medium text-gray-500 text-sm">
-					{{ dayjs().format("D MMM, YYYY") }}
+					{{ checkinTimestamp ? dayjs(checkinTimestamp).format("D MMM, YYYY") : "" }}
 				</div>
 			</div>
 
@@ -90,6 +90,7 @@ const DOCTYPE = "Employee Checkin"
 const socket = inject("$socket")
 const employee = inject("$employee")
 const dayjs = inject("$dayjs")
+const serverNow = ref(null)
 const __ = inject("$translate")
 const checkinTimestamp = ref(null)
 const latitude = ref(0)
@@ -144,9 +145,30 @@ const fetchLocation = () => {
 		navigator.geolocation.getCurrentPosition(handleLocationSuccess, handleLocationError)
 	}
 }
+async function fetchServerTime() {
+	try {
+		const res = await fetch("/api/method/frappe.ping", { credentials: "include" })
+		const dateHeader = res.headers.get("Date")
+		return dateHeader ? new Date(dateHeader) : null
+	} catch {
+		return null
+	}
+}
 
 const handleEmployeeCheckin = () => {
-	checkinTimestamp.value = dayjs().format("YYYY-MM-DD HH:mm:ss")
+	fetchServerTime().then((serverTime) => {
+		if (serverTime) {
+			checkinTimestamp.value = serverTime
+		} else {
+			toast({
+				title: __("Error"),
+				text: __("Unable to fetch server time. Please try again."),
+				icon: "alert-circle",
+				position: "bottom-center",
+				iconClasses: "text-red-500",
+			})
+		}
+	})
 
 	if (settings.data?.allow_geolocation_tracking) {
 		fetchLocation()
@@ -160,7 +182,6 @@ const submitLog = (logType) => {
 		{
 			employee: employee.data.name,
 			log_type: logType,
-			time: checkinTimestamp.value,
 			latitude: latitude.value,
 			longitude: longitude.value,
 		},
@@ -193,6 +214,10 @@ const submitLog = (logType) => {
 }
 
 onMounted(() => {
+	fetchServerTime().then((serverTime) => {
+		if (serverTime) serverNow.value = serverTime
+	})
+
 	socket.emit("doctype_subscribe", DOCTYPE)
 	socket.on("list_update", (data) => {
 		if (data.doctype == DOCTYPE) {

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -38,15 +38,15 @@
 		:is-open="isModalOpen"
 		:initial-breakpoint="1"
 		:breakpoints="[0, 1]"
-		@didDismiss="isModalOpen = false"
+		@didDismiss="handleModalDismiss"
 	>
 		<div class="h-120 w-full flex flex-col items-center justify-center gap-5 p-4 mb-5">
 			<div class="flex flex-col gap-1.5 mt-2 items-center justify-center">
 				<div class="font-bold text-xl">
-					{{ checkinTimestamp ? dayjs(checkinTimestamp).format("hh:mm:ss a") : "" }}
+					{{ liveCheckinTimestamp ? dayjs(liveCheckinTimestamp).format("hh:mm:ss a") : "" }}
 				</div>
 				<div class="font-medium text-gray-500 text-sm">
-					{{ checkinTimestamp ? dayjs(checkinTimestamp).format("D MMM, YYYY") : "" }}
+					{{ liveCheckinTimestamp ? dayjs(liveCheckinTimestamp).format("D MMM, YYYY") : "" }}
 				</div>
 			</div>
 
@@ -92,12 +92,15 @@ const employee = inject("$employee")
 const dayjs = inject("$dayjs")
 const serverNow = ref(null)
 const __ = inject("$translate")
-const checkinTimestamp = ref(null)
 const latitude = ref(0)
 const longitude = ref(0)
 const locationStatus = ref("")
 const isModalOpen = ref(false)
 const fetchingServerTime = ref(false)
+const serverTimeAnchor = ref(null)
+const deviceElapsedAnchor = ref(null)
+const liveCheckinTimestamp = ref(null)
+let tickInterval = null
 
 const checkins = createListResource({
 	doctype: DOCTYPE,
@@ -159,15 +162,33 @@ async function fetchServerTime() {
 	}
 }
 
+function startLiveClock() {
+	stopLiveClock()
+	liveCheckinTimestamp.value = serverTimeAnchor.value.toDate()
+
+	tickInterval = setInterval(() => {
+		const elapsedMs = Date.now() - deviceElapsedAnchor.value
+		liveCheckinTimestamp.value = serverTimeAnchor.value.add(elapsedMs, "millisecond").toDate()
+	}, 1000)
+}
+
+function stopLiveClock() {
+	if (tickInterval) {
+		clearInterval(tickInterval)
+		tickInterval = null
+	}
+}
+
 const handleEmployeeCheckin = async () => {
 	fetchingServerTime.value = true
-	checkinTimestamp.value = null
 
 	const serverTime = await fetchServerTime()
 	fetchingServerTime.value = false
 
 	if (serverTime) {
-		checkinTimestamp.value = serverTime
+		serverTimeAnchor.value = dayjs(serverTime)
+		deviceElapsedAnchor.value = Date.now()
+		startLiveClock()
 		isModalOpen.value = true
 
 		if (settings.data?.allow_geolocation_tracking) {
@@ -184,6 +205,11 @@ const handleEmployeeCheckin = async () => {
 	}
 }
 
+function handleModalDismiss() {
+	isModalOpen.value = false
+	stopLiveClock()
+}
+
 const submitLog = (logType) => {
 	const actionLabel = logType === "IN" ? __("Check-in") : __("Check-out")
 
@@ -197,6 +223,7 @@ const submitLog = (logType) => {
 		{
 			onSuccess() {
 				isModalOpen.value = false
+				stopLiveClock()
 				toast({
 					title: __("Success"),
 					text: __("{0} successful!", [actionLabel]),
@@ -236,6 +263,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+	stopLiveClock()
 	socket.emit("doctype_unsubscribe", DOCTYPE)
 	socket.off("list_update")
 })

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -165,9 +165,10 @@ async function fetchServerTime() {
 function startLiveClock() {
 	stopLiveClock()
 	liveCheckinTimestamp.value = serverTimeAnchor.value.toDate()
+	deviceElapsedAnchor.value = performance.now()
 
 	tickInterval = setInterval(() => {
-		const elapsedMs = Date.now() - deviceElapsedAnchor.value
+		const elapsedMs = performance.now() - deviceElapsedAnchor.value
 		liveCheckinTimestamp.value = serverTimeAnchor.value.add(elapsedMs, "millisecond").toDate()
 	}, 1000)
 }

--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -15,7 +15,7 @@
 			<Button
 				class="mt-4 mb-1 drop-shadow-sm py-5 text-base"
 				id="open-checkin-modal"
-				:loading="checkins.list.loading"
+				:loading="checkins.list.loading || fetchingServerTime"
 				@click="handleEmployeeCheckin"
 			>
 				<template #prefix>
@@ -35,10 +35,10 @@
 
 	<ion-modal
 		v-if="settings.data?.allow_employee_checkin_from_mobile_app"
-		ref="modal"
-		trigger="open-checkin-modal"
+		:is-open="isModalOpen"
 		:initial-breakpoint="1"
 		:breakpoints="[0, 1]"
+		@didDismiss="isModalOpen = false"
 	>
 		<div class="h-120 w-full flex flex-col items-center justify-center gap-5 p-4 mb-5">
 			<div class="flex flex-col gap-1.5 mt-2 items-center justify-center">
@@ -80,7 +80,7 @@
 <script setup>
 import { createListResource, toast, FeatherIcon } from "frappe-ui"
 import { computed, inject, ref, onMounted, onBeforeUnmount } from "vue"
-import { IonModal, modalController } from "@ionic/vue"
+import { IonModal } from "@ionic/vue"
 
 import { formatTimestamp } from "@/utils/formatters"
 import { settings } from "@/data/settings"
@@ -96,6 +96,8 @@ const checkinTimestamp = ref(null)
 const latitude = ref(0)
 const longitude = ref(0)
 const locationStatus = ref("")
+const isModalOpen = ref(false)
+const fetchingServerTime = ref(false)
 
 const checkins = createListResource({
 	doctype: DOCTYPE,
@@ -147,31 +149,38 @@ const fetchLocation = () => {
 }
 async function fetchServerTime() {
 	try {
-		const res = await fetch("/api/method/frappe.ping", { credentials: "include" })
-		const dateHeader = res.headers.get("Date")
-		return dateHeader ? new Date(dateHeader) : null
+		const res = await fetch("/api/method/hrms.hr.doctype.employee_checkin.employee_checkin.get_server_time", {
+			credentials: "include",
+		})
+		const data = await res.json()
+		return data.message || null
 	} catch {
 		return null
 	}
 }
 
-const handleEmployeeCheckin = () => {
-	fetchServerTime().then((serverTime) => {
-		if (serverTime) {
-			checkinTimestamp.value = serverTime
-		} else {
-			toast({
-				title: __("Error"),
-				text: __("Unable to fetch server time. Please try again."),
-				icon: "alert-circle",
-				position: "bottom-center",
-				iconClasses: "text-red-500",
-			})
-		}
-	})
+const handleEmployeeCheckin = async () => {
+	fetchingServerTime.value = true
+	checkinTimestamp.value = null
 
-	if (settings.data?.allow_geolocation_tracking) {
-		fetchLocation()
+	const serverTime = await fetchServerTime()
+	fetchingServerTime.value = false
+
+	if (serverTime) {
+		checkinTimestamp.value = serverTime
+		isModalOpen.value = true
+
+		if (settings.data?.allow_geolocation_tracking) {
+			fetchLocation()
+		}
+	} else {
+		toast({
+			title: __("Error"),
+			text: __("Unable to fetch server time. Please try again."),
+			icon: "alert-circle",
+			position: "bottom-center",
+			iconClasses: "text-red-500",
+		})
 	}
 }
 
@@ -187,7 +196,7 @@ const submitLog = (logType) => {
 		},
 		{
 			onSuccess() {
-				modalController.dismiss()
+				isModalOpen.value = false
 				toast({
 					title: __("Success"),
 					text: __("{0} successful!", [actionLabel]),

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -512,3 +512,8 @@ def calculate_time_difference(start_time, end_time):
 	time_difference = abs(start_time - end_time)
 
 	return round(time_difference.total_seconds() / 3600, 2)
+
+
+@frappe.whitelist()
+def get_server_time():
+	return frappe.utils.now_datetime().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## What existing problem does the pull request solve?

**In HRMS PWA** - The Employee Checkin UI currently uses the client/device time to display the check-in/check-out timestamp.

Since the device clock can be incorrect or manually changed, the timestamp displayed to an employee may not reflect the actual server time.

This PR updates the Employee Checkin flow to fetch the current server time and use it for displaying the check-in/check-out timestamp. This ensures that the time shown in the check-in flow is consistent with the server rather than being dependent on the employee's device clock.

### Example

The issue and the resulting behavior are demonstrated below:

**1. Device time modified**

The device date/time was manually changed to **28 August, 9:01 PM**, while the actual server date/time was **29 August, 9:45 PM**.


**2. Server time displayed on Check In**

When the employee clicks **Check In**, the confirmation modal displays the actual server time (**29 August, 9:45 PM**) instead of the modified device time.


**3. Employee Checkin record**

After confirming the check-in, the Employee Checkin record is created successfully through the existing server-side flow.


### Changes

* Fetch the current server time before displaying the Check In/Check Out confirmation.
* Added fetchServerTime(), which reads the current time from the server's HTTP Date response header (via frappe.ping) rather than the device clock.
* Use the server time for the timestamp displayed in the Employee Checkin modal.
* Use the server date for the dashboard date display.
* Display an error message if the server time cannot be retrieved.
* No client-provided timestamp is sent when creating the Employee Checkin record; the existing server-side flow remains responsible for the recorded check-in time.

### Testing

* Manually changed the device date/time to **28 August, 9:01 PM**.
* Verified that the actual server date/time was **29 August, 9:45 PM**.
* Opened the Employee Checkin dialog.
* Verified that the dialog displayed the server date/time instead of the modified device time.
* Confirmed the check-in successfully.
* Verified that the Employee Checkin record was created successfully.

Screenshots/GIFs
1. Modified device time

The device time was manually changed to 28 August, 9:01 PM.
<img width="1080" height="800" alt="IMG_20260828_210213" src="https://github.com/user-attachments/assets/85531183-d26a-4222-9305-0903290405da" />

2. Server time displayed in Check In modal

After clicking Check In, the modal displays the actual server time: 29 August, 9:45 PM.
<img width="720" height="1600" alt="IMG_20260828_210534 (1)" src="https://github.com/user-attachments/assets/9305acf5-569a-46cf-9551-61db3fce18da" />


<!-- Add Screenshot 2 -->

3. Employee Checkin record

The Employee Checkin record after confirming the check-in.

<img width="720" height="1600" alt="IMG_20260828_210622" src="https://github.com/user-attachments/assets/af3d5e71-3e8e-437c-a9d4-ac3d89078fa2" />


closes #XXXX
