### PR TITLE
perf: batch feedback counts in appraisal overview

### DIFF
--- a/hrms/hr/report/appraisal_overview/appraisal_overview.py
+++ b/hrms/hr/report/appraisal_overview/appraisal_overview.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Count
 
 
 def execute(filters: dict | None = None) -> tuple:
@@ -67,9 +68,15 @@ def get_columns() -> list[dict]:
 
 def get_data(filters: dict | None = None) -> list[dict]:
 	Appraisal = frappe.qb.DocType("Appraisal")
+	query = frappe.qb.from_(Appraisal).where(Appraisal.docstatus != 2)
+
+	for condition in ["appraisal_cycle", "employee", "department", "designation", "company"]:
+		if filters.get(condition):
+			query = query.where(Appraisal[condition] == filters.get(condition))
+
+	filtered_appraisals = query.select(Appraisal.name)
 	query = (
-		frappe.qb.from_(Appraisal)
-		.select(
+		query.select(
 			Appraisal.employee,
 			Appraisal.employee_name,
 			Appraisal.designation,
@@ -81,21 +88,25 @@ def get_data(filters: dict | None = None) -> list[dict]:
 			Appraisal.self_score,
 			Appraisal.final_score,
 		)
-		.where(Appraisal.docstatus != 2)
+		.orderby(Appraisal.appraisal_cycle)
+		.orderby(Appraisal.final_score, order=frappe.qb.desc)
+	)
+	appraisals = query.run(as_dict=True)
+	if not appraisals:
+		return appraisals
+
+	Feedback = frappe.qb.DocType("Employee Performance Feedback")
+	feedback_counts = dict(
+		frappe.qb.from_(Feedback)
+		.select(Feedback.appraisal, Count(Feedback.name))
+		.where(Feedback.docstatus == 1)
+		.where(Feedback.appraisal.isin(filtered_appraisals))
+		.groupby(Feedback.appraisal)
+		.run()
 	)
 
-	for condition in ["appraisal_cycle", "employee", "department", "designation", "company"]:
-		if filters.get(condition):
-			query = query.where(Appraisal[condition] == filters.get(condition))
-
-	query = query.orderby(Appraisal.appraisal_cycle)
-	query = query.orderby(Appraisal.final_score, order=frappe.qb.desc)
-	appraisals = query.run(as_dict=True)
-
 	for row in appraisals:
-		row["feedback_count"] = frappe.db.count(
-			"Employee Performance Feedback", {"appraisal": row.appraisal, "docstatus": 1}
-		)
+		row["feedback_count"] = feedback_counts.get(row.appraisal, 0)
 
 	return appraisals
 

--- a/hrms/hr/report/appraisal_overview/test_appraisal_overview.py
+++ b/hrms/hr/report/appraisal_overview/test_appraisal_overview.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 
 from erpnext.setup.doctype.designation.test_designation import create_designation
@@ -8,7 +10,7 @@ from hrms.hr.doctype.appraisal_template.test_appraisal_template import create_ap
 from hrms.hr.doctype.employee_performance_feedback.test_employee_performance_feedback import (
 	create_performance_feedback,
 )
-from hrms.hr.report.appraisal_overview.appraisal_overview import execute
+from hrms.hr.report.appraisal_overview.appraisal_overview import execute, get_data
 from hrms.tests.test_utils import create_company
 from hrms.tests.utils import HRMSTestSuite
 
@@ -68,6 +70,47 @@ class TestAppraisalOverview(HRMSTestSuite):
 
 		self.assertEqual(len(data), 1)
 		self.assertEqual(data[0].employee, self.employee2)
+
+	def test_feedback_counts(self):
+		cycle = create_appraisal_cycle(kra_evaluation_method="Manual Rating")
+		cycle.create_appraisals()
+		appraisals = dict(
+			frappe.get_all(
+				"Appraisal",
+				filters={"appraisal_cycle": cycle.name},
+				fields=["employee", "name"],
+				as_list=True,
+			)
+		)
+
+		for _ in range(2):
+			create_performance_feedback(self.employee1, self.reviewer, appraisals[self.employee1]).submit()
+		create_performance_feedback(self.employee1, self.reviewer, appraisals[self.employee1])
+		cancelled = create_performance_feedback(self.employee1, self.reviewer, appraisals[self.employee1])
+		cancelled.submit()
+		cancelled.cancel()
+		create_performance_feedback(self.employee2, self.reviewer, appraisals[self.employee2]).submit()
+
+		with patch.object(frappe.db, "sql", wraps=frappe.db.sql) as sql:
+			data = get_data({"appraisal_cycle": cycle.name})
+		self.assertEqual(sql.call_count, 2, sql.call_args_list)
+
+		self.assertEqual(
+			{row.employee: row.feedback_count for row in data},
+			{self.employee1: 2, self.employee2: 1, self.reviewer: 0},
+		)
+
+		with patch.object(frappe.db, "sql", wraps=frappe.db.sql) as sql:
+			data = get_data({"appraisal_cycle": cycle.name, "employee": self.employee2})
+		self.assertEqual(sql.call_count, 2, sql.call_args_list)
+		self.assertEqual(len(data), 1)
+		self.assertEqual(data[0].feedback_count, 1)
+
+	def test_empty_appraisal_overview(self):
+		with patch.object(frappe.db, "sql", wraps=frappe.db.sql) as sql:
+			data = get_data({"appraisal_cycle": "_Test Missing Appraisal Cycle"})
+		self.assertEqual(sql.call_count, 1, sql.call_args_list)
+		self.assertEqual(data, [])
 
 	def create_appraisal_data(self, appraisal):
 		# GOAL SCORE


### PR DESCRIPTION
**Description:**
  Appraisal Overview currently runs one feedback-count query per appraisal. This change fetches submitted feedback counts in one grouped query, reducing report data queries from N + 1 to 2.

  Feedback counts, scores, filters, and ordering remain unchanged. Draft and cancelled feedback are excluded, and appraisals without submitted feedback show zero.
