### PR TITLE
Fix: Show Accounts for Employer Contribution #5163

### DIFF
--- a/hrms/__init__.py
+++ b/hrms/__init__.py
@@ -3,7 +3,7 @@ import inspect
 
 import frappe
 
-__version__ = "16.17.0"
+__version__ = "16.17.1"
 
 
 def refetch_resource(cache_key: str | list, user=None):

--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -153,7 +153,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.statistical_component != 1 && doc.type != \"Employer Contribution\"",
+   "depends_on": "eval:doc.statistical_component != 1",
    "fieldname": "section_break_5",
    "fieldtype": "Section Break",
    "label": "Accounts"


### PR DESCRIPTION
## Issue

The **Accounts** section in the Salary Component form was not displayed when the component type was set to **Employer Contribution**. This prevented users from configuring the required company and account mappings for employer contribution components.

## Changes

* Updated the Salary Component form to display the **Accounts** section for **Employer Contribution** components.
* Preserved the existing account configuration workflow for other salary component types.
* Verified that the Accounts section is visible and can be configured correctly for Employer Contribution components.

## Before

The **Accounts** section was hidden when the Salary Component type was set to **Employer Contribution**.

<img width="902" height="652" alt="Before - Accounts section hidden for Employer Contribution" src="https://github.com/user-attachments/assets/df5bc0ba-ab1e-42c2-8979-3a6d125dfb9c" />

## After

The **Accounts** section is now displayed for **Employer Contribution** components, allowing users to configure the required company and account details.

<img width="1035" height="667" alt="After - Accounts section displayed for Employer Contribution" src="https://github.com/user-attachments/assets/bd04a627-88fc-4a26-8976-570afa18b1f6" />

## Verification

Confirmed that the **Accounts** section is visible and can be configured correctly for **Employer Contribution** components.
