### PR TITLE
fix(expense_claim): prevent half-posted Expense Claim when an advance row is not fully linked

### DIFF
--- a/hrms/hr/doctype/expense_claim/expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/expense_claim.py
@@ -488,6 +488,9 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 					)
 				)
 
+		for data in self.advances:
+			self.validate_advance_linkage(data)
+
 		if self.is_paid:
 			if not self.mode_of_payment:
 				frappe.throw(_("Mode of payment is required to make a payment").format(self.employee))
@@ -558,41 +561,62 @@ class ExpenseClaim(AccountsController, PWANotificationsMixin):
 		precision = self.precision("total_advance_amount")
 
 		for d in self.get("advances"):
-			advance_details = frappe.db.get_value(
-				"Employee Advance",
-				d.employee_advance,
-				["employee", "currency", "advance_account", "paid_amount"],
-				as_dict=True,
-			)
-			if not advance_details or self.employee != advance_details.employee:
-				frappe.throw(_("Selected employee advance is not of employee {}").format(self.employee))
-
-			validate_employee_advance_currency_and_account(self, d.employee_advance, advance_details)
-
-			self.round_floats_in(d)
-			if d.allocated_amount and flt(d.allocated_amount) > flt(
-				flt(d.unclaimed_amount) - flt(d.return_amount), precision
-			):
-				frappe.throw(
-					_("Row {0}# Allocated amount {1} cannot be greater than unclaimed amount {2}").format(
-						d.idx, d.allocated_amount, d.unclaimed_amount
-					)
-				)
+			self.validate_advance_row(d, precision)
 
 			self.total_advance_amount += flt(d.allocated_amount)
 			self.set_base_fields_amount(d, ["advance_paid", "unclaimed_amount"], d.exchange_rate)
 			self.set_base_fields_amount(d, ["allocated_amount"])
 
 		if self.total_advance_amount:
-			self.round_floats_in(self, ["total_advance_amount"])
-			amount_with_taxes = flt(
-				(flt(self.total_sanctioned_amount, precision) + flt(self.total_taxes_and_charges, precision)),
-				precision,
-			)
-			self.set_base_fields_amount(self, ["total_advance_amount"])
+			self.validate_total_advance_amount(precision)
 
-			if flt(self.total_advance_amount, precision) > amount_with_taxes:
-				frappe.throw(_("Total advance amount cannot be greater than total sanctioned amount"))
+	def validate_advance_row(self, d, precision):
+		advance_details = frappe.db.get_value(
+			"Employee Advance",
+			d.employee_advance,
+			["employee", "currency", "advance_account", "paid_amount"],
+			as_dict=True,
+		)
+		if not advance_details or self.employee != advance_details.employee:
+			frappe.throw(_("Selected employee advance is not of employee {}").format(self.employee))
+
+		validate_employee_advance_currency_and_account(self, d.employee_advance, advance_details)
+		self.validate_advance_linkage(d)
+
+		self.round_floats_in(d)
+		if d.allocated_amount and flt(d.allocated_amount) > flt(
+			flt(d.unclaimed_amount) - flt(d.return_amount), precision
+		):
+			frappe.throw(
+				_("Row {0}# Allocated amount {1} cannot be greater than unclaimed amount {2}").format(
+					d.idx, d.allocated_amount, d.unclaimed_amount
+				)
+			)
+
+	def validate_advance_linkage(self, d):
+		# advance_account and the payment reference are set by get_advances; a row added
+		# without them cannot book its accounting entry against the advance
+		if d.allocated_amount and not (d.advance_account and d.reference_type and d.reference_name):
+			frappe.throw(
+				_("Row {0}: {1}, {2} and {3} are required against advance {4}.").format(
+					d.idx,
+					frappe.bold(_("Advance Account")),
+					frappe.bold(_("Reference Type")),
+					frappe.bold(_("Reference Name")),
+					frappe.bold(d.employee_advance),
+				)
+			)
+
+	def validate_total_advance_amount(self, precision):
+		self.round_floats_in(self, ["total_advance_amount"])
+		amount_with_taxes = flt(
+			(flt(self.total_sanctioned_amount, precision) + flt(self.total_taxes_and_charges, precision)),
+			precision,
+		)
+		self.set_base_fields_amount(self, ["total_advance_amount"])
+
+		if flt(self.total_advance_amount, precision) > amount_with_taxes:
+			frappe.throw(_("Total advance amount cannot be greater than total sanctioned amount"))
 
 	def validate_sanctioned_amount(self):
 		for d in self.get("expenses"):

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -278,8 +278,6 @@ class TestExpenseClaim(HRMSTestSuite):
 			make_payment_entry,
 		)
 
-		frappe.db.delete("Employee Advance")
-
 		payable_account = get_payable_account("_Test Company")
 		claim = make_expense_claim(
 			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
@@ -295,7 +293,7 @@ class TestExpenseClaim(HRMSTestSuite):
 			{"employee_advance": advance.name, "allocated_amount": 1000, "unclaimed_amount": 1000},
 		)
 
-		self.assertRaises(frappe.ValidationError, claim.save)
+		self.assertRaisesRegex(frappe.ValidationError, "required against advance", claim.save)
 
 	def test_advance_with_non_receivable_account(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (

--- a/hrms/hr/doctype/expense_claim/test_expense_claim.py
+++ b/hrms/hr/doctype/expense_claim/test_expense_claim.py
@@ -272,6 +272,31 @@ class TestExpenseClaim(HRMSTestSuite):
 		self.assertEqual(advance_row.unclaimed_amount, 1000)
 		self.assertEqual(advance_row.allocated_amount, 1000)
 
+	def test_validate_advances_blocks_incompletely_linked_advance(self):
+		from hrms.hr.doctype.employee_advance.test_employee_advance import (
+			make_employee_advance,
+			make_payment_entry,
+		)
+
+		frappe.db.delete("Employee Advance")
+
+		payable_account = get_payable_account("_Test Company")
+		claim = make_expense_claim(
+			payable_account, 1000, 1000, "_Test Company", "Travel Expenses - _TC", do_not_submit=True
+		)
+
+		advance = make_employee_advance(claim.employee)
+		make_payment_entry(advance)
+
+		# advance_account / reference_type / reference_name are set by get_advances;
+		# a row added without them cannot book its accounting entry
+		claim.append(
+			"advances",
+			{"employee_advance": advance.name, "allocated_amount": 1000, "unclaimed_amount": 1000},
+		)
+
+		self.assertRaises(frappe.ValidationError, claim.save)
+
 	def test_advance_with_non_receivable_account(self):
 		from hrms.hr.doctype.employee_advance.test_employee_advance import (
 			make_employee_advance,


### PR DESCRIPTION
### Problem
- An Expense Claim linked to an employee advance could be submitted with the advance row missing its account and payment reference (these are filled by Get Advances on the form, but **a claim created via the API can skip them**).
- Submission then failed midway while posting the accounting entry for the advance, but only after the claim was already submitted, **leaving the General Ledger unbalanced.**
- The claim couldn't be edited or cancelled afterwards, since both retry the same failing step.

### Fix
- Validates that each advance row has its account and reference before the claim is submitted, so it's stopped early with a **clear message instead of half-posting.**
- Minor: split validate_advances into smaller methods for readability.