### PR TITLE
Fix: Show Accounts for Employer Contribution #5163

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -153,7 +153,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.statistical_component != 1 && doc.type != \"Employer Contribution\"",
+   "depends_on": "eval:doc.statistical_component != 1",
    "fieldname": "section_break_5",
    "fieldtype": "Section Break",
    "label": "Accounts"


### PR DESCRIPTION
**Issue**

The Accounts section in the Salary Component form was not displayed when the component type was set to Employer Contribution. This prevented users from configuring the appropriate company and account mappings for employer contribution components.


**Changes**

- Updated the Salary Component form to display the Accounts section for Employer Contribution components.
- Ensured the existing account configuration workflow remains functional.
- Verified that the change integrates correctly with the payroll flow.


**Before**

The Accounts section was hidden for Employer Contribution components.

![Before](https://github.com/user-attachments/assets/b85c2ea6-c29e-45c5-93d9-a1df54f51734)


**After**

The Accounts section is now displayed for Employer Contribution components, allowing users to configure the required company and account details.

![After](https://github.com/user-attachments/assets/0651e003-fec5-4024-a9cb-1a8c69830455)


Confirmed that the Accounts section is visible and can be configured correctly for Employer Contribution components.
