### PR TITLE
fix(pwa): false "check-in successful" message when Employee Checkin isn't actually created

### DIFF
--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -165,7 +165,18 @@ const submitLog = (logType) => {
 			longitude: longitude.value,
 		},
 		{
-			onSuccess() {
+			onSuccess(data) {
+				if (!data?.name) {
+					toast({
+						title: __("Error"),
+						text: __("{0} failed!", [actionLabel]),
+						icon: "alert-circle",
+						position: "bottom-center",
+						iconClasses: "text-red-500",
+					})
+					return
+				}
+
 				modalController.dismiss()
 				toast({
 					title: __("Success"),
@@ -176,7 +187,7 @@ const submitLog = (logType) => {
 				})
 			},
 			onError(error) {
-				let messages = error.messages || []
+				let messages = error.messages?.length ? error.messages : [__("{0} failed!", [actionLabel])]
 
 				for (const message of messages) {
 					toast({


### PR DESCRIPTION
### Problem
- PWA showed "**Check-in successful!**" even when the Employee Checkin record wasn't actually created, since `onSuccess` is not validating the response before confirming.

### Fix
- Validate the response (data?.name) before showing success, and fall back to failure message when the server doesn't return one, so a failed check-in/out is never silently reported as successful.
<img width="350" height="536" alt="image" src="https://github.com/user-attachments/assets/6ac4694e-a224-47d2-8dad-93c74022e845" />

