### PR TITLE
fix: validate salary structure for timesheet salaries

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2662,10 +2662,30 @@ def get_lwp_or_ppl_for_date_range(employee, start_date, end_date):
 
 
 @frappe.whitelist()
-def make_salary_slip_from_timesheet(source_name: str, target_doc: str | Document | None = None) -> Document:
+def make_salary_slip_from_timesheet(source_name: str | Document | None = None) -> Document:
 	frappe.has_permission("Timesheet", "read", source_name, throw=True)
 	target = frappe.new_doc("Salary Slip")
 	set_missing_values(source_name, target)
+	if not target.check_sal_struct():
+		frappe.throw(
+			_("Cannot create Salary Slip: no active Salary Structure is assigned to employee {0}.").format(
+				frappe.bold(target.employee_name)
+			)
+		)
+
+	timesheet_config = frappe.get_cached_value(
+		"Salary Structure",
+		target.salary_structure,
+		["salary_slip_based_on_timesheet", "salary_component"],
+		as_dict=True,
+	)
+	if not timesheet_config or not timesheet_config.salary_slip_based_on_timesheet:
+		frappe.throw(
+			_(
+				"The Assigned Salary Structure {0} for the employee {1} is not configured for Salary Slip based on Timesheet."
+			).format(frappe.bold(target.salary_structure), frappe.bold(target.employee_name))
+		)
+
 	target.run_method("get_emp_and_working_day_details")
 
 	return target

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2685,7 +2685,12 @@ def make_salary_slip_from_timesheet(source_name: str, target_doc: str | Document
 				"The Assigned Salary Structure {0} for the employee {1} is not configured for Salary Slip based on Timesheet."
 			).format(frappe.bold(target.salary_structure), frappe.bold(target.employee_name))
 		)
-
+	if not timesheet_config.salary_component:
+		frappe.throw(
+			_(
+				"The Assigned Salary Structure {0} for the employee {1} does not have a Salary Component configured for Salary Slip based on Timesheet."
+			).format(frappe.bold(target.salary_structure), frappe.bold(target.employee_name))
+		)
 	target.run_method("get_emp_and_working_day_details")
 
 	return target

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2662,7 +2662,7 @@ def get_lwp_or_ppl_for_date_range(employee, start_date, end_date):
 
 
 @frappe.whitelist()
-def make_salary_slip_from_timesheet(source_name: str | Document | None = None) -> Document:
+def make_salary_slip_from_timesheet(source_name: str, target_doc: str | Document | None = None) -> Document:
 	frappe.has_permission("Timesheet", "read", source_name, throw=True)
 	target = frappe.new_doc("Salary Slip")
 	set_missing_values(source_name, target)


### PR DESCRIPTION
**Description:** Prevent Salary Slip creation from a submitted Timesheet when the employee does not have a valid timesheet-based Salary Structure


**Before:**

[Screencast from 2026-09-04 17-05-12.webm](https://github.com/user-attachments/assets/408b59c2-2faa-4a5b-8967-053270f6d1a8)


**After:**

[Screencast from 2026-09-04 17-06-22.webm](https://github.com/user-attachments/assets/796f38b2-f5c2-418f-8390-ca1db5ce5e75)
