### PR TITLE
feat(pwa): add compensatory leave requests

### DIFF
--- a/frontend/src/components/CompensatoryLeaveRequestItem.vue
+++ b/frontend/src/components/CompensatoryLeaveRequestItem.vue
@@ -1,0 +1,58 @@
+<template>
+	<ListItem
+		:isTeamRequest="props.isTeamRequest"
+		:employee="props.doc.employee"
+		:employeeName="props.doc.employee_name"
+	>
+		<template #left>
+			<LeaveIcon class="h-5 w-5 text-gray-500" />
+			<div class="flex flex-col items-start gap-1.5">
+				<div class="text-base font-normal text-gray-800">
+					{{ __(props.doc.leave_type, null, "Leave Type") }}
+				</div>
+				<div class="text-xs font-normal text-gray-500">
+					<span>{{ workDates }}</span>
+					<span class="whitespace-pre"> &middot; </span>
+					<span class="whitespace-nowrap">{{ __("{0}d", [totalDays]) }}</span>
+				</div>
+			</div>
+		</template>
+		<template #right>
+			<Badge variant="outline" :theme="colorMap[status] || 'gray'" :label="__(status)" size="md" />
+			<FeatherIcon name="chevron-right" class="h-5 w-5 text-gray-500" />
+		</template>
+	</ListItem>
+</template>
+
+<script setup>
+import { computed, inject } from "vue"
+import { Badge, FeatherIcon } from "frappe-ui"
+import ListItem from "@/components/ListItem.vue"
+import LeaveIcon from "@/components/icons/LeaveIcon.vue"
+
+const props = defineProps({
+	doc: { type: Object, required: true },
+	isTeamRequest: { type: Boolean, default: false },
+	workflowStateField: String,
+})
+const dayjs = inject("$dayjs")
+const __ = inject("$translate")
+const workDates = computed(() => {
+	const from = dayjs(props.doc.work_from_date).format("D MMM")
+	return props.doc.work_from_date === props.doc.work_end_date
+		? from
+		: `${from} - ${dayjs(props.doc.work_end_date).format("D MMM")}`
+})
+const totalDays = computed(
+	() =>
+		dayjs(props.doc.work_end_date).diff(dayjs(props.doc.work_from_date), "day") +
+		1 -
+		(props.doc.half_day ? 0.5 : 0)
+)
+const status = computed(() =>
+	props.workflowStateField
+		? props.doc[props.workflowStateField]
+		: ["Draft", "Submitted", "Cancelled"][props.doc.docstatus]
+)
+const colorMap = { Draft: "gray", Submitted: "blue", Cancelled: "red" }
+</script>

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -149,6 +149,7 @@ import AttendanceRequestItem from "@/components/AttendanceRequestItem.vue"
 import ShiftRequestItem from "@/components/ShiftRequestItem.vue"
 import ShiftAssignmentItem from "@/components/ShiftAssignmentItem.vue"
 import LeaveRequestItem from "@/components/LeaveRequestItem.vue"
+import CompensatoryLeaveRequestItem from "@/components/CompensatoryLeaveRequestItem.vue"
 import ExpenseClaimItem from "@/components/ExpenseClaimItem.vue"
 import EmployeeAdvanceItem from "@/components/EmployeeAdvanceItem.vue"
 import ListFiltersActionSheet from "@/components/ListFiltersActionSheet.vue"
@@ -195,6 +196,7 @@ const listItemComponent = {
 	"Shift Request": markRaw(ShiftRequestItem),
 	"Shift Assignment": markRaw(ShiftAssignmentItem),
 	"Leave Application": markRaw(LeaveRequestItem),
+	"Compensatory Leave Request": markRaw(CompensatoryLeaveRequestItem),
 	"Expense Claim": markRaw(ExpenseClaimItem),
 	"Employee Advance": markRaw(EmployeeAdvanceItem),
 }

