### PR TITLE
fix: update mandatory depends for accounts in salary component

### DIFF
--- a/hrms/payroll/doctype/salary_component/salary_component.json
+++ b/hrms/payroll/doctype/salary_component/salary_component.json
@@ -163,6 +163,7 @@
    "fieldname": "accounts",
    "fieldtype": "Table",
    "label": "Accounts",
+   "mandatory_depends_on": "eval:doc.statistical_component != 1 && doc.type != \"Employer Contribution\"",
    "options": "Salary Component Account"
   },
   {
@@ -297,7 +298,7 @@
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-06 13:01:43.187327",
+ "modified": "2026-09-11 12:49:34.111687",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",


### PR DESCRIPTION
**Description:** Update accounts field as mandatory in the salary component if the component is not an statistical and not an employer contribution

**Before:**

[Screencast from 2026-09-10 18-02-26.webm](https://github.com/user-attachments/assets/ac7af05f-9d34-49c8-a5c9-6949a1f110c5)


**After:**

[Screencast from 2026-09-10 17-58-35.webm](https://github.com/user-attachments/assets/84039d39-8e11-4288-b59d-dfa6b4a978a6)
