### PR TITLE
Restrict data-changing whitelisted methods to POST

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -117,7 +117,7 @@ def get_unread_notifications_count() -> int:
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def mark_all_notifications_as_read() -> None:
 	frappe.db.set_value(
 		"PWA Notification",
@@ -749,7 +749,7 @@ def get_attachments(dt: str, dn: str):
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def upload_base64_file(
 	content: str, filename: str, dt: str | None = None, dn: str | None = None, fieldname: str | None = None
 ):
@@ -793,7 +793,7 @@ def upload_base64_file(
 	).insert()
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def delete_attachment(filename: str):
 	attached_to_doctype, attached_to_name = frappe.db.get_value(
 		"File", filename, ["attached_to_doctype", "attached_to_name"]

--- a/hrms/api/roster.py
+++ b/hrms/api/roster.py
@@ -79,7 +79,7 @@ def get_schedule_from_assignment(shift_schedule_assignment: str):
 	return {"frequency": frequency, "repeat_on_days": repeat_on_days}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_shift_schedule_assignment(
 	employee: str,
 	company: str,
@@ -124,7 +124,7 @@ def create_shift_schedule_assignment(
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def delete_shift_schedule_assignment(shift_schedule_assignment: str) -> None:
 	shift_schedule_assignment_doc = frappe.get_doc("Shift Schedule Assignment", shift_schedule_assignment)
 	shift_schedule_assignment_doc.check_permission("delete")
@@ -141,7 +141,7 @@ def delete_shift_schedule_assignment(shift_schedule_assignment: str) -> None:
 	frappe.delete_doc("Shift Schedule Assignment", shift_schedule_assignment, ignore_permissions=True)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def swap_shift(
 	src_shift: str, src_date: str, tgt_employee: str, tgt_date: str, tgt_shift: str | None
 ) -> None:
@@ -190,7 +190,7 @@ def swap_shift(
 		)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def break_shift(assignment: str | ShiftAssignment, date: str) -> None:
 	if isinstance(assignment, str):
 		assignment = frappe.get_doc("Shift Assignment", assignment)
@@ -223,7 +223,7 @@ def break_shift(assignment: str | ShiftAssignment, date: str) -> None:
 		)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def insert_shift(
 	employee: str,
 	company: str,

--- a/hrms/hr/doctype/appraisal/appraisal.py
+++ b/hrms/hr/doctype/appraisal/appraisal.py
@@ -246,7 +246,7 @@ class Appraisal(Document, AppraisalMixin):
 
 		self.final_score = flt(final_score, self.precision("final_score"))
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def add_feedback(self, feedback: str, feedback_ratings: list) -> Document:
 		feedback = frappe.get_doc(
 			{

--- a/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
+++ b/hrms/hr/doctype/appraisal_cycle/appraisal_cycle.py
@@ -129,7 +129,7 @@ class AppraisalCycle(Document):
 
 		return appraisal_templates
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def create_appraisals(self):
 		self.check_permission("write")
 		if not self.appraisees:
@@ -168,7 +168,7 @@ class AppraisalCycle(Document):
 			msg, title=_("Appraisal Template Missing"), indicator="yellow", raise_exception=raise_exception
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def complete_cycle(self):
 		self.check_permission("write")
 

--- a/hrms/hr/doctype/attendance/attendance.py
+++ b/hrms/hr/doctype/attendance/attendance.py
@@ -384,7 +384,7 @@ def mark_attendance(
 	return attendance.name
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def mark_bulk_attendance(data: str | dict):
 	import json
 

--- a/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/hrms/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -166,7 +166,7 @@ def _get_unmarked_attendance_with_shift(unmarked_attendance, shift, date):
 	return shiftwise_unmarked_attendance
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def mark_employee_attendance(
 	employee_list: list | str,
 	status: str,

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -156,7 +156,7 @@ class EmployeeCheckin(Document):
 			)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def add_log_based_on_employee_field(
 	employee_field_value: str | int,
 	timestamp: str | datetime,
@@ -218,7 +218,7 @@ def add_log_based_on_employee_field(
 	return doc
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def bulk_fetch_shift(checkins: list[str] | str) -> None:
 	if isinstance(checkins, str):
 		checkins = frappe.json.loads(checkins)

--- a/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
+++ b/hrms/hr/doctype/employee_onboarding/employee_onboarding.py
@@ -90,7 +90,7 @@ class EmployeeOnboarding(EmployeeBoardingController):
 	def on_cancel(self):
 		super().on_cancel()
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def mark_onboarding_as_completed(self):
 		self.check_permission("write")
 		for activity in self.activities:

--- a/hrms/hr/doctype/employee_referral/employee_referral.py
+++ b/hrms/hr/doctype/employee_referral/employee_referral.py
@@ -76,7 +76,7 @@ class EmployeeReferral(Document):
 		self.db_set("status", "Cancelled")
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_job_applicant(source_name: str, target_doc: str | Document | None = None) -> Document:
 	emp_ref = frappe.get_doc("Employee Referral", source_name)
 	# just for Api call if some set status apart from default Status

--- a/hrms/hr/doctype/exit_interview/exit_interview.py
+++ b/hrms/hr/doctype/exit_interview/exit_interview.py
@@ -91,7 +91,7 @@ class ExitInterview(Document):
 			frappe.db.set_value("Employee", self.employee, "held_on", None)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def send_exit_questionnaire(interviews: str | list) -> None:
 	interviews = get_interviews(interviews)
 	validate_questionnaire_settings()

--- a/hrms/hr/doctype/goal/goal.py
+++ b/hrms/hr/doctype/goal/goal.py
@@ -225,7 +225,7 @@ def _update_goal_completion_status(goals: list[dict]) -> list[dict]:
 	return goals
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def update_progress(progress: float, goal: str) -> None:
 	goal = frappe.get_doc("Goal", goal)
 	goal.progress = progress
@@ -235,7 +235,7 @@ def update_progress(progress: float, goal: str) -> None:
 	return goal
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def update_status(status: str, goals: str | list) -> None:
 	if isinstance(goals, str):
 		import json
@@ -253,7 +253,7 @@ def update_status(status: str, goals: str | list) -> None:
 	return goals
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def add_tree_node():
 	from frappe.desk.treeview import make_tree_args
 

--- a/hrms/hr/doctype/interview/interview.py
+++ b/hrms/hr/doctype/interview/interview.py
@@ -107,7 +107,7 @@ class Interview(Document):
 		status_map = {"Cleared": "Accepted", "Rejected": "Rejected"}
 		return status_map.get(self.status, None)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def reschedule_interview(
 		self, scheduled_on: datetime.date, from_time: datetime.time, to_time: datetime.time
 	) -> None:
@@ -220,7 +220,7 @@ def get_skill_wise_average_rating(interview: str) -> list[dict]:
 	).run(as_dict=True)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def update_job_applicant_status(status: str, job_applicant: str):
 	try:
 		if not job_applicant:
@@ -348,7 +348,7 @@ def get_expected_skill_set(interview_type: str):
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_interview_feedback(data: str | dict, interview_name: str, interviewer: str, job_applicant: str):
 	import json
 

--- a/hrms/hr/doctype/job_applicant/job_applicant.py
+++ b/hrms/hr/doctype/job_applicant/job_applicant.py
@@ -160,7 +160,7 @@ def make_employee(source_name: str, target_doc: str | Document | None = None) ->
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_kanban_board(board_name: str) -> dict:
 	frappe.has_permission("Job Applicant", throw=True)
 
@@ -212,7 +212,7 @@ def create_interview(job_applicant: str, interview_type: str) -> Document:
 	return interview
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def schedule_interview(
 	job_applicant: str,
 	interview_type: str,

--- a/hrms/hr/doctype/job_requisition/job_requisition.py
+++ b/hrms/hr/doctype/job_requisition/job_requisition.py
@@ -56,7 +56,7 @@ class JobRequisition(Document):
 			},
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def associate_job_opening(self, job_opening: str) -> None:
 		frappe.has_permission("Job Opening", "write", job_opening, throw=True)
 		frappe.db.set_value(

--- a/hrms/hr/doctype/leave_allocation/leave_allocation.py
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation.py
@@ -269,7 +269,7 @@ class LeaveAllocation(Document):
 				BackDatedAllocationError,
 			)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def set_total_leaves_allocated(self):
 		self.unused_leaves = flt(
 			get_carry_forwarded_leaves(self.employee, self.leave_type, self.from_date, self.carry_forward),
@@ -358,7 +358,7 @@ class LeaveAllocation(Document):
 		)
 		create_leave_ledger_entry(self, args, submit)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def allocate_leaves_manually(self, new_leaves: str | float, from_date: str | datetime.date | None = None):
 		self.check_permission("write")
 		if from_date and not (getdate(self.from_date) <= getdate(from_date) <= getdate(self.to_date)):
@@ -438,7 +438,7 @@ class LeaveAllocation(Document):
 
 		return _get_monthly_earned_leave(doj, annual_allocation, frequency, rounding)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def create_leave_adjustment(
 		self,
 		adjustment_type: str,
@@ -460,7 +460,7 @@ class LeaveAllocation(Document):
 		leave_adjustment.submit()
 		frappe.msgprint(_("Adjustment Created Successfully"), indicator="green", alert=True)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def retry_failed_allocations(self, failed_allocations: list) -> None:
 		if not frappe.has_permission(doctype="Leave Allocation", ptype="write", user=frappe.session.user):
 			frappe.throw(_("You do not have permission to complete this action"), frappe.PermissionError)
@@ -621,7 +621,7 @@ def show_expire_leave_dialog(expired_leaves, leave_type):
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def expire_carried_forward_allocation():
 	if frappe.has_permission(doctype="Leave Allocation", ptype="submit", user=frappe.session.user):
 		process_expired_allocation()

--- a/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
+++ b/hrms/hr/doctype/leave_control_panel/leave_control_panel.py
@@ -52,7 +52,7 @@ class LeaveControlPanel(Document):
 			mandatory_fields.extend(["leave_type", "no_of_days"])
 		validate_bulk_tool_fields(self, mandatory_fields, employees, "from_date", "to_date")
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def allocate_leave(self, employees: list):
 		self.validate_fields(employees)
 		if self.allocate_based_on_leave_policy:

--- a/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/hrms/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -231,7 +231,7 @@ def get_remaining_leaves(allocation):
 	)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def expire_allocation(allocation: str | Document | frappe._dict, expiry_date: datetime.date | None = None):
 	"""expires non-carry forwarded allocation"""
 	import json

--- a/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -489,7 +489,7 @@ def calculate_pro_rated_leaves(
 	return rounded(leaves)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_assignment_for_multiple_employees(employees: str | list[str], data: str | dict) -> list[str]:
 	if isinstance(employees, str):
 		employees = json.loads(employees)
@@ -527,7 +527,7 @@ def create_assignment_for_multiple_employees(employees: str | list[str], data: s
 	return docs_name
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_assignment(employee: str, data: frappe._dict) -> Document:
 	assignment = frappe.new_doc("Leave Policy Assignment")
 	assignment.employee = employee

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -119,7 +119,7 @@ class OvertimeSlip(Document):
 				)
 			)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def get_emp_and_overtime_details(self):
 		records = self.get_attendance_records()
 		if len(records):

--- a/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
+++ b/hrms/hr/doctype/shift_assignment_tool/shift_assignment_tool.py
@@ -202,7 +202,7 @@ class ShiftAssignmentTool(Document):
 			.where((end_time_case >= shift_start) & (ShiftType.start_time <= shift_end))
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def bulk_assign(self, employees: list):
 		if self.action == "Assign Shift":
 			mandatory_fields = ["shift_type"]
@@ -280,7 +280,7 @@ class ShiftAssignmentTool(Document):
 			after_commit=True,
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def bulk_process_shift_requests(self, shift_requests: list, status: str):
 		if not shift_requests:
 			frappe.throw(

--- a/hrms/hr/doctype/shift_type/shift_type.py
+++ b/hrms/hr/doctype/shift_type/shift_type.py
@@ -145,7 +145,7 @@ class ShiftType(Document):
 			{"shift": self.name, "attendance": ["is", "not set"], "skip_auto_attendance": 0, "offshift": 0},
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def process_auto_attendance(self, is_manually_triggered: int | bool = False) -> None | str:
 		if self.has_incorrect_shift_config():
 			return

--- a/hrms/overrides/employee_payment_entry.py
+++ b/hrms/overrides/employee_payment_entry.py
@@ -321,7 +321,7 @@ def get_total_amount_and_exchange_rate(ref_doc, party_account_currency, company_
 
 
 # update exchange rate in linked advance
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def set_exchange_rate_in_advance(doc: Document, method: None = None):
 	if doc.references:
 		for reference_doc in doc.references:

--- a/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.py
+++ b/hrms/payroll/doctype/bulk_salary_structure_assignment/bulk_salary_structure_assignment.py
@@ -81,7 +81,7 @@ class BulkSalaryStructureAssignment(Document):
 		)
 		return query.run(as_dict=True)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def bulk_assign_structure(self, employees: list) -> None:
 		mandatory_fields = ["salary_structure", "from_date", "company"]
 		validate_bulk_tool_fields(self, mandatory_fields, employees)

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry.py
@@ -300,7 +300,7 @@ class PayrollEntry(Document):
 			if employee.employee in withheld_salaries:
 				employee.is_salary_withheld = 1
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def create_salary_slips(self) -> None:
 		"""
 		Creates salary slip for selected employees if already not created
@@ -363,7 +363,7 @@ class PayrollEntry(Document):
 
 		return ss_list
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def submit_salary_slips(self) -> None:
 		self.check_permission("write")
 		salary_slips = self.get_sal_slip_list(ss_status=0)
@@ -952,7 +952,7 @@ class PayrollEntry(Document):
 			),
 		}
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def make_bank_entry(self, for_withheld_salaries: bool = False) -> Document | None:
 		self.check_permission("write")
 		self.employee_based_payroll_payable_entries = {}
@@ -1263,7 +1263,7 @@ class PayrollEntry(Document):
 
 		return self._holidays_between_dates.get(key) or 0
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def create_overtime_slips(self) -> None:
 		self.check_permission("write")
 
@@ -1302,7 +1302,7 @@ class PayrollEntry(Document):
 			else:
 				create_overtime_slips_for_employees(employees, args)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def submit_overtime_slips(self) -> None:
 		self.check_permission("write")
 

--- a/hrms/payroll/doctype/salary_component/salary_component.py
+++ b/hrms/payroll/doctype/salary_component/salary_component.py
@@ -155,7 +155,7 @@ class SalaryComponent(Document):
 			.run(pluck=True)
 		)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def update_salary_structures(
 		self, field: str, value: str | int | float | None, structures: list | None = None
 	) -> None:

--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2718,7 +2718,7 @@ def on_doctype_update():
 	frappe.db.add_index("Salary Slip", ["employee", "start_date", "end_date"])
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def enqueue_email_salary_slips(names: list | str) -> None:
 	"""enqueue bulk emailing salary slips"""
 	import json

--- a/hrms/payroll/doctype/salary_structure/salary_structure.py
+++ b/hrms/payroll/doctype/salary_structure/salary_structure.py
@@ -198,7 +198,7 @@ class SalaryStructure(Document):
 
 		return employees
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def assign_salary_structure(
 		self,
 		branch: str | None = None,

--- a/hrms/subscription_utils.py
+++ b/hrms/subscription_utils.py
@@ -63,7 +63,7 @@ def get_active_employees() -> int:
 	return frappe.db.count("Employee", {"status": "Active"})
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def subscription_updated(app: str, plan: str):
 	if app in ["hrms", "erpnext"] and plan:
 		update_erpnext_access()


### PR DESCRIPTION
- Added `methods=["POST"]` to whitelisted endpoints that create, update, or delete data (~50 across roster, attendance, leave, payroll, recruitment, etc.)
- These were declared with a bare `@frappe.whitelist()`, which also permits GET