### PR TITLE
fix: validate working days in project profitability report

### DIFF
--- a/hrms/hr/report/project_profitability/project_profitability.py
+++ b/hrms/hr/report/project_profitability/project_profitability.py
@@ -48,6 +48,7 @@ def get_rows(filters):
 			Timesheet.total_billed_hours,
 			Timesheet.name.as_("timesheet"),
 			SalarySlip.base_gross_pay,
+			SalarySlip.name.as_("salary_slip"),
 			SalarySlip.total_working_days,
 			Timesheet.total_billed_hours,
 		)
@@ -81,6 +82,13 @@ def calculate_cost_and_profit(data):
 	precision = cint(frappe.db.get_default("float_precision")) or 2
 
 	for row in data:
+		if flt(row.total_working_days) <= 0:
+			frappe.throw(
+				_(
+					"Cannot calculate project profitability. Total Working Days must be greater than zero. Please review Salary Slip {0}."
+				).format(frappe.utils.get_link_to_form("Salary Slip", row.salary_slip))
+			)
+
 		row.utilization = flt(
 			flt(row.total_billed_hours) / (flt(row.total_working_days) * flt(standard_working_hours)),
 			precision,

--- a/hrms/hr/report/project_profitability/test_project_profitability.py
+++ b/hrms/hr/report/project_profitability/test_project_profitability.py
@@ -55,6 +55,7 @@ class TestProjectProfitability(HRMSTestSuite):
 		self.assertEqual(self.salary_slip.base_gross_pay, row.base_gross_pay)
 		self.assertEqual(timesheet.total_billed_hours, row.total_billed_hours)
 		self.assertEqual(self.salary_slip.total_working_days, row.total_working_days)
+		self.assertEqual(self.salary_slip.name, row.salary_slip)
 
 		standard_working_hours = frappe.db.get_single_value("HR Settings", "standard_working_hours")
 		utilization = flt(


### PR DESCRIPTION
**Description:** Project Profitability fails with a `ZeroDivisionError` when a linked Salary Slip has zero or missing Total Working Days

**Before:**

[Screencast from 2026-09-09 02-15-22.webm](https://github.com/user-attachments/assets/f6bb3349-e607-421f-883a-bd8bbbff5ba3)

**After:**

[Screencast from 2026-09-09 02-14-18.webm](https://github.com/user-attachments/assets/12dedb6b-98c6-47c9-bcde-7942030a952b)
