### PR TITLE
feat(goal_tree): add icons for Update Progress and Mark as Completed

### DIFF
--- a/hrms/hr/doctype/goal/goal_tree.js
+++ b/hrms/hr/doctype/goal/goal_tree.js
@@ -230,6 +230,7 @@ frappe.treeview_settings["Goal"] = {
 	toolbar: [
 		{
 			label: __("Update Progress"),
+			icon: "trending-up",
 			condition: function (node) {
 				return !node.root && !node.expandable;
 			},
@@ -255,6 +256,7 @@ frappe.treeview_settings["Goal"] = {
 		},
 		{
 			label: __("Mark as Completed"),
+			icon: "check",
 			condition: function (node) {
 				return !node.is_root && !node.expandable && node.data.status != "Completed";
 			},


### PR DESCRIPTION
## Goal tree view — action icons

Aligns the Goal tree with the new Frappe tree view UX (frappe/frappe#42189) by adding icons to its row actions: **Update Progress** (`trending-up`) and **Mark as Completed** (`check`).

**Requires** frappe/frappe#42189. 
Related: frappe/erpnext#58520
`no-docs`