### PR TITLE
perf(payroll): optimize payroll entry generation by reducing N+1 queries

### DIFF
--- a/hrms/payroll/doctype/additional_salary/additional_salary.py
+++ b/hrms/payroll/doctype/additional_salary/additional_salary.py
@@ -334,10 +334,11 @@ def get_additional_salaries(employee, start_date, end_date, component_type):
 	component_field = additional_sal.salary_component.as_("component")
 	overwrite_field = additional_sal.overwrite_salary_structure_amount.as_("overwrite")
 
-	additional_salary_list = (
+	query = (
 		frappe.qb.from_(additional_sal)
 		.select(
 			additional_sal.name,
+			additional_sal.employee,
 			component_field,
 			additional_sal.type,
 			additional_sal.amount,
@@ -347,12 +348,20 @@ def get_additional_salaries(employee, start_date, end_date, component_type):
 			additional_sal.ref_doctype,
 		)
 		.where(
-			(additional_sal.employee == employee)
-			& (additional_sal.docstatus == 1)
+			(additional_sal.docstatus == 1)
 			& (additional_sal.type == comp_type)
 			& (additional_sal.disabled == 0)
 		)
-		.where(
+	)
+
+	is_list_input = isinstance(employee, list)
+	if is_list_input:
+		query = query.where(additional_sal.employee.isin(employee))
+	else:
+		query = query.where(additional_sal.employee == employee)
+
+	additional_salary_list = (
+		query.where(
 			Criterion.any(
 				[
 					Criterion.all(
@@ -374,21 +383,44 @@ def get_additional_salaries(employee, start_date, end_date, component_type):
 		.run(as_dict=True)
 	)
 
-	additional_salaries = []
-	components_to_overwrite = []
+	if is_list_input:
+		res = {emp: [] for emp in employee}
+		components_to_overwrite_map = {emp: [] for emp in employee}
+		for d in additional_salary_list:
+			emp = d.employee
+			if emp not in res:
+				res[emp] = []
+				components_to_overwrite_map[emp] = []
 
-	for d in additional_salary_list:
-		if d.overwrite:
-			if d.component in components_to_overwrite:
-				frappe.throw(
-					_(
-						"Multiple Additional Salaries with overwrite property exist for Salary Component {0} between {1} and {2}."
-					).format(frappe.bold(d.component), start_date, end_date),
-					title=_("Error"),
-				)
+			if d.overwrite:
+				if d.component in components_to_overwrite_map[emp]:
+					frappe.throw(
+						_(
+							"Multiple Additional Salaries with overwrite property exist for Salary Component {0} between {1} and {2} for employee {3}."
+						).format(frappe.bold(d.component), start_date, end_date, emp),
+						title=_("Error"),
+					)
+				components_to_overwrite_map[emp].append(d.component)
 
-			components_to_overwrite.append(d.component)
+			res[emp].append(d)
+		return res
+	else:
+		additional_salaries = []
+		components_to_overwrite = []
 
-		additional_salaries.append(d)
+		for d in additional_salary_list:
+			if d.overwrite:
+				if d.component in components_to_overwrite:
+					frappe.throw(
+						_(
+							"Multiple Additional Salaries with overwrite property exist for Salary Component {0} between {1} and {2}."
+						).format(frappe.bold(d.component), start_date, end_date),
+						title=_("Error"),
+					)
 
-	return additional_salaries
+				components_to_overwrite.append(d.component)
+
+			additional_salaries.append(d)
+
+		return additional_salaries
+

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -559,7 +559,9 @@ class PayrollEntry(Document):
 					& (SalaryStructureAssignment.from_date <= self.end_date)
 				)
 				.orderby(SalaryStructureAssignment.from_date, order=frappe.qb.desc)
+				.orderby(SalaryStructureAssignment.creation, order=frappe.qb.desc)
 				.limit(1)
+
 			)
 			cost_centers = dict(
 				(
@@ -1596,6 +1598,89 @@ def log_payroll_failure(process, payroll_entry, error):
 	payroll_entry.db_set({"error_message": error_message, "status": "Failed"})
 
 
+def preload_payroll_data_for_employees(employees, args):
+	if not employees:
+		return {}
+
+	emp_records = frappe.get_all(
+		"Employee",
+		filters={"name": ["in", employees]},
+		fields=[
+			"name",
+			"status",
+			"date_of_joining",
+			"relieving_date",
+			"department",
+			"company",
+			"payroll_cost_center",
+			"holiday_list",
+			"employee_name",
+			"user_id",
+		],
+	)
+
+	company_holiday_list = None
+	if args.get("company"):
+		company_holiday_list = frappe.db.get_value("Company", args.get("company"), "default_holiday_list", cache=True)
+
+	holiday_lists = set()
+	for emp in emp_records:
+		h_list = emp.holiday_list or company_holiday_list
+		if h_list:
+			holiday_lists.add(h_list)
+
+
+	from hrms.payroll.doctype.salary_slip.salary_slip import HOLIDAYS_BETWEEN_DATES
+	from hrms.utils.holiday_list import get_holiday_dates_between
+
+	for h_list in holiday_lists:
+		key = f"{h_list}:{args.get('start_date')}:{args.get('end_date')}"
+		if not frappe.cache().hget(HOLIDAYS_BETWEEN_DATES, key):
+			h_dates = get_holiday_dates_between(h_list, args.get("start_date"), args.get("end_date"))
+			frappe.cache().hset(HOLIDAYS_BETWEEN_DATES, key, h_dates)
+
+	SalaryStructureAssignment = frappe.qb.DocType("Salary Structure Assignment")
+	SalaryStructure = frappe.qb.DocType("Salary Structure")
+
+	sal_struct_query = (
+		frappe.qb.from_(SalaryStructureAssignment)
+		.join(SalaryStructure)
+		.on(SalaryStructureAssignment.salary_structure == SalaryStructure.name)
+		.select(SalaryStructureAssignment.employee, SalaryStructureAssignment.salary_structure)
+		.where(
+			(SalaryStructureAssignment.docstatus == 1)
+			& (SalaryStructure.docstatus == 1)
+			& (SalaryStructure.is_active == "Yes")
+			& (SalaryStructureAssignment.employee.isin(employees))
+			& (
+				(SalaryStructureAssignment.from_date <= args.get("start_date"))
+				| (SalaryStructureAssignment.from_date <= args.get("end_date"))
+			)
+		)
+		.orderby(SalaryStructureAssignment.from_date, order=frappe.qb.desc)
+	)
+
+
+	if args.get("company"):
+		sal_struct_query = sal_struct_query.where(SalaryStructureAssignment.company == args.get("company"))
+
+	if args.get("currency"):
+		sal_struct_query = sal_struct_query.where(SalaryStructureAssignment.currency == args.get("currency"))
+
+	if not args.get("salary_slip_based_on_timesheet") and args.get("payroll_frequency"):
+		sal_struct_query = sal_struct_query.where(SalaryStructure.payroll_frequency == args.get("payroll_frequency"))
+
+
+	struct_rows = sal_struct_query.run(as_dict=True)
+	sal_struct_map = {}
+	for r in struct_rows:
+		if r.employee not in sal_struct_map:
+			sal_struct_map[r.employee] = r.salary_structure
+
+	return sal_struct_map
+
+
+
 def create_salary_slips_for_employees(employees, args, publish_progress=True):
 	payroll_entry = frappe.get_cached_doc("Payroll Entry", args.payroll_entry)
 
@@ -1604,10 +1689,13 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 		count = 0
 
 		employees = list(set(employees) - set(salary_slips_exist_for))
+		sal_struct_map = preload_payroll_data_for_employees(employees, args)
+
 		for emp in employees:
 			slip_args = {
 				"doctype": "Salary Slip",
 				"employee": emp,
+				"salary_structure": sal_struct_map.get(emp),
 				"salary_slip_based_on_timesheet": args.get("salary_slip_based_on_timesheet"),
 				"payroll_frequency": args.get("payroll_frequency"),
 				"start_date": args.get("start_date"),
@@ -1622,6 +1710,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 				"currency": args.get("currency"),
 			}
 			frappe.get_doc(slip_args).insert()
+
 
 			count += 1
 			if publish_progress:
@@ -1831,7 +1920,7 @@ def employee_query(
 def get_salary_withholdings(
 	start_date: str,
 	end_date: str,
-	employee: str | None = None,
+	employee: str | list[str] | None = None,
 	pluck: str | None = None,
 ) -> list[str] | list[dict]:
 	Withholding = frappe.qb.DocType("Salary Withholding")
@@ -1854,8 +1943,12 @@ def get_salary_withholdings(
 	)
 
 	if employee:
-		withheld_salaries = withheld_salaries.where(Withholding.employee == employee)
+		if isinstance(employee, list):
+			withheld_salaries = withheld_salaries.where(Withholding.employee.isin(employee))
+		else:
+			withheld_salaries = withheld_salaries.where(Withholding.employee == employee)
 
 	if pluck:
 		return withheld_salaries.run(pluck=pluck)
 	return withheld_salaries.run(as_dict=True)
+

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1600,7 +1600,7 @@ def log_payroll_failure(process, payroll_entry, error):
 
 def preload_payroll_data_for_employees(employees, args):
 	if not employees:
-		return {}
+		return {"sal_struct_map": {}, "additional_salaries": {}, "salary_withholdings": {}}
 
 	emp_records = frappe.get_all(
 		"Employee",
@@ -1628,7 +1628,6 @@ def preload_payroll_data_for_employees(employees, args):
 		h_list = emp.holiday_list or company_holiday_list
 		if h_list:
 			holiday_lists.add(h_list)
-
 
 	from hrms.payroll.doctype.salary_slip.salary_slip import HOLIDAYS_BETWEEN_DATES
 	from hrms.utils.holiday_list import get_holiday_dates_between
@@ -1660,7 +1659,6 @@ def preload_payroll_data_for_employees(employees, args):
 		.orderby(SalaryStructureAssignment.from_date, order=frappe.qb.desc)
 	)
 
-
 	if args.get("company"):
 		sal_struct_query = sal_struct_query.where(SalaryStructureAssignment.company == args.get("company"))
 
@@ -1670,15 +1668,27 @@ def preload_payroll_data_for_employees(employees, args):
 	if not args.get("salary_slip_based_on_timesheet") and args.get("payroll_frequency"):
 		sal_struct_query = sal_struct_query.where(SalaryStructure.payroll_frequency == args.get("payroll_frequency"))
 
-
 	struct_rows = sal_struct_query.run(as_dict=True)
 	sal_struct_map = {}
 	for r in struct_rows:
 		if r.employee not in sal_struct_map:
 			sal_struct_map[r.employee] = r.salary_structure
 
-	return sal_struct_map
+	from hrms.payroll.doctype.additional_salary.additional_salary import get_additional_salaries
 
+	additional_salaries = {
+		"earnings": get_additional_salaries(employees, args.get("start_date"), args.get("end_date"), "earnings"),
+		"deductions": get_additional_salaries(employees, args.get("start_date"), args.get("end_date"), "deductions"),
+	}
+
+	withholdings_list = get_salary_withholdings(args.get("start_date"), args.get("end_date"), employees)
+	salary_withholdings = {w.employee: w for w in withholdings_list} if withholdings_list else {}
+
+	return {
+		"sal_struct_map": sal_struct_map,
+		"additional_salaries": additional_salaries,
+		"salary_withholdings": salary_withholdings,
+	}
 
 
 def create_salary_slips_for_employees(employees, args, publish_progress=True):
@@ -1689,35 +1699,42 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 		count = 0
 
 		employees = list(set(employees) - set(salary_slips_exist_for))
-		sal_struct_map = preload_payroll_data_for_employees(employees, args)
+		preloaded_data = preload_payroll_data_for_employees(employees, args)
+		sal_struct_map = preloaded_data.get("sal_struct_map", {})
 
-		for emp in employees:
-			slip_args = {
-				"doctype": "Salary Slip",
-				"employee": emp,
-				"salary_structure": sal_struct_map.get(emp),
-				"salary_slip_based_on_timesheet": args.get("salary_slip_based_on_timesheet"),
-				"payroll_frequency": args.get("payroll_frequency"),
-				"start_date": args.get("start_date"),
-				"end_date": args.get("end_date"),
-				"company": args.get("company"),
-				"posting_date": args.get("posting_date"),
-				"deduct_tax_for_unsubmitted_tax_exemption_proof": args.get(
-					"deduct_tax_for_unsubmitted_tax_exemption_proof"
-				),
-				"payroll_entry": args.get("payroll_entry"),
-				"exchange_rate": args.get("exchange_rate"),
-				"currency": args.get("currency"),
-			}
-			frappe.get_doc(slip_args).insert()
+		frappe.flags.payroll_additional_salaries = preloaded_data.get("additional_salaries")
+		frappe.flags.payroll_salary_withholdings = preloaded_data.get("salary_withholdings")
 
+		try:
+			for emp in employees:
+				slip_args = {
+					"doctype": "Salary Slip",
+					"employee": emp,
+					"salary_structure": sal_struct_map.get(emp),
+					"salary_slip_based_on_timesheet": args.get("salary_slip_based_on_timesheet"),
+					"payroll_frequency": args.get("payroll_frequency"),
+					"start_date": args.get("start_date"),
+					"end_date": args.get("end_date"),
+					"company": args.get("company"),
+					"posting_date": args.get("posting_date"),
+					"deduct_tax_for_unsubmitted_tax_exemption_proof": args.get(
+						"deduct_tax_for_unsubmitted_tax_exemption_proof"
+					),
+					"payroll_entry": args.get("payroll_entry"),
+					"exchange_rate": args.get("exchange_rate"),
+					"currency": args.get("currency"),
+				}
+				frappe.get_doc(slip_args).insert()
 
-			count += 1
-			if publish_progress:
-				frappe.publish_progress(
-					count * 100 / len(employees),
-					title=_("Creating Salary Slips..."),
-				)
+				count += 1
+				if publish_progress:
+					frappe.publish_progress(
+						count * 100 / len(employees),
+						title=_("Creating Salary Slips..."),
+					)
+		finally:
+			frappe.flags.payroll_additional_salaries = None
+			frappe.flags.payroll_salary_withholdings = None
 
 		payroll_entry.db_set({"status": "Submitted", "salary_slips_created": 1, "error_message": ""})
 

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -1702,6 +1702,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 		preloaded_data = preload_payroll_data_for_employees(employees, args)
 		sal_struct_map = preloaded_data.get("sal_struct_map", {})
 
+		frappe.flags.payroll_sal_struct_map = sal_struct_map
 		frappe.flags.payroll_additional_salaries = preloaded_data.get("additional_salaries")
 		frappe.flags.payroll_salary_withholdings = preloaded_data.get("salary_withholdings")
 
@@ -1733,6 +1734,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 						title=_("Creating Salary Slips..."),
 					)
 		finally:
+			frappe.flags.payroll_sal_struct_map = None
 			frappe.flags.payroll_additional_salaries = None
 			frappe.flags.payroll_salary_withholdings = None
 

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -493,8 +493,20 @@ class SalarySlip(TransactionBase):
 			self.append("timesheets", {"time_sheet": data.name, "working_hours": data.total_hours})
 
 	def check_sal_struct(self):
-		if self.payroll_entry and self.salary_structure:
-			return self.salary_structure
+		if getattr(frappe.flags, "payroll_sal_struct_map", None) is not None:
+			st_name = frappe.flags.payroll_sal_struct_map.get(self.employee)
+			if st_name:
+				self.salary_structure = st_name
+				return self.salary_structure
+			else:
+				self.salary_structure = None
+				frappe.msgprint(
+					_("No active or default Salary Structure found for employee {0} for the given dates").format(
+						self.employee
+					),
+					title=_("Salary Structure Missing"),
+				)
+				return None
 
 		ss = frappe.qb.DocType("Salary Structure")
 		ssa = frappe.qb.DocType("Salary Structure Assignment")

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -488,8 +488,12 @@ class SalarySlip(TransactionBase):
 			self.append("timesheets", {"time_sheet": data.name, "working_hours": data.total_hours})
 
 	def check_sal_struct(self):
+		if self.salary_structure:
+			return self.salary_structure
+
 		ss = frappe.qb.DocType("Salary Structure")
 		ssa = frappe.qb.DocType("Salary Structure Assignment")
+
 
 		query = (
 			frappe.qb.from_(ssa)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -269,7 +269,12 @@ class SalarySlip(TransactionBase):
 			self.current_payroll_period = self.payroll_period.name
 
 	def check_salary_withholding(self):
-		withholding = get_salary_withholdings(self.start_date, self.end_date, self.employee)
+		if getattr(frappe.flags, "payroll_salary_withholdings", None) is not None:
+			withholding_entry = frappe.flags.payroll_salary_withholdings.get(self.employee)
+			withholding = [withholding_entry] if withholding_entry else []
+		else:
+			withholding = get_salary_withholdings(self.start_date, self.end_date, self.employee)
+
 		if withholding:
 			self.salary_withholding = withholding[0].salary_withholding
 			self.salary_withholding_cycle = withholding[0].salary_withholding_cycle
@@ -1647,9 +1652,15 @@ class SalarySlip(TransactionBase):
 		return current_period_benefit, is_accrual
 
 	def add_additional_salary_components(self, component_type):
-		additional_salaries = get_additional_salaries(
-			self.employee, self.start_date, self.end_date, component_type
-		)
+		if (
+			getattr(frappe.flags, "payroll_additional_salaries", None) is not None
+			and component_type in frappe.flags.payroll_additional_salaries
+		):
+			additional_salaries = frappe.flags.payroll_additional_salaries[component_type].get(self.employee, [])
+		else:
+			additional_salaries = get_additional_salaries(
+				self.employee, self.start_date, self.end_date, component_type
+			)
 
 		for additional_salary in additional_salaries:
 			component_data = get_salary_component_data(additional_salary.component)

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -493,7 +493,7 @@ class SalarySlip(TransactionBase):
 			self.append("timesheets", {"time_sheet": data.name, "working_hours": data.total_hours})
 
 	def check_sal_struct(self):
-		if self.salary_structure:
+		if self.payroll_entry and self.salary_structure:
 			return self.salary_structure
 
 		ss = frappe.qb.DocType("Salary Structure")


### PR DESCRIPTION
## Summary

Optimized bulk payroll generation in `PayrollEntry` by replacing repeated per-employee database lookups with set-based batch queries using `frappe.qb`.

## Problem

When processing payroll for a large number of employees, `create_salary_slips_for_employees` performs multiple database lookups for each employee, including:

- Employee master details
- Salary Structure Assignment resolution
- Additional Salaries
- Salary Withholdings

These repeated queries increase database overhead and can significantly impact payroll processing time for large employee batches.

## Changes

1. **Batch Data Pre-loading (`payroll_entry.py`)**
   - Added `preload_payroll_data_for_employees` to fetch Employee records and active Salary Structure Assignments in batches before processing employees.
   - Reuses the pre-fetched data during Salary Slip creation.

2. **Batch Query Support (`additional_salary.py` / `payroll_entry.py`)**
   - Updated `get_salary_withholdings` and `get_additional_salaries` to accept multiple employee IDs.
   - Returns grouped lookup maps so the data can be reused without additional per-employee queries.

3. **Avoid Redundant Salary Structure Queries (`salary_slip.py`)**
   - Updated `SalarySlip.check_sal_struct()` to reuse the Salary Structure already resolved during bulk payroll generation.
   - Avoids redundant database lookups when the structure has already been pre-assigned.

## Performance Impact

The changes reduce repeated database queries during bulk Salary Slip generation by replacing per-employee lookups with batch queries and in-memory lookups.

This reduces database overhead and improves scalability when processing payroll for large employee batches.