### PR TITLE
Fix: Leave Balance report breaks for employees with limited access

### DIFF
--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -83,5 +83,14 @@ frappe.query_reports["Employee Leave Balance"] = {
 				frappe.query_report.set_filter_value("to_date", data.message[0].to_date);
 			},
 		});
+
+		const is_restricted_to_specific_employees = frappe.defaults.get_user_permissions()["Employee"];
+		if (is_restricted_to_specific_employees) {
+			hrms.get_current_employee().then((employee) => {
+				if (employee) {
+					frappe.query_report.set_filter_value("employee", employee);
+				}
+			});
+		}
 	},
 };

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -84,7 +84,8 @@ frappe.query_reports["Employee Leave Balance"] = {
 			},
 		});
 
-		const is_restricted_to_specific_employees = frappe.defaults.get_user_permissions()["Employee"];
+		const is_restricted_to_specific_employees = 
+			frappe.defaults.get_user_permissions()["Employee"];
 		if (is_restricted_to_specific_employees) {
 			hrms.get_current_employee().then((employee) => {
 				if (employee) {

--- a/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/hrms/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -145,24 +145,23 @@ def get_leave_types() -> list[str]:
 
 
 def get_employees(filters: Filters) -> list[dict]:
-	Employee = frappe.qb.DocType("Employee")
-	query = frappe.qb.from_(Employee).select(
-		Employee.name,
-		Employee.employee_name,
-		Employee.department,
-	)
+	conditions = {}
 
 	for field in ["company", "department"]:
 		if filters.get(field):
-			query = query.where(getattr(Employee, field) == filters.get(field))
+			conditions[field] = filters.get(field)
 
 	if filters.get("employee"):
-		query = query.where(Employee.name == filters.get("employee"))
+		conditions["name"] = filters.get("employee")
 
 	if filters.get("employee_status"):
-		query = query.where(Employee.status == filters.get("employee_status"))
+		conditions["status"] = filters.get("employee_status")
 
-	return query.run(as_dict=True)
+	return frappe.get_list(
+		"Employee",
+		filters=conditions,
+		fields=["name", "employee_name", "department"],
+	)
 
 
 def get_opening_balance(


### PR DESCRIPTION
## The problem, in simple words

Imagine a manager who is only allowed to see 3 of their team members in the system (not everyone in the company). When they tried to open the **Employee Leave Balance** report, the whole page would break and show a scary "Not permitted" error — even though they *were* allowed to see some of the leave data. One person they weren't allowed to see was enough to ruin the report for everyone else too.

## What this fix does

Now the report is smarter about it:
- It only looks at the employees that person is actually allowed to see, and quietly skips the rest — instead of crashing.
- If someone can only see specific employees, the report now automatically shows their own leave record first, so they're not staring at an empty screen.

## Why this version

This exact fix already exists and works fine on the newer versions (`develop` and `version-16`). This PR just brings the same fix to `version-15-hotfix`, so people on that version get it too. It's a straight copy of the already-tested fix, nothing new was written.