### PR TITLE
fix: reset hardcoded letter head on reports

### DIFF
--- a/hrms/hr/report/employee_exits/employee_exits.json
+++ b/hrms/hr/report/employee_exits/employee_exits.json
@@ -9,7 +9,7 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Test",
+ "letter_head": null,
  "modified": "2021-12-05 19:47:18.332319",
  "modified_by": "Administrator",
  "module": "HR",

--- a/hrms/hr/report/leave_ledger/leave_ledger.json
+++ b/hrms/hr/report/leave_ledger/leave_ledger.json
@@ -8,7 +8,7 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Frappe",
+ "letter_head": null,
  "letterhead": null,
  "modified": "2024-04-07 14:46:16.056637",
  "modified_by": "Administrator",

--- a/hrms/payroll/report/income_tax_computation/income_tax_computation.json
+++ b/hrms/payroll/report/income_tax_computation/income_tax_computation.json
@@ -9,7 +9,7 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "",
+ "letter_head": null,
  "modified": "2022-02-23 13:07:30.347861",
  "modified_by": "Administrator",
  "module": "Payroll",


### PR DESCRIPTION
Some standard reports had a letter head hardcoded in their definition, left over from a developer's site. This blocked deleting those Letter Heads, since the reports still linked to them. Reset the letter head to blank on the affected reports (Employee Exits, Leave Ledger, Income Tax Computation) so they fall back to the default.

https://support.frappe.io/helpdesk/tickets/77004?view=VIEW-HD+Ticket-70178