### PR TITLE
fix: clear unused dates when Is Recurring is toggled

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.js
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.js
@@ -83,6 +83,15 @@ frappe.ui.form.on("Additional Salary", {
 		});
 	},
 
+	is_recurring: function (frm) {
+		if (frm.doc.is_recurring) {
+			frm.set_value("payroll_date", null);
+		} else {
+			frm.set_value("from_date", null);
+			frm.set_value("to_date", null);
+		}
+	},
+
 	salary_component: function (frm) {
 		if (!frm.doc.ref_doctype) {
 			frm.trigger("get_salary_component_amount");

--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -41,8 +41,11 @@ class AdditionalSalary(Document):
 	# end: auto-generated types
 
 	def before_validate(self):
-		if self.payroll_date and self.is_recurring:
+		if self.is_recurring:
 			self.payroll_date = None
+		else:
+			self.from_date = None
+			self.to_date = None
 
 	def on_submit(self):
 		self.update_employee_referral()


### PR DESCRIPTION
### Problem

In Additional Salary, From Date and To Date show when Is Recurring is on.
Payroll Date shows when it is off.
Turning Is Recurring on cleared the Payroll Date. But turning it off did
not clear From Date and To Date. The old dates stayed saved in the record
even though the fields were hidden.
This is not just a display issue. The duplicate check and the overlap
check both read these dates. So a record could clash with other records
for no reason the user can see.

https://github.com/user-attachments/assets/0910cf74-fbfc-4f4f-a501-c56f7c36ba41



### Fix

- Clear From Date and To Date when Is Recurring is off, the same way
  Payroll Date is cleared when it is on.


https://github.com/user-attachments/assets/216e077e-af41-4f5f-8c7c-4501eee2bfbd



### How to test

1. Open a new Additional Salary.
2. Tick Is Recurring. Set From Date and To Date. Save.
3. Untick Is Recurring. Set a Payroll Date. Save.
4. From Date and To Date are now empty.

no-docs

