### PR TITLE
backport: fix Employee Leave Balance report crashing for restricted users

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -83,5 +83,14 @@ frappe.query_reports["Employee Leave Balance"] = {
 				frappe.query_report.set_filter_value("to_date", data.message[0].to_date);
 			},
 		});
+
+		const is_restricted_to_specific_employees = frappe.defaults.get_user_permissions()["Employee"];
+		if (is_restricted_to_specific_employees) {
+			hrms.get_current_employee().then((employee) => {
+				if (employee) {
+					frappe.query_report.set_filter_value("employee", employee);
+				}
+			});
+		}
 	},
 };

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -145,24 +145,23 @@ def get_leave_types() -> list[str]:
 
 
 def get_employees(filters: Filters) -> list[dict]:
-	Employee = frappe.qb.DocType("Employee")
-	query = frappe.qb.from_(Employee).select(
-		Employee.name,
-		Employee.employee_name,
-		Employee.department,
-	)
+	conditions = {}
 
 	for field in ["company", "department"]:
 		if filters.get(field):
-			query = query.where(getattr(Employee, field) == filters.get(field))
+			conditions[field] = filters.get(field)
 
 	if filters.get("employee"):
-		query = query.where(Employee.name == filters.get("employee"))
+		conditions["name"] = filters.get("employee")
 
 	if filters.get("employee_status"):
-		query = query.where(Employee.status == filters.get("employee_status"))
+		conditions["status"] = filters.get("employee_status")
 
-	return query.run(as_dict=True)
+	return frappe.get_list(
+		"Employee",
+		filters=conditions,
+		fields=["name", "employee_name", "department"],
+	)
 
 
 def get_opening_balance(


### PR DESCRIPTION
## What this fixes

If a user only had access to a few specific employees (set up via User Permissions), running the **Employee Leave Balance** report could fail completely with a "Not permitted" error, even though they were allowed to see some of the data.

This backports the existing fix from `develop`/`version-16` (#... commit 551bdd061 / be6125b8f) to `version-15`:
- The report now only fetches employees the current user is actually allowed to see, instead of trying to fetch everyone and failing partway through.
- If the user's access is restricted to specific employees, the report now conveniently defaults its Employee filter to their own record.

## Note

Clean cherry-pick of the already-merged fix from `version-16` (`be6125b8f3f46a9d3d3fb55ecc6d5dae46fbd00b`), no changes needed to adapt it to `version-15`.