### PR TITLE
fix: prevent duplicate error notifications in the pwa

### DIFF
--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -176,7 +176,7 @@
 			<!-- custom form button eg: Download button in salary slips -->
 			<div
 				v-if="!showFormButton"
-				class="px-4 pt-4 pb-4 standalone:pb-safe-bottom sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-lg"
+				class="px-4 pt-4 pb-4 standalone:pb-safe-bottom sm:w-96 bg-white sticky bottom-0 w-full shrink-0 shadow-xl z-40 border-t rounded-t-lg"
 			>
 				<slot name="formButton"></slot>
 			</div>
@@ -192,7 +192,7 @@
 			<!-- save/submit/cancel -->
 			<div
 				v-else-if="isFormDirty || (!workflow?.hasWorkflow && formButton)"
-				class="px-4 pt-4 pb-4 standalone:pb-safe-bottom sm:w-96 bg-white sticky bottom-0 w-full drop-shadow-xl z-40 border-t rounded-t-lg"
+				class="px-4 pt-4 pb-4 standalone:pb-safe-bottom sm:w-96 bg-white sticky bottom-0 w-full shrink-0 shadow-xl z-40 border-t rounded-t-lg"
 			>
 				<ErrorMessage
 					class="mb-2"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -36,7 +36,10 @@ import "./main.css"
 const app = createApp(App)
 const socket = initSocket()
 
-setConfig("resourceFetcher", frappeRequest)
+setConfig("resourceFetcher", (options) =>
+	// Resources invoke onError themselves after the request rejects.
+	frappeRequest({ ...options, onError: undefined })
+)
 app.use(resourcesPlugin)
 app.use(translationsPlugin)
 


### PR DESCRIPTION
**Description:** Fixes duplicate error notifications in the PWA by ensuring each failed resource request invokes its error handler only once. Also updates the shared form footer’s shadow and sizing to improve the layout when validation messages wrap

Closes: #4744 

**Before:**

https://github.com/user-attachments/assets/62385984-0322-4a5a-95c0-e5657ef586ac



**After:**

https://github.com/user-attachments/assets/19fd9c1e-a607-478c-b104-05627de106c3