--- a/frontend/src/router/leaves.js
+++ b/frontend/src/router/leaves.js
@@ -1,5 +1,21 @@
 const routes = [
 	{
+		name: "CompensatoryLeaveRequestListView",
+		path: "/compensatory-leave-requests",
+		component: () => import("@/views/leave/CompensatoryLeaveRequestList.vue"),
+	},
+	{
+		name: "CompensatoryLeaveRequestFormView",
+		path: "/compensatory-leave-requests/new",
+		component: () => import("@/views/leave/CompensatoryLeaveRequestForm.vue"),
+	},
+	{
+		name: "CompensatoryLeaveRequestDetailView",
+		path: "/compensatory-leave-requests/:id",
+		props: true,
+		component: () => import("@/views/leave/CompensatoryLeaveRequestForm.vue"),
+	},
+	{
 		name: "LeaveApplicationListView",
 		path: "/leave-applications",
 		component: () => import("@/views/leave/List.vue"),

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -43,6 +43,11 @@ const quickLinks = [
 		route: "LeaveApplicationFormView",
 	},
 	{
+		icon: markRaw(LeaveIcon),
+		title: __("Request Compensatory Leave"),
+		route: "CompensatoryLeaveRequestFormView",
+	},
+	{
 		icon: markRaw(ExpenseIcon),
 		title: __("Claim an Expense"),
 		route: "ExpenseClaimFormView",

--- a/frontend/src/views/leave/CompensatoryLeaveRequestForm.vue
+++ b/frontend/src/views/leave/CompensatoryLeaveRequestForm.vue
@@ -1,0 +1,91 @@
+<template>
+	<ion-page>
+		<ion-content :fullscreen="true">
+			<FormView
+				v-if="formFields.data"
+				:key="props.id || 'new'"
+				doctype="Compensatory Leave Request"
+				v-model="request"
+				:isSubmittable="true"
+				:fields="fields"
+				:id="props.id"
+				@validateForm="validateForm"
+			/>
+		</ion-content>
+	</ion-page>
+</template>
+
+<script setup>
+import { IonPage, IonContent } from "@ionic/vue"
+import { createResource } from "frappe-ui"
+import { computed, inject, ref, watch } from "vue"
+import FormView from "@/components/FormView.vue"
+
+const props = defineProps({ id: String })
+const employee = inject("$employee")
+const request = ref({})
+
+const formFields = createResource({
+	url: "hrms.api.get_doctype_fields",
+	params: { doctype: "Compensatory Leave Request" },
+	auto: true,
+})
+
+const fields = computed(() =>
+	(formFields.data || [])
+		.filter((field) => {
+			if (!props.id && ["employee", "employee_name", "department"].includes(field.fieldname)) {
+				return false
+			}
+			return field.fieldname !== "leave_allocation" || request.value.leave_allocation
+		})
+		.map((field) => {
+			field = { ...field }
+			if (
+				["employee", "employee_name", "department", "leave_allocation"].includes(field.fieldname)
+			) {
+				field.read_only = true
+			}
+			if (field.fieldname === "leave_type") {
+				field.reqd = true
+				field.linkFilters = { is_compensatory: 1 }
+			}
+			if (field.fieldname === "half_day_date") {
+				field.hidden = !request.value.half_day
+				field.reqd = Boolean(request.value.half_day)
+				field.minDate = request.value.work_from_date
+				field.maxDate = request.value.work_end_date
+			}
+			if (field.fieldname === "work_end_date") {
+				field.minDate = request.value.work_from_date
+			}
+			return field
+		})
+)
+
+watch(
+	() => request.value.work_from_date,
+	(date) => {
+		if (!request.value.work_end_date) request.value.work_end_date = date
+	}
+)
+
+watch(
+	() => [request.value.half_day, request.value.work_from_date, request.value.work_end_date],
+	([halfDay, fromDate, toDate]) => {
+		if (!halfDay || !fromDate || !toDate || fromDate > toDate) return
+
+		const halfDayDate = request.value.half_day_date
+		if (fromDate === toDate) {
+			request.value.half_day_date = fromDate
+		} else if (halfDayDate && (halfDayDate < fromDate || halfDayDate > toDate)) {
+			request.value.half_day_date = null
+		}
+	}
+)
+
+function validateForm() {
+	if (!props.id) request.value.employee = employee.data.name
+	if (!request.value.half_day) request.value.half_day_date = null
+}
+</script>

--- a/frontend/src/views/leave/CompensatoryLeaveRequestList.vue
+++ b/frontend/src/views/leave/CompensatoryLeaveRequestList.vue
@@ -1,0 +1,35 @@
+<template>
+	<ion-page>
+		<ListView
+			doctype="Compensatory Leave Request"
+			:pageTitle="__('Compensatory Leave Requests')"
+			:tabButtons="TAB_BUTTONS"
+			:fields="FIELDS"
+			:filterConfig="FILTER_CONFIG"
+		/>
+	</ion-page>
+</template>
+
+<script setup>
+import { IonPage } from "@ionic/vue"
+import { inject } from "vue"
+import ListView from "@/components/ListView.vue"
+
+const __ = inject("$translate")
+const TAB_BUTTONS = ["My Requests", "Team Requests"] // __("My Requests"), __("Team Requests")
+const FIELDS = [
+	"name",
+	"employee",
+	"employee_name",
+	"leave_type",
+	"work_from_date",
+	"work_end_date",
+	"half_day",
+	"docstatus",
+]
+const FILTER_CONFIG = [
+	{ fieldname: "leave_type", fieldtype: "Link", label: __("Leave Type"), options: "Leave Type" },
+	{ fieldname: "work_from_date", fieldtype: "Date", label: __("Work From Date") },
+	{ fieldname: "work_end_date", fieldtype: "Date", label: __("Work End Date") },
+]
+</script>

--- a/frontend/src/views/leave/Dashboard.vue
+++ b/frontend/src/views/leave/Dashboard.vue
@@ -5,20 +5,18 @@
 				<LeaveBalance />
 
 				<div class="flex flex-col gap-7 mt-5 px-4 w-full">
-					<router-link
-						:to="{ name: 'LeaveApplicationFormView' }"
-						v-slot="{ navigate }"
-					>
-						<Button
-							@click="navigate"
-							variant="solid"
-							class="py-5 text-base w-full"
-						>
+					<router-link :to="{ name: 'LeaveApplicationFormView' }" v-slot="{ navigate }">
+						<Button @click="navigate" variant="solid" class="py-5 text-base w-full">
 							{{ __("Request a Leave") }}
 						</Button>
 					</router-link>
+					<router-link :to="{ name: 'CompensatoryLeaveRequestListView' }" v-slot="{ navigate }">
+						<Button @click="navigate" variant="outline" class="py-5 text-base w-full">
+							{{ __("Compensatory Leave Requests") }}
+						</Button>
+					</router-link>
 					<div>
-						<div class="text-lg text-gray-800 font-bold">{{ __('Recent Leaves') }} </div>
+						<div class="text-lg text-gray-800 font-bold">{{ __("Recent Leaves") }}</div>
 						<RequestList
 							:component="markRaw(LeaveRequestItem)"
 							:items="myLeaves.data"


### PR DESCRIPTION
**Description:** Compensatory Leave Requests to the PWA, allowing employees to create requests with work dates, half-day details, and reasons, and view their own and team requests. Includes shortcuts on Home and the Leaves dashboard, while reusing existing permissions, backend validation, and leave allocation logic.

Closes: #4271

[Screencast from 2026-09-11 16-16-41.webm](https://github.com/user-attachments/assets/305c7127-cf70-493b-92ae-36b1915de7d1)

`no-docs`
