### PR TITLE
feat(shift_type): allow Holiday List Assignment to override Shift Type's Holiday List

### DIFF
--- a/hrms/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
+++ b/hrms/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
@@ -196,6 +196,13 @@ class TestCompensatoryLeaveRequest(HRMSTestSuite):
 		create_holiday_list("2023-01-01", "2023-12-31")
 
 		employee = get_employee()
+		# keep the assignment's from_date consistent with the holiday list recreated above
+		frappe.db.set_value(
+			"Holiday List Assignment",
+			{"assigned_to": employee.name, "holiday_list": self.holiday_list},
+			"from_date",
+			"2023-01-01",
+		)
 		boundary_date = "2023-12-31"
 		add_date_to_holiday_list(boundary_date, self.holiday_list)
 		mark_attendance(employee, boundary_date, "Present")

--- a/hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
+++ b/hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.json
@@ -16,7 +16,8 @@
   "holiday_list",
   "from_date",
   "holiday_list_start",
-  "holiday_list_end"
+  "holiday_list_end",
+  "override_shift_holiday_list"
  ],
  "fields": [
   {
@@ -101,13 +102,20 @@
    "fieldtype": "Date",
    "label": "Assignment Starts From",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "If checked, this Holiday List will be used instead of the Shift Type's Holiday List for auto attendance",
+   "fieldname": "override_shift_holiday_list",
+   "fieldtype": "Check",
+   "label": "Override Shift Type's Holiday List"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-07 16:11:21.856458",
+ "modified": "2026-09-02 14:20:15.136585",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Holiday List Assignment",

--- a/hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.py
+++ b/hrms/hr/doctype/holiday_list_assignment/holiday_list_assignment.py
@@ -26,6 +26,7 @@ class HolidayListAssignment(Document):
 		from_date: DF.Date
 		holiday_list: DF.Link
 		naming_series: DF.Literal["HR-HLA-.YYYY.-"]
+		override_shift_holiday_list: DF.Check
 	# end: auto-generated types
 
 	@property

--- a/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
+++ b/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 
 import frappe
-from frappe.utils import add_months, add_years, get_year_ending, get_year_start, getdate
+from frappe.utils import add_months, get_year_ending, get_year_start, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
@@ -73,22 +73,6 @@ class IntegrationTestHolidayListAssignment(HRMSTestSuite):
 		employee = make_employee("test_default_hla@example.com", company="_Test Company")
 		holiday_list = get_holiday_list_for_employee(employee, as_on=getdate())
 		self.assertEqual(holiday_list, self.holiday_list)
-
-	def test_expired_holiday_list_assignment_is_not_used(self):
-		employee = make_employee("test_expired_hla@example.com", company="_Test Company")
-		expired_holiday_list = make_holiday_list(
-			list_name="Test HLA Expired",
-			from_date=get_year_start(add_years(getdate(), -1)),
-			to_date=get_year_ending(add_years(getdate(), -1)),
-		)
-		create_holiday_list_assignment(
-			"Employee",
-			assigned_to=employee,
-			holiday_list=expired_holiday_list,
-			from_date=get_year_start(add_years(getdate(), -1)),
-		)
-		holiday_list = get_holiday_list_for_employee(employee, raise_exception=False, as_on=getdate())
-		self.assertIsNone(holiday_list)
 
 
 def create_holiday_list_assignment(

--- a/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
+++ b/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
@@ -82,6 +82,7 @@ def create_holiday_list_assignment(
 	company="_Test Company",
 	do_not_submit=False,
 	from_date=None,
+	override_shift_holiday_list=0,
 ):
 	if not frappe.db.exists(
 		"Holiday List Assignment",
@@ -95,6 +96,7 @@ def create_holiday_list_assignment(
 		if not from_date:
 			from_date = frappe.db.get_value("Holiday List", holiday_list, "from_date")
 		hla.from_date = from_date
+		hla.override_shift_holiday_list = override_shift_holiday_list
 		hla.save()
 		if do_not_submit:
 			return hla

--- a/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
+++ b/hrms/hr/doctype/holiday_list_assignment/test_holiday_list_assignment.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 
 import frappe
-from frappe.utils import add_months, get_year_ending, get_year_start, getdate
+from frappe.utils import add_months, add_years, get_year_ending, get_year_start, getdate
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
@@ -73,6 +73,22 @@ class IntegrationTestHolidayListAssignment(HRMSTestSuite):
 		employee = make_employee("test_default_hla@example.com", company="_Test Company")
 		holiday_list = get_holiday_list_for_employee(employee, as_on=getdate())
 		self.assertEqual(holiday_list, self.holiday_list)
+
+	def test_expired_holiday_list_assignment_is_not_used(self):
+		employee = make_employee("test_expired_hla@example.com", company="_Test Company")
+		expired_holiday_list = make_holiday_list(
+			list_name="Test HLA Expired",
+			from_date=get_year_start(add_years(getdate(), -1)),
+			to_date=get_year_ending(add_years(getdate(), -1)),
+		)
+		create_holiday_list_assignment(
+			"Employee",
+			assigned_to=employee,
+			holiday_list=expired_holiday_list,
+			from_date=get_year_start(add_years(getdate(), -1)),
+		)
+		holiday_list = get_holiday_list_for_employee(employee, raise_exception=False, as_on=getdate())
+		self.assertIsNone(holiday_list)
 
 
 def create_holiday_list_assignment(

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -20,7 +20,6 @@ from frappe.utils import (
 	time_diff,
 )
 
-from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.setup.doctype.holiday_list.holiday_list import is_half_holiday, is_holiday
 
 from hrms.hr.doctype.attendance.attendance import mark_attendance
@@ -30,7 +29,7 @@ from hrms.hr.doctype.employee_checkin.employee_checkin import (
 )
 from hrms.hr.doctype.shift_assignment.shift_assignment import get_employee_shift, get_shift_details
 from hrms.utils import get_date_range
-from hrms.utils.holiday_list import get_holiday_dates_between
+from hrms.utils.holiday_list import get_holiday_dates_between, get_holiday_list_for_employee
 
 EMPLOYEE_CHUNK_SIZE = 50
 
@@ -414,8 +413,14 @@ class ShiftType(Document):
 		return list(set(assigned_employees) - set(inactive_employees))
 
 	def get_holiday_list(self, employee: str, date=None) -> str:
-		holiday_list_name = self.holiday_list or get_holiday_list_for_employee(employee, False, as_on=date)
-		return holiday_list_name
+		assigned_holiday_list = get_holiday_list_for_employee(employee, False, as_on=date, as_dict=True)
+		if assigned_holiday_list and assigned_holiday_list.override_shift_holiday_list:
+			return assigned_holiday_list.holiday_list
+
+		if self.holiday_list:
+			return self.holiday_list
+
+		return assigned_holiday_list.holiday_list if assigned_holiday_list else None
 
 	def should_mark_attendance(self, employee: str, attendance_date: str) -> bool:
 		"""Determines whether attendance should be marked on holidays or not"""

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -335,12 +335,39 @@ class ShiftType(Document):
 		date_range = get_date_range(start_date, end_date)
 
 		# skip marking absent on holidays
-		holiday_list = self.get_holiday_list(employee)
-		holiday_dates = get_holiday_dates_between(holiday_list, start_date, end_date)
+		holiday_dates = set()
+		for from_date, to_date in self.get_holiday_list_date_ranges(employee, start_date, end_date):
+			holiday_list = self.get_holiday_list(employee, from_date)
+			holiday_dates.update(get_holiday_dates_between(holiday_list, from_date, to_date))
 		# skip dates with attendance
 		marked_attendance_dates = self.get_marked_attendance_dates_between(employee, start_date, end_date)
 
 		return sorted(set(date_range) - set(holiday_dates) - set(marked_attendance_dates))
+
+	def get_holiday_list_date_ranges(
+		self, employee: str, start_date: str, end_date: str
+	) -> list[tuple[str, str]]:
+		"""Splits [start_date, end_date] into ranges at each Holiday List Assignment change,
+		so every range resolves against the assignment active on those dates.
+		"""
+		company = frappe.db.get_value("Employee", employee, "company")
+		HLA = frappe.qb.DocType("Holiday List Assignment")
+		assignment_from_dates = (
+			frappe.qb.from_(HLA)
+			.select(HLA.from_date)
+			.distinct()
+			.where(HLA.assigned_to.isin([employee, company]))
+			.where(HLA.docstatus == 1)
+			.where(HLA.from_date > start_date)
+			.where(HLA.from_date <= end_date)
+			.orderby(HLA.from_date)
+		).run(pluck=True)
+
+		from_dates = [start_date, *(getdate(from_date) for from_date in assignment_from_dates)]
+		return [
+			(from_date, add_days(from_dates[idx + 1], -1) if idx + 1 < len(from_dates) else end_date)
+			for idx, from_date in enumerate(from_dates)
+		]
 
 	def get_start_and_end_dates(self, employee):
 		"""Returns start and end dates for checking attendance and marking absent

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -442,7 +442,9 @@ class ShiftType(Document):
 	def get_holiday_list(self, employee: str, date=None) -> str:
 		assigned_holiday_list = get_holiday_list_for_employee(employee, False, as_on=date, as_dict=True)
 		if assigned_holiday_list and assigned_holiday_list.override_shift_holiday_list:
-			return assigned_holiday_list.holiday_list
+			# ignore the override if its holiday list has since expired
+			if getdate(assigned_holiday_list.holiday_list_to_date) >= getdate(date):
+				return assigned_holiday_list.holiday_list
 
 		if self.holiday_list:
 			return self.holiday_list

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import frappe
 from frappe.utils import (
 	add_days,
+	add_years,
 	get_datetime,
 	get_time,
 	get_year_ending,
@@ -687,6 +688,26 @@ class TestShiftType(HRMSTestSuite):
 		)
 		# employee's holiday list assignment is used once override is checked
 		self.assertEqual(shift_type.get_holiday_list(employee), self.holiday_list)
+
+	def test_expired_override_assignment_does_not_override_shift_holiday_list(self):
+		shift_type = setup_shift_type()
+		employee = make_employee("test_expired_override@example.com", company="_Test Company")
+
+		expired_holiday_list = make_holiday_list(
+			"Test Expired Override Holiday List",
+			from_date=get_year_start(add_years(getdate(), -1)),
+			to_date=get_year_ending(add_years(getdate(), -1)),
+		)
+		create_holiday_list_assignment(
+			"Employee",
+			assigned_to=employee,
+			holiday_list=expired_holiday_list,
+			from_date=get_year_start(add_years(getdate(), -1)),
+			override_shift_holiday_list=1,
+		)
+
+		# override is checked, but its holiday list has expired, so shift type's list is used
+		self.assertEqual(shift_type.get_holiday_list(employee), shift_type.holiday_list)
 
 	def test_skip_absent_marking_for_a_fallback_default_shift(self):
 		"""

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -15,7 +15,10 @@ from frappe.utils import (
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
-from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import assign_holiday_list
+from hrms.hr.doctype.holiday_list_assignment.test_holiday_list_assignment import (
+	assign_holiday_list,
+	create_holiday_list_assignment,
+)
 from hrms.hr.doctype.leave_application.test_leave_application import get_first_sunday
 from hrms.hr.doctype.shift_type.shift_type import update_last_sync_of_checkin
 from hrms.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
@@ -608,6 +611,28 @@ class TestShiftType(HRMSTestSuite):
 			{"attendance_date": first_sunday, "employee": employee},
 		)
 		self.assertIsNone(attendance)
+
+	def test_shift_type_holiday_list_overridden_by_holiday_list_assignment(self):
+		shift_type = setup_shift_type()
+		employee = make_employee("test_hla_override_shift@example.com", company="_Test Company")
+
+		create_holiday_list_assignment(
+			"Employee",
+			assigned_to=employee,
+			holiday_list=self.holiday_list,
+			from_date=get_year_start(getdate()),
+		)
+		# shift type's holiday list is used when override is not set
+		self.assertEqual(shift_type.get_holiday_list(employee), shift_type.holiday_list)
+
+		frappe.db.set_value(
+			"Holiday List Assignment",
+			{"assigned_to": employee, "holiday_list": self.holiday_list},
+			"override_shift_holiday_list",
+			1,
+		)
+		# employee's holiday list assignment is used once override is checked
+		self.assertEqual(shift_type.get_holiday_list(employee), self.holiday_list)
 
 	def test_skip_absent_marking_for_a_fallback_default_shift(self):
 		"""

--- a/hrms/hr/doctype/shift_type/test_shift_type.py
+++ b/hrms/hr/doctype/shift_type/test_shift_type.py
@@ -523,6 +523,60 @@ class TestShiftType(HRMSTestSuite):
 			"Absent",
 		)
 
+	def test_backfill_recognizes_holidays_across_assignment_change(self):
+		employee = make_employee("test_holiday_backfill@example.com", company="_Test Company")
+		today = getdate()
+		process_attendance_after = add_days(today, -6)
+
+		shift_type = setup_shift_type(
+			shift_type="Test Holiday Backfill",
+			process_attendance_after=process_attendance_after,
+			last_sync_of_checkin=f"{today} 15:00:00",
+		)
+		shift_type.holiday_list = None
+		shift_type.save()
+
+		make_shift_assignment(shift_type.name, employee, process_attendance_after)
+
+		old_holiday_list = make_holiday_list(
+			"Test Holiday Backfill Old",
+			from_date=process_attendance_after,
+			to_date=today,
+			add_weekly_offs=False,
+		)
+		new_holiday_list = make_holiday_list(
+			"Test Holiday Backfill New",
+			from_date=process_attendance_after,
+			to_date=today,
+			add_weekly_offs=False,
+		)
+		old_list_holiday = add_days(today, -5)
+		new_list_holiday = add_days(today, -1)
+		add_date_to_holiday_list(old_list_holiday, old_holiday_list)
+		add_date_to_holiday_list(new_list_holiday, new_holiday_list)
+
+		# employee follows old_holiday_list first, then switches to new_holiday_list partway through the backfill range
+		create_holiday_list_assignment(
+			"Employee",
+			assigned_to=employee,
+			holiday_list=old_holiday_list,
+			from_date=process_attendance_after,
+		)
+		create_holiday_list_assignment(
+			"Employee", assigned_to=employee, holiday_list=new_holiday_list, from_date=add_days(today, -2)
+		)
+
+		shift_type.process_auto_attendance()
+
+		# old_list_holiday falls under old_holiday_list's assignment period and must still be recognized,
+		# even though new_holiday_list is the assignment active "today"
+		self.assertIsNone(
+			frappe.db.get_value("Attendance", {"employee": employee, "attendance_date": old_list_holiday})
+		)
+		self.assertIsNone(
+			frappe.db.get_value("Attendance", {"employee": employee, "attendance_date": new_list_holiday})
+		)
+
 	def test_do_not_mark_absent_before_shift_actual_end_time(self):
 		from hrms.hr.doctype.employee_checkin.test_employee_checkin import make_checkin
 

--- a/hrms/hr/utils.py
+++ b/hrms/hr/utils.py
@@ -728,7 +728,7 @@ def get_holidays_for_employee(employee, start_date, end_date, raise_exception=Tr
 
 	return: list of dicts with `holiday_date` and `description`
 	"""
-	holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception)
+	holiday_list = get_holiday_list_for_employee(employee, raise_exception=raise_exception, as_on=start_date)
 
 	if not holiday_list:
 		return []

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -119,12 +119,16 @@ def get_holiday_list_for_employee(
 def get_assigned_holiday_list(assigned_to: str, as_on=None, as_dict: bool = False) -> str:
 	as_on = frappe.utils.getdate(as_on)
 	HLA = frappe.qb.DocType("Holiday List Assignment")
+	HolidayList = frappe.qb.DocType("Holiday List")
 	query = (
 		frappe.qb.from_(HLA)
+		.join(HolidayList)
+		.on(HLA.holiday_list == HolidayList.name)
 		.select(HLA.holiday_list)
 		.where(HLA.assigned_to == assigned_to)
 		.where(HLA.from_date <= as_on)
 		.where(HLA.docstatus == 1)
+		.where(HolidayList.to_date >= as_on)
 		.orderby(HLA.from_date, order=frappe.qb.desc)
 		.limit(1)
 	)

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -119,21 +119,25 @@ def get_holiday_list_for_employee(
 def get_assigned_holiday_list(assigned_to: str, as_on=None, as_dict: bool = False) -> str:
 	as_on = frappe.utils.getdate(as_on)
 	HLA = frappe.qb.DocType("Holiday List Assignment")
-	HolidayList = frappe.qb.DocType("Holiday List")
 	query = (
 		frappe.qb.from_(HLA)
-		.join(HolidayList)
-		.on(HLA.holiday_list == HolidayList.name)
 		.select(HLA.holiday_list)
 		.where(HLA.assigned_to == assigned_to)
 		.where(HLA.from_date <= as_on)
 		.where(HLA.docstatus == 1)
-		.where(HolidayList.to_date >= as_on)
 		.orderby(HLA.from_date, order=frappe.qb.desc)
 		.limit(1)
 	)
 	if as_dict:
-		query = query.select(HLA.from_date, HLA.override_shift_holiday_list)
+		# also expose the Holiday List's own to_date, for callers to check if it has expired
+		HolidayList = frappe.qb.DocType("Holiday List")
+		query = (
+			query.join(HolidayList)
+			.on(HLA.holiday_list == HolidayList.name)
+			.select(
+				HLA.from_date, HLA.override_shift_holiday_list, HolidayList.to_date.as_("holiday_list_to_date")
+			)
+		)
 		holiday_list = query.run(as_dict=True)
 		return holiday_list[0] if holiday_list else None
 

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -129,7 +129,7 @@ def get_assigned_holiday_list(assigned_to: str, as_on=None, as_dict: bool = Fals
 		.limit(1)
 	)
 	if as_dict:
-		query = query.select(HLA.from_date)
+		query = query.select(HLA.from_date, HLA.override_shift_holiday_list)
 		holiday_list = query.run(as_dict=True)
 		return holiday_list[0] if holiday_list else None
 

--- a/hrms/utils/holiday_list.py
+++ b/hrms/utils/holiday_list.py
@@ -135,7 +135,9 @@ def get_assigned_holiday_list(assigned_to: str, as_on=None, as_dict: bool = Fals
 			query.join(HolidayList)
 			.on(HLA.holiday_list == HolidayList.name)
 			.select(
-				HLA.from_date, HLA.override_shift_holiday_list, HolidayList.to_date.as_("holiday_list_to_date")
+				HLA.from_date,
+				HLA.override_shift_holiday_list,
+				HolidayList.to_date.as_("holiday_list_to_date"),
 			)
 		)
 		holiday_list = query.run(as_dict=True)


### PR DESCRIPTION
### Reason

- Some employees were being marked absent on holidays even though the correct holiday calendar was assigned to them.
- This happened because the Shift they were on already had its **own Holiday List set** and that always took priority over the holiday assigned to the individual employee via Holiday List Assignment.

### Changes done

- Added a new checkbox, **"Override Shift Type's Holiday List"**, on the Holiday List Assignment form.
- When this is enabled for an employee or a company, their assigned holiday calendar will be used instead of the one set on the Shift, so they won't be marked absent on their actual holidays anymore.

`no-docs`