### PR TITLE
fix(pwa): preserve last checkin log during background reloads

### DIFF
--- a/frontend/src/components/CheckInPanel.vue
+++ b/frontend/src/components/CheckInPanel.vue
@@ -107,7 +107,7 @@ const checkins = createListResource({
 checkins.reload()
 
 const lastLog = computed(() => {
-	if (checkins.list.loading || !checkins.data) return {}
+	if (!checkins.data?.length) return {}
 	return checkins.data[0]
 })
 


### PR DESCRIPTION
### Problem
- After a morning check-in, an employee's **first check-out** attempt from the mobile app is sometimes recorded as Check In. A second attempt records Check Out correctly. Affects multiple employees, mostly during the evening check-out rush

### Fix
- `lastLog` now returns the previous log during refreshes and only falls back to empty on the genuine first load (which the button's existing :loading guard already covers).
- Follow-up to https://github.com/frappe/hrms/pull/4934, which fixed the same class of issue for the initial page load but not for background reloads while the modal is open.