### PR TITLE
fix: staffing plan number of positions not decreasing when vacancies is reduced

### DIFF
--- a/hrms/hr/doctype/staffing_plan/staffing_plan.js
+++ b/hrms/hr/doctype/staffing_plan/staffing_plan.js
@@ -106,9 +106,7 @@ var set_number_of_positions = function (frm, cdt, cdn) {
 				frappe.model.set_value(cdt, cdn, "current_count", data.message.employee_count);
 				frappe.model.set_value(cdt, cdn, "current_openings", data.message.job_openings);
 				let total_positions = cint(data.message.employee_count) + cint(child.vacancies);
-				if (cint(child.number_of_positions) < total_positions) {
-					frappe.model.set_value(cdt, cdn, "number_of_positions", total_positions);
-				}
+				frappe.model.set_value(cdt, cdn, "number_of_positions", total_positions);
 			} else {
 				// No employees for this designation
 				frappe.model.set_value(cdt, cdn, "current_count", 0);

--- a/hrms/hr/doctype/staffing_plan/test_staffing_plan.py
+++ b/hrms/hr/doctype/staffing_plan/test_staffing_plan.py
@@ -102,6 +102,47 @@ class TestStaffingPlan(HRMSTestSuite):
 		self.assertEqual(staffing_plan_detail.current_count, 1)
 		self.assertEqual(staffing_plan_detail.number_of_positions, 5)
 
+	def test_number_of_positions_updates_when_vacancies_decrease(self):
+		# Covers the server-side invariant only: StaffingPlan.set_number_of_positions()
+		# (staffing_plan.py) must always recompute number_of_positions as
+		# vacancies + current_count, even when vacancies is reduced.
+		#
+		# NOTE: this does NOT cover the client-side bug it was written for, where
+		# staffing_plan.js's `set_number_of_positions` skipped the update on the
+		# desk form when the newly computed total was lower than the current
+		# value (so decreasing Vacancies did not decrease Number of Positions
+		# on screen until save). This repo has no JS/UI test harness for desk
+		# form scripts, so that fix has to be verified manually in the browser
+		# whenever hrms/hr/doctype/staffing_plan/staffing_plan.js is touched.
+		frappe.get_doc({"doctype": "Designation", "designation_name": "_Test SP Designation"}).insert(
+			ignore_if_duplicate=True
+		)
+
+		if frappe.db.exists("Staffing Plan", "Test Vacancy Decrease"):
+			frappe.delete_doc("Staffing Plan", "Test Vacancy Decrease", force=True)
+
+		staffing_plan = frappe.new_doc("Staffing Plan")
+		staffing_plan.company = "_Test Company 10"
+		staffing_plan.name = "Test Vacancy Decrease"
+		staffing_plan.from_date = nowdate()
+		staffing_plan.to_date = add_days(nowdate(), 10)
+		staffing_plan.append(
+			"staffing_details",
+			{"designation": "_Test SP Designation", "vacancies": 2, "estimated_cost_per_position": 50000},
+		)
+		staffing_plan.insert()
+		self.assertEqual(staffing_plan.staffing_details[0].number_of_positions, 2)
+
+		# decreasing vacancies should decrease number_of_positions
+		staffing_plan.staffing_details[0].vacancies = 1
+		staffing_plan.save()
+		self.assertEqual(staffing_plan.staffing_details[0].number_of_positions, 1)
+
+		# increasing vacancies again should still work
+		staffing_plan.staffing_details[0].vacancies = 3
+		staffing_plan.save()
+		self.assertEqual(staffing_plan.staffing_details[0].number_of_positions, 3)
+
 
 def make_company(name=None, abbr=None):
 	if not name:


### PR DESCRIPTION
## Fix Number of Positions Not Updating When Vacancies Decrease

### Use Case:

When editing a Staffing Plan, users may increase or decrease the required Vacancies based on manpower requirements. `Number of Positions` should always reflect the latest Vacancy count so that the Staffing Plan shows the correct number of positions during editing.

### Problem

In Staffing Plan, `Number of Positions` was updated when Vacancies increased but did not decrease when Vacancies were reduced.

For example:

* Vacancies `2` → Number of Positions `2`
* Vacancies reduced to `1` → Number of Positions incorrectly remained `2`
* Vacancies increased to `3` → Number of Positions updated to `3`

### Root Cause

The client-side `set_number_of_positions` function only updated the value when the newly calculated total was greater than the existing value. This prevented `Number of Positions` from decreasing in the UI.

### Fix

Removed the one-sided comparison and made the client-side calculation unconditional:

`number_of_positions = employee_count + vacancies`

This keeps the client-side calculation consistent with the server-side logic.


Before:

[Before_fix.webm](https://github.com/user-attachments/assets/e972ca56-3e43-471f-80c0-094eab4fbde5)

After : 

[After_fix.webm](https://github.com/user-attachments/assets/89ac7f38-bde8-47f8-8854-5657eb48c84a)

Backport Needed : v15,v16