### PR TITLE
fix: remove Leave Period from Employee Grade connections

### DIFF
--- a/hrms/hr/doctype/employee_grade/employee_grade_dashboard.py
+++ b/hrms/hr/doctype/employee_grade/employee_grade_dashboard.py
@@ -2,7 +2,7 @@ def get_data():
 	return {
 		"transactions": [
 			{
-				"items": ["Employee", "Leave Period"],
+				"items": ["Employee"],
 			},
 			{"items": ["Employee Onboarding Template", "Employee Separation Template"]},
 		]


### PR DESCRIPTION
Leave Period has no field that links back to Employee Grade, so the connection could never show any records. It only added an empty card to the Employee Grade form.

Before:
<img width="2434" height="558" alt="image" src="https://github.com/user-attachments/assets/2cdeadaa-c78f-4173-88bc-1e8c768da44d" />

After:
<img width="2220" height="562" alt="image" src="https://github.com/user-attachments/assets/bef3d11e-9af9-4340-9b04-27772056be47" />

no-docs